### PR TITLE
fix: restore link preview support for sent messages

### DIFF
--- a/src/entities/auth/model/stores.ts
+++ b/src/entities/auth/model/stores.ts
@@ -352,6 +352,11 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
       const chatDbKit = initChatDb(
         address.value!,
         async (roomId: string) => pcrypto.value?.rooms[roomId],
+        undefined,
+        async (url: string) => {
+          const { fetchPreview } = await import("@/features/messaging/model/use-link-preview");
+          return fetchPreview(url);
+        },
       );
       chatStore.setChatDbKit(chatDbKit);
 

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -4623,6 +4623,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       pollInfo: msg.pollInfo,
       transferInfo: msg.transferInfo,
       linkPreview: msg.linkPreview,
+      noPreview: !!(raw.content as any)?.no_preview,
       deleted: msg.deleted,
       systemMeta: msg.systemMeta,
       // Preserve raw event for decryption retry

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -10,6 +10,7 @@ import { useConnectivity } from "@/shared/lib/connectivity";
 import { enqueue, dequeue, getQueue } from "@/shared/lib/offline-queue";
 import type { QueuedMessage } from "@/shared/lib/offline-queue";
 import { isChatDbReady, getChatDb } from "@/shared/lib/local-db";
+import { detectUrl, fetchPreview } from "./use-link-preview";
 import { invalidateDownloadCache } from "./use-file-download";
 import { registerUploadAbort, unregisterUploadAbort, abortUpload } from "./upload-abort-registry";
 import { withTimeout } from "@/shared/lib/with-timeout";
@@ -80,7 +81,7 @@ export function useMessages() {
    * (message is visible in UI), false if the message was silently dropped
    * before any UI update (caller should restore input text).
    */
-  const sendMessage = async (content: string, linkPreview?: LinkPreview): Promise<boolean> => {
+  const sendMessage = async (content: string, previewDismissed?: boolean): Promise<boolean> => {
     const MAX_MESSAGE_LENGTH = 65536;
     if (content.length > MAX_MESSAGE_LENGTH) {
       console.warn('[sendMessage] Message exceeds max length, truncating');
@@ -117,26 +118,29 @@ export function useMessages() {
           return true; // message IS visible (as failed)
         }
 
-        // 3. Enqueue for background sync
+        // 3. Enqueue for background sync (no linkPreview in payload — always async)
         await dbKit.syncEngine.enqueue(
           "send_message",
           roomId,
-          {
-            content: trimmed,
-            ...(linkPreview ? {
-              linkPreview: {
-                url: linkPreview.url,
-                site_name: linkPreview.siteName,
-                title: linkPreview.title,
-                description: linkPreview.description,
-                image_url: linkPreview.imageUrl,
-                image_width: linkPreview.imageWidth,
-                image_height: linkPreview.imageHeight,
-              },
-            } : {}),
-          },
+          { content: trimmed, ...(previewDismissed ? { noPreview: true } : {}) },
           localMsg.clientId,
         );
+
+        // 4. Async preview fetch — fire-and-forget, skip if user dismissed preview
+        if (!previewDismissed) {
+          const url = detectUrl(trimmed);
+          if (url) {
+            fetchPreview(url).then(preview => {
+              if (!preview) return;
+              dbKit.messages.getByClientId(localMsg.clientId).then(msg => {
+                if (msg?.localId) {
+                  dbKit.db.messages.update(msg.localId, { linkPreview: preview });
+                }
+              });
+            }).catch(() => {});
+          }
+        }
+
         return true;
       } catch (e) {
         console.error("[sendMessage] Dexie path failed:", {
@@ -166,7 +170,6 @@ export function useMessages() {
       timestamp: Date.now(),
       status: MessageStatus.sending,
       type: MessageType.text,
-      ...(linkPreview ? { linkPreview } : {}),
     };
 
     // Optimistic insert FIRST — even if we can't send, user sees their message
@@ -189,37 +192,9 @@ export function useMessages() {
       let serverEventId: string;
       if (roomCrypto?.canBeEncrypt()) {
         const encrypted = await roomCrypto.encryptEvent(trimmed);
-        if (linkPreview) {
-          (encrypted as Record<string, unknown>).url_preview = {
-            url: linkPreview.url,
-            site_name: linkPreview.siteName,
-            title: linkPreview.title,
-            description: linkPreview.description,
-            image_url: linkPreview.imageUrl,
-            image_width: linkPreview.imageWidth,
-            image_height: linkPreview.imageHeight,
-          };
-        }
         serverEventId = await matrixService.sendEncryptedText(roomId, encrypted);
       } else {
-        if (linkPreview) {
-          const content: Record<string, unknown> = {
-            body: trimmed,
-            msgtype: "m.text",
-            url_preview: {
-              url: linkPreview.url,
-              site_name: linkPreview.siteName,
-              title: linkPreview.title,
-              description: linkPreview.description,
-              image_url: linkPreview.imageUrl,
-              image_width: linkPreview.imageWidth,
-              image_height: linkPreview.imageHeight,
-            },
-          };
-          serverEventId = await matrixService.sendEncryptedText(roomId, content);
-        } else {
-          serverEventId = await matrixService.sendText(roomId, trimmed);
-        }
+        serverEventId = await matrixService.sendText(roomId, trimmed);
       }
       if (serverEventId) {
         chatStore.updateMessageIdAndStatus(roomId, tempId, serverEventId, MessageStatus.sent);
@@ -1164,7 +1139,7 @@ export function useMessages() {
   };
 
   /** Send message with reply context. Returns true if optimistic insert succeeded. */
-  const sendReply = async (content: string, linkPreview?: LinkPreview): Promise<boolean> => {
+  const sendReply = async (content: string, previewDismissed?: boolean): Promise<boolean> => {
     const roomId = chatStore.activeRoomId;
     const replyTo = chatStore.replyingTo;
     if (!roomId || !content.trim() || !replyTo) return false;
@@ -1204,27 +1179,29 @@ export function useMessages() {
           return true;
         }
 
-        // 3. Enqueue for background sync
+        // 3. Enqueue for background sync (no linkPreview — always async)
         await dbKit.syncEngine.enqueue(
           "send_message",
           roomId,
-          {
-            content: trimmed,
-            replyToEventId: replyTo.id,
-            ...(linkPreview ? {
-              linkPreview: {
-                url: linkPreview.url,
-                site_name: linkPreview.siteName,
-                title: linkPreview.title,
-                description: linkPreview.description,
-                image_url: linkPreview.imageUrl,
-                image_width: linkPreview.imageWidth,
-                image_height: linkPreview.imageHeight,
-              },
-            } : {}),
-          },
+          { content: trimmed, replyToEventId: replyTo.id, ...(previewDismissed ? { noPreview: true } : {}) },
           localMsg.clientId,
         );
+
+        // 4. Async preview fetch — fire-and-forget, skip if user dismissed preview
+        if (!previewDismissed) {
+          const url = detectUrl(trimmed);
+          if (url) {
+            fetchPreview(url).then(preview => {
+              if (!preview) return;
+              dbKit.messages.getByClientId(localMsg.clientId).then(msg => {
+                if (msg?.localId) {
+                  dbKit.db.messages.update(msg.localId, { linkPreview: preview });
+                }
+              });
+            }).catch(() => {});
+          }
+        }
+
         return true;
       } catch (e) {
         console.error("[sendReply] Dexie path failed:", {
@@ -1253,7 +1230,6 @@ export function useMessages() {
       status: MessageStatus.sending,
       type: MessageType.text,
       replyTo: replyToData,
-      ...(linkPreview ? { linkPreview } : {}),
     };
 
     // Optimistic insert FIRST
@@ -1279,23 +1255,10 @@ export function useMessages() {
         },
       };
 
-      if (linkPreview) {
-        msgContent.url_preview = {
-          url: linkPreview.url,
-          site_name: linkPreview.siteName,
-          title: linkPreview.title,
-          description: linkPreview.description,
-          image_url: linkPreview.imageUrl,
-          image_width: linkPreview.imageWidth,
-          image_height: linkPreview.imageHeight,
-        };
-      }
-
       let serverEventId: string;
       if (roomCrypto?.canBeEncrypt()) {
         const encrypted = await roomCrypto.encryptEvent(trimmed);
         const encContent: Record<string, unknown> = { ...encrypted, "m.relates_to": msgContent["m.relates_to"] };
-        if (msgContent.url_preview) encContent.url_preview = msgContent.url_preview;
         serverEventId = await matrixService.sendEncryptedText(roomId, encContent);
       } else {
         serverEventId = await matrixService.sendEncryptedText(roomId, msgContent);

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -174,9 +174,9 @@ const handleSend = async () => {
       chatStore.editingMessage = null;
       inserted = true;
     } else if (chatStore.replyingTo) {
-      inserted = await sendReply(rawText, linkPreview.activePreview.value ?? undefined);
+      inserted = await sendReply(rawText, linkPreview.dismissed.value);
     } else {
-      inserted = await sendMessage(rawText, linkPreview.activePreview.value ?? undefined);
+      inserted = await sendMessage(rawText, linkPreview.dismissed.value);
     }
   } catch (e) {
     console.error("[handleSend] Unexpected error:", e);

--- a/src/shared/lib/local-db/__tests__/link-preview-merge.test.ts
+++ b/src/shared/lib/local-db/__tests__/link-preview-merge.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Dexie from "dexie";
+import "fake-indexeddb/auto";
+import { MessageRepository } from "../message-repository";
+import type { ChatDatabase, LocalMessage } from "../schema";
+import { MessageType } from "@/entities/chat/model/types";
+
+class TestDb extends Dexie {
+  messages!: Dexie.Table<LocalMessage, number>;
+  rooms!: Dexie.Table<any, string>;
+  decryptionQueue!: Dexie.Table<any, number>;
+  listenedMessages!: Dexie.Table<any, string>;
+  pendingOps!: Dexie.Table<any, number>;
+  users!: Dexie.Table<any, string>;
+  syncState!: Dexie.Table<any, string>;
+  attachments!: Dexie.Table<any, number>;
+
+  constructor() {
+    super("TestDb_linkPreview", { indexedDB, IDBKeyRange });
+    this.version(1).stores({
+      messages:
+        "++localId, eventId, clientId, [roomId+timestamp], [roomId+status], senderId",
+      rooms: "id, updatedAt, membership, isDeleted",
+      decryptionQueue: "++id, status, [status+nextAttemptAt]",
+      listenedMessages: "eventId",
+      pendingOps: "++id, status",
+      users: "address",
+      syncState: "key",
+      attachments: "++id, messageLocalId, status",
+    });
+  }
+}
+
+function makeLocalMsg(overrides: Partial<LocalMessage> = {}): LocalMessage {
+  return {
+    eventId: overrides.eventId ?? `$evt_${Math.random().toString(36).slice(2)}`,
+    clientId: overrides.clientId ?? `cli_${Math.random().toString(36).slice(2)}`,
+    roomId: overrides.roomId ?? "!room:server",
+    senderId: overrides.senderId ?? "user1",
+    content: overrides.content ?? "Check https://example.com",
+    timestamp: overrides.timestamp ?? Date.now(),
+    type: overrides.type ?? MessageType.text,
+    status: overrides.status ?? "synced",
+    version: 1,
+    softDeleted: false,
+    ...overrides,
+  } as LocalMessage;
+}
+
+const PREVIEW = {
+  url: "https://example.com",
+  title: "Example",
+  description: "An example page",
+  siteName: "Example.com",
+};
+
+describe("upsertFromServer — linkPreview merge on own echo", () => {
+  let db: TestDb;
+  let repo: MessageRepository;
+
+  beforeEach(async () => {
+    db = new TestDb();
+    await db.open();
+    repo = new MessageRepository(db as unknown as ChatDatabase);
+  });
+
+  afterEach(async () => {
+    await db.delete();
+  });
+
+  it("preserves local linkPreview when server echo lacks it", async () => {
+    // 1. Create local pending message with linkPreview
+    const local = makeLocalMsg({
+      eventId: null,
+      clientId: "txn_123",
+      status: "pending",
+      linkPreview: PREVIEW,
+    });
+    local.localId = (await db.messages.add(local)) as number;
+
+    // 2. Server echo arrives without linkPreview
+    const serverMsg = makeLocalMsg({
+      eventId: "$server_evt_1",
+      clientId: "txn_123",
+      status: "synced",
+      serverTs: Date.now(),
+    });
+
+    const result = await repo.upsertFromServer(serverMsg);
+    expect(result).toBe("updated");
+
+    // 3. Verify linkPreview preserved from local
+    const updated = await db.messages.get(local.localId!);
+    expect(updated!.linkPreview).toEqual(PREVIEW);
+    expect(updated!.eventId).toBe("$server_evt_1");
+    expect(updated!.status).toBe("synced");
+  });
+
+  it("uses server linkPreview when local has none", async () => {
+    // 1. Create local pending message without linkPreview
+    const local = makeLocalMsg({
+      eventId: null,
+      clientId: "txn_456",
+      status: "pending",
+    });
+    local.localId = (await db.messages.add(local)) as number;
+
+    // 2. Server echo has linkPreview (parsed from url_preview)
+    const serverMsg = makeLocalMsg({
+      eventId: "$server_evt_2",
+      clientId: "txn_456",
+      status: "synced",
+      linkPreview: PREVIEW,
+      serverTs: Date.now(),
+    });
+
+    const result = await repo.upsertFromServer(serverMsg);
+    expect(result).toBe("updated");
+
+    const updated = await db.messages.get(local.localId!);
+    expect(updated!.linkPreview).toEqual(PREVIEW);
+  });
+
+  it("preserves localBlobUrl during echo merge", async () => {
+    const local = makeLocalMsg({
+      eventId: null,
+      clientId: "txn_789",
+      status: "pending",
+      localBlobUrl: "blob:http://localhost/abc",
+    });
+    local.localId = (await db.messages.add(local)) as number;
+
+    const serverMsg = makeLocalMsg({
+      eventId: "$server_evt_3",
+      clientId: "txn_789",
+      status: "synced",
+      serverTs: Date.now(),
+    });
+
+    // localBlobUrl present + status not failed → upload in-flight path
+    const result = await repo.upsertFromServer(serverMsg);
+    expect(result).toBe("updated");
+
+    const updated = await db.messages.get(local.localId!);
+    expect(updated!.localBlobUrl).toBe("blob:http://localhost/abc");
+  });
+});
+
+describe("createLocal — stores linkPreview", () => {
+  let db: TestDb;
+  let repo: MessageRepository;
+
+  beforeEach(async () => {
+    db = new TestDb();
+    await db.open();
+    repo = new MessageRepository(db as unknown as ChatDatabase);
+    // Insert a room so createLocal's room update doesn't fail
+    await db.rooms.add({ id: "!room:server", updatedAt: Date.now(), membership: "join", isDeleted: false });
+  });
+
+  afterEach(async () => {
+    await db.delete();
+  });
+
+  it("persists linkPreview in the optimistic message", async () => {
+    const msg = await repo.createLocal({
+      roomId: "!room:server",
+      senderId: "user1",
+      content: "Check https://example.com",
+      type: MessageType.text,
+      linkPreview: PREVIEW,
+    });
+
+    const stored = await db.messages.get(msg.localId!);
+    expect(stored!.linkPreview).toEqual(PREVIEW);
+  });
+});

--- a/src/shared/lib/local-db/event-writer.ts
+++ b/src/shared/lib/local-db/event-writer.ts
@@ -12,6 +12,12 @@ import {
 import { WriteBuffer, type BufferedWrite } from "./write-buffer";
 import { perfMark, perfMeasure } from "@/shared/lib/perf-markers";
 import { tRaw } from "@/shared/lib/i18n";
+import type { LinkPreview } from "@/entities/chat/model/types";
+
+const URL_RE = /https?:\/\/[^\s<>]+/;
+
+/** Callback type for fetching OG link preview metadata */
+export type FetchPreviewFn = (url: string) => Promise<LinkPreview | null>;
 
 // ---------------------------------------------------------------------------
 // Types for parsed events coming from chat-store / Matrix SDK layer
@@ -34,6 +40,8 @@ export interface ParsedMessage {
   /** Present when the message is our own echo (matched by clientId) */
   clientId?: string;
   linkPreview?: import("@/entities/chat/model/types").LinkPreview;
+  /** Sender explicitly dismissed link preview — receiver should not generate one */
+  noPreview?: boolean;
   deleted?: boolean;
   systemMeta?: { template: string; senderAddr: string; targetAddr?: string };
   /** Raw encrypted event JSON — stored for decryption retry when content is "[encrypted]" */
@@ -120,6 +128,7 @@ export class EventWriter {
     private roomRepo: RoomRepository,
     private userRepo: UserRepository,
     onChange?: OnChangeCallback,
+    private fetchPreviewFn?: FetchPreviewFn,
   ) {
     this.onChange = onChange;
   }
@@ -275,6 +284,14 @@ export class EventWriter {
         await this.applyPendingEdit(parsed.eventId, parsed.roomId);
       }
       this.onChange?.(parsed.roomId);
+
+      // Async link preview for incoming messages — skip if sender dismissed preview.
+      if (!parsed.linkPreview && !parsed.noPreview && parsed.type === MessageType.text && this.fetchPreviewFn) {
+        const url = parsed.content.match(URL_RE)?.[0];
+        if (url) {
+          this.fetchAndStoreLinkPreview(url, localMsg);
+        }
+      }
     }
 
     return out.result;
@@ -571,6 +588,22 @@ export class EventWriter {
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------
+
+  /** Fire-and-forget: fetch OG preview for a URL and patch the Dexie record. */
+  private fetchAndStoreLinkPreview(url: string, localMsg: LocalMessage): void {
+    if (!this.fetchPreviewFn) return;
+    this.fetchPreviewFn(url).then(preview => {
+      if (!preview) return;
+      const key = localMsg.eventId
+        ? this.messageRepo.getByEventId(localMsg.eventId).then(m => m?.localId)
+        : Promise.resolve(localMsg.localId);
+
+      return key.then(localId => {
+        if (!localId) return;
+        return this.db.messages.update(localId, { linkPreview: preview });
+      });
+    }).catch(() => { /* preview fetch failed — non-critical */ });
+  }
 
   /** Convert a ParsedMessage to a LocalMessage for DB insertion */
   private toLocalMessage(parsed: ParsedMessage): LocalMessage {

--- a/src/shared/lib/local-db/index.ts
+++ b/src/shared/lib/local-db/index.ts
@@ -82,6 +82,7 @@ export function initChatDb(
   userId: string,
   getRoomCrypto: (roomId: string) => Promise<PcryptoRoomInstance | undefined>,
   onChange?: (roomId: string) => void,
+  fetchPreviewFn?: (url: string) => Promise<import("@/entities/chat/model/types").LinkPreview | null>,
 ): ChatDbKit {
   // If same user, return existing kit
   if (currentKit && currentUserId === userId) {
@@ -102,7 +103,7 @@ export function initChatDb(
   const users = new UserRepository(db);
   const listened = new ListenedRepository(db);
   const syncEngine = new SyncEngine(db, messages, rooms, getRoomCrypto, onChange);
-  const eventWriter = new EventWriter(db, messages, rooms, users, onChange);
+  const eventWriter = new EventWriter(db, messages, rooms, users, onChange, fetchPreviewFn);
   const decryptionWorker = new DecryptionWorker(db, async (roomId: string) => {
     const crypto = await getRoomCrypto(roomId);
     if (!crypto) return undefined;

--- a/src/shared/lib/local-db/message-repository.ts
+++ b/src/shared/lib/local-db/message-repository.ts
@@ -88,6 +88,7 @@ export class MessageRepository {
     transferInfo?: LocalMessage["transferInfo"];
     pollInfo?: LocalMessage["pollInfo"];
     fileInfo?: LocalMessage["fileInfo"];
+    linkPreview?: LocalMessage["linkPreview"];
     localBlobUrl?: string;
     uploadProgress?: number;
   }): Promise<LocalMessage> {
@@ -111,6 +112,7 @@ export class MessageRepository {
       transferInfo: params.transferInfo,
       pollInfo: params.pollInfo,
       fileInfo: params.fileInfo,
+      linkPreview: params.linkPreview,
       localBlobUrl: params.localBlobUrl,
       uploadProgress: params.uploadProgress,
     };
@@ -166,12 +168,18 @@ export class MessageRepository {
           await this.db.messages.update(existing.localId!, {
             eventId: msg.eventId,
             serverTs: msg.serverTs ?? msg.timestamp,
+            // Merge local-only fields that the server echo may lack
+            linkPreview: existing.linkPreview ?? msg.linkPreview,
           });
         } else {
           await this.db.messages.update(existing.localId!, {
             eventId: msg.eventId,
             status: "synced" as LocalMessageStatus,
             serverTs: msg.serverTs ?? msg.timestamp,
+            // Merge local-only fields: prefer local (set during optimistic insert),
+            // fall back to server (parsed from url_preview in event content)
+            linkPreview: existing.linkPreview ?? msg.linkPreview,
+            localBlobUrl: existing.localBlobUrl ?? msg.localBlobUrl,
           });
         }
         return "updated";

--- a/src/shared/lib/local-db/sync-engine.ts
+++ b/src/shared/lib/local-db/sync-engine.ts
@@ -179,6 +179,7 @@ export class SyncEngine {
       content: string;
       replyToEventId?: string;
       forwardedFrom?: { senderId: string; senderName?: string };
+      noPreview?: boolean;
     };
     const matrixService = getMatrixClientService();
     const roomCrypto = await this.getRoomCrypto(op.roomId);
@@ -200,6 +201,10 @@ export class SyncEngine {
           sender_name: payload.forwardedFrom.senderName,
         };
       }
+      // Signal that sender explicitly dismissed the preview
+      if (payload.noPreview) {
+        (encrypted as Record<string, unknown>).no_preview = true;
+      }
 
       serverEventId = await matrixService.sendEncryptedText(op.roomId, encrypted, op.clientId);
     } else {
@@ -217,6 +222,9 @@ export class SyncEngine {
           sender_id: payload.forwardedFrom.senderId,
           sender_name: payload.forwardedFrom.senderName,
         };
+      }
+      if (payload.noPreview) {
+        content.no_preview = true;
       }
       serverEventId = await matrixService.sendEncryptedText(op.roomId, content, op.clientId);
     }


### PR DESCRIPTION
## Summary
- Sync missing commits from upstream
- Restores link preview support for sent messages

## Test plan
- [ ] Verify link previews display correctly for sent messages