### PR TITLE
chore: sync master — migrate update source to pocketnetteam

### DIFF
--- a/android/app/src/main/java/com/forta/chat/updater/AppUpdater.kt
+++ b/android/app/src/main/java/com/forta/chat/updater/AppUpdater.kt
@@ -38,7 +38,7 @@ object AppUpdater {
 
     private const val TAG = "AppUpdater"
 
-    private const val GITHUB_OWNER = "greenShirtMystery"
+    private const val GITHUB_OWNER = "pocketnetteam"
     private const val GITHUB_REPO = "forta.chat"
     private const val RELEASES_URL =
         "https://api.github.com/repos/$GITHUB_OWNER/$GITHUB_REPO/releases/latest"


### PR DESCRIPTION
## Summary
- Syncs latest commits from upstream including link preview fix and update source migration
- App updater now points to `pocketnetteam/forta.chat`

## Test plan
- [ ] Verify update checker fetches from correct repo