### PR TITLE
feat: add terms acceptance checkbox to registration

### DIFF
--- a/src/features/auth/ui/register-form/steps/ProfileStep.vue
+++ b/src/features/auth/ui/register-form/steps/ProfileStep.vue
@@ -14,6 +14,7 @@ const localeStore = useLocaleStore();
 
 const name = ref("");
 const about = ref("");
+const acceptedTerms = ref(false);
 const loading = ref(false);
 const error = ref("");
 
@@ -97,7 +98,7 @@ watch(name, () => {
 });
 
 const canSubmit = computed(() => {
-  return name.value.trim().length > 0 && !nameError.value && !nameChecking.value && !loading.value;
+  return name.value.trim().length > 0 && !nameError.value && !nameChecking.value && !loading.value && acceptedTerms.value;
 });
 
 const handleAvatarClick = () => avatarFileInput.value?.click();
@@ -226,6 +227,27 @@ const handleSubmit = async () => {
     </div>
 
     <p v-if="error" class="mt-3 text-xs text-color-bad">{{ error }}</p>
+
+    <!-- Terms checkbox -->
+    <label class="mt-4 flex cursor-pointer items-start gap-2.5 text-[13px] leading-snug text-text-on-main-bg-color">
+      <input
+        v-model="acceptedTerms"
+        type="checkbox"
+        class="mt-0.5 h-4 w-4 shrink-0 cursor-pointer accent-color-bg-ac"
+        :disabled="loading"
+      />
+      <span>
+        {{ t("register.acceptTerms").split("{terms}")[0] }}<router-link
+          to="/legal/terms"
+          class="font-medium text-color-txt-ac hover:underline"
+          @click.stop
+        >{{ t("register.termsOfService") }}</router-link>{{ t("register.acceptTerms").split("{terms}")[1].split("{privacy}")[0] }}<router-link
+          to="/legal/privacy"
+          class="font-medium text-color-txt-ac hover:underline"
+          @click.stop
+        >{{ t("register.privacyPolicy") }}</router-link>{{ t("register.acceptTerms").split("{privacy}")[1] }}
+      </span>
+    </label>
 
     <!-- Submit -->
     <button

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -644,6 +644,10 @@ export const en = {
   "register.step3Text": "Syncing data and preparing your chat...",
   "register.errorTitle": "Registration error",
   "register.backToName": "Back to name entry",
+  "register.acceptTerms": "I agree to the {terms} and {privacy}",
+  "register.termsOfService": "Terms of Service",
+  "register.privacyPolicy": "Privacy Policy",
+  "register.mustAcceptTerms": "You must accept the terms to continue",
   "invite.shareText": "Join me on Forta Chat!",
 
   // ── Language names ──

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -646,6 +646,10 @@ export const ru: Record<TranslationKey, string> = {
   "register.step3Text": "Синхронизируем данные и готовим ваш чат...",
   "register.errorTitle": "Ошибка регистрации",
   "register.backToName": "Назад к вводу имени",
+  "register.acceptTerms": "Я принимаю {terms} и {privacy}",
+  "register.termsOfService": "Условия использования",
+  "register.privacyPolicy": "Политику конфиденциальности",
+  "register.mustAcceptTerms": "Необходимо принять условия для продолжения",
   "invite.shareText": "Присоединяйтесь ко мне в Forta Chat!",
 
   // ── Language names ──


### PR DESCRIPTION
## Summary
- Added mandatory "I agree to Terms of Service and Privacy Policy" checkbox to registration ProfileStep
- Submit button is disabled until checkbox is checked
- Terms/Privacy links open `/legal/terms` and `/legal/privacy` without toggling the checkbox
- Added i18n keys for EN and RU locales

## Test Plan
- [ ] Open /register, verify checkbox appears above Continue button
- [ ] Verify Continue button is disabled until checkbox is checked
- [ ] Click "Terms of Service" link — navigates to /legal/terms without toggling checkbox
- [ ] Click "Privacy Policy" link — navigates to /legal/privacy without toggling checkbox
- [ ] Check the box, fill name, verify Continue works normally