### PR TITLE
fix: encryption guard for public and large rooms

### DIFF
--- a/src/entities/chat/model/__tests__/encryption-guard.test.ts
+++ b/src/entities/chat/model/__tests__/encryption-guard.test.ts
@@ -62,14 +62,13 @@ describe("canBeEncrypt uses actual member count", () => {
     "utf-8",
   );
 
-  it("checks getJoinedMemberCount before usersinfo length", () => {
-    // getJoinedMemberCount comes from server summary — accurate even with lazyLoadMembers
+  it("uses Math.max of server count and usersinfo for threshold", () => {
     expect(source).toContain("getJoinedMemberCount");
-    expect(source).toContain("actualMemberCount >= 50");
+    expect(source).toContain("Math.max(serverCount, usersinfoArray.length)");
+    expect(source).toContain("memberCount >= 50");
   });
 
   it("prepare() also uses getJoinedMemberCount for skip threshold", () => {
-    // prepare() should use actual count to skip expensive key fetching
     expect(source).toContain("Math.max(actualMemberCount, Object.keys(users).length)");
   });
 });

--- a/src/entities/chat/model/__tests__/encryption-guard.test.ts
+++ b/src/entities/chat/model/__tests__/encryption-guard.test.ts
@@ -9,7 +9,8 @@ import type { PeerKeysStatus } from "../types";
  * 1. PeerKeysStatus type includes "not-encrypted"
  * 2. checkPeerKeys distinguishes public/large rooms from missing keys
  * 3. ensureRoomCrypto skips public rooms
- * 4. peerKeysOk allows send for all statuses except "missing"
+ * 4. canBeEncrypt uses getJoinedMemberCount for accurate member count
+ * 5. peerKeysOk allows send for all statuses except "missing"
  */
 
 describe("peerKeysOk guard", () => {
@@ -38,7 +39,6 @@ describe("checkPeerKeys logic branches", () => {
   });
 
   it("returns 'missing' when canBeEncrypt is false for small private rooms", () => {
-    // The 'missing' branch: canBeEncrypt false + memberCount < 50
     expect(source).toContain('peerKeysStatus.set(roomId, "missing")');
   });
 
@@ -51,18 +51,31 @@ describe("ensureRoomCrypto public room guard", () => {
   const source = readFileSync(resolve(__dirname, "../chat-store.ts"), "utf-8");
 
   it("skips pcrypto.addRoom for public rooms", () => {
-    // Matches Bastyon's prepareChat behavior: public rooms skip encryption setup
     expect(source).toContain("// Skip encryption setup for public rooms");
     expect(source).toContain("if (isRoomPublic(roomId)) return undefined;");
   });
 });
 
+describe("canBeEncrypt uses actual member count", () => {
+  const source = readFileSync(
+    resolve(__dirname, "../../../matrix/model/matrix-crypto.ts"),
+    "utf-8",
+  );
+
+  it("checks getJoinedMemberCount before usersinfo length", () => {
+    // getJoinedMemberCount comes from server summary — accurate even with lazyLoadMembers
+    expect(source).toContain("getJoinedMemberCount");
+    expect(source).toContain("actualMemberCount >= 50");
+  });
+
+  it("prepare() also uses getJoinedMemberCount for skip threshold", () => {
+    // prepare() should use actual count to skip expensive key fetching
+    expect(source).toContain("Math.max(actualMemberCount, Object.keys(users).length)");
+  });
+});
+
 describe("PeerKeysStatus type", () => {
   const source = readFileSync(resolve(__dirname, "../types.ts"), "utf-8");
-
-  it("includes 'not-encrypted' value", () => {
-    expect(source).toContain('"not-encrypted"');
-  });
 
   it("has all four status values", () => {
     expect(source).toContain('"unknown"');

--- a/src/entities/chat/model/__tests__/encryption-guard.test.ts
+++ b/src/entities/chat/model/__tests__/encryption-guard.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import type { PeerKeysStatus } from "../types";
+
+/**
+ * Tests for encryption guard logic.
+ * Verifies that:
+ * 1. PeerKeysStatus type includes "not-encrypted"
+ * 2. checkPeerKeys distinguishes public/large rooms from missing keys
+ * 3. ensureRoomCrypto skips public rooms
+ * 4. peerKeysOk allows send for all statuses except "missing"
+ */
+
+describe("peerKeysOk guard", () => {
+  it.each<{ status: PeerKeysStatus; expected: boolean }>([
+    { status: "not-encrypted", expected: true },
+    { status: "available", expected: true },
+    { status: "unknown", expected: true },
+    { status: "missing", expected: false },
+  ])("peerKeysOk=$expected when status=$status", ({ status, expected }) => {
+    // Mirrors MessageInput.vue peerKeysOk logic: status !== "missing"
+    const peerKeysOk = status !== "missing";
+    expect(peerKeysOk).toBe(expected);
+  });
+});
+
+describe("checkPeerKeys logic branches", () => {
+  const source = readFileSync(resolve(__dirname, "../chat-store.ts"), "utf-8");
+
+  it("checks isRoomPublic first and returns 'not-encrypted'", () => {
+    expect(source).toContain('if (isRoomPublic(roomId))');
+    expect(source).toContain('peerKeysStatus.set(roomId, "not-encrypted")');
+  });
+
+  it("checks memberCount >= 50 for large rooms", () => {
+    expect(source).toContain("memberCount >= 50");
+  });
+
+  it("returns 'missing' when canBeEncrypt is false for small private rooms", () => {
+    // The 'missing' branch: canBeEncrypt false + memberCount < 50
+    expect(source).toContain('peerKeysStatus.set(roomId, "missing")');
+  });
+
+  it("returns 'available' when canBeEncrypt is true", () => {
+    expect(source).toContain('peerKeysStatus.set(roomId, "available")');
+  });
+});
+
+describe("ensureRoomCrypto public room guard", () => {
+  const source = readFileSync(resolve(__dirname, "../chat-store.ts"), "utf-8");
+
+  it("skips pcrypto.addRoom for public rooms", () => {
+    // Matches Bastyon's prepareChat behavior: public rooms skip encryption setup
+    expect(source).toContain("// Skip encryption setup for public rooms");
+    expect(source).toContain("if (isRoomPublic(roomId)) return undefined;");
+  });
+});
+
+describe("PeerKeysStatus type", () => {
+  const source = readFileSync(resolve(__dirname, "../types.ts"), "utf-8");
+
+  it("includes 'not-encrypted' value", () => {
+    expect(source).toContain('"not-encrypted"');
+  });
+
+  it("has all four status values", () => {
+    expect(source).toContain('"unknown"');
+    expect(source).toContain('"available"');
+    expect(source).toContain('"missing"');
+    expect(source).toContain('"not-encrypted"');
+  });
+});

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -3080,6 +3080,22 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     }
   };
 
+  /** Get actual member count from Matrix server summary.
+   *  Falls back to local room.members.length if server data unavailable.
+   *  Unlike room.members (which may be partially loaded with lazyLoadMembers),
+   *  getJoinedMemberCount() uses the room summary from /sync. */
+  const getRoomMemberCount = (roomId: string): number => {
+    try {
+      const matrixService = getMatrixClientService();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const matrixRoom = matrixService.getRoom(roomId) as any;
+      const serverCount = matrixRoom?.getJoinedMemberCount?.() ?? 0;
+      if (serverCount > 0) return serverCount;
+    } catch { /* fallback below */ }
+    const room = getRoomById(roomId);
+    return room?.members.length ?? 0;
+  };
+
   /** Check if room has public join rules */
   const isRoomPublic = (roomId: string): boolean => {
     try {
@@ -5661,6 +5677,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     exitSelectionMode,
     forwardingMessages,
     getDisplayName,
+    getRoomMemberCount,
     getRoomPowerLevels,
     getTypingUsers,
     handleKicked,

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -3376,6 +3376,9 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     const matrixRoom = matrixService.getRoom(roomId);
     if (!matrixRoom) return undefined;
 
+    // Skip encryption setup for public rooms (matches Bastyon's prepareChat behavior)
+    if (isRoomPublic(roomId)) return undefined;
+
     try {
       return await pcrypto.addRoom(matrixRoom as Record<string, unknown>);
     } catch (e) {
@@ -5560,9 +5563,19 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     return 0;
   };
 
-  /** Check if all peers in a room have published encryption keys.
-   *  Updates peerKeysStatus map and returns the status. */
+  /** Check encryption status for a room.
+   *  Updates peerKeysStatus map and returns the status.
+   *  - "available": room supports encryption and all peers have keys
+   *  - "missing": room could support encryption but peers lack keys
+   *  - "not-encrypted": room is public or too large for encryption
+   *  - "unknown": crypto not initialized yet */
   const checkPeerKeys = async (roomId: string): Promise<PeerKeysStatus> => {
+    // Public rooms — encryption disabled by design
+    if (isRoomPublic(roomId)) {
+      peerKeysStatus.set(roomId, "not-encrypted");
+      return "not-encrypted";
+    }
+
     const authStore = useAuthStore();
     const roomCrypto = authStore.pcrypto?.rooms[roomId];
     if (!roomCrypto) {
@@ -5571,9 +5584,23 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     }
 
     const canEncrypt = roomCrypto.canBeEncrypt();
-    const status: PeerKeysStatus = canEncrypt ? "available" : "missing";
-    peerKeysStatus.set(roomId, status);
-    return status;
+    if (!canEncrypt) {
+      // canBeEncrypt returns false for rooms with ≥50 members or missing peer keys.
+      // Distinguish "too large" from "missing keys":
+      const matrixService = getMatrixClientService();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const matrixRoom = matrixService.getRoom(roomId) as any;
+      const memberCount = matrixRoom?.getJoinedMemberCount?.() ?? 0;
+      if (memberCount >= 50) {
+        peerKeysStatus.set(roomId, "not-encrypted");
+        return "not-encrypted";
+      }
+      peerKeysStatus.set(roomId, "missing");
+      return "missing";
+    }
+
+    peerKeysStatus.set(roomId, "available");
+    return "available";
   };
 
   /** Reset all in-memory state and account-specific localStorage (called on logout) */

--- a/src/entities/chat/model/types.ts
+++ b/src/entities/chat/model/types.ts
@@ -160,4 +160,4 @@ export interface TransferInfo {
 }
 
 /** Peer encryption key status for a room */
-export type PeerKeysStatus = "unknown" | "available" | "missing";
+export type PeerKeysStatus = "unknown" | "available" | "missing" | "not-encrypted";

--- a/src/entities/matrix/model/matrix-crypto.ts
+++ b/src/entities/matrix/model/matrix-crypto.ts
@@ -637,15 +637,14 @@ export class Pcrypto {
         if (!pcrypto.user?.private || pcrypto.user.private.length !== 12) return false;
         if (!pcrypto.user.userinfo?.id || !users[pcrypto.user.userinfo.id]) return false;
 
-        // Use actual room member count from server summary (not lazy-loaded usersinfo).
-        // With lazyLoadMembers, usersinfo may contain only a fraction of real members
-        // (e.g. 19 out of 800), causing false positives.
+        // Use the MAXIMUM of server summary count and locally loaded users.
+        // getJoinedMemberCount() comes from /sync summary — accurate for large rooms.
+        // usersinfo may only have lazy-loaded fraction (e.g. 19 out of 800).
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const actualMemberCount = (chat as any).getJoinedMemberCount?.() ?? 0;
-        if (actualMemberCount >= 50) return false;
-
+        const serverCount = (chat as any).getJoinedMemberCount?.() ?? 0;
         const usersinfoArray = Object.values(usersinfo);
-        if (usersinfoArray.length <= 1 || usersinfoArray.length >= 50) return false;
+        const memberCount = Math.max(serverCount, usersinfoArray.length);
+        if (memberCount <= 1 || memberCount >= 50) return false;
 
         // ALL participants must have 12 published keys for ECDH to work
         return usersinfoArray.every(u => u.keys && u.keys.length >= m);

--- a/src/entities/matrix/model/matrix-crypto.ts
+++ b/src/entities/matrix/model/matrix-crypto.ts
@@ -637,6 +637,13 @@ export class Pcrypto {
         if (!pcrypto.user?.private || pcrypto.user.private.length !== 12) return false;
         if (!pcrypto.user.userinfo?.id || !users[pcrypto.user.userinfo.id]) return false;
 
+        // Use actual room member count from server summary (not lazy-loaded usersinfo).
+        // With lazyLoadMembers, usersinfo may contain only a fraction of real members
+        // (e.g. 19 out of 800), causing false positives.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const actualMemberCount = (chat as any).getJoinedMemberCount?.() ?? 0;
+        if (actualMemberCount >= 50) return false;
+
         const usersinfoArray = Object.values(usersinfo);
         if (usersinfoArray.length <= 1 || usersinfoArray.length >= 50) return false;
 
@@ -651,7 +658,11 @@ export class Pcrypto {
         // when there are ≥50 participants (canBeEncrypt returns false),
         // so fetching everyone's crypto keys is wasted work that blocks
         // message rendering for seconds in 1000+ member rooms.
-        const memberCount = Object.keys(users).length;
+        // Use getJoinedMemberCount (from server summary) as primary check —
+        // Object.keys(users) may be incomplete with lazyLoadMembers.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const actualMemberCount = (chat as any).getJoinedMemberCount?.() ?? 0;
+        const memberCount = Math.max(actualMemberCount, Object.keys(users).length);
         if (memberCount < 50) {
           await getusersinfo();
         }

--- a/src/features/chat-info/ui/ChatInfoPanel.vue
+++ b/src/features/chat-info/ui/ChatInfoPanel.vue
@@ -468,7 +468,11 @@ const openGallery = (tab: "media" | "files" | "links" | "voice" = "media") => {
                 <h2 v-if="isUnresolvedName(roomDisplayName)" class="mx-auto h-5 w-32 animate-pulse rounded bg-neutral-grad-2" />
                 <h2 v-else class="text-lg font-semibold text-text-color">{{ roomDisplayName }}</h2>
                 <p class="text-sm text-text-on-main-bg-color">
-                  {{ room.isGroup ? t("info.members", { count: room.members.length }) : t("info.directMessage") }}
+                  {{ room.isGroup ? t("info.members", { count: chatStore.getRoomMemberCount(room.id) }) : t("info.directMessage") }}
+                </p>
+                <p v-if="room.isGroup && chatStore.peerKeysStatus.get(room.id) === 'not-encrypted'" class="mt-1 flex items-center justify-center gap-1 text-xs text-text-on-main-bg-color/60">
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 9.9-1"/></svg>
+                  {{ t("chat.unencryptedRoom") }}
                 </p>
 
                 <!-- Topic / Description -->
@@ -668,7 +672,7 @@ const openGallery = (tab: "media" | "files" | "links" | "voice" = "media") => {
             <div v-if="room.isGroup" class="border-t border-neutral-grad-0 px-4 py-3">
               <div class="mb-2 flex items-center justify-between">
                 <span class="text-xs font-medium uppercase text-text-on-main-bg-color">
-                  {{ t("chatInfo.members") }} ({{ room.members.length }})
+                  {{ t("chatInfo.members") }} ({{ chatStore.getRoomMemberCount(room.id) }})
                 </span>
                 <!-- Add member button (admin only) -->
                 <button

--- a/src/features/chat-info/ui/ChatInfoPanel.vue
+++ b/src/features/chat-info/ui/ChatInfoPanel.vue
@@ -67,6 +67,11 @@ const refreshRoomPublic = () => {
 
 watch(room, refreshRoomPublic, { immediate: true });
 
+// Refresh encryption status when panel opens or room changes
+watch([room, () => props.show], async ([r, visible]) => {
+  if (r && visible) await chatStore.checkPeerKeys(r.id);
+}, { immediate: true });
+
 const inviteLink = computed(() => {
   if (!room.value) return "";
   return `${APP_PUBLIC_URL}/#/join?room=${encodeURIComponent(room.value.id)}`;

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -116,6 +116,8 @@ const peerKeysOk = computed(() => {
   const roomId = chatStore.activeRoomId;
   if (!roomId) return true;
   const status = chatStore.peerKeysStatus.get(roomId);
+  // Block send only when peers are missing keys in a private room.
+  // "not-encrypted" rooms (public / large) allow plain-text send.
   return status !== "missing";
 });
 

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -626,6 +626,7 @@ export const en = {
   // ── Misc ──
   "chat.messageNotFound": "Message not found",
   "chat.peerKeysMissing": "Peer hasn't published encryption keys yet. Messaging is temporarily unavailable.",
+  "chat.unencryptedRoom": "Messages in this room are not encrypted",
   "tor.disable": "Disable Tor",
   "register.registrationFailed": "Registration failed",
   "register.captchaLoadFailed": "Failed to load captcha",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -628,6 +628,7 @@ export const ru: Record<TranslationKey, string> = {
   // ── Misc ──
   "chat.messageNotFound": "Сообщение не найдено",
   "chat.peerKeysMissing": "Собеседник ещё не опубликовал ключи шифрования. Отправка сообщений временно недоступна.",
+  "chat.unencryptedRoom": "Сообщения в этой комнате не шифруются",
   "tor.disable": "Отключить Tor",
   "register.registrationFailed": "Ошибка регистрации",
   "register.captchaLoadFailed": "Не удалось загрузить капчу",

--- a/src/widgets/chat-window/ChatWindow.vue
+++ b/src/widgets/chat-window/ChatWindow.vue
@@ -281,7 +281,7 @@ const subtitle = computed(() => {
   if (typingText.value) return typingText.value;
   const room = chatStore.activeRoom;
   if (!room) return "";
-  if (room.isGroup) return t("chat.members", { count: room.members.length });
+  if (room.isGroup) return t("chat.members", { count: chatStore.getRoomMemberCount(room.id) });
   return "";
 });
 
@@ -487,7 +487,7 @@ onUnmounted(() => {
             <template v-if="chatStore.activeRoom?.isGroup">
               {{ t("chat.inviteGroup", { name: activeRoomTitle.text }) }}
               <br />
-              <span class="text-xs">{{ t("chat.members", { count: chatStore.activeRoom.members.length }) }}</span>
+              <span class="text-xs">{{ t("chat.members", { count: chatStore.getRoomMemberCount(chatStore.activeRoom.id) }) }}</span>
             </template>
             <template v-else>
               {{ t("chat.invitePersonal", { name: activeRoomTitle.text }) }}

--- a/src/widgets/chat-window/ChatWindow.vue
+++ b/src/widgets/chat-window/ChatWindow.vue
@@ -85,13 +85,21 @@ watch(() => chatStore.activeRoomId, (_newId, oldId) => {
 const peerKeysMissing = computed(() => {
   const roomId = chatStore.activeRoomId;
   if (!roomId) return false;
-  // Only show warning for 1:1 chats — group chats don't require all members to have keys
+  const status = chatStore.peerKeysStatus.get(roomId);
+  // Show warning only when peers lack keys (not for public/large rooms)
   if (chatStore.activeRoom?.isGroup) return false;
-  return chatStore.peerKeysStatus.get(roomId) === "missing";
+  return status === "missing";
+});
+
+/** True when the active room does not use encryption (public or ≥50 members) */
+const isUnencryptedRoom = computed(() => {
+  const roomId = chatStore.activeRoomId;
+  if (!roomId) return false;
+  return chatStore.peerKeysStatus.get(roomId) === "not-encrypted";
 });
 
 watch(() => chatStore.activeRoomId, async (roomId) => {
-  if (roomId && !chatStore.activeRoom?.isGroup) {
+  if (roomId) {
     await chatStore.checkPeerKeys(roomId);
   }
 }, { immediate: true });
@@ -527,6 +535,13 @@ onUnmounted(() => {
             <path d="M12 9v4m0 4h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
           </svg>
           <span>{{ t("chat.peerKeysMissing") }}</span>
+        </div>
+        <div v-else-if="isUnencryptedRoom" class="mx-4 my-2 rounded-lg bg-slate-50 dark:bg-slate-900/40 border border-slate-200 dark:border-slate-700 px-3 py-2 text-xs text-slate-500 dark:text-slate-400 flex items-center gap-2">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0">
+            <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+            <path d="M7 11V7a5 5 0 0 1 9.9-1"/>
+          </svg>
+          <span>{{ t("chat.unencryptedRoom") }}</span>
         </div>
         <MessageList ref="messageListRef" />
         <SelectionBar

--- a/src/widgets/chat-window/ChatWindow.vue
+++ b/src/widgets/chat-window/ChatWindow.vue
@@ -91,12 +91,6 @@ const peerKeysMissing = computed(() => {
   return status === "missing";
 });
 
-/** True when the active room does not use encryption (public or ≥50 members) */
-const isUnencryptedRoom = computed(() => {
-  const roomId = chatStore.activeRoomId;
-  if (!roomId) return false;
-  return chatStore.peerKeysStatus.get(roomId) === "not-encrypted";
-});
 
 watch(() => chatStore.activeRoomId, async (roomId) => {
   if (roomId) {
@@ -535,13 +529,6 @@ onUnmounted(() => {
             <path d="M12 9v4m0 4h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
           </svg>
           <span>{{ t("chat.peerKeysMissing") }}</span>
-        </div>
-        <div v-else-if="isUnencryptedRoom" class="mx-4 my-2 rounded-lg bg-slate-50 dark:bg-slate-900/40 border border-slate-200 dark:border-slate-700 px-3 py-2 text-xs text-slate-500 dark:text-slate-400 flex items-center gap-2">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0">
-            <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
-            <path d="M7 11V7a5 5 0 0 1 9.9-1"/>
-          </svg>
-          <span>{{ t("chat.unencryptedRoom") }}</span>
         </div>
         <MessageList ref="messageListRef" />
         <SelectionBar


### PR DESCRIPTION
## Summary

- **Главный фикс**: `canBeEncrypt()` использует `Math.max(getJoinedMemberCount(), usersinfo.length)` вместо только `usersinfo.length` — с lazyLoadMembers комнаты на 800 человек показывали 19 загруженных и ошибочно шифровали сообщения
- `ensureRoomCrypto` пропускает публичные комнаты (как в оригинальном Bastyon)
- `checkPeerKeys` различает `"not-encrypted"` (публичная/большая) vs `"missing"` (нет ключей)
- Member count в шапке и деталках показывает реальное число из server summary
- Индикатор шифрования в ChatInfoPanel (под member count)

## Test plan
- [ ] Зайти в публичную комнату (800+ участников) — сообщения отправляются открытым текстом
- [ ] Проверить member count в шапке — показывает реальное число, а не 19
- [ ] Открыть деталки группы — видно "Сообщения не шифруются"
- [ ] Приватный чат 1:1 — сообщения шифруются как раньше
- [ ] Приватная группа <50 — шифрование работает
- [ ] `npm run test` — encryption-guard.test.ts (12 тестов)