### PR TITLE
fix: reliable voice message duration for recipients

### DIFF
--- a/src/entities/chat/lib/chat-helpers.test.ts
+++ b/src/entities/chat/lib/chat-helpers.test.ts
@@ -279,7 +279,8 @@ describe("parseFileInfo", () => {
     const info = parseFileInfo(content, "m.audio");
     expect(info).toBeDefined();
     expect(info!.duration).toBe(45);
-    expect(info!.waveform).toEqual([100, 200, 300, 400]);
+    // Waveform values >1 are normalized from 0-1024 to 0-1
+    expect(info!.waveform).toEqual([100 / 1024, 200 / 1024, 300 / 1024, 400 / 1024]);
     expect(info!.secrets).toEqual({ block: 10, keys: "audiokeys", v: 1 });
   });
 

--- a/src/entities/chat/lib/chat-helpers.ts
+++ b/src/entities/chat/lib/chat-helpers.ts
@@ -79,13 +79,21 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
   }
 
   if (msgtype === "m.audio" && info) {
+    // Waveform arrives as integers 0-1024 (MSC3245), normalize to 0-1 floats
+    const rawWaveform = info.waveform as number[] | undefined;
+    const normalizedWaveform = rawWaveform?.length
+      ? rawWaveform.map((v: number) => v > 1 ? v / 1024 : v)
+      : undefined;
+
     return {
       name: (content.body as string) ?? "Audio",
       type: info.mimetype ?? "audio/mpeg",
       size: info.size ?? 0,
       url: info.url ?? (content.url as string) ?? "",
-      duration: info.duration ? Math.round(info.duration / 1000) : undefined,
-      waveform: info.waveform,
+      duration: typeof info.duration === "number" && info.duration > 0
+        ? Math.round(info.duration / 1000)
+        : undefined,
+      waveform: normalizedWaveform,
       secrets: info.secrets ? {
         block: info.secrets.block,
         keys: info.secrets.keys,

--- a/src/features/messaging/model/use-audio-playback.ts
+++ b/src/features/messaging/model/use-audio-playback.ts
@@ -147,7 +147,10 @@ function setupAudioListeners(el: HTMLAudioElement) {
     state.value = "failed";
   };
   el.onloadedmetadata = () => {
-    duration.value = el.duration;
+    // Only update if finite — Chromium reports Infinity for webm blobs
+    if (Number.isFinite(el.duration) && el.duration > 0) {
+      duration.value = el.duration;
+    }
   };
 
   // Diagnostic listeners (mobile debugging)

--- a/src/features/messaging/ui/VoiceMessage.vue
+++ b/src/features/messaging/ui/VoiceMessage.vue
@@ -66,7 +66,15 @@ watch(playing, (isPlaying) => {
   }
 });
 
-const totalDuration = computed(() => props.message.fileInfo?.duration ?? 0);
+// Prefer stored metadata duration; fall back to audio element duration once loaded
+const totalDuration = computed(() => {
+  const meta = props.message.fileInfo?.duration;
+  if (meta && meta > 0) return meta;
+  if (active.value && Number.isFinite(playback.duration.value) && playback.duration.value > 0) {
+    return playback.duration.value;
+  }
+  return 0;
+});
 
 const formatTime = (seconds: number) => {
   const m = Math.floor(seconds / 60);


### PR DESCRIPTION
## Summary
- Guard `onloadedmetadata` against `Infinity` duration (Chromium webm blob bug) in `use-audio-playback.ts`
- Add fallback to audio element duration in `VoiceMessage.vue` when metadata duration is missing
- Normalize MSC3245 waveform integers (0-1024) to 0-1 floats on receive in `parseFileInfo`
- Use strict type check for `info.duration` instead of falsy check

## Test plan
- [ ] Send voice message and verify duration displays correctly for sender
- [ ] Receive voice message and verify duration is not 0:00
- [ ] Test with webm codec (Chromium) — duration should not show as Infinity
- [ ] Test playback seek/progress with received voice messages
- [ ] Verify waveform visualization matches between sender and receiver