### PR TITLE
fix: sync package-lock.json with @capgo/capacitor-share-target

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@capacitor/push-notifications": "^8.0.2",
         "@capacitor/share": "^8.0.1",
         "@capacitor/status-bar": "^8.0.1",
+        "@capgo/capacitor-share-target": "^8.0.25",
         "@noble/secp256k1": "^2.3.0",
         "@vee-validate/zod": "^4.13.2",
         "audio-recorder-polyfill": "^0.4.1",
@@ -338,6 +339,15 @@
       "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.4.tgz",
       "integrity": "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==",
       "license": "ISC"
+    },
+    "node_modules/@capgo/capacitor-share-target": {
+      "version": "8.0.25",
+      "resolved": "https://registry.npmjs.org/@capgo/capacitor-share-target/-/capacitor-share-target-8.0.25.tgz",
+      "integrity": "sha512-W0pKjIHV/PVvYPQi1QTaitKU6aC4W5ginReE/EB4Bz4lxqy59zS1j8TFv+BpbValEDuMw4F8ouqeByeZxLChog==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
     },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",


### PR DESCRIPTION
## Summary
- Adds missing `@capgo/capacitor-share-target@8.0.25` to package-lock.json
- Fixes CI build failure where `npm ci` fails due to lock file desync

## Test plan
- [ ] CI passes (npm ci succeeds)