### PR TITLE
fix: add postinstall stub for cap sync CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "electron:build:linux": "vite build && electron-builder --config electron-builder.json --linux",
     "cap:build": "vite build && cap sync android",
     "cap:open": "cap open android",
-    "cap:run": "cap run android"
+    "cap:run": "cap run android",
+    "postinstall": "node -e \"const fs=require('fs'),p='node_modules/@capgo/capacitor-webview-version-checker/scripts';fs.mkdirSync(p,{recursive:true});const f=p+'/generate-version-share-data.mjs';if(!fs.existsSync(f))fs.writeFileSync(f,'// stub\\n')\""
   },
   "dependencies": {
     "@capacitor-community/file-opener": "^8.0.0",


### PR DESCRIPTION
## Summary
- **Fix CI:** `cap sync android` fails because `@capgo/capacitor-webview-version-checker` doesn't include `scripts/` in its npm tarball. Added a `postinstall` script that creates the missing stub file
- **Cleanup:** Removed `yarn.lock` and `pnpm-lock.yaml` from git — CI uses npm, extra lockfiles only cause confusion. Added both to `.gitignore`

## Test plan
- [ ] Merge → tag v1.9.3 → verify Android Release workflow passes