### PR TITLE
fix: use default import for glob CJS module in minify script

### DIFF
--- a/scripts/minify-public-js.mjs
+++ b/scripts/minify-public-js.mjs
@@ -5,7 +5,8 @@
  */
 import { readFile, writeFile } from "fs/promises";
 import { resolve, relative } from "path";
-import { glob } from "glob";
+import pkg from "glob";
+const { glob } = pkg;
 import { minify } from "terser";
 
 const DIST_JS = resolve("dist/js");


### PR DESCRIPTION
## Summary
- Node.js 20 does not support named ESM imports from the CommonJS `glob` package
- Switches to default import + destructure pattern as recommended by Node.js error message
- Fixes CI Android Release build failure

## Test plan
- [ ] CI build passes with this fix