### PR TITLE
fix: promisify glob v7 for ESM compat in minify script

### DIFF
--- a/scripts/minify-public-js.mjs
+++ b/scripts/minify-public-js.mjs
@@ -5,9 +5,11 @@
  */
 import { readFile, writeFile } from "fs/promises";
 import { resolve, relative } from "path";
-import pkg from "glob";
-const { glob } = pkg;
+import { promisify } from "util";
+import globCb from "glob";
 import { minify } from "terser";
+
+const glob = promisify(globCb);
 
 const DIST_JS = resolve("dist/js");
 


### PR DESCRIPTION
## Summary
- Glob 7.x exports a callback function as default — `util.promisify` is needed for async/await usage in ESM
- Previous fix incorrectly tried to destructure a named `glob` export that doesn't exist in v7
- Fixes CI Android Release build failure

## Test plan
- [ ] CI build passes with this fix