### PR TITLE
feat: add app download banner for Android web users

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -20,6 +20,7 @@ import { computeKeyboardHeight, shouldScrollIntoView } from "@/shared/lib/keyboa
 import { useRouter } from "vue-router";
 import { initAndroidBackListener, useAndroidBackHandler } from "@/shared/lib/composables/use-android-back-handler";
 import RegistrationStepper from "@/features/auth/ui/RegistrationStepper.vue";
+import { AppDownloadBanner } from "@/features/app-download-banner";
 import { useI18n } from "@/shared/lib/i18n";
 
 import { AppPages, AppRoutes, EAppProviders } from "./providers";
@@ -273,6 +274,7 @@ onUnmounted(() => {
 
 <template>
   <div class="safe-top relative flex flex-col bg-background-total-theme text-text-color" style="height: 100vh; height: 100dvh">
+    <AppDownloadBanner />
     <!-- Registration stepper overlay — shows progress during blockchain registration -->
     <RegistrationStepper
       v-if="authStore.registrationPending || authStore.registrationPhase === 'done' || authStore.registrationUsernameError"

--- a/src/features/app-download-banner/index.ts
+++ b/src/features/app-download-banner/index.ts
@@ -1,0 +1,1 @@
+export { default as AppDownloadBanner } from "./ui/AppDownloadBanner.vue";

--- a/src/features/app-download-banner/ui/AppDownloadBanner.vue
+++ b/src/features/app-download-banner/ui/AppDownloadBanner.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { isWeb } from "@/shared/lib/platform";
+import { useI18n } from "@/shared/lib/i18n";
+
+const DISMISS_KEY = "app-download-banner-dismissed";
+const DOWNLOAD_URL = "https://forta.chat/#/download";
+
+const { t } = useI18n();
+const visible = ref(false);
+
+const isAndroidBrowser = isWeb && /Android/i.test(navigator.userAgent);
+
+onMounted(() => {
+  if (isAndroidBrowser && !localStorage.getItem(DISMISS_KEY)) {
+    visible.value = true;
+  }
+});
+
+const dismiss = () => {
+  visible.value = false;
+  localStorage.setItem(DISMISS_KEY, "1");
+};
+
+const openDownload = () => {
+  window.open(DOWNLOAD_URL, "_blank", "noopener");
+};
+</script>
+
+<template>
+  <transition name="app-banner">
+    <div
+      v-if="visible"
+      class="flex items-center gap-3 bg-sky-600 px-3 py-2 text-white shadow-md"
+    >
+      <!-- App icon -->
+      <img
+        src="/forta-icon.png"
+        alt="Forta Chat"
+        class="h-10 w-10 shrink-0 rounded-lg"
+      />
+
+      <div class="min-w-0 flex-1">
+        <div class="text-sm font-semibold leading-tight">Forta Chat</div>
+        <div class="text-xs leading-tight opacity-80">
+          {{ t("appBanner.subtitle") }}
+        </div>
+      </div>
+
+      <button
+        class="shrink-0 rounded-full bg-white px-3 py-1 text-xs font-semibold text-sky-600 active:bg-sky-50"
+        @click="openDownload"
+      >
+        {{ t("appBanner.download") }}
+      </button>
+
+      <button
+        class="shrink-0 p-1 opacity-70 active:opacity-100"
+        :aria-label="t('appBanner.close')"
+        @click="dismiss"
+      >
+        <svg class="h-4 w-4" viewBox="0 0 16 16" fill="none">
+          <path
+            d="M4 4l8 8M12 4l-8 8"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+          />
+        </svg>
+      </button>
+    </div>
+  </transition>
+</template>
+
+<style scoped>
+.app-banner-enter-active,
+.app-banner-leave-active {
+  transition: max-height 250ms ease, opacity 250ms ease;
+  overflow: hidden;
+}
+.app-banner-enter-from,
+.app-banner-leave-to {
+  max-height: 0;
+  opacity: 0;
+}
+.app-banner-enter-to,
+.app-banner-leave-from {
+  max-height: 64px;
+  opacity: 1;
+}
+</style>

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -646,6 +646,11 @@ export const en = {
   "register.backToName": "Back to name entry",
   "invite.shareText": "Join me on Forta Chat!",
 
+  // ── App download banner ──
+  "appBanner.subtitle": "Get the app for a better experience",
+  "appBanner.download": "Download",
+  "appBanner.close": "Close",
+
   // ── Language names ──
   "locale.en": "English",
   "locale.ru": "Русский",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -648,6 +648,11 @@ export const ru: Record<TranslationKey, string> = {
   "register.backToName": "Назад к вводу имени",
   "invite.shareText": "Присоединяйтесь ко мне в Forta Chat!",
 
+  // ── App download banner ──
+  "appBanner.subtitle": "Скачайте приложение для лучшего опыта",
+  "appBanner.download": "Скачать",
+  "appBanner.close": "Закрыть",
+
   // ── Language names ──
   "locale.en": "English",
   "locale.ru": "Русский",


### PR DESCRIPTION
## Summary
- Adds a smart app banner shown to Android users visiting forta.chat from a mobile browser
- Banner prompts to download the native app with a link to `https://forta.chat/#/download`
- Dismissible with localStorage persistence — won't show again after closing
- Only visible on web platform (not in Capacitor native app or Electron)

## Test plan
- [ ] Open forta.chat in Chrome on Android — banner should appear at the top
- [ ] Tap "Download" — should open `https://forta.chat/#/download` in new tab
- [ ] Tap × to dismiss — banner hides and doesn't reappear on reload
- [ ] Open in Capacitor native app — banner should NOT appear
- [ ] Open on desktop browser — banner should NOT appear
- [ ] Verify both EN and RU translations display correctly