### PR TITLE
fix: Android keyboard positioning

### DIFF
--- a/android/app/src/main/java/com/forta/chat/MainActivity.kt
+++ b/android/app/src/main/java/com/forta/chat/MainActivity.kt
@@ -107,5 +107,8 @@ class MainActivity : BridgeActivity() {
             })();
         """.trimIndent()
         webView.post { webView.evaluateJavascript(js, null) }
+        // Second injection at +100ms covers devices where the IME inset fires before
+        // the keyboard animation settles (1-3 frame latency on slow Android 7 hardware).
+        webView.postDelayed({ webView.evaluateJavascript(js, null) }, 100)
     }
 }

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -102,6 +102,24 @@ onBeforeUnmount(() => {
   document.removeEventListener("mousemove", handleGlobalMouseMove);
 });
 
+// On Android: when the keyboard opens, scroll the input container into view.
+// The textarea has `data-keyboard-aware` which intentionally skips the global
+// App.vue focusin handler (which uses block:"center"). Here we use block:"end"
+// so the input sits at the bottom of the viewport directly above the keyboard.
+if (isNative) {
+  const handleKeyboardOpen = (e: Event) => {
+    const height = (e as CustomEvent).detail?.height as number | undefined;
+    if ((height ?? 0) > 0) {
+      // Wait one animation frame so safe-bottom padding-bottom has expanded first
+      requestAnimationFrame(() => {
+        inputRootRef.value?.scrollIntoView({ block: "end", behavior: "smooth" });
+      });
+    }
+  };
+  window.addEventListener("native-keyboard-change", handleKeyboardOpen);
+  onBeforeUnmount(() => window.removeEventListener("native-keyboard-change", handleKeyboardOpen));
+}
+
 // --- Edit/reply ---
 watch(() => chatStore.editingMessage, (editing) => {
   if (editing) {

--- a/src/shared/lib/keyboard-height.test.ts
+++ b/src/shared/lib/keyboard-height.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { computeKeyboardHeight, shouldScrollIntoView } from "./keyboard-height";
 
 describe("computeKeyboardHeight", () => {
@@ -22,6 +22,46 @@ describe("computeKeyboardHeight", () => {
   it("handles negative webKbh gracefully (takes max with nativeKbh)", () => {
     // visualViewport can sometimes report height > innerHeight briefly
     expect(computeKeyboardHeight({ isNativeEvent: false, nativeKbh: 0, webKbh: -10 })).toBe(0);
+  });
+});
+
+describe("computeKeyboardHeight — Samsung hysteresis", () => {
+  beforeEach(() => {
+    // Reset module-level lastNativeKbh to 0 by sending a native event with height=0.
+    // This ensures each test starts from a clean state.
+    computeKeyboardHeight({ isNativeEvent: true, nativeKbh: 0, webKbh: 0 });
+  });
+
+  it("holds prior native value when non-native event fires near-zero after large native value (Samsung stale scroll)", () => {
+    // Prime: native keyboard opened at 280px
+    computeKeyboardHeight({ isNativeEvent: true, nativeKbh: 280, webKbh: 0 });
+    // Samsung stale visualViewport fires with webKbh=44 before native-keyboard-change height=0 arrives
+    const result = computeKeyboardHeight({ isNativeEvent: false, nativeKbh: 0, webKbh: 44 });
+    expect(result).toBe(280);
+  });
+
+  it("returns correct webKbh after native event already zeroed (hysteresis cleared)", () => {
+    // Prime: native keyboard opened at 280px
+    computeKeyboardHeight({ isNativeEvent: true, nativeKbh: 280, webKbh: 0 });
+    // Native event fires first with height=0 — clears hysteresis
+    computeKeyboardHeight({ isNativeEvent: true, nativeKbh: 0, webKbh: 0 });
+    // Now visualViewport fires with stale webKbh=44 — hysteresis is cleared, returns candidate
+    const result = computeKeyboardHeight({ isNativeEvent: false, nativeKbh: 0, webKbh: 44 });
+    expect(result).toBe(44);
+  });
+
+  it("allows upward increase — does not block webKbh > lastNativeKbh", () => {
+    // Prime: native keyboard opened at 280px
+    computeKeyboardHeight({ isNativeEvent: true, nativeKbh: 280, webKbh: 0 });
+    // visualViewport reports 290 (slightly larger) — this is a legitimate increase
+    const result = computeKeyboardHeight({ isNativeEvent: false, nativeKbh: 0, webKbh: 290 });
+    expect(result).toBe(290);
+  });
+
+  it("returns webKbh with no prior native event (no hysteresis on first event)", () => {
+    // No prime — lastNativeKbh starts at 0 after beforeEach reset
+    const result = computeKeyboardHeight({ isNativeEvent: false, nativeKbh: 0, webKbh: 50 });
+    expect(result).toBe(50);
   });
 });
 

--- a/src/shared/lib/keyboard-height.ts
+++ b/src/shared/lib/keyboard-height.ts
@@ -13,15 +13,39 @@ export interface KeyboardHeightInput {
   webKbh: number;
 }
 
+// Tracks the last keyboard height reported by a native event.
+// Used for Samsung hysteresis: when visualViewport fires a stale near-zero
+// scroll event before the native-keyboard-change height=0 arrives, we hold
+// the prior native value to prevent a visible blank-space flash.
+let lastNativeKbh = 0;
+
 /**
  * Compute the effective keyboard height.
  *
  * - Native events (from WindowInsets via MainActivity.kt) are authoritative.
- * - For visualViewport events (web fallback), take the larger of web/native.
+ * - For visualViewport events (web fallback), take the larger of web/native,
+ *   but guard against Samsung's scroll-vs-resize race: if the last native
+ *   event reported a large keyboard height (>50px) and the current candidate
+ *   is near-zero (<50px), hold the prior native value until the native event
+ *   explicitly zeroes it.
  */
 export function computeKeyboardHeight(input: KeyboardHeightInput): number {
-  if (input.isNativeEvent) return input.nativeKbh;
-  return Math.max(input.webKbh, input.nativeKbh);
+  if (input.isNativeEvent) {
+    lastNativeKbh = input.nativeKbh;
+    return input.nativeKbh;
+  }
+
+  const candidate = Math.max(input.webKbh, input.nativeKbh);
+
+  // Hysteresis guard: prevent false-zero from Samsung stale visualViewport scroll.
+  // Only holds when native already confirmed a large keyboard AND candidate drops
+  // near-zero. Once the native event fires with 0, lastNativeKbh is reset and
+  // this guard no longer applies.
+  if (lastNativeKbh > 50 && candidate < 50) {
+    return lastNativeKbh;
+  }
+
+  return candidate;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Samsung hysteresis guard** in `computeKeyboardHeight`: holds last native keyboard height when stale `visualViewport` scroll event fires near-zero during keyboard close race
- **+100ms retry injection** in `MainActivity.kt` `injectKeyboardHeight`: second CSS variable injection via `postDelayed` covers 1-3 frame latency on slow Android 7 devices  
- **Scroll handler** in `MessageInput.vue`: `native-keyboard-change` listener calls `scrollIntoView({ block: "end" })` inside `requestAnimationFrame` on keyboard open, gated on `isNative`

## Test plan

- [x] 14/14 keyboard-height unit tests pass (4 new hysteresis tests)
- [x] `npm run build` passes
- [ ] Open keyboard on Android Pixel — input stays above keyboard
- [ ] Open/close keyboard on Samsung — no blank gap flash
- [ ] `adb logcat | grep native-keyboard` shows 2 events per keyboard open