### PR TITLE
fix: remove extra parameter from getsubscribeschannels request

### DIFF
--- a/src/app/providers/initializers/app-initializer.ts
+++ b/src/app/providers/initializers/app-initializer.ts
@@ -688,7 +688,7 @@ export class AppInitializer {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             method: "getsubscribeschannels",
-            parameters: [address, blockNumber, page, pageSize, 1],
+            parameters: [address, blockNumber, page, pageSize],
             options: { node: AppInitializer.NODE_ID },
           }),
         }


### PR DESCRIPTION
## Summary
- Remove hardcoded fifth parameter (`1`) from `getsubscribeschannels` API call
- Backend expects 4 parameters: `[address, blockNumber, page, pageSize]`

## Test plan
- [ ] Verify channel subscriptions load correctly
- [ ] Confirm no regressions in channel list display