### PR TITLE
fix: remove unsupported windowSize from configChanges

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
 
         <activity
             android:windowSoftInputMode="adjustResize"
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation|density|windowSize"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation|density"
             android:name=".MainActivity"
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"


### PR DESCRIPTION
## Summary
- Remove `windowSize` from `configChanges` in AndroidManifest.xml — AAPT rejects it as an invalid flag, causing the release build to fail

## Test plan
- [ ] Android release build passes in CI