### PR TITLE
ci: add VITE_BUG_REPORT_TOKEN to build workflows

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -27,6 +27,9 @@ jobs:
 
       - name: Build web assets
         run: npx vite build
+        env:
+          VITE_BUG_REPORT_TOKEN: ${{ secrets.VITE_BUG_REPORT_TOKEN }}
+          VITE_KLIPY_API_KEY: ${{ secrets.VITE_KLIPY_API_KEY }}
 
       - name: Sync Capacitor Android
         run: npx cap sync android

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
         run: npx vite build && node scripts/minify-public-js.mjs
         env:
           VITE_KLIPY_API_KEY: ${{ secrets.VITE_KLIPY_API_KEY }}
+          VITE_BUG_REPORT_TOKEN: ${{ secrets.VITE_BUG_REPORT_TOKEN }}
 
       - name: Deploy to server via FTP
         uses: SamKirkland/FTP-Deploy-Action@v4.3.5


### PR DESCRIPTION
## Summary
- Add `VITE_BUG_REPORT_TOKEN` secret to both Android release and web deploy workflows
- Secret already added to repository via `gh secret set`

## Test plan
- [ ] Android release build picks up the token
- [ ] Web deploy build picks up the token