### PR TITLE
fix: upload bug report screenshots sequentially to avoid 409 conflict

### DIFF
--- a/src/shared/lib/bug-report/bug-report-sender.ts
+++ b/src/shared/lib/bug-report/bug-report-sender.ts
@@ -191,10 +191,9 @@ export async function sendBugReport(
 
   const results: ScreenshotResult[] = [];
   if (input.screenshots?.length) {
-    const uploads = input.screenshots.map((data, i) =>
-      uploadScreenshot(token, data, i),
-    );
-    results.push(...(await Promise.all(uploads)));
+    for (let i = 0; i < input.screenshots.length; i++) {
+      results.push(await uploadScreenshot(token, input.screenshots[i], i));
+    }
   }
 
   const res = await fetch(`${API_BASE}/repos/${REPO}/issues`, {


### PR DESCRIPTION
## Summary
- Parallel `PUT` requests to GitHub Contents API caused 409 SHA conflicts when uploading multiple screenshots — each upload creates a commit, invalidating the SHA for the next request
- Replaced `Promise.all` with sequential `for` loop so each screenshot upload completes before the next begins

## Test plan
- [ ] Attach 2+ screenshots to a bug report and submit — all should upload successfully
- [ ] Verify single screenshot still works
- [ ] Verify fallback (base64 in issue body) still works if upload fails for other reasons