### PR TITLE
fix: eliminate Android keyboard double-resize

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
             android:value="messages" />
 
         <activity
-            android:windowSoftInputMode="adjustResize"
+            android:windowSoftInputMode="adjustNothing"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode|navigation|density"
             android:name=".MainActivity"
             android:label="@string/title_activity_main"

--- a/android/app/src/main/java/com/forta/chat/MainActivity.kt
+++ b/android/app/src/main/java/com/forta/chat/MainActivity.kt
@@ -30,10 +30,10 @@ class MainActivity : BridgeActivity() {
     private var insetLeft = 0
     private var insetRight = 0
     private var keyboardHeight = 0
+    private var appBottomInset = 0
 
-    // Named Runnable references — removable in onDestroy (WR-02 fix per D-13)
-    private val reinjectSafeArea: Runnable = Runnable { injectSafeAreaInsets() }
-    private val reinjectKeyboard: Runnable = Runnable { injectKeyboardHeight() }
+    // Named Runnable reference — removable in onDestroy
+    private val reinjectAll: Runnable = Runnable { injectAllCssVars() }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         registerPlugin(TorPlugin::class.java)
@@ -45,7 +45,7 @@ class MainActivity : BridgeActivity() {
         registerPlugin(LocalePlugin::class.java)
         super.onCreate(savedInstanceState)
 
-        // Enable edge-to-edge: content draws behind system bars, insets are non-zero
+        // Edge-to-edge: content draws behind system bars, insets are non-zero
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
         // Auto-check for updates (respects 1-hour cache)
@@ -53,11 +53,11 @@ class MainActivity : BridgeActivity() {
             AppUpdater.checkForUpdateIfNeeded(this@MainActivity, isManual = false)
         }
 
-        // Inject real safe area insets + keyboard height as CSS variables into the WebView.
-        // With edge-to-edge enabled, adjustResize alone doesn't resize the window on API 30+.
-        // We must explicitly read Type.ime() insets to get keyboard height.
+        // Read system bar + IME insets and inject as CSS custom properties.
+        // With adjustNothing the system does not resize the WebView — we handle
+        // ALL keyboard adaptation via --app-bottom-inset in CSS.
         val rootView = findViewById<View>(android.R.id.content)
-        ViewCompat.setOnApplyWindowInsetsListener(rootView) { view, insets ->
+        ViewCompat.setOnApplyWindowInsetsListener(rootView) { _, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             val ime = insets.getInsets(WindowInsetsCompat.Type.ime())
             val density = resources.displayMetrics.density
@@ -67,65 +67,67 @@ class MainActivity : BridgeActivity() {
             insetLeft   = (systemBars.left   / density).toInt()
             insetRight  = (systemBars.right  / density).toInt()
 
-            // With adjustResize: ime.bottom includes nav bar when keyboard is open.
-            // Subtract systemBars.bottom (nav bar) to get pure keyboard height.
-            // Clamp to 0..60% screen to guard against OEM firmware anomalies (D-05).
+            // Pure keyboard height (IME minus nav bar).
+            // Clamp to 0..60% screen to guard against OEM firmware anomalies.
             val rawIme  = (ime.bottom / density).toInt()
             val pureKbd = (rawIme - insetBottom).coerceAtLeast(0)
             val maxKbd  = (resources.displayMetrics.heightPixels / density * 0.6).toInt()
             keyboardHeight = pureKbd.coerceAtMost(maxKbd)
 
-            injectSafeAreaInsets()
-            injectKeyboardHeight()
+            // Total bottom inset: whichever is bigger — IME or nav bar.
+            // Used by CSS to shrink the root container above the keyboard/nav bar.
+            appBottomInset = (maxOf(ime.bottom, systemBars.bottom) / density).toInt()
 
-            // CRITICAL: Do NOT return WindowInsetsCompat.CONSUMED.
-            // Pass insets through so the WebView performs its own visual viewport resize (M139+).
-            // This is the D-03 correction layer: on API 30+ with edge-to-edge,
-            // pass-through ensures the WebView's visual viewport shrinks correctly.
-            ViewCompat.onApplyWindowInsets(view, insets)
+            injectAllCssVars()
+
+            // CONSUME insets — do NOT pass through to WebView.
+            // Pass-through caused double-resize on Xiaomi/Infinix/MOBI WebViews
+            // where both adjustResize AND visual-viewport reacted to IME insets.
+            WindowInsetsCompat.CONSUMED
         }
     }
 
     override fun onResume() {
         super.onResume()
-        // Re-inject after resume — WebView may have reloaded or CSS may have overridden values
-        injectSafeAreaInsets()
-        injectKeyboardHeight()
+        // Re-inject after resume — WebView may have reloaded or CSS may have been reset
+        injectAllCssVars()
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        activityScope.cancel()                              // WR-01: prevent coroutine leak (D-12)
-        bridge?.webView?.removeCallbacks(reinjectSafeArea)  // WR-02: cancel pending safe area re-inject (D-13)
-        bridge?.webView?.removeCallbacks(reinjectKeyboard)  // WR-02: cancel pending keyboard re-inject (D-13)
+        activityScope.cancel()
+        bridge?.webView?.removeCallbacks(reinjectAll)
     }
 
-    private fun injectSafeAreaInsets() {
+    /**
+     * Inject all layout CSS custom properties in a single JS call.
+     *
+     * --safe-area-inset-*   : system bar insets (status bar, nav bar)
+     * --safe-area-inset-bottom : 0 when keyboard is open (nav bar is behind keyboard)
+     * --keyboardheight      : pure keyboard height (used by MediaPreview)
+     * --app-bottom-inset    : max(ime, navBar) — total bottom space to avoid
+     */
+    private fun injectAllCssVars() {
         val webView = bridge?.webView ?: return
-        if (isFinishing || isDestroyed) return  // WR-02 guard (D-13)
+        if (isFinishing || isDestroyed) return
+
+        // When keyboard is open, nav bar is behind it — effective safe-area-inset-bottom = 0
+        val effectiveBottom = if (keyboardHeight > 0) 0 else insetBottom
+
         val js = """
             (function() {
                 var s = document.documentElement.style;
                 s.setProperty('--safe-area-inset-top',    '${insetTop}px');
-                s.setProperty('--safe-area-inset-bottom', '${insetBottom}px');
+                s.setProperty('--safe-area-inset-bottom', '${effectiveBottom}px');
                 s.setProperty('--safe-area-inset-left',   '${insetLeft}px');
                 s.setProperty('--safe-area-inset-right',  '${insetRight}px');
+                s.setProperty('--keyboardheight',         '${keyboardHeight}px');
+                s.setProperty('--app-bottom-inset',       '${appBottomInset}px');
             })();
         """.trimIndent()
-        webView.post { if (!isFinishing && !isDestroyed) webView.evaluateJavascript(js, null) }
-        webView.removeCallbacks(reinjectSafeArea)       // cancel any pending retry
-        webView.postDelayed(reinjectSafeArea, 500)      // named Runnable — removable in onDestroy
-    }
 
-    private fun injectKeyboardHeight() {
-        val webView = bridge?.webView ?: return
-        if (isFinishing || isDestroyed) return  // WR-02 guard (D-13)
-        val js = """
-            (function() {
-                document.documentElement.style.setProperty('--keyboardheight', '${keyboardHeight}px');
-            })();
-        """.trimIndent()
         webView.post { if (!isFinishing && !isDestroyed) webView.evaluateJavascript(js, null) }
-        // No postDelayed retry: adjustResize fires insets only after layout is final (D-02).
+        webView.removeCallbacks(reinjectAll)
+        webView.postDelayed(reinjectAll, 500)
     }
 }

--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -255,7 +255,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="safe-top relative flex flex-col bg-background-total-theme text-text-color" style="height: 100vh; height: 100dvh">
+  <div class="safe-top relative flex flex-col bg-background-total-theme text-text-color" style="height: calc(100vh - var(--app-bottom-inset, 0px)); height: calc(100dvh - var(--app-bottom-inset, 0px))">
     <AppDownloadBanner />
     <!-- Registration stepper overlay — shows progress during blockchain registration -->
     <RegistrationStepper

--- a/src/app/styles/main.css
+++ b/src/app/styles/main.css
@@ -35,6 +35,7 @@
   --app-margin-top: max(env(safe-area-inset-top), var(--app-margin-top-default));
   --app-margin-bottom-default: 0px;
   --keyboardheight: 0px;
+  --app-bottom-inset: 0px;
   --app-margin-bottom: max(env(safe-area-inset-bottom), var(--app-margin-bottom-default));
 }
 


### PR DESCRIPTION
## Summary

- Заменяет `adjustResize` + pass-through insets на `adjustNothing` + consumed insets — WebView больше не зависит от visual viewport API для keyboard adaptation
- Все layout-изменения при открытии клавиатуры управляются CSS-переменными из native `WindowInsetsCompat` listener
- Добавляет `--app-bottom-inset` (= `max(IME, navBar)`) — единая переменная для высоты root-контейнера
- `--safe-area-inset-bottom` автоматически = 0 при открытой клавиатуре (nav bar скрыт за ней)

## Root cause

На Xiaomi, Infinix и MOBI устройствах (WebView 137-147, Android 13-15) происходило **двойное сжатие viewport**:
1. `adjustResize` уменьшал окно WebView
2. Pass-through insets заставлял WebView **дополнительно** реагировать через visual viewport API
3. `safe-bottom` padding добавлялся поверх — даже когда nav bar скрыт за клавиатурой

Результат: header уезжал за экран, белое пятно между input и клавиатурой.

## Changes

| File | Change |
|------|--------|
| `AndroidManifest.xml` | `adjustResize` → `adjustNothing` |
| `MainActivity.kt` | Consume insets, inject `--app-bottom-inset`, `--safe-area-inset-bottom=0` при клавиатуре |
| `App.vue` | Root height = `calc(100dvh - var(--app-bottom-inset))` |
| `main.css` | CSS-var `--app-bottom-inset: 0px` |

## Test plan

- [ ] Открыть чат → тап на поле ввода → клавиатура появляется → header видим, input ровно над клавиатурой, нет белого пятна
- [ ] Закрыть клавиатуру → layout возвращается к нормальному, nav bar padding корректен
- [ ] Проверить на устройствах с gesture navigation и 3-button navigation
- [ ] MediaPreview → caption input → клавиатура → padding корректен
- [ ] Проверить модалы (safe-all), панели (safe-y) — не сломаны
- [ ] Desktop (Electron) — без регрессий (--app-bottom-inset = 0px по умолчанию)

### Target devices
- Xiaomi M2102J20SG (Android 13, WebView 147)
- Infinix X6853 (Android 15, WebView 146)
- unknown MOBI (Android 15, WebView 137)