### PR TITLE
fix: prevent Android WebView RTL text direction flip in portrait (#BUG-03)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
+        android:supportsRtl="false"
         android:theme="@style/AppTheme">
 
         <meta-data

--- a/android/app/src/main/java/com/forta/chat/MainActivity.kt
+++ b/android/app/src/main/java/com/forta/chat/MainActivity.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import android.view.View.LAYOUT_DIRECTION_LTR
 import com.getcapacitor.BridgeActivity
 import com.forta.chat.plugins.tor.TorPlugin
 import com.forta.chat.plugins.calls.CallPlugin
@@ -44,6 +45,11 @@ class MainActivity : BridgeActivity() {
         registerPlugin(PushDataPlugin::class.java)
         registerPlugin(LocalePlugin::class.java)
         super.onCreate(savedInstanceState)
+
+        // BUG-03: Force LTR layout direction on the root view.
+        // Prevents Android WebView from inheriting system RTL direction
+        // which causes reversed text in portrait on some OEM firmware.
+        window.decorView.layoutDirection = LAYOUT_DIRECTION_LTR
 
         // Edge-to-edge: content draws behind system bars, insets are non-zero
         WindowCompat.setDecorFitsSystemWindows(window, false)
@@ -116,13 +122,15 @@ class MainActivity : BridgeActivity() {
 
         val js = """
             (function() {
-                var s = document.documentElement.style;
+                var d = document.documentElement;
+                var s = d.style;
                 s.setProperty('--safe-area-inset-top',    '${insetTop}px');
                 s.setProperty('--safe-area-inset-bottom', '${effectiveBottom}px');
                 s.setProperty('--safe-area-inset-left',   '${insetLeft}px');
                 s.setProperty('--safe-area-inset-right',  '${insetRight}px');
                 s.setProperty('--keyboardheight',         '${keyboardHeight}px');
                 s.setProperty('--app-bottom-inset',       '${appBottomInset}px');
+                if (d.getAttribute('dir') !== 'ltr') d.setAttribute('dir', 'ltr');
             })();
         """.trimIndent()
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html dir="ltr" lang="en">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -35,6 +35,27 @@
     <div id="app">
       <div id="appLoading"></div>
     </div>
+    <!--
+      BUG-03: Prevent Android WebView from flipping text direction to RTL.
+      Must run before any framework code — inline script, not module.
+    -->
+    <script>
+      (function() {
+        var html = document.documentElement;
+        // Force LTR immediately
+        html.setAttribute('dir', 'ltr');
+
+        // Watch for any runtime injection of dir="rtl" by WebView or plugins
+        var observer = new MutationObserver(function(mutations) {
+          for (var i = 0; i < mutations.length; i++) {
+            if (mutations[i].attributeName === 'dir' && html.getAttribute('dir') !== 'ltr') {
+              html.setAttribute('dir', 'ltr');
+            }
+          }
+        });
+        observer.observe(html, { attributes: true, attributeFilter: ['dir'] });
+      })();
+    </script>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/src/app/styles/main.css
+++ b/src/app/styles/main.css
@@ -171,6 +171,18 @@
   --bubble-radius-small: 4px;
 }
 
+/*
+ * BUG-03 fix: Force LTR text direction globally.
+ * Android WebView + supportsRtl can inherit system RTL layout direction
+ * in portrait orientation on certain OEM firmware (Xiaomi/MIUI, OnePlus).
+ * This triple-layer defense prevents any direction flip.
+ */
+html,
+html[dir="rtl"] {
+  direction: ltr !important;
+  unicode-bidi: isolate;
+}
+
 html {
   font-size: 1em;
   line-height: 1.5;
@@ -180,6 +192,16 @@ html {
   overflow-x: hidden;
   background: rgb(var(--background-total-theme));
   overscroll-behavior: none;
+}
+
+/* BUG-03: Force LTR on all text inputs and contenteditable areas */
+input,
+textarea,
+[contenteditable="true"],
+[contenteditable=""] {
+  direction: ltr !important;
+  unicode-bidi: plaintext;
+  text-align: left;
 }
 
 body {


### PR DESCRIPTION
## Summary

- Fixes reversed text (RTL direction) appearing exclusively in portrait orientation on Android WebView
- Confirmed on: Xiaomi (Android 15/16), OnePlus (Android 14), OUKITEL (Android 11)
- Text typed/displayed backwards ("еквотсо В" instead of "В отставке"), corrects itself when rotated to landscape

## Root Cause

`android:supportsRtl="true"` in AndroidManifest combined with no `dir` attribute on `<html>` allows Android WebView to inherit system RTL layout direction. On certain OEM firmware (MIUI, OxygenOS), portrait and landscape orientation changes pass through different Chromium rendering code paths — portrait inherits the (incorrect) RTL direction, landscape resets to LTR correctly.

## Changes

Four-layer defense to make the fix bulletproof:

| Layer | File | Fix |
|-------|------|-----|
| Android Manifest | `AndroidManifest.xml` | `supportsRtl="false"` — disables OS-level RTL inheritance |
| Android Activity | `MainActivity.kt` | Force `LAYOUT_DIRECTION_LTR` on decorView + re-assert `dir="ltr"` on every CSS var injection (fires on resume & rotation) |
| HTML | `index.html` | `dir="ltr" lang="en"` on `<html>` + inline MutationObserver that reverts any runtime `dir` changes |
| CSS | `main.css` | `direction: ltr !important` on `html` (including `html[dir="rtl"]`), `unicode-bidi: plaintext` on inputs |

## Test plan

- [ ] Install on Xiaomi device (Android 15/16) — verify text displays LTR in portrait
- [ ] Rotate to landscape and back — confirm no direction flip
- [ ] Type in chat input in portrait — verify characters appear left-to-right
- [ ] Test on OnePlus LE2115 (Android 14) — same checks
- [ ] Test on OUKITEL WP5 Pro (Android 11) — same checks
- [ ] Verify no regression on devices that previously worked correctly