### PR TITLE
fix: disable Tor by default and fix zero-audio on Chinese Android OEMs

### DIFF
--- a/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
@@ -90,6 +90,15 @@ class AudioRouter(private val context: Context) {
         activeDevice = if (callType == "video") Device.SPEAKER else Device.EARPIECE
         audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
 
+        // OEM fix: Some Chinese ROMs (MIUI, RealmeUI, XOS) reset audio mode
+        // asynchronously after init. Re-apply after a short delay to catch resets.
+        mainHandler.postDelayed({
+            if (isActive && audioManager.mode != AudioManager.MODE_IN_COMMUNICATION) {
+                Log.w(TAG, "Audio mode was reset by system — re-applying MODE_IN_COMMUNICATION")
+                audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+            }
+        }, 500)
+
         audioManager.registerAudioDeviceCallback(deviceCallback, mainHandler)
 
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallForegroundService.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallForegroundService.kt
@@ -281,14 +281,17 @@ class CallForegroundService : Service() {
             .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
             .build()
 
-        audioFocusRequest = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+        // Use AUDIOFOCUS_GAIN (not TRANSIENT) — Chinese OEM firmwares (MIUI,
+        // RealmeUI, XOS) may return audio focus prematurely with transient mode,
+        // causing zero-way audio. Full gain properly displaces media players.
+        audioFocusRequest = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
             .setAudioAttributes(attrs)
-            .setAcceptsDelayedFocusGain(false)
+            .setAcceptsDelayedFocusGain(true)
             .setOnAudioFocusChangeListener(audioFocusChangeListener)
             .build()
 
         val result = am.requestAudioFocus(audioFocusRequest!!)
-        Log.d("WebRTCAudio", "Audio focus requested, result=$result")
+        Log.d("WebRTCAudio", "Audio focus requested (GAIN), result=$result")
     }
 
     private fun abandonAudioFocus() {

--- a/android/app/src/main/java/com/forta/chat/plugins/webrtc/NativeWebRTCManager.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/webrtc/NativeWebRTCManager.kt
@@ -300,12 +300,28 @@ class NativeWebRTCManager(private val context: Context) {
     fun startLocalAudio(peerId: String) {
         Log.d("WebRTCAudio", "startLocalAudio: begin, peerId=$peerId")
 
-        // Ensure AudioManager is in voice call mode for proper routing
+        // === OEM audio fix (Xiaomi MIUI / Realme UI / INFINIX XOS) ===
+        // Must configure AudioManager BEFORE creating AudioTrack.
+        // Chinese OEM firmwares aggressively mute the mic if VoIP mode
+        // isn't established before the first audio capture starts.
         try {
             val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+
+            // 1. Force VoIP mode — must happen before AudioTrack creation
             audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+
+            // 2. Ensure mic is not muted at system level (some ROMs persist mute)
+            if (audioManager.isMicrophoneMute) {
+                audioManager.isMicrophoneMute = false
+                Log.w("WebRTCAudio", "startLocalAudio: system mic was muted — force-unmuted")
+            }
+
+            // 3. Disable speakerphone initially (AudioRouter sets correct device later)
+            @Suppress("DEPRECATION")
             audioManager.isSpeakerphoneOn = false
-            Log.d("WebRTCAudio", "startLocalAudio: AudioManager set to MODE_IN_COMMUNICATION")
+
+            Log.d("WebRTCAudio", "startLocalAudio: AudioManager configured " +
+                "(mode=${audioManager.mode}, micMute=${audioManager.isMicrophoneMute})")
         } catch (e: Exception) {
             Log.w("WebRTCAudio", "startLocalAudio: failed to set audio mode", e)
         }

--- a/src/app/providers/index.ts
+++ b/src/app/providers/index.ts
@@ -74,31 +74,35 @@ export const setupProviders = async (app: App) => {
       }).catch((e) => console.warn('[Telemetry] Collection failed:', e));
     }).catch((e) => console.warn('[Telemetry] Module load failed:', e));
 
-    // Start Tor daemon in background — does NOT block boot.
-    // App loads with direct connections; switches to Tor when ready.
-    bootStatus.setStep("tor");
-    const { torService } = await import('@/shared/lib/tor');
-    torService.initBackground();
-    // Wire store to native torService reactive state
-    useTorStore().init();
+    // Wire store to native torService reactive state (always — for settings UI)
+    const torStore = useTorStore();
+    torStore.init();
 
-    // Notify user if Tor fails to start (after app is mounted)
-    const torWatch = watch(
-      () => torService.initFailed.value,
-      (failed) => {
-        if (failed) {
-          import('@/shared/lib/use-toast').then(({ useToast }) => {
-            const { toast } = useToast();
-            toast(
-              'Secure connection unavailable. You can enable Tor in Settings.',
-              'error',
-              8000,
-            );
-          });
-          torWatch(); // stop watching
-        }
-      },
-    );
+    // Only start Tor daemon if user previously opted in.
+    // Default is "neveruse" (opt-in) — app boots instantly via clearnet.
+    if (torStore.isEnabled) {
+      bootStatus.setStep("tor");
+      const { torService } = await import('@/shared/lib/tor');
+      torService.initBackground();
+
+      // Notify user if Tor fails to start
+      const torWatch = watch(
+        () => torService.initFailed.value,
+        (failed) => {
+          if (failed) {
+            import('@/shared/lib/use-toast').then(({ useToast }) => {
+              const { toast } = useToast();
+              toast(
+                'Secure connection unavailable. You can enable Tor in Settings.',
+                'error',
+                8000,
+              );
+            });
+            torWatch(); // stop watching
+          }
+        },
+      );
+    }
   }
 
   // Static pages (e.g. /download landing) don't need chat scripts —

--- a/src/entities/tor/model/stores.ts
+++ b/src/entities/tor/model/stores.ts
@@ -8,9 +8,9 @@ const NAMESPACE = "tor";
 
 export const useTorStore = defineStore(NAMESPACE, () => {
   const { setLSValue: setLSMode, value: lsMode } =
-    useLocalStorage<TorMode>("tor_mode", "auto");
+    useLocalStorage<TorMode>("tor_mode", "neveruse");
 
-  const mode = ref<TorMode>(lsMode || "auto");
+  const mode = ref<TorMode>(lsMode || "neveruse");
   const status = ref<TorStatus>("stopped");
   const info = ref("");
 


### PR DESCRIPTION
## Summary

- **BUG-09 (Tor opt-in):** Change Tor default from `"auto"` to `"neveruse"`. First launch boots instantly via clearnet; Tor daemon only starts when user explicitly enables it in Settings. Existing users who already set a Tor mode keep their preference (persisted in localStorage).
- **BUG-07 (Zero audio on Chinese OEMs):** Fix zero-way audio on Xiaomi MIUI, Realme UI, INFINIX XOS devices by:
  - Setting `MODE_IN_COMMUNICATION` and force-unmuting mic **before** AudioTrack creation (OEM firmwares mute mic if VoIP mode isn't pre-established)
  - Upgrading AudioFocus from `GAIN_TRANSIENT` to `GAIN` (OEM ROMs return transient focus prematurely)
  - Adding 500ms retry in AudioRouter to catch async audio mode resets by Chinese ROM subsystems
- **WebRTC clearnet routing:** Confirmed that WebRTC media already bypasses Tor (native libwebrtc uses its own socket layer, not WebView HTTP proxy). No code change needed — documented in commit.

## Files Changed

| File | Change |
|------|--------|
| `src/entities/tor/model/stores.ts` | Default `"auto"` → `"neveruse"` |
| `src/app/providers/index.ts` | Conditional `initBackground()` — skip Tor daemon when disabled |
| `android/.../NativeWebRTCManager.kt` | Pre-track audio mode + mic unmute check |
| `android/.../CallForegroundService.kt` | `AUDIOFOCUS_GAIN` + `setAcceptsDelayedFocusGain(true)` |
| `android/.../AudioRouter.kt` | 500ms retry for OEM audio mode reset |

## Test Plan

- [ ] Fresh install → verify app boots without Tor delay (no "tor" boot step)
- [ ] Enable Tor in Settings → verify Tor starts and connects
- [ ] Restart app → verify Tor still starts (preference persisted)
- [ ] Disable Tor → restart → verify instant boot again
- [ ] Voice call on Xiaomi/Realme device → verify two-way audio works
- [ ] Video call → verify speaker is default output
- [ ] Call with Bluetooth headset → verify auto-switch
- [ ] Call while Tor is enabled → verify audio/video works (WebRTC bypasses Tor)