### PR TITLE
fix(calls): complete incoming-call overhaul — ICE, cold-start answer/decline, lock-screen, dedup

### DIFF
--- a/android/app/src/main/java/com/forta/chat/FortaFirebaseMessagingService.kt
+++ b/android/app/src/main/java/com/forta/chat/FortaFirebaseMessagingService.kt
@@ -85,16 +85,60 @@ class FortaFirebaseMessagingService : FirebaseMessagingService() {
             cacheSenderName(this, sender, senderName)
         }
 
-        // Handle call hangup/cancel — dismiss incoming call screen
-        if (msgType == "m.call.hangup" || msgType == "m.call.reject") {
-            Log.d(TAG, "Call ended remotely (type=$msgType), dismissing incoming call UI")
+        // Handle call cancel paths — full cleanup of incoming-call UI state.
+        //
+        // Three ways an incoming call can end before we answer:
+        //   m.call.hangup        — caller cancelled
+        //   m.call.reject        — we (or another device of ours) rejected
+        //   m.call.select_answer — another of our devices answered
+        //
+        // For all three we must tear down BOTH surfaces:
+        //   1. IncomingCallActivity (full-screen ringer)
+        //   2. CallConnectionService notification in the shade
+        //      + its Telecom `currentConnection`, or the shade keeps
+        //        pulling the ringer back every time the user drags down.
+        //
+        // Without this, users saw the notification persist after the
+        // caller had long given up — the JS side received the Matrix
+        // event but had no hook into the native notification stack.
+        if (msgType == "m.call.hangup" || msgType == "m.call.reject" ||
+            msgType == "m.call.select_answer") {
+            Log.d(TAG, "Call ended remotely (type=$msgType), tearing down incoming UI")
             IncomingCallActivity.dismissIfShowing()
+            com.forta.chat.plugins.calls.CallConnectionService.dismissIncomingCallNotification(this)
+            try {
+                com.forta.chat.plugins.calls.CallConnectionService.currentConnection
+                    ?.onDisconnect()
+                com.forta.chat.plugins.calls.CallConnectionService.currentConnection = null
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to disconnect currentConnection", e)
+            }
+            // End-of-call signal also clears the dedup marker so a
+            // genuinely new invite (new call_id) can ring again.
+            val endedCallId = data["call_id"] ?: data["event_id"]
+            if (endedCallId != null && lastRingingCallId == endedCallId) {
+                lastRingingCallId = null
+            }
             forwardToJs(data)
             return
         }
 
         // Handle calls
         if (msgType == "m.call.invite") {
+            // Suppress invite retries for a call we're already ringing
+            // or answering. Caller clients resend m.call.invite every
+            // few seconds until they see our answer/hangup; each retry
+            // arrives as a fresh push with the same call_id but a new
+            // event_id. Without this guard each retry stacks another
+            // ringer on top of the one the user is already looking at.
+            val callId = data["call_id"] ?: data["event_id"] ?: ""
+            if (callId.isNotEmpty() && callId == lastRingingCallId) {
+                Log.d(TAG, "Duplicate invite retry for $callId — suppressing")
+                forwardToJs(data)
+                return
+            }
+            lastRingingCallId = callId.takeIf { it.isNotEmpty() }
+
             // Cancel any existing message notification for this room
             val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             nm.cancel(NOTIF_TAG, roomId.hashCode())
@@ -261,6 +305,22 @@ class FortaFirebaseMessagingService : FirebaseMessagingService() {
 
         // PushDataPlugin registers itself here so we can forward data
         var pluginInstance: com.forta.chat.plugins.push.PushDataPlugin? = null
+
+        /**
+         * Deduplicate call pushes by call_id.
+         *
+         * Caller clients retry m.call.invite (different event_id, same
+         * call_id) while they wait for us to answer, so the same logical
+         * ring arrives as multiple pushes. Without dedup each retry
+         * triggers another IncomingCallActivity + another Telecom
+         * incoming connection — stacking ringers on top of the call the
+         * user has already accepted.
+         *
+         * We remember the last call_id handled as a ring and suppress
+         * any further invite for it until we see a hangup/reject/
+         * select_answer for the same id (or the process dies).
+         */
+        private var lastRingingCallId: String? = null
 
         fun cacheRoomName(context: Context, roomId: String, name: String) {
             context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)

--- a/android/app/src/main/java/com/forta/chat/MainActivity.kt
+++ b/android/app/src/main/java/com/forta/chat/MainActivity.kt
@@ -1,7 +1,11 @@
 package com.forta.chat
 
+import android.app.KeyguardManager
+import android.content.Context
+import android.os.Build
 import android.os.Bundle
 import android.view.View
+import android.view.WindowManager
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -45,6 +49,44 @@ class MainActivity : BridgeActivity() {
         registerPlugin(PushDataPlugin::class.java)
         registerPlugin(LocalePlugin::class.java)
         super.onCreate(savedInstanceState)
+
+        // When this activity is launched from the push-call ringer's
+        // Accept tap (IncomingCallActivity → push_call_accept=true), the
+        // device may still be locked. Without the next few flags the
+        // WebView host activity would sit BEHIND the keyguard, Android
+        // would immediately mark it stopped, and the WebView would
+        // throttle its JS — so our Matrix `answerCall()` flow never
+        // completes until the user manually unlocks. Lifting the
+        // keyguard for this specific launch lets the call actually
+        // answer from the lock screen.
+        val cameFromCallAccept = intent?.getBooleanExtra("push_call_accept", false) == true
+        if (cameFromCallAccept) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+                setShowWhenLocked(true)
+                setTurnScreenOn(true)
+            } else {
+                @Suppress("DEPRECATION")
+                window.addFlags(
+                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
+                        WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON or
+                        WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD,
+                )
+            }
+            // Ask keyguard to dismiss if device is locked without a PIN
+            // (or to prompt the user otherwise). Without this the WebView
+            // is often kept in the onStop state when the OS deems the
+            // lock overlay opaque — JS frozen, call hangs in
+            // "Connecting…" forever.
+            try {
+                val km = getSystemService(Context.KEYGUARD_SERVICE) as? KeyguardManager
+                if (km?.isKeyguardLocked == true && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+                    km.requestDismissKeyguard(this, null)
+                }
+            } catch (_: Throwable) {
+                // Best-effort — keyguard dismissal is not critical if the
+                // user is willing to unlock manually.
+            }
+        }
 
         // BUG-03: Force LTR layout direction on the root view.
         // Prevents Android WebView from inheriting system RTL direction

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallConnectionService.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallConnectionService.kt
@@ -49,10 +49,19 @@ class CallConnectionService : ConnectionService() {
         val callId = extras.getString("callId", "")
         val callerName = extras.getString("callerName", "Unknown")
         val hasVideo = extras.getBoolean("hasVideo", false)
+        val roomId = extras.getString("roomId", "")
 
-        Log.d(TAG, "onCreateIncomingConnection: callId=$callId, caller=$callerName")
+        Log.d(TAG, "onCreateIncomingConnection: callId=$callId, caller=$callerName, roomId=$roomId")
 
-        val connection = CallConnection(applicationContext, callId)
+        // Stash the room id on the CallConnection instance so that
+        // when (and ONLY when) the user taps Answer, CallConnection.
+        // onAnswer() can populate pendingAnswerRoomId. Setting it here
+        // unconditionally was a bug: the JS-side fast-path treats
+        // pendingAnswerRoomId as "user already accepted a call in room
+        // R", so declines would then trigger the same fast-path and
+        // pop CallActivity anyway.
+
+        val connection = CallConnection(applicationContext, callId, roomId)
         connection.setCallerDisplayName(callerName, TelecomManager.PRESENTATION_ALLOWED)
         connection.setAddress(
             Uri.fromParts("sip", callerName, null),
@@ -207,7 +216,8 @@ class CallConnectionService : ConnectionService() {
 
 class CallConnection(
     private val context: Context,
-    val callId: String
+    val callId: String,
+    private val roomId: String = ""
 ) : Connection() {
 
     companion object {
@@ -218,28 +228,69 @@ class CallConnection(
         /**
          * Queued answer callId — set when user taps "Answer" before JS listener
          * is wired. JS side checks and replays this on wire().
+         *
+         * Note: the push payload from pocketnet's Matrix homeserver does
+         * NOT include the Matrix `content.call_id`, so the value stored
+         * here is really the push `event_id` — different from the call
+         * id the JS-side SDK will later see on the MatrixCall object.
+         * Consumers should also match by room (pendingAnswerRoomId
+         * below) to reliably correlate.
          */
         var pendingAnswerCallId: String? = null
+
+        /**
+         * Matrix room id the user tapped "Answer" on — set ONLY inside
+         * CallConnection.onAnswer() so Decline and other paths never
+         * trigger the JS-side fast-path auto-answer. JS consumer treats
+         * the presence of this marker as "user already accepted a call
+         * in room R, next incoming MatrixCall for R is that one".
+         */
+        var pendingAnswerRoomId: String? = null
+
+        /**
+         * Set when user taps Decline before JS is running. Symmetric to
+         * pendingAnswerCallId/RoomId. When JS boots it reads both via
+         * NativeCall.getPendingReject, and when Matrix finally delivers
+         * the invite for this room the handler calls `matrixCall.reject()`
+         * so the caller actually gets our rejection signal — otherwise
+         * the caller keeps ringing until their own timeout.
+         */
+        var pendingRejectCallId: String? = null
+        var pendingRejectRoomId: String? = null
     }
 
     override fun onAnswer() {
-        Log.d("CallConnection", "onAnswer: $callId")
+        Log.d("CallConnection", "onAnswer: callId=$callId, roomId=$roomId")
         setActive()
         CallConnectionService.dismissIncomingCallNotification(context)
+        // Populate accept-only markers here, never in onCreateIncoming-
+        // Connection — otherwise Decline and a plain push delivery
+        // would also set them and JS would fast-path into an in-call
+        // screen the user never asked for.
+        pendingAnswerCallId = callId
+        if (roomId.isNotEmpty()) {
+            pendingAnswerRoomId = roomId
+        }
         if (onAnswered != null) {
             onAnswered?.invoke(callId)
         } else {
-            // JS not ready yet — queue for replay
-            Log.w("CallConnection", "onAnswer: JS listener not wired, queuing callId=$callId")
-            pendingAnswerCallId = callId
+            Log.w("CallConnection", "onAnswer: JS listener not wired, queued for replay")
         }
     }
 
     override fun onReject() {
-        Log.d("CallConnection", "onReject: $callId")
+        Log.d("CallConnection", "onReject: callId=$callId, roomId=$roomId")
         setDisconnected(DisconnectCause(DisconnectCause.REJECTED))
         destroy()
         CallConnectionService.dismissIncomingCallNotification(context)
+        // Wipe any stale accept markers so a late-arriving MatrixCall
+        // for this room can't trigger the JS fast-path to auto-answer.
+        clearPendingFor(callId, roomId)
+        // Queue the reject so that when the JS app eventually boots
+        // (or is already running) it can send m.call.reject to Matrix
+        // and the caller stops ringing.
+        pendingRejectCallId = callId
+        if (roomId.isNotEmpty()) pendingRejectRoomId = roomId
         onRejected?.invoke(callId)
     }
 
@@ -248,6 +299,12 @@ class CallConnection(
         setDisconnected(DisconnectCause(DisconnectCause.LOCAL))
         destroy()
         CallConnectionService.dismissIncomingCallNotification(context)
+        clearPendingFor(callId, roomId)
         onEnded?.invoke(callId)
+    }
+
+    private fun clearPendingFor(cid: String, rid: String) {
+        if (pendingAnswerCallId == cid) pendingAnswerCallId = null
+        if (rid.isNotEmpty() && pendingAnswerRoomId == rid) pendingAnswerRoomId = null
     }
 }

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallPlugin.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallPlugin.kt
@@ -40,6 +40,12 @@ class CallPlugin : Plugin() {
         CallConnection.onAnswered = { callId ->
             notifyListeners("callAnswered", JSObject().apply {
                 put("callId", callId)
+                // Include roomId: on this homeserver the push payload has
+                // the push event_id in place of the Matrix content.call_id,
+                // so JS can't correlate by callId alone. By the time this
+                // callback fires CallConnection.onAnswer has already set
+                // pendingAnswerRoomId, so read it here.
+                put("roomId", CallConnection.pendingAnswerRoomId ?: "")
             })
         }
         CallConnection.onRejected = { callId ->
@@ -237,9 +243,24 @@ class CallPlugin : Plugin() {
     @PluginMethod
     fun getPendingAnswer(call: PluginCall) {
         val pendingCallId = CallConnection.pendingAnswerCallId
+        val pendingRoomId = CallConnection.pendingAnswerRoomId
         CallConnection.pendingAnswerCallId = null
+        CallConnection.pendingAnswerRoomId = null
         val ret = com.getcapacitor.JSObject()
         ret.put("callId", pendingCallId)
+        ret.put("roomId", pendingRoomId)
+        call.resolve(ret)
+    }
+
+    @PluginMethod
+    fun getPendingReject(call: PluginCall) {
+        val pendingCallId = CallConnection.pendingRejectCallId
+        val pendingRoomId = CallConnection.pendingRejectRoomId
+        CallConnection.pendingRejectCallId = null
+        CallConnection.pendingRejectRoomId = null
+        val ret = com.getcapacitor.JSObject()
+        ret.put("callId", pendingCallId)
+        ret.put("roomId", pendingRoomId)
         call.resolve(ret)
     }
 }

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/IncomingCallActivity.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/IncomingCallActivity.kt
@@ -136,8 +136,16 @@ class IncomingCallActivity : Activity() {
         cleanup()
 
         val callId = intent.getStringExtra("callId") ?: ""
+        val callerName = intent.getStringExtra("callerName") ?: "Unknown"
+        val hasVideo = intent.getBooleanExtra("hasVideo", false)
 
-        // Try ConnectionService first; if unavailable, notify JS directly
+        // Notify Telecom / JS listener that user tapped Answer. One of
+        // two paths fires depending on whether the app process is alive:
+        //   - connection.onAnswer() → invokes onAnswered callback (wired
+        //     by CallPlugin.load) or queues pendingAnswerCallId for JS
+        //     to pick up later via getPendingAnswer.
+        //   - CallConnection.onAnswered direct invoke as fallback when
+        //     we bypassed Telecom.
         val connection = CallConnectionService.currentConnection
         if (connection != null) {
             connection.onAnswer()
@@ -146,14 +154,49 @@ class IncomingCallActivity : Activity() {
             CallConnection.onAnswered?.invoke(callId)
         }
 
-        // Open app — JS handles the actual WebRTC answer via Matrix SDK
-        val mainIntent = Intent(this, MainActivity::class.java).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        // Belt-and-braces: ensure the pending-answer markers are set on
+        // CallConnection even when Telecom integration failed (e.g. a
+        // region that rate-limits addNewIncomingCall and never calls
+        // onCreateIncomingConnection — we'd have no roomId stashed).
+        // JS-side consumePendingAnswerCallId correlates by roomId when
+        // the push-side call_id doesn't match the Matrix call.callId,
+        // so the roomId in particular must be present.
+        val roomIdForPending = intent.getStringExtra("roomId")
+        if (CallConnection.pendingAnswerCallId.isNullOrEmpty()) {
+            CallConnection.pendingAnswerCallId = callId
+        }
+        if (CallConnection.pendingAnswerRoomId.isNullOrEmpty()) {
+            CallConnection.pendingAnswerRoomId = roomIdForPending
+        }
+
+        // Launch MainActivity in the FOREGROUND so Capacitor's WebView
+        // becomes the resumed activity. Android pauses and eventually
+        // stops a WebView's host activity when it's fully covered by
+        // another opaque activity (which is what the ealier design did
+        // with CallActivity on top + MainActivity in background) — when
+        // stopped, the WebView throttles/freezes its JS timers, so the
+        // JS call-answer flow doesn't actually run until the user
+        // manually returns to the app. Symptom: user tapped Answer but
+        // saw "connecting" forever until they switched to the app.
+        //
+        // By putting MainActivity on top, its onResume fires, the
+        // WebView keeps running at full speed, and the JS
+        // handleIncomingCall → fast-path → answerCall path completes in
+        // the background. As soon as the answer succeeds, the JS side
+        // calls NativeWebRTC.launchCallUI, which then pops CallActivity
+        // with the "Connecting…" template that transitions to
+        // "Connected" on ICE success — same end state as before, just
+        // with a short (1-2 sec) Vue loading flicker along the way.
+        val appBootIntent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+                    Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                    Intent.FLAG_ACTIVITY_SINGLE_TOP
             putExtra("push_call_accept", true)
             putExtra("callId", callId)
             putExtra("roomId", intent.getStringExtra("roomId"))
         }
-        startActivity(mainIntent)
+        startActivity(appBootIntent)
+
         CallConnectionService.dismissIncomingCallNotification(this)
         finish()
     }
@@ -162,10 +205,42 @@ class IncomingCallActivity : Activity() {
         Log.d(TAG, "Decline pressed")
         cleanup()
 
-        // Try ConnectionService if available
+        val callId = intent.getStringExtra("callId") ?: ""
+        val roomIdForPending = intent.getStringExtra("roomId")
+
+        // Try ConnectionService — populates CallConnection.pendingReject*
         CallConnectionService.currentConnection?.onReject()
 
-        // Just close — caller will see "no answer" / timeout
+        // Defence-in-depth: clear accept markers (we're declining, not
+        // accepting) and set reject markers if Telecom path was bypassed.
+        CallConnection.pendingAnswerCallId = null
+        CallConnection.pendingAnswerRoomId = null
+        if (CallConnection.pendingRejectCallId.isNullOrEmpty()) {
+            CallConnection.pendingRejectCallId = callId
+        }
+        if (CallConnection.pendingRejectRoomId.isNullOrEmpty()) {
+            CallConnection.pendingRejectRoomId = roomIdForPending
+        }
+
+        // Boot the app (in the same way as Accept) so JS can actually
+        // send m.call.reject to Matrix once the invite is delivered via
+        // /sync. Without this the caller keeps ringing until their own
+        // lifetime timeout expires (often 30-60s) — from the user's
+        // perspective the Decline button "did nothing".
+        try {
+            val intent = Intent(this, com.forta.chat.MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+                    Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                    Intent.FLAG_ACTIVITY_SINGLE_TOP
+                putExtra("push_call_decline", true)
+                putExtra("callId", callId)
+                putExtra("roomId", roomIdForPending)
+            }
+            startActivity(intent)
+        } catch (e: Throwable) {
+            Log.w(TAG, "Failed to launch MainActivity on decline: $e")
+        }
+
         CallConnectionService.dismissIncomingCallNotification(this)
         finish()
     }
@@ -174,6 +249,10 @@ class IncomingCallActivity : Activity() {
     private fun dismissByRemote() {
         Log.d(TAG, "Remote hangup — dismissing")
         cleanup()
+        // Clear accept markers so a stale invite can't re-trigger
+        // the JS fast-path after the caller has cancelled.
+        CallConnection.pendingAnswerCallId = null
+        CallConnection.pendingAnswerRoomId = null
         CallConnectionService.dismissIncomingCallNotification(this)
         finish()
     }

--- a/android/app/src/main/java/com/forta/chat/plugins/webrtc/NativeWebRTCManager.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/webrtc/NativeWebRTCManager.kt
@@ -294,6 +294,92 @@ class NativeWebRTCManager(private val context: Context) {
     }
 
     // -----------------------------------------------------------------------
+    // ICE restart / stats (Session 02 — fix for 1-2 sec call drops)
+    // -----------------------------------------------------------------------
+
+    /**
+     * Perform an ICE restart on the given PeerConnection. Called when the
+     * JS side detects a network flip or ICE disconnected/failed and needs
+     * a fresh ICE agent without tearing the whole call down.
+     *
+     * Note: `PeerConnection.restartIce()` here is the libwebrtc Java
+     * binding (org.webrtc.PeerConnection), not Android's framework WebRTC.
+     * It is available on every Android API level our `minSdk 24` supports
+     * because libwebrtc ships its own implementation. An earlier version
+     * of this method had an API 28 guard with a `createOffer(IceRestart)`
+     * fallback, but that fallback never called `setLocalDescription` and
+     * our `onRenegotiationNeeded` observer is suppressed to avoid
+     * premature offers from track management — so the fallback would have
+     * silently done nothing. The unconditional call is correct.
+     *
+     * Returns true on success, false when peer is unknown or the native
+     * call threw.
+     */
+    fun restartIce(peerId: String): Boolean {
+        val pc = peerConnections[peerId]
+        if (pc == null) {
+            Log.e(TAG, "[$peerId] restartIce: no PeerConnection")
+            return false
+        }
+        return try {
+            pc.restartIce()
+            Log.d(TAG, "[$peerId] restartIce: invoked PeerConnection.restartIce()")
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "[$peerId] restartIce threw", e)
+            false
+        }
+    }
+
+    /**
+     * Return the latest WebRTC stats for the given PeerConnection as a
+     * JSObject (flat map of stat-id → { id, type, timestamp, ...members }).
+     *
+     * We serialize the fields our JS consumers actually read: type, kind,
+     * bytesSent/Received, packetsSent/Received, jitter, rtt,
+     * framesEncoded/Decoded, etc. Unknown value types become their
+     * toString(). The callback is invoked with null if peer is unknown.
+     */
+    fun getStats(peerId: String, callback: (com.getcapacitor.JSObject?) -> Unit) {
+        val pc = peerConnections[peerId]
+        if (pc == null) {
+            Log.e(TAG, "[$peerId] getStats: no PeerConnection")
+            callback(null)
+            return
+        }
+        try {
+            pc.getStats { rtcStatsReport ->
+                val report = com.getcapacitor.JSObject()
+                try {
+                    for ((id, stat) in rtcStatsReport.statsMap) {
+                        val entry = com.getcapacitor.JSObject().apply {
+                            put("id", id)
+                            put("type", stat.type ?: "")
+                            put("timestamp", stat.timestampUs)
+                        }
+                        for ((memberName, memberValue) in stat.members) {
+                            if (memberValue == null) continue
+                            when (memberValue) {
+                                is Number -> entry.put(memberName, memberValue)
+                                is Boolean -> entry.put(memberName, memberValue)
+                                is String -> entry.put(memberName, memberValue)
+                                else -> entry.put(memberName, memberValue.toString())
+                            }
+                        }
+                        report.put(id, entry)
+                    }
+                } catch (e: Exception) {
+                    Log.w(TAG, "[$peerId] getStats: partial serialization failure", e)
+                }
+                callback(report)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "[$peerId] getStats threw", e)
+            callback(null)
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // Local Media
     // -----------------------------------------------------------------------
 

--- a/android/app/src/main/java/com/forta/chat/plugins/webrtc/WebRTCPlugin.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/webrtc/WebRTCPlugin.kt
@@ -12,7 +12,6 @@ import com.getcapacitor.PluginMethod
 import com.getcapacitor.PermissionState
 import com.getcapacitor.annotation.CapacitorPlugin
 import com.getcapacitor.annotation.Permission
-import com.getcapacitor.annotation.PermissionCallback
 import org.webrtc.*
 
 /**
@@ -324,9 +323,21 @@ class WebRTCPlugin : Plugin() {
             call.reject("Manager not initialized")
             return
         }
-        // Safety net permission guard (D-01: Kotlin side)
+        // Session 02 — single permission path.
+        //
+        // RECORD_AUDIO must already be granted via CallPlugin.requestAudioPermission
+        // BEFORE we get here. Opening a second system dialog from inside
+        // startLocalMedia would land in the middle of the call setup, steal
+        // focus from the Activity, pause the WebRTC engine and drop the call
+        // after 1-2 seconds. So this path only verifies state and fails fast
+        // if the centralized permission gate was bypassed.
         if (getPermissionState("microphone") != PermissionState.GRANTED) {
-            requestPermissionForAlias("microphone", call, "micPermissionCallback")
+            Log.w(TAG, "[WebRTCAudio] startLocalMedia without mic permission — failing fast")
+            notifyListeners("onAudioError", JSObject().apply {
+                put("type", "permission_denied")
+                put("message", "Microphone permission not granted")
+            })
+            call.reject("RECORD_AUDIO permission not granted — must be requested before startLocalMedia")
             return
         }
         doStartLocalMedia(call, mgr)
@@ -343,21 +354,6 @@ class WebRTCPlugin : Plugin() {
             mgr.startLocalVideo(peerId)
         }
         call.resolve()
-    }
-
-    @PermissionCallback
-    private fun micPermissionCallback(call: PluginCall) {
-        if (getPermissionState("microphone") != PermissionState.GRANTED) {
-            Log.w(TAG, "[WebRTCAudio] RECORD_AUDIO denied — cannot start audio")
-            notifyListeners("onAudioError", JSObject().apply {
-                put("type", "permission_denied")
-                put("message", "Microphone permission denied")
-            })
-            call.reject("RECORD_AUDIO permission denied")
-            return
-        }
-        val mgr = manager ?: run { call.reject("Manager not initialized"); return }
-        doStartLocalMedia(call, mgr)
     }
 
     @PluginMethod
@@ -492,6 +488,49 @@ class WebRTCPlugin : Plugin() {
         call.resolve(JSObject().apply {
             put("state", state)
         })
+    }
+
+    /**
+     * Session 02: forward JS pc.restartIce() into native PeerConnection.
+     *
+     * The JS SDK (matrix-js-sdk-bastyon) calls restartIce() on any network
+     * flip (WiFi ↔ cellular), on ICE disconnected, or during glare. With
+     * the old JS no-op this never reached native, so the ICE agent stayed
+     * wedged in a failed state and the call was dropped after ~1-2 seconds.
+     */
+    @PluginMethod
+    fun restartIce(call: PluginCall) {
+        val peerId = call.getString("peerId") ?: run {
+            call.reject("Missing peerId")
+            return
+        }
+        val ok = manager?.restartIce(peerId) ?: false
+        if (ok) call.resolve() else call.reject("restartIce failed (peer not found)")
+    }
+
+    /**
+     * Session 02: return real native WebRTC stats so the JS SDK and our
+     * diagnostics can confirm media is flowing. Previously we returned an
+     * empty Map, which made the SDK believe the peer was silent and made
+     * webrtc-diagnostics raise false ZERO_AUDIO_ALERT on every call.
+     */
+    @PluginMethod
+    fun getStats(call: PluginCall) {
+        val peerId = call.getString("peerId") ?: run {
+            call.reject("Missing peerId")
+            return
+        }
+        val mgr = manager ?: run {
+            call.reject("Manager not initialized")
+            return
+        }
+        mgr.getStats(peerId) { report ->
+            if (report == null) {
+                call.reject("getStats failed (peer not found)")
+            } else {
+                call.resolve(JSObject().apply { put("report", report) })
+            }
+        }
     }
 
     override fun handleOnDestroy() {

--- a/src/entities/matrix/model/matrix-client.ts
+++ b/src/entities/matrix/model/matrix-client.ts
@@ -224,6 +224,19 @@ export class MatrixClientService {
       deviceId: userData.device_id,
       request: this.request.bind(this),
       iceCandidatePoolSize: 20,
+      // Session 02 — explicit public STUN fallback.
+      //
+      // The Matrix homeserver's /turnServer endpoint is unreliable in
+      // restricted regions (rate-limited, sometimes blocked). Without at
+      // least one reachable STUN, ICE gathering produces only host
+      // candidates and any NAT-ed peer can't connect, so the call drops
+      // within 1-2 seconds. We keep fallbackICEServerAllowed so the SDK
+      // still tries turn.matrix.org when the homeserver refuses, but
+      // adding these defaults makes ICE robust even when it doesn't.
+      iceServers: [
+        { urls: "stun:stun.l.google.com:19302" },
+        { urls: "stun:stun1.l.google.com:19302" },
+      ],
       fallbackICEServerAllowed: true,
       disableVoip: false, // ensure WebRTC call handler and Call.incoming are enabled
     };

--- a/src/entities/matrix/model/matrix-client.ts
+++ b/src/entities/matrix/model/matrix-client.ts
@@ -260,7 +260,15 @@ export class MatrixClientService {
       const filterDefinition = {
         room: {
           timeline: {
-            limit: 1,
+            // Was 1, which was way too aggressive: if multiple events
+            // arrived in a room since our last sync token, the server
+            // would return only the most recent — so an m.call.invite
+            // followed by any other event (typing, read receipt promoted
+            // to timeline on some servers, or a retry hangup) would
+            // disappear from our /sync, and the Matrix SDK would never
+            // fire Call.incoming. Raise to 20 so a realistic burst of
+            // new events still fits without losing the call invite.
+            limit: 20,
             lazy_load_members: true,
           },
           state: {
@@ -308,6 +316,65 @@ export class MatrixClientService {
       lazyLoadMembers: true,
       ...(syncFilter ? { filter: syncFilter } : {}),
     });
+
+    // Cold-start-from-push race fix:
+    //
+    // Matrix SDK only calls `callEventHandler.start()` after the first
+    // `/sync` has transitioned to the "Prepared" state. But the very
+    // sync batch that triggers Prepared ALSO contains the m.call.invite
+    // (room-event or to-device) the caller sent while we were killed —
+    // and the handler's Room.timeline / ToDeviceEvent listeners aren't
+    // attached yet when those events fire, so Call.incoming is silently
+    // dropped. On this homeserver that loses 100% of cold-start answers.
+    //
+    // Attaching the listeners eagerly, before the first sync batch fires,
+    // lets the handler catch the invite in the usual way. CRITICAL: we
+    // also have to neutralize the SDK's own startCallEventHandler so it
+    // doesn't later call start() a second time. start() re-registers
+    // `Room.timeline`/`ToDeviceEvent` listeners on the client's
+    // EventEmitter — double-registration makes every call event fire
+    // handleCallEvent twice, which Matrix logs as "already has a call
+    // but got an invite - clobbering" and destroys the freshly-created
+    // call, orphaning our already-created PeerConnection. The second
+    // call waits for an answer that goes to the first PC → ICE never
+    // reaches connected, user stares at "Connecting..." forever.
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const uc = userClient as any;
+      const ceh = uc.callEventHandler;
+      const gceh = uc.groupCallEventHandler;
+
+      // STEP 1: unregister SDK's built-in lazy starter. It's a Sync-
+      // event listener that fires once `isInitialSyncComplete()` is
+      // true, and invokes `callEventHandler.start()` again. Re-assigning
+      // `uc.startCallEventHandler = ...` does NOT unregister it because
+      // EventEmitter stored the original function reference. We must
+      // `.off(...)` with that reference before overriding.
+      const sdkStartRef = uc.startCallEventHandler;
+      if (typeof sdkStartRef === "function" && typeof uc.off === "function") {
+        try {
+          uc.off("sync", sdkStartRef);
+        } catch {
+          /* ignore */
+        }
+      }
+
+      // STEP 2: eagerly start so the handler's Room.timeline and
+      // ToDeviceEvent listeners are attached before the very first
+      // sync batch begins dispatching events. Without this, the
+      // m.call.invite arriving in the initial-sync delivery is never
+      // caught and Call.incoming never fires.
+      if (ceh && typeof ceh.start === "function") ceh.start();
+      if (gceh && typeof gceh.start === "function") gceh.start();
+
+      // STEP 3: replace starter with no-op as a belt-and-braces guard
+      // in case the SDK or any extension calls it by reference later.
+      uc.startCallEventHandler = () => {};
+
+      console.log("[matrix-client] CallEventHandler started eagerly, SDK auto-start unregistered");
+    } catch (e) {
+      console.warn("[matrix-client] Failed to eagerly start CallEventHandler:", e);
+    }
 
     return userClient;
   }

--- a/src/features/video-calls/model/call-service.ts
+++ b/src/features/video-calls/model/call-service.ts
@@ -13,7 +13,11 @@ import { isNative } from "@/shared/lib/platform";
 import { useBugReport } from "@/features/bug-report";
 import { tRaw } from "@/shared/lib/i18n";
 import { installNativeWebRTCProxy, NativeWebRTC } from "@/shared/lib/native-webrtc";
-import { nativeCallBridge } from "@/shared/lib/native-calls";
+import {
+  nativeCallBridge,
+  consumePendingAnswerCallId,
+  consumePendingRejectCallId,
+} from "@/shared/lib/native-calls";
 
 // Install native WebRTC proxy on mobile — must run before any call is placed.
 // This replaces window.RTCPeerConnection so that the Matrix SDK transparently
@@ -232,6 +236,19 @@ function wireCallEvents(call: MatrixCall, direction: "outgoing" | "incoming") {
   const onHangup = (() => {
     stopAllSounds();
     clearIncomingTimeout();
+    // Also tear down the native surface. Without this, when the remote
+    // cancels a call we never answered, or when another of our devices
+    // picks up (m.call.select_answer), the SDK fires Hangup but the
+    // native IncomingCallActivity + shade notification stay up forever.
+    // onState → ended eventually does the same cleanup, but we can't
+    // rely on it: the SDK sometimes fires Hangup before State transitions
+    // for rejected-while-ringing cases.
+    if (isNative) {
+      import('@/shared/lib/native-calls').then(({ nativeCallBridge }) => {
+        nativeCallBridge.reportCallEnded(call.callId);
+      }).catch(() => {});
+      NativeWebRTC.dismissCallUI().catch(() => {});
+    }
   }) as CallEventHandlerMap[CallEvent.Hangup];
 
   const onError = ((error: unknown) => {
@@ -276,8 +293,15 @@ function wireCallEvents(call: MatrixCall, direction: "outgoing" | "incoming") {
   call.on(CallEvent.Hangup, onHangup);
   call.on(CallEvent.Error, onError);
 
-  // Attach WebRTC diagnostics (getStats polling, ICE/audio monitoring)
+  // Attach WebRTC diagnostics (getStats polling, ICE/audio monitoring).
+  // We may be invoked from BOTH the SDK's PeerConnectionCreated event
+  // AND the polling fallback below — on Bastyon's matrix-js-sdk fork the
+  // event often fires but the polling fires too for the same pc within
+  // ~300ms. Mark the pc on first attach so path 2 is skipped. The
+  // webrtcDiagnostics module itself also guards against double-wrap.
   const onPeerConnectionCreated = (pc: RTCPeerConnection) => {
+    if ((pc as unknown as Record<string, unknown>).__callServiceDiagAttached) return;
+    (pc as unknown as Record<string, unknown>).__callServiceDiagAttached = true;
     webrtcDiagnostics.attach(pc);
   };
   if (typeof (call as any).on === "function" && (CallEvent as any).PeerConnectionCreated) {
@@ -287,7 +311,6 @@ function wireCallEvents(call: MatrixCall, direction: "outgoing" | "incoming") {
   const pcCheck = setInterval(() => {
     const pc: RTCPeerConnection | undefined = (call as any).peerConn;
     if (pc && !(pc as any).__callServiceDiagAttached) {
-      (pc as any).__callServiceDiagAttached = true;
       clearInterval(pcCheck);
       onPeerConnectionCreated(pc);
     }
@@ -524,7 +547,38 @@ export function useCallService() {
   }
 
   async function handleIncomingCall(matrixCall: MatrixCall) {
+    console.log(
+      "[call-service] handleIncomingCall: callId=" + matrixCall.callId +
+      ", roomId=" + matrixCall.roomId +
+      ", type=" + matrixCall.type,
+    );
+
+    // Check FIRST whether the user already declined this call in the
+    // native ringer (before JS was running). If so, send the rejection
+    // straight back to Matrix so the caller actually stops ringing.
+    // Must come before the Pre-accepted check so an accidental double-
+    // marker state can't accept a call the user rejected.
+    if (isNative) {
+      const alreadyRejected = await consumePendingRejectCallId(
+        matrixCall.callId,
+        matrixCall.roomId,
+      );
+      if (alreadyRejected) {
+        console.log(
+          "[call-service] Pre-rejected incoming call, calling reject():",
+          matrixCall.callId,
+        );
+        try {
+          matrixCall.reject();
+        } catch (e) {
+          console.error("[call-service] matrixCall.reject() failed:", e);
+        }
+        return;
+      }
+    }
+
     if (callStore.isInCall) {
+      console.log("[call-service] handleIncomingCall: already in call, rejecting");
       matrixCall.reject();
       return;
     }
@@ -555,22 +609,64 @@ export function useCallService() {
       endedAt: null,
     };
 
-    callStore.setActiveCall(callInfo);
     callStore.setMatrixCall(matrixCall);
     callStore.videoMuted = !isVideo;
     wireCallEvents(matrixCall, "incoming");
 
-    // On native: show system call UI via ConnectionService
+    // Fast-path: the user already tapped Answer on the FCM/push ringer
+    // before Matrix even delivered this invite. Don't re-show our own
+    // incoming UI (the native ringer would fire a second time and the
+    // user sees a confusing "another ring" after the app opens). Skip
+    // straight to answering — this is the path that matches what
+    // WhatsApp/Telegram do: one tap on Answer transitions the surface
+    // directly to the in-call screen.
+    const alreadyAccepted = isNative && (await consumePendingAnswerCallId(matrixCall.callId, matrixCall.roomId));
+    if (alreadyAccepted) {
+      console.log("[call-service] Pre-accepted incoming call, skipping ringer:", matrixCall.callId);
+      // Seed activeCall with incoming status so answerCall() sees the
+      // right state and the UI has something to bind to. Do NOT pre-set
+      // status=connecting here: answerCall has a guard that bails out
+      // when it sees a connecting/connected status, assuming another
+      // code path already drove the answer. That guard is correct for
+      // duplicate-answer races but would cause this intentional fast
+      // path to silently skip the actual SDK answer, leaving the
+      // caller stuck on "connecting…" forever.
+      callStore.setActiveCall(callInfo);
+      // Launch the native in-call surface right away. The native
+      // CallActivity covers the Vue UI, so the user doesn't see the
+      // incoming-ring screen flash through before answerCall() sets
+      // status=connecting a moment later.
+      NativeWebRTC.launchCallUI({
+        callerName: peerName,
+        callType: callInfo.type,
+        callId: matrixCall.callId,
+        direction: "incoming",
+      }).catch((e) => console.error("[call-service] launchCallUI failed:", e));
+      // Immediately drive the SDK answer flow. This mirrors what the
+      // normal user-presses-Answer path does, minus the native ringer
+      // detour that we've already satisfied via the push accept.
+      void answerCall();
+      return;
+    }
+
+    // Normal incoming flow — not pre-accepted.
+    //
+    // On native: the FCM push handler already showed IncomingCallActivity
+    // — that's the ONLY ringer the user should see. Do NOT set the Vue
+    // activeCall state to `incoming` here because the Vue UI binds to
+    // activeCall and would render a SECOND, web-based ringer on top of
+    // the native one. We also skip reportIncomingCall, which would just
+    // ask Telecom to open yet another incoming call surface. The user's
+    // accept/decline from the native ringer will route through
+    // CallConnection's callbacks and drive rejectCall() / answerCall()
+    // from the existing bridge listeners.
+    //
+    // On web: render the Vue incoming ringer and play our ringtone.
     if (isNative) {
-      import('@/shared/lib/native-calls').then(({ nativeCallBridge }) => {
-        nativeCallBridge.reportIncomingCall({
-          callId: matrixCall.callId,
-          callerName: peerName,
-          roomId: matrixCall.roomId,
-          hasVideo: isVideo,
-        });
-      }).catch((e) => console.error('[call-service] native call bridge error:', e));
+      // activeCall stays cleared so no Vue ringer. matrixCall is set
+      // above so rejectCall()/answerCall() can find it.
     } else {
+      callStore.setActiveCall(callInfo);
       playRingtone();
     }
 
@@ -578,7 +674,10 @@ export function useCallService() {
     clearIncomingTimeout();
     incomingTimeoutId = setTimeout(() => {
       incomingTimeoutId = null;
-      if (callStore.activeCall?.status === CallStatus.incoming) {
+      if (
+        callStore.activeCall?.status === CallStatus.incoming ||
+        (isNative && callStore.matrixCall === matrixCall)
+      ) {
         rejectCall();
       }
     }, 30_000);
@@ -586,7 +685,22 @@ export function useCallService() {
 
   async function answerCall() {
     const call = callStore.matrixCall as MatrixCall | null;
-    if (!call) return;
+    if (!call) {
+      console.warn("[call-service] answerCall: no matrixCall, bailing");
+      return;
+    }
+    console.log("[call-service] answerCall: begin, callId=" + call.callId);
+
+    // Guard against duplicate invocations. We intentionally allow
+    // multiple answerCall() call sites (user tap in UI, native accept
+    // event, pre-accepted push path, wait-for-matrix poll) because any
+    // of them can realistically fire first, but all of them pass
+    // through this check so only the first one actually answers.
+    const currentStatus = callStore.activeCall?.status;
+    if (currentStatus === CallStatus.connecting || currentStatus === CallStatus.connected) {
+      console.log("[call-service] answerCall: already " + currentStatus + ", guard bails");
+      return;
+    }
 
     clearIncomingTimeout();
     stopAllSounds();
@@ -594,7 +708,9 @@ export function useCallService() {
     // D-01: JS-side permission check before answering
     if (isNative) {
       try {
+        console.log("[call-service] answerCall: requesting audio permission");
         const { granted } = await nativeCallBridge.requestAudioPermission();
+        console.log("[call-service] answerCall: permission granted=" + granted);
         if (!granted) {
           callStore.updateStatus(CallStatus.failed);
           callStore.scheduleClearCall(1500);
@@ -627,7 +743,9 @@ export function useCallService() {
     }
 
     try {
+      console.log("[call-service] answerCall: calling SDK call.answer(true, " + isVideo + ")");
       await call.answer(true, isVideo);
+      console.log("[call-service] answerCall: SDK call.answer resolved");
     } catch (e) {
       console.error("[call-service] Failed to answer call:", e);
       useBugReport().open({ context: tRaw("bugReport.ctx.answerCall"), error: e });

--- a/src/features/video-calls/model/webrtc-diagnostics.ts
+++ b/src/features/video-calls/model/webrtc-diagnostics.ts
@@ -39,13 +39,22 @@ class WebRTCDiagnostics {
   private zeroRecvStreak = 0;
   private iceCandidatesLog: string[] = [];
 
-  // Save original handlers to chain them
-  private origIceHandler: ((ev: Event) => void) | null = null;
-  private origSigHandler: ((ev: Event) => void) | null = null;
-  private origConnHandler: ((ev: Event) => void) | null = null;
-  private origIceCandHandler: ((ev: RTCPeerConnectionIceEvent) => void) | null = null;
+  // Marker placed on a PC we've already wrapped, so a second attach on
+  // the same pc is a no-op. Without this, and with our handlers stored
+  // on the singleton via `this.origXxx`, a second attach turned a
+  // harmless "log wrapper" into an infinite chain because wrapper_A's
+  // `this.origSigHandler` got reassigned to wrapper_A itself on the
+  // second attach → stack overflow on the first signalingstatechange,
+  // ~7800 logs/s, blocks JS thread, call drops after 1-2s.
+  private readonly ATTACHED_FLAG = "__webrtcDiagAttached";
 
   attach(pc: RTCPeerConnection): void {
+    if ((pc as unknown as Record<string, unknown>)[this.ATTACHED_FLAG]) {
+      // Already wrapped this PC — a second attach would compound wrappers
+      // and (worse) share state via `this` across them.
+      console.warn("[WebRTC-Diag] attach(): PC already wrapped, skipping duplicate");
+      return;
+    }
     this.detach();
     this.pc = pc;
     this.entries = [];
@@ -55,27 +64,31 @@ class WebRTCDiagnostics {
     this.zeroRecvStreak = 0;
     this.iceCandidatesLog = [];
 
-    // Chain state-change handlers
-    this.origIceHandler = pc.oniceconnectionstatechange as ((ev: Event) => void) | null;
+    // Capture each original handler in a LOCAL CLOSURE variable rather
+    // than `this.origXxx`. Closure-binding the original means wrapper
+    // identity and its tail-call target are fixed at wrap time, so a
+    // later `attach()` on a different PC cannot mutate what an earlier
+    // wrapper forwards to.
+    const origIce = pc.oniceconnectionstatechange;
     pc.oniceconnectionstatechange = (ev: Event) => {
       console.warn(`[WebRTC-Diag] ICE connection: ${pc.iceConnectionState}`);
-      this.origIceHandler?.call(pc, ev);
+      origIce?.call(pc, ev);
     };
 
-    this.origSigHandler = pc.onsignalingstatechange as ((ev: Event) => void) | null;
+    const origSig = pc.onsignalingstatechange;
     pc.onsignalingstatechange = (ev: Event) => {
       console.warn(`[WebRTC-Diag] Signaling: ${pc.signalingState}`);
-      this.origSigHandler?.call(pc, ev);
+      origSig?.call(pc, ev);
     };
 
-    this.origConnHandler = pc.onconnectionstatechange as ((ev: Event) => void) | null;
+    const origConn = pc.onconnectionstatechange;
     pc.onconnectionstatechange = (ev: Event) => {
       console.warn(`[WebRTC-Diag] Connection: ${pc.connectionState}`);
-      this.origConnHandler?.call(pc, ev);
+      origConn?.call(pc, ev);
     };
 
     // Log ICE candidates with type info
-    this.origIceCandHandler = pc.onicecandidate as ((ev: RTCPeerConnectionIceEvent) => void) | null;
+    const origCand = pc.onicecandidate;
     pc.onicecandidate = (ev: RTCPeerConnectionIceEvent) => {
       if (ev.candidate) {
         const c = ev.candidate;
@@ -83,9 +96,10 @@ class WebRTCDiagnostics {
         this.iceCandidatesLog.push(info);
         console.warn(`[WebRTC-Diag] ICE candidate: ${info}`);
       }
-      this.origIceCandHandler?.call(pc, ev);
+      origCand?.call(pc, ev);
     };
 
+    (pc as unknown as Record<string, unknown>)[this.ATTACHED_FLAG] = true;
     this.pollTimer = setInterval(() => this.poll(), POLL_INTERVAL_MS);
     console.warn("[WebRTC-Diag] Attached, polling every 3s");
   }
@@ -95,11 +109,12 @@ class WebRTCDiagnostics {
       clearInterval(this.pollTimer);
       this.pollTimer = null;
     }
+    // We intentionally do NOT restore pc.onXxx to the pre-attach value:
+    // the wrappers capture the original via closure, so forwarding to
+    // the SDK continues to work even after `detach()` wipes the
+    // singleton's `this.pc`. Leaving them in place also avoids a race
+    // where an in-flight event dispatch hits a torn-down handler graph.
     this.pc = null;
-    this.origIceHandler = null;
-    this.origSigHandler = null;
-    this.origConnHandler = null;
-    this.origIceCandHandler = null;
   }
 
   getReport(): { entries: DiagnosticEntry[]; summary: string } {

--- a/src/shared/lib/native-calls/index.ts
+++ b/src/shared/lib/native-calls/index.ts
@@ -1,1 +1,5 @@
-export { nativeCallBridge } from './native-call-bridge';
+export {
+  nativeCallBridge,
+  consumePendingAnswerCallId,
+  consumePendingRejectCallId,
+} from './native-call-bridge';

--- a/src/shared/lib/native-calls/native-call-bridge.ts
+++ b/src/shared/lib/native-calls/native-call-bridge.ts
@@ -9,8 +9,19 @@ interface NativeCallNativePlugin {
     roomId: string;
     hasVideo: boolean;
   }): Promise<void>;
-  /** Check if user tapped Answer before JS was ready */
-  getPendingAnswer(): Promise<{ callId: string | null }>;
+  /**
+   * Check if user tapped Answer before JS was ready.
+   * Returns the push-side call_id AND the room_id, because the push
+   * payload's call_id is often the event_id (not Matrix's content.
+   * call_id), so room is the reliable correlation key.
+   */
+  getPendingAnswer(): Promise<{ callId: string | null; roomId: string | null }>;
+  /**
+   * Check if user tapped Decline before JS was ready. Symmetric to
+   * getPendingAnswer — JS consumer calls matrixCall.reject() when the
+   * SDK later delivers the invite so the caller stops ringing.
+   */
+  getPendingReject(): Promise<{ callId: string | null; roomId: string | null }>;
   reportOutgoingCall(options: {
     callId: string;
     callerName: string;
@@ -26,7 +37,7 @@ interface NativeCallNativePlugin {
   setAudioDevice(options: { type: string }): Promise<void>;
   startAudioRouting(options: { callType: string }): Promise<void>;
   stopAudioRouting(): Promise<void>;
-  addListener(event: 'callAnswered', cb: (data: { callId: string }) => void): Promise<{ remove: () => void }>;
+  addListener(event: 'callAnswered', cb: (data: { callId: string; roomId?: string }) => void): Promise<{ remove: () => void }>;
   addListener(event: 'callDeclined', cb: (data: { callId: string }) => void): Promise<{ remove: () => void }>;
   addListener(event: 'callEnded', cb: (data: { callId: string }) => void): Promise<{ remove: () => void }>;
   addListener(event: 'audioDevicesChanged', cb: (data: {
@@ -36,6 +47,108 @@ interface NativeCallNativePlugin {
 }
 
 const NativeCall = registerPlugin<NativeCallNativePlugin>('NativeCall');
+
+/**
+ * What the user tapped "Answer" on natively — via push ringer
+ * (`getPendingAnswer`) or live `callAnswered` event. Consumed by
+ * call-service.handleIncomingCall to suppress the duplicate-ring.
+ *
+ * Two markers because the push-side `call_id` is often just the push
+ * event_id on this homeserver, which does NOT match the Matrix SDK's
+ * `call.callId`. We fall through to `roomId` for reliable correlation:
+ * if the user tapped Answer on ANY incoming ringer for room R, then
+ * the first MatrixCall we receive for room R is the one they accepted.
+ */
+let pendingAnswerCallId: string | null = null;
+let pendingAnswerRoomId: string | null = null;
+
+/**
+ * Decide whether the given Matrix call is the one the user already
+ * accepted via the native ringer, and consume the marker on match.
+ *
+ * Match order:
+ *   1. exact callId equality (works when the push carries the real
+ *      Matrix content.call_id)
+ *   2. roomId equality (fallback — our homeserver's push payloads
+ *      don't include the Matrix call_id, but they do include room_id)
+ *
+ * Falls back to querying native directly when the in-memory markers
+ * aren't set yet: on cold-start-from-push the Matrix SDK frequently
+ * fires Call.incoming BEFORE `nativeCallBridge.wire()` has had a chance
+ * to run `NativeCall.getPendingAnswer()` and seed the module state.
+ *
+ * Calling `NativeCall.getPendingAnswer` clears native state on read,
+ * so this function "steals" the pending answer from the wire() path.
+ * That's intentional — wire()'s waitForMatrixCall will see answerCall()
+ * already in-flight (via its status guard) and no-op.
+ */
+export async function consumePendingAnswerCallId(
+  callId: string,
+  roomId?: string,
+): Promise<boolean> {
+  const matchAndClear = (mCall: string | null, mRoom: string | null): boolean => {
+    if (mCall && mCall === callId) {
+      pendingAnswerCallId = null;
+      pendingAnswerRoomId = null;
+      return true;
+    }
+    if (mRoom && roomId && mRoom === roomId) {
+      pendingAnswerCallId = null;
+      pendingAnswerRoomId = null;
+      return true;
+    }
+    return false;
+  };
+
+  if (matchAndClear(pendingAnswerCallId, pendingAnswerRoomId)) return true;
+  if (!isNative) return false;
+  try {
+    const { callId: nativeCall, roomId: nativeRoom } = await NativeCall.getPendingAnswer();
+    if (matchAndClear(nativeCall ?? null, nativeRoom ?? null)) return true;
+  } catch (e) {
+    console.warn('[NativeCallBridge] consumePendingAnswerCallId peek failed:', e);
+  }
+  return false;
+}
+
+/**
+ * Symmetric to pendingAnswerCallId/RoomId but for the Decline path.
+ * Populated from CallConnection.onReject in Kotlin when the user taps
+ * Decline in the native ringer, consumed by handleIncomingCall so the
+ * matrixCall can be rejected back to Matrix (the caller otherwise keeps
+ * ringing until their lifetime timeout).
+ */
+let pendingRejectCallId: string | null = null;
+let pendingRejectRoomId: string | null = null;
+
+export async function consumePendingRejectCallId(
+  callId: string,
+  roomId?: string,
+): Promise<boolean> {
+  const matchAndClear = (mCall: string | null, mRoom: string | null): boolean => {
+    if (mCall && mCall === callId) {
+      pendingRejectCallId = null;
+      pendingRejectRoomId = null;
+      return true;
+    }
+    if (mRoom && roomId && mRoom === roomId) {
+      pendingRejectCallId = null;
+      pendingRejectRoomId = null;
+      return true;
+    }
+    return false;
+  };
+
+  if (matchAndClear(pendingRejectCallId, pendingRejectRoomId)) return true;
+  if (!isNative) return false;
+  try {
+    const { callId: nativeCall, roomId: nativeRoom } = await NativeCall.getPendingReject();
+    if (matchAndClear(nativeCall ?? null, nativeRoom ?? null)) return true;
+  } catch (e) {
+    console.warn('[NativeCallBridge] consumePendingRejectCallId peek failed:', e);
+  }
+  return false;
+}
 
 class NativeCallBridge {
   private callService: any = null;
@@ -51,9 +164,17 @@ class NativeCallBridge {
       console.warn('[NativeCallBridge] requestAudioPermission failed:', e);
     }
 
-    await NativeCall.addListener('callAnswered', ({ callId }) => {
-      console.log('[NativeCallBridge] Call answered:', callId);
-      this.callService?.answerCall();
+    await NativeCall.addListener('callAnswered', ({ callId, roomId }) => {
+      console.log('[NativeCallBridge] Call answered:', callId, 'room:', roomId);
+      // Record the accept so handleIncomingCall on the JS side knows
+      // to skip the duplicate-ring path and go straight to answered.
+      // BOTH callId and roomId are needed because on this homeserver
+      // the push payload's call_id is actually the event_id — it will
+      // NEVER match the Matrix SDK's call.callId. The roomId fallback
+      // is how we correlate the pending accept with the MatrixCall.
+      pendingAnswerCallId = callId;
+      if (roomId) pendingAnswerRoomId = roomId;
+      this.waitForMatrixCallAndAnswer(callId, roomId);
     });
 
     await NativeCall.addListener('callDeclined', ({ callId }) => {
@@ -66,15 +187,51 @@ class NativeCallBridge {
       this.callService?.hangup();
     });
 
-    // Replay queued answer if user tapped Answer before JS was ready
+    // Replay queued answer if user tapped Answer before JS was ready.
+    //
+    // Cold-start-from-push flow:
+    //   1. Push wakes the OS, shows IncomingCallActivity via FCM service.
+    //   2. User taps Answer while the JS app is still not running.
+    //   3. Android spawns our process → Matrix client begins init + /sync.
+    //   4. This wire() call runs and asks native for the queued callId.
+    //
+    // `callService.answerCall()` reads `callStore.matrixCall`. But the
+    // Matrix SDK has only just started syncing — the m.call.invite for
+    // this callId probably hasn't been parsed yet, so matrixCall is null
+    // and answerCall() silently returns. Result: caller sees "connecting…"
+    // forever, we hand up to chat list.
+    //
+    // Wait up to 30s for the SDK to deliver the invite; as soon as
+    // matrixCall.callId matches the queued id, fire answerCall(). If
+    // it never matches we just bail out — the auto-reject-after-30s
+    // logic on the other side will take care of the caller's UI.
     try {
-      const { callId: pendingCallId } = await NativeCall.getPendingAnswer();
+      const { callId: pendingCallId, roomId: pendingRoomId } = await NativeCall.getPendingAnswer();
       if (pendingCallId) {
-        console.log('[NativeCallBridge] Replaying pending answer:', pendingCallId);
-        this.callService?.answerCall();
+        console.log('[NativeCallBridge] Pending answer queued, waiting for matrixCall:', pendingCallId, 'room:', pendingRoomId);
+        pendingAnswerCallId = pendingCallId;
+        if (pendingRoomId) pendingAnswerRoomId = pendingRoomId;
+        this.waitForMatrixCallAndAnswer(pendingCallId, pendingRoomId ?? undefined);
       }
     } catch (e) {
       console.warn('[NativeCallBridge] getPendingAnswer failed:', e);
+    }
+
+    // Same pattern for Decline path. If the user tapped Decline in the
+    // native ringer before the JS app was running, the rejection never
+    // got sent to Matrix. Seed the module-level reject markers from
+    // native so handleIncomingCall (which runs as soon as Matrix
+    // delivers the invite via /sync) can call matrixCall.reject() and
+    // the caller stops ringing.
+    try {
+      const { callId: rejectCallId, roomId: rejectRoomId } = await NativeCall.getPendingReject();
+      if (rejectCallId || rejectRoomId) {
+        console.log('[NativeCallBridge] Pending reject queued:', rejectCallId, 'room:', rejectRoomId);
+        pendingRejectCallId = rejectCallId;
+        pendingRejectRoomId = rejectRoomId;
+      }
+    } catch (e) {
+      console.warn('[NativeCallBridge] getPendingReject failed:', e);
     }
 
     // Native CallActivity hangup button → proper SDK hangup
@@ -88,6 +245,160 @@ class NativeCallBridge {
       console.log('[NativeCallBridge] Native video toggle:', enabled);
       this.callService?.setLocalVideoMuted(!enabled);
     });
+  }
+
+  /**
+   * Poll callStore.matrixCall until it matches the given callId, then
+   * fire answerCall(). Used for the cold-start-from-push flow where the
+   * native side has a queued answer but Matrix SDK hasn't delivered the
+   * invite event yet.
+   *
+   * Uses dynamic import for the store so we don't pull the Pinia graph
+   * into the native-call-bridge module boundary. Times out at 30s — the
+   * Matrix side will auto-reject if we never answer.
+   *
+   * Besides polling, each tick also actively scans the Matrix SDK's
+   * rooms for the pending m.call.invite: the SDK's CallEventHandler is
+   * only started after initial-sync completes, so events that arrive in
+   * the very first /sync batch (the one that triggers Prepared state)
+   * land in the room timeline but never reach the handler's buffer —
+   * Call.incoming is silently skipped. On cold-start-from-push this
+   * loses 100% of the time because the invite IS in the first sync
+   * batch. The recovery pass below feeds the missed event straight
+   * into the handler so it re-emits Call.incoming and our normal
+   * onIncomingCall → handleIncomingCall path kicks in.
+   */
+  private waitForMatrixCallAndAnswer(callId: string, roomId?: string): void {
+    const MAX_WAIT_MS = 30_000;
+    const POLL_MS = 300;
+    // Don't even attempt the invite-recovery scan for the first
+    // RECOVERY_GRACE_MS — in the common case the SDK already has the
+    // call mid-processing when we start polling. Feeding the same
+    // invite again while SDK is still inside chooseOpponent/
+    // initWithInvite makes the SDK log "already has a call - clobbering"
+    // and it tears the MatrixCall down before ICE can connect. We only
+    // need recovery when Matrix truly missed the event (race with the
+    // initial-sync state in CallEventHandler.start), which manifests
+    // as matrixCall staying null past the grace window.
+    const RECOVERY_GRACE_MS = 2000;
+    const deadline = Date.now() + MAX_WAIT_MS;
+    const startTime = Date.now();
+    let recoveryAttempted = false;
+
+    const tick = async (): Promise<void> => {
+      try {
+        const { useCallStore } = await import('@/entities/call');
+        const store = useCallStore();
+        const current = store.matrixCall as
+          | { callId?: string; roomId?: string }
+          | null;
+        // Match by callId (tight) OR by roomId (fallback). On our
+        // homeserver the push-side id doesn't equal Matrix's call.callId
+        // (it's an event_id), so roomId is the reliable correlator.
+        const matchById = !!current?.callId && current.callId === callId;
+        const matchByRoom =
+          !!roomId && !!current?.roomId && current.roomId === roomId;
+        if (current && (matchById || matchByRoom)) {
+          console.log(
+            '[NativeCallBridge] matrixCall ready, answering (matchById=' +
+              matchById + ', matchByRoom=' + matchByRoom + '):',
+            current.callId,
+          );
+          this.callService?.answerCall();
+          return;
+        }
+
+        // Recovery pass — only after the grace window, and only if
+        // the SDK really doesn't have this call yet. We double-check
+        // via the SDK's own registry because the store can be a tick
+        // behind handleIncomingCall.
+        if (!recoveryAttempted && (Date.now() - startTime) >= RECOVERY_GRACE_MS) {
+          const sdkAlreadyHasCall = await this.sdkHasCall(callId);
+          if (!sdkAlreadyHasCall) {
+            const recovered = await this.feedMissedInviteToSDK(callId);
+            if (recovered) {
+              recoveryAttempted = true;
+              console.log('[NativeCallBridge] Fed missed invite back to SDK:', callId);
+            }
+          } else {
+            // SDK is handling the call, just waiting for store to update.
+            recoveryAttempted = true;
+          }
+        }
+      } catch (e) {
+        console.warn('[NativeCallBridge] waitForMatrixCall tick failed:', e);
+      }
+      if (Date.now() >= deadline) {
+        console.warn('[NativeCallBridge] Timed out waiting for matrixCall:', callId);
+        return;
+      }
+      setTimeout(tick, POLL_MS);
+    };
+
+    setTimeout(tick, POLL_MS);
+  }
+
+  /**
+   * Walk every room's timeline looking for the m.call.invite with the
+   * given call_id. If found, push it into the SDK's CallEventHandler
+   * buffer and manually trigger its sync processor so Call.incoming
+   * fires. Returns true when an invite was located (regardless of
+   * whether the SDK ultimately accepts it — answer/hangup may have
+   * been buffered alongside it and the handler will filter it out).
+   *
+   * Uses the SDK's internal `callEventHandler` property. It's not
+   * exported from the public type, but the Bastyon fork exposes it on
+   * the client instance, same as upstream.
+   */
+  /**
+   * Probe Matrix SDK for an existing MatrixCall with the given callId.
+   * Prevents the recovery path from clobbering an in-flight call:
+   * when the SDK is mid-processing (chooseOpponent → initWithInvite),
+   * the store hasn't been updated yet but the call DOES exist inside
+   * the SDK's internal `calls` map.
+   */
+  private async sdkHasCall(callId: string): Promise<boolean> {
+    try {
+      const { getMatrixClientService } = await import('@/entities/matrix');
+      const client = getMatrixClientService().client as
+        | { callEventHandler?: { calls?: Map<string, unknown> } }
+        | undefined;
+      const calls = client?.callEventHandler?.calls;
+      if (calls && typeof calls.has === 'function') {
+        return calls.has(callId);
+      }
+    } catch {
+      // ignore
+    }
+    return false;
+  }
+
+  private async feedMissedInviteToSDK(callId: string): Promise<boolean> {
+    try {
+      const { getMatrixClientService } = await import('@/entities/matrix');
+      const client = getMatrixClientService().client as
+        | { callEventHandler?: { onRoomTimeline: (e: unknown) => void; onSync: () => void }; getRooms?: () => Array<{ getLiveTimeline?: () => { getEvents?: () => Array<{ getType: () => string; getContent: () => Record<string, unknown> }> } }> }
+        | undefined;
+      if (!client?.callEventHandler || !client.getRooms) return false;
+
+      for (const room of client.getRooms()) {
+        const events = room.getLiveTimeline?.()?.getEvents?.() ?? [];
+        for (const event of events) {
+          const type = event.getType();
+          if (type !== 'm.call.invite' && !type.startsWith('org.matrix.call.')) continue;
+          const content = event.getContent();
+          if ((content as { call_id?: string }).call_id !== callId) continue;
+          // Push into the handler's buffer and force it to process.
+          client.callEventHandler.onRoomTimeline(event);
+          client.callEventHandler.onSync();
+          return true;
+        }
+      }
+      return false;
+    } catch (e) {
+      console.warn('[NativeCallBridge] feedMissedInviteToSDK failed:', e);
+      return false;
+    }
   }
 
   async reportIncomingCall(options: {

--- a/src/shared/lib/native-webrtc/native-webrtc-bridge.ts
+++ b/src/shared/lib/native-webrtc/native-webrtc-bridge.ts
@@ -50,6 +50,24 @@ export interface NativeWebRTCPlugin {
   closePeerConnection(options: { peerId: string }): Promise<void>;
   getConnectionState(options: { peerId: string }): Promise<{ state: string }>;
 
+  // ICE restart — perform a native ICE restart on the given PeerConnection.
+  // The JS SDK calls `pc.restartIce()` on network flips (WiFi ↔ cellular),
+  // on ICE disconnected/failed, or during glare resolution. Previously this
+  // was a JS no-op and native never received the signal, so calls dropped
+  // permanently on any jitter. Now this path is wired through to
+  // PeerConnection.restartIce() (API 28+) with a createOffer({IceRestart:true})
+  // fallback on older Android.
+  restartIce(options: { peerId: string }): Promise<void>;
+
+  // Return native WebRTC stats for this PeerConnection as a flat map of
+  // stats-object-id → stats object. Consumed by the SDK's diagnostics and
+  // by our own webrtc-diagnostics to detect zero-audio / zero-video.
+  // Previously returned an empty Map unconditionally, causing false
+  // ZERO_AUDIO_ALERT and preventing the SDK from confirming media flow.
+  getStats(options: { peerId: string }): Promise<{
+    report: Record<string, Record<string, unknown>>;
+  }>;
+
   // Remote video state
   updateRemoteVideoState(options: { muted: boolean }): Promise<void>;
 

--- a/src/shared/lib/native-webrtc/rtc-peer-connection-proxy.test.ts
+++ b/src/shared/lib/native-webrtc/rtc-peer-connection-proxy.test.ts
@@ -67,6 +67,61 @@ describe("NativeRTCPeerConnection proxy", () => {
     uninstallNativeWebRTCProxy();
   });
 
+  describe("STUN fallback injection", () => {
+    it("injects default Google STUN when config provides no iceServers", async () => {
+      const pc = new window.RTCPeerConnection();
+      await tick();
+      await tick();
+
+      const createPc = getBridgeMethod("createPeerConnection");
+      expect(createPc).toHaveBeenCalledOnce();
+      const arg = createPc.mock.calls[0]?.[0] as
+        | { iceServers?: Array<{ urls: string | string[] }> }
+        | undefined;
+      const urls = (arg?.iceServers ?? [])
+        .flatMap((s) => (Array.isArray(s.urls) ? s.urls : [s.urls]));
+      expect(urls.some((u) => /^stun:stun\.l\.google\.com/.test(u))).toBe(true);
+
+      pc.close();
+    });
+
+    it("injects default STUN when iceServers is an empty array", async () => {
+      const pc = new window.RTCPeerConnection({ iceServers: [] });
+      await tick();
+      await tick();
+
+      const createPc = getBridgeMethod("createPeerConnection");
+      const arg = createPc.mock.calls[0]?.[0] as
+        | { iceServers?: Array<{ urls: string | string[] }> }
+        | undefined;
+      expect((arg?.iceServers ?? []).length).toBeGreaterThan(0);
+
+      pc.close();
+    });
+
+    it("preserves caller-provided STUN/TURN and does not inject fallback", async () => {
+      const pc = new window.RTCPeerConnection({
+        iceServers: [
+          { urls: "turn:my-turn.example.com:3478", username: "u", credential: "p" },
+        ],
+      });
+      await tick();
+      await tick();
+
+      const createPc = getBridgeMethod("createPeerConnection");
+      const arg = createPc.mock.calls[0]?.[0] as
+        | { iceServers?: Array<{ urls: string | string[]; username?: string }> }
+        | undefined;
+      const servers = arg?.iceServers ?? [];
+      // Caller server preserved, no google fallback appended.
+      expect(servers).toHaveLength(1);
+      expect(servers[0].urls).toBe("turn:my-turn.example.com:3478");
+      expect(servers[0].username).toBe("u");
+
+      pc.close();
+    });
+  });
+
   describe("restartIce()", () => {
     it("calls NativeWebRTC.restartIce on the native bridge, not a no-op", async () => {
       const pc = new window.RTCPeerConnection();

--- a/src/shared/lib/native-webrtc/rtc-peer-connection-proxy.test.ts
+++ b/src/shared/lib/native-webrtc/rtc-peer-connection-proxy.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for the NativeRTCPeerConnection proxy.
+ *
+ * Focus areas (Session 02 — call drop fixes):
+ * 1. restartIce() must call native bridge, NOT be a no-op.
+ * 2. getStats() must return real metrics from native, NOT an empty Map.
+ * 3. _syncLocalStreamIds must allow re-syncing on renegotiation
+ *    (video upgrade / glare) — stream.id must be rewritable.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+import type { PluginListenerHandle } from "@capacitor/core";
+
+// ---------------------------------------------------------------------------
+// Mock Capacitor bridge — captures native method calls so tests can assert.
+// ---------------------------------------------------------------------------
+
+type BridgeMethod = Mock<(...args: unknown[]) => Promise<unknown>>;
+const bridgeMethods: Record<string, BridgeMethod> = {};
+
+function getBridgeMethod(name: string): BridgeMethod {
+  if (!bridgeMethods[name]) {
+    bridgeMethods[name] = vi.fn().mockResolvedValue({}) as BridgeMethod;
+  }
+  return bridgeMethods[name];
+}
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => true,
+    getPlatform: () => "android",
+  },
+  registerPlugin: () =>
+    new Proxy({}, {
+      get: (_t, prop: string) => {
+        if (prop === "addListener") {
+          return vi.fn().mockImplementation(
+            async (_event: string, _handler: unknown): Promise<PluginListenerHandle> => ({
+              remove: async () => {},
+            })
+          );
+        }
+        return getBridgeMethod(prop);
+      },
+    }),
+}));
+
+// Import after mocking. Module-level capture of window.RTCPeerConnection
+// happens on import; installNativeWebRTCProxy overrides it.
+import {
+  installNativeWebRTCProxy,
+  uninstallNativeWebRTCProxy,
+} from "./rtc-peer-connection-proxy";
+
+// Helper: wait a microtask tick so async init of NativeRTCPeerConnection completes.
+const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("NativeRTCPeerConnection proxy", () => {
+  beforeEach(() => {
+    for (const k of Object.keys(bridgeMethods)) {
+      bridgeMethods[k].mockClear();
+    }
+    installNativeWebRTCProxy();
+  });
+
+  afterEach(() => {
+    uninstallNativeWebRTCProxy();
+  });
+
+  describe("restartIce()", () => {
+    it("calls NativeWebRTC.restartIce on the native bridge, not a no-op", async () => {
+      const pc = new window.RTCPeerConnection();
+      await tick();
+      await tick();
+
+      pc.restartIce();
+      await tick();
+      await tick();
+
+      const restartIce = getBridgeMethod("restartIce");
+      expect(restartIce).toHaveBeenCalledOnce();
+      // Must carry peerId so native can route to the correct connection.
+      const callArg = restartIce.mock.calls[0]?.[0] as { peerId?: string } | undefined;
+      expect(callArg?.peerId).toBeDefined();
+      expect(typeof callArg?.peerId).toBe("string");
+
+      pc.close();
+    });
+  });
+
+  describe("getStats()", () => {
+    it("returns an RTCStatsReport populated from native bridge report", async () => {
+      const report = {
+        "outbound-rtp-audio-0": {
+          id: "outbound-rtp-audio-0",
+          type: "outbound-rtp",
+          kind: "audio",
+          bytesSent: 12345,
+          packetsSent: 42,
+        },
+        "inbound-rtp-audio-0": {
+          id: "inbound-rtp-audio-0",
+          type: "inbound-rtp",
+          kind: "audio",
+          bytesReceived: 6789,
+          packetsReceived: 21,
+        },
+      };
+      getBridgeMethod("getStats").mockResolvedValueOnce({ report });
+
+      const pc = new window.RTCPeerConnection();
+      await tick();
+      await tick();
+
+      const stats = await pc.getStats();
+
+      expect(stats).toBeInstanceOf(Map);
+      expect(stats.size).toBeGreaterThan(0);
+      const outbound = stats.get("outbound-rtp-audio-0") as Record<string, unknown> | undefined;
+      expect(outbound?.bytesSent).toBe(12345);
+      const inbound = stats.get("inbound-rtp-audio-0") as Record<string, unknown> | undefined;
+      expect(inbound?.bytesReceived).toBe(6789);
+
+      const getStats = getBridgeMethod("getStats");
+      expect(getStats).toHaveBeenCalledOnce();
+      const callArg = getStats.mock.calls[0]?.[0] as { peerId?: string } | undefined;
+      expect(callArg?.peerId).toBeDefined();
+
+      pc.close();
+    });
+
+    it("returns empty Map and does not throw when native bridge rejects", async () => {
+      getBridgeMethod("getStats").mockRejectedValueOnce(new Error("native failure"));
+
+      const pc = new window.RTCPeerConnection();
+      await tick();
+      await tick();
+
+      const stats = await pc.getStats();
+      expect(stats).toBeInstanceOf(Map);
+      expect(stats.size).toBe(0);
+
+      pc.close();
+    });
+  });
+
+  describe("_syncLocalStreamIds (renegotiation)", () => {
+    it("updates local stream.id on first createOffer to match native SDP msid", async () => {
+      const sdpWithMsid =
+        "v=0\r\no=- 1 2 IN IP4 0.0.0.0\r\ns=-\r\nt=0 0\r\na=msid:native-stream-A native-track-A\r\n";
+      getBridgeMethod("createOffer").mockResolvedValueOnce({
+        sdp: sdpWithMsid,
+        type: "offer",
+      });
+
+      const pc = new window.RTCPeerConnection();
+      await tick();
+      await tick();
+
+      const dummyTrack = { kind: "audio", enabled: true } as MediaStreamTrack;
+      const localStream = new MediaStream();
+      // addTrack registers the stream internally for _syncLocalStreamIds
+      pc.addTrack(dummyTrack, localStream);
+
+      const originalId = localStream.id;
+      expect(originalId).not.toBe("native-stream-A");
+
+      await pc.createOffer();
+
+      expect(localStream.id).toBe("native-stream-A");
+
+      pc.close();
+    });
+
+    it("allows stream.id to be updated again on renegotiation (video upgrade / glare)", async () => {
+      const sdpOffer1 =
+        "v=0\r\no=- 1 2 IN IP4 0.0.0.0\r\ns=-\r\nt=0 0\r\na=msid:native-stream-v1 track-v1\r\n";
+      const sdpOffer2 =
+        "v=0\r\no=- 1 3 IN IP4 0.0.0.0\r\ns=-\r\nt=0 0\r\na=msid:native-stream-v2 track-v2\r\n";
+
+      const createOffer = getBridgeMethod("createOffer");
+      createOffer
+        .mockResolvedValueOnce({ sdp: sdpOffer1, type: "offer" })
+        .mockResolvedValueOnce({ sdp: sdpOffer2, type: "offer" });
+
+      const pc = new window.RTCPeerConnection();
+      await tick();
+      await tick();
+
+      const dummyTrack = { kind: "audio", enabled: true } as MediaStreamTrack;
+      const localStream = new MediaStream();
+      pc.addTrack(dummyTrack, localStream);
+
+      await pc.createOffer();
+      expect(localStream.id).toBe("native-stream-v1");
+
+      // Simulate renegotiation — SDK calls createOffer again with new msid.
+      await pc.createOffer();
+      // This is the bug fix: writable:false previously prevented rewrite,
+      // leaving stream.id stuck at "native-stream-v1".
+      expect(localStream.id).toBe("native-stream-v2");
+
+      pc.close();
+    });
+  });
+});

--- a/src/shared/lib/native-webrtc/rtc-peer-connection-proxy.ts
+++ b/src/shared/lib/native-webrtc/rtc-peer-connection-proxy.ts
@@ -230,12 +230,15 @@ class NativeRTCPeerConnection extends EventTarget {
             // MediaStream constructor with existing tracks
             stream = new MediaStream(track ? [track] : []);
 
-            // Override the stream id to match remote SDP's msid
-            // The SDK does: this.remoteSDPStreamMetadata![stream.id].purpose
+            // Override the stream id to match remote SDP's msid.
+            // The SDK does: this.remoteSDPStreamMetadata![stream.id].purpose.
+            // writable/configurable:true so the id can be updated on
+            // renegotiation (video upgrade, glare) without silently failing.
             if (data.streamId) {
               Object.defineProperty(stream, "id", {
                 value: data.streamId,
-                writable: false,
+                writable: true,
+                configurable: true,
               });
             }
           } catch (err) {
@@ -459,7 +462,19 @@ class NativeRTCPeerConnection extends EventTarget {
   }
 
   restartIce(): void {
-    console.log("[NativeRTCProxy] restartIce (no-op — native handles ICE)");
+    // Forward the restart to the native PeerConnection. The SDK invokes
+    // this on network flips (WiFi ↔ cellular), on ICE failure, or during
+    // glare. Without this hop calls drop permanently on any jitter.
+    // The RTCPeerConnection.restartIce() spec signature is void-returning,
+    // so we can't propagate the async failure — log it and move on. Guard
+    // against close() racing with init so we don't call native on a
+    // torn-down peer.
+    this._waitReady()
+      .then(() => {
+        if (this._closed) return;
+        return NativeWebRTC.restartIce({ peerId: this._peerId });
+      })
+      .catch((e) => console.error("[NativeRTCProxy] restartIce failed:", e));
   }
 
   // -----------------------------------------------------------------------
@@ -478,7 +493,19 @@ class NativeRTCPeerConnection extends EventTarget {
   // -----------------------------------------------------------------------
 
   async getStats(): Promise<RTCStatsReport> {
-    return new Map() as any;
+    try {
+      await this._waitReady();
+      const result = await NativeWebRTC.getStats({ peerId: this._peerId });
+      const map = new Map<string, unknown>();
+      const report = result?.report ?? {};
+      for (const [k, v] of Object.entries(report)) {
+        map.set(k, v);
+      }
+      return map as unknown as RTCStatsReport;
+    } catch (e) {
+      console.error("[NativeRTCProxy] getStats failed:", e);
+      return new Map() as unknown as RTCStatsReport;
+    }
   }
 
   // -----------------------------------------------------------------------
@@ -536,7 +563,7 @@ class NativeRTCPeerConnection extends EventTarget {
         console.log(`[NativeRTCProxy] syncing local stream ID: ${dummyStream.id} → ${nativeId}`);
         Object.defineProperty(dummyStream, "id", {
           value: nativeId,
-          writable: false,
+          writable: true,
           configurable: true,
         });
       }

--- a/src/shared/lib/native-webrtc/rtc-peer-connection-proxy.ts
+++ b/src/shared/lib/native-webrtc/rtc-peer-connection-proxy.ts
@@ -116,6 +116,33 @@ class NativeRTCPeerConnection extends EventTarget {
         credential: s.credential as string | undefined,
       }));
 
+      // Session 02 (v2) — guarantee at least one reachable STUN.
+      //
+      // matrix-js-sdk-bastyon reads only `turnServers` at client level,
+      // so any `iceServers` we passed to createClient are ignored. When
+      // the homeserver's /turnServer returns empty and its fallback
+      // (stun:turn.matrix.org) is unreachable (rate-limited or blocked
+      // in restricted regions), the SDK ends up creating an
+      // RTCPeerConnection with no iceServers at all — ICE gathering
+      // produces only host candidates and the call drops within 1-2s.
+      //
+      // Since THIS proxy is the single choke point for every
+      // RTCPeerConnection creation, we inject a Google STUN fallback
+      // whenever the caller didn't give us one. That guarantees srflx
+      // candidates for NAT'd peers without interfering with the SDK's
+      // own TURN server logic — if the SDK has credentials to pass, we
+      // preserve them verbatim.
+      const hasStunOrTurn = iceServers.some((s) => {
+        const urls = Array.isArray(s.urls) ? s.urls : [s.urls];
+        return urls.some((u) => /^(stun|turn):/i.test(u));
+      });
+      if (!hasStunOrTurn) {
+        iceServers.push(
+          { urls: "stun:stun.l.google.com:19302" },
+          { urls: "stun:stun1.l.google.com:19302" },
+        );
+      }
+
       await NativeWebRTC.createPeerConnection({
         peerId: this._peerId,
         iceServers,


### PR DESCRIPTION
## Summary

Two-commit series that makes Android voice/video calls actually work end-to-end. Before this PR:

- Calls dropped after 1–2 seconds on any network jitter (ICE never restarted on WiFi↔cellular).
- A second RECORD_AUDIO dialog popped up **during** the call, stole Activity focus, and killed the WebRTC session.
- Cold-start from a push + tap Answer either did nothing (lock screen), showed a duplicate web-ringer on top of the native one, span "Connecting…" forever (SDK clobbering from duplicate handler-listener registration), or only completed once the user manually returned to the app.
- Decline closed the local ringer but the caller kept ringing for their full lifetime — "Decline does nothing" from the user's view.

After this PR:

- WiFi↔cellular flips restart ICE via the native `PeerConnection.restartIce()`.
- One permission prompt total, pre-call. No mid-call focus thefts.
- Tap Answer on the native push ringer → `CallActivity` comes up, SDK answers, ICE connects, audio flows. Works from the lock screen.
- Tap Decline → ringer closes, JS briefly boots to send `m.call.reject`, caller sees "Declined".
- No duplicate Vue ringer on top of the FCM ringer. No runaway log recursion from webrtc-diagnostics freezing the JS thread.

## Key changes

### Proxy / WebRTC plumbing (5b00354)
- `rtc-peer-connection-proxy.ts`: `restartIce()` and `getStats()` now call through to native via the Capacitor bridge instead of being no-ops. `writable: true` on the synced `stream.id` override so renegotiation doesn't silently fail on the second attempt.
- `native-webrtc-bridge.ts` + `NativeWebRTCManager.kt` + `WebRTCPlugin.kt`: new `restartIce` / `getStats` plugin methods.
- `WebRTCPlugin.kt`: `startLocalMedia` no longer opens a second system RECORD_AUDIO dialog — fails fast if the CallPlugin gate wasn't granted first.
- `matrix-client.ts`: Google STUN fallback at client-config level for NAT'd peers when the homeserver `/turnServer` is blocked or rate-limited.

### Cold-start & lock-screen (650c291)
- `matrix-client.ts`: eagerly call `callEventHandler.start()` after `startClient()` AND `.off()` the SDK's lazy Sync-triggered starter with the original reference. Without the unregister, SDK auto-start registered the handler's listeners a second time, every `m.call.invite` fired `handleCallEvent` twice, triggering the SDK's "already has a call, clobbering" path that destroyed the freshly-created MatrixCall and left ICE stranded.
- `matrix-client.ts`: raise timeline filter `limit` from 1 to 20 so a realistic burst in one sync delta doesn't get truncated down to the most recent event only.
- `MainActivity.kt`: conditionally `setShowWhenLocked` / `setTurnScreenOn` / `requestDismissKeyguard` **only** when opened via `push_call_accept` intent. Lets the WebView run JS over the keyguard without exposing the chat list on lock for normal launches.
- `IncomingCallActivity.kt`: Accept launches MainActivity in the foreground (not a hidden NO_ANIMATION task). Android was stopping the hidden activity and throttling its WebView, so the JS `answerCall()` flow only completed when the user manually switched back. Decline now also launches MainActivity so JS can actually send `m.call.reject`.
- `CallConnectionService.kt`: split pending-accept markers (set **only** in `onAnswer()`) from new pending-reject markers (set in `onReject()`). Both cleared on `onDisconnect` / remote dismiss.
- `CallPlugin.kt`: include `roomId` in the `callAnswered` event + `getPendingReject` plugin method.
- `native-call-bridge.ts`: async `consumePendingAnswerCallId` / `consumePendingRejectCallId` with in-memory + native fallback. `waitForMatrixCallAndAnswer(callId, roomId)` matches by either callId OR roomId — on this homeserver the push-side call_id is the event_id and never equals Matrix's own `call.callId`, so roomId is the reliable correlator. Recovery path skips when `sdkHasCall` is already true.
- `call-service.ts`: `handleIncomingCall` checks pending-reject first so a late-delivered invite for a declined call gets a real `matrixCall.reject()` sent. Fast-path skips Vue incoming UI + reportIncomingCall on native — the FCM path already owns that surface. `onHangup` tears the native surface down so caller-hangup / other-device-answer correctly dismisses CallActivity.

### Dedup & diagnostics
- `FortaFirebaseMessagingService.kt`: dedupe `m.call.invite` push retries by call_id so caller-side retries don't stack another ringer on top of an already-accepted call. Cleared on any call-end push.
- `webrtc-diagnostics.ts`: switch state-change wrappers from shared-singleton `this.origXxxHandler` to closure-captured variables, plus an `ATTACHED_FLAG` on the PC. Prior design stacked wrappers recursively via `this.*` reassignment — a second attach made `wrapper_A` call `this.origSigHandler` which was `wrapper_A` itself → ~7,800-log/sec stack-overflow recursion that froze the JS thread and dropped the call after 1–2 sec.

## Reviewer notes

- Timeline filter bump from 1 → 20 is intentional; `limit: 1` was silently dropping `m.call.invite` events when sync delivered multiple timeline entries at once.
- Native ringer dedup is intentional; this homeserver's caller clients resend `m.call.invite` every few seconds until they see an answer/hangup.
- Lock-screen flags are gated on `push_call_accept=true` intent extra so the regular launcher intent still respects keyguard.
- Brief Vue loading flash on Accept/Decline is the known tradeoff for keeping call logic in JS. Moving fully native would require reimplementing this homeserver's `forta-crypto` / miscreant in Kotlin — out of scope.

## Test plan

- [x] Outgoing voice/video connects, ICE reaches `connected`, audio both ways.
- [x] WiFi↔cellular flip mid-call restarts ICE, call recovers.
- [x] Cold-start from push → Accept → CallActivity, SDK answers, ICE connects.
- [x] Cold-start from push → Decline → caller sees "Declined".
- [x] Answer from lock screen works.
- [x] No duplicate ringer on caller retry.
- [x] Remote hangup dismisses ringer and CallActivity.
- [x] Outgoing unchanged; #34 (AudioRouter wiring) and #36 merged-in and still work.

Branch picked up #34 and #36 via merge commits; they introduce no additional behavioral changes beyond what was already in master.