### PR TITLE
fix(sidebar): stop chat list and avatar flicker

### DIFF
--- a/src/app/styles/main.css
+++ b/src/app/styles/main.css
@@ -40,12 +40,14 @@
   }
 }
 
-/* vue-virtual-scroller: vertical item-view gets no inline height from JS (only grid mode does).
-   contain:size ignores child intrinsic height — set explicit height matching :item-size via
-   --recycle-item-size on the RecycleScroller root. */
+/* vue-virtual-scroller item-view: isolate layout+paint so mutating one row
+   doesn't invalidate siblings. `size` containment was dropped on purpose:
+   it required an explicit --recycle-item-size, which only ContactList set,
+   and caused visible flicker on other lists (ChannelList, ContactsPanel)
+   plus on every reactive patch to the active list. :item-size from the
+   scroller already supplies positioning height. */
 .vue-recycle-scroller.ready.direction-vertical .vue-recycle-scroller__item-view {
-  contain: strict;
-  height: var(--recycle-item-size);
+  contain: layout paint;
 }
 
 @media (max-height: 500px) {

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -12,6 +12,7 @@ import { defineStore } from "pinia";
 import { computed, reactive, ref, shallowRef, triggerRef, watch } from "vue";
 import { perfMark, perfMeasure, perfCount } from "@/shared/lib/perf-markers";
 import { yieldToMain, yieldEveryN } from "@/shared/lib/yield-to-main";
+import { createPatchScheduler } from "@/shared/lib/patch-scheduler";
 import { isNative } from "@/shared/lib/platform";
 
 
@@ -1042,11 +1043,44 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     });
   };
 
+  // ---------------------------------------------------------------------------
+  // Batched sortedRooms patches (rAF-coalesced)
+  //
+  // WHY: when the user opens an unread room, setActiveRoom triggers multiple
+  // writes to _sortedRoomsRef in quick succession (in-memory optimistic patch
+  // + Dexie clearUnread → observeRoomChanges microtask → another patch). Each
+  // mutation creates a new array reference, which cascades through
+  // allFilteredRooms → RecycleScroller. With `contain: strict` on every item,
+  // those back-to-back commits produce visible flicker in the sidebar.
+  //
+  // Coalescing all patches arriving within a single animation frame into one
+  // `_sortedRoomsRef.value` assignment collapses the cascade to a single render.
+  // ---------------------------------------------------------------------------
+  const sortedRoomsPatcher = createPatchScheduler<RoomChange>((batch) => {
+    applyPatchSortedRooms(batch);
+  });
+
+  /** Cancel scheduled flush and drop pending changes.
+   *  Call this before direct `_sortedRoomsRef.value` assignments
+   *  (fallback recompute, fullRebuildSortedRoomsAsync, cleanup) so stale
+   *  patches don't later overwrite the freshly-built state. */
+  const cancelPendingPatches = () => sortedRoomsPatcher.cancel();
+
   const patchSortedRooms = (changes: RoomChange[]) => {
+    sortedRoomsPatcher.schedule(changes);
+  };
+
+  const applyPatchSortedRooms = (changes: RoomChange[]) => {
     perfCount("sortedRooms:patch");
+    // Dedupe by roomId — only the final state for each room matters in a frame
+    const dedup = new Map<string, RoomChange>();
+    for (const c of changes) {
+      const id = c.type === "delete" ? c.roomId : c.room.id;
+      dedup.set(id, c);
+    }
     const arr = [..._sortedRoomsRef.value];
     const pinned = pinnedRoomIds.value;
-    for (const change of changes) {
+    for (const change of dedup.values()) {
       if (change.type === "delete") {
         const idx = arr.findIndex(r => r.id === change.roomId);
         if (idx !== -1) arr.splice(idx, 1);
@@ -1078,6 +1112,9 @@ export const useChatStore = defineStore(NAMESPACE, () => {
 
   const fullRebuildSortedRoomsAsync = async () => {
     perfCount("sortedRooms:fullRebuild");
+    // Drop any scheduled delta patches — we're about to rebuild from dexieRoomMap,
+    // which is already up-to-date with everything those patches would have applied.
+    cancelPendingPatches();
     const allRooms = Array.from(dexieRoomMap.values());
     if (allRooms.length === 0 && rooms.value.length > 0) {
       _sortedRoomsRef.value = computeSortedRoomsFallback(rooms.value, pinnedRoomIds.value);
@@ -1101,6 +1138,9 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       if (aPinned !== bPinned) return bPinned - aPinned;
       return getSortKey(b) - getSortKey(a);
     });
+    // Drop patches that arrived during the async yield — dexieRoomMap mutated
+    // in lock-step with those deltas, so `mapped` already reflects them.
+    cancelPendingPatches();
     _sortedRoomsRef.value = mapped;
 
     // Prune stale cache entries when cache grows beyond 1.5x current room count
@@ -1253,6 +1293,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
         // Rebuild when pins or Matrix ignore list changes (sidebar membership).
         if (pinsChanged || ignoredChanged) scheduleFullSortedRebuild();
       } else {
+        cancelPendingPatches();
         _sortedRoomsRef.value = computeSortedRoomsFallback(rooms.value, pinnedRoomIds.value);
       }
     },
@@ -5855,6 +5896,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     matrixRoomAddresses.clear();
     profilesRequestedForRooms.clear();
     roomFetchStates.clear();
+    cancelPendingPatches();
     _sortedRoomsRef.value = [];
     messageWindowSize.value = 50;
 

--- a/src/entities/user/ui/UserAvatar.vue
+++ b/src/entities/user/ui/UserAvatar.vue
@@ -16,7 +16,11 @@ const { isVisible } = useLazyLoad(rootRef);
 
 const user = computed(() => userStore.getUser(props.address));
 
-// Only load profile when element is visible
+// Lazy-load the profile data when element enters viewport, but always render
+// the underlying Avatar — it falls back to a colored initials tile when src/name
+// are empty. Previously we swapped between a gray placeholder div and Avatar on
+// isVisible flip, which produced visible flicker on every RecycleScroller recycle
+// (each recycled row starts with isVisible=false for a frame).
 watch(isVisible, (visible) => {
   if (visible) userStore.loadUserIfMissing(props.address);
 });
@@ -29,20 +33,9 @@ watch(() => props.address, (addr) => {
 <template>
   <div ref="rootRef">
     <Avatar
-      v-if="isVisible"
       :src="user?.image"
       :name="user?.name || address"
       :size="props.size"
-    />
-    <div
-      v-else
-      class="rounded-full bg-neutral-grad-0"
-      :class="{
-        'h-8 w-8': props.size === 'sm',
-        'h-10 w-10': props.size === 'md',
-        'h-14 w-14': props.size === 'lg',
-        'h-20 w-20': props.size === 'xl',
-      }"
     />
   </div>
 </template>

--- a/src/features/contacts/ui/ContactList.vue
+++ b/src/features/contacts/ui/ContactList.vue
@@ -712,19 +712,12 @@ const onRoomContextMenu = (e: MouseEvent, room: ChatRoom) => {
 
 <template>
   <div class="flex flex-col">
-    <!-- Skeleton placeholder during initial sync -->
-    <div v-if="filteredRooms.length === 0 && chatStore.isSyncing" class="flex flex-col">
-      <div v-for="i in 6" :key="i" class="flex h-[68px] w-full items-center gap-3 px-3 py-2.5 animate-pulse">
-        <div class="h-10 w-10 shrink-0 rounded-full bg-neutral-grad-0" />
-        <div class="flex min-w-0 flex-1 flex-col gap-1.5">
-          <div class="h-3.5 w-2/5 rounded bg-neutral-grad-0" />
-          <div class="h-3 w-3/5 rounded bg-neutral-grad-0" />
-        </div>
-      </div>
-    </div>
-
+    <!-- Empty state. A separate skeleton for "initial load" lives in ChatSidebar and is
+         keyed off `sortedRooms.length === 0 && !roomsInitialized`. Showing another skeleton
+         here based on isSyncing caused visible flicker on every WebSocket reconnect
+         (isSyncing flips between RECONNECTING and idle). -->
     <div
-      v-else-if="filteredRooms.length === 0 && chatStore.roomsInitialized"
+      v-if="filteredRooms.length === 0 && chatStore.roomsInitialized"
       class="flex flex-col items-center gap-3 px-6 py-12 text-center"
     >
       <div class="flex h-14 w-14 items-center justify-center rounded-full bg-neutral-grad-0">
@@ -748,7 +741,7 @@ const onRoomContextMenu = (e: MouseEvent, room: ChatRoom) => {
         <!-- Channel item (same layout as chat room) -->
         <button
           v-if="isChannel(item)"
-          class="flex h-[68px] w-full cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-neutral-grad-0 active:bg-neutral-grad-0"
+          class="flex h-[68px] w-full cursor-pointer items-center gap-3 px-3 py-2.5 hover:bg-neutral-grad-0 active:bg-neutral-grad-0"
           :class="(item as Channel).address === channelStore.activeChannelAddress ? 'bg-color-bg-ac/10' : ''"
           @click="handleSelectChannel(item as Channel)"
         >
@@ -784,7 +777,7 @@ const onRoomContextMenu = (e: MouseEvent, room: ChatRoom) => {
         <!-- Chat room item -->
         <button
           v-else
-          class="flex h-[68px] w-full cursor-pointer items-center gap-3 px-3 py-2.5 transition-colors hover:bg-neutral-grad-0 active:bg-neutral-grad-0"
+          class="flex h-[68px] w-full cursor-pointer items-center gap-3 px-3 py-2.5 hover:bg-neutral-grad-0 active:bg-neutral-grad-0"
           :class="[
             selectionStore.isSelected((item as ChatRoom).id) ? 'bg-color-bg-ac/8' :
             (item as ChatRoom).id === chatStore.activeRoomId ? 'bg-color-bg-ac/10' : ''

--- a/src/shared/lib/__tests__/patch-scheduler.test.ts
+++ b/src/shared/lib/__tests__/patch-scheduler.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createPatchScheduler } from "../patch-scheduler";
+
+describe("createPatchScheduler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("coalesces multiple schedule() calls in the same tick into one flush", async () => {
+    const flushes: string[][] = [];
+    const s = createPatchScheduler<string>((b) => flushes.push([...b]), { useRaf: false });
+
+    s.schedule(["a"]);
+    s.schedule(["b"]);
+    s.schedule(["c", "d"]);
+
+    expect(flushes).toHaveLength(0); // deferred
+
+    await vi.runAllTimersAsync();
+    // Also drain microtasks explicitly — fake timers don't advance microtask queue
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(flushes).toHaveLength(1);
+    expect(flushes[0]).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("cancel() drops pending items without flushing", async () => {
+    const flushes: string[][] = [];
+    const s = createPatchScheduler<string>((b) => flushes.push([...b]), { useRaf: false });
+
+    s.schedule(["a", "b"]);
+    s.cancel();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(flushes).toHaveLength(0);
+  });
+
+  it("schedule() after cancel() schedules a fresh flush", async () => {
+    const flushes: string[][] = [];
+    const s = createPatchScheduler<string>((b) => flushes.push([...b]), { useRaf: false });
+
+    s.schedule(["a"]);
+    s.cancel();
+    s.schedule(["b"]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(flushes).toHaveLength(1);
+    expect(flushes[0]).toEqual(["b"]);
+  });
+
+  it("empty schedule() is a no-op", async () => {
+    const flushes: string[][] = [];
+    const s = createPatchScheduler<string>((b) => flushes.push([...b]), { useRaf: false });
+
+    s.schedule([]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(flushes).toHaveLength(0);
+  });
+
+  it("uses requestAnimationFrame when available", async () => {
+    const rafCalls: FrameRequestCallback[] = [];
+    const raf = vi.fn((cb: FrameRequestCallback): number => {
+      rafCalls.push(cb);
+      return rafCalls.length;
+    });
+    vi.stubGlobal("requestAnimationFrame", raf);
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    try {
+      const flushes: string[][] = [];
+      const s = createPatchScheduler<string>((b) => flushes.push([...b]));
+
+      s.schedule(["a"]);
+      s.schedule(["b"]);
+
+      expect(raf).toHaveBeenCalledTimes(1); // one rAF for the whole batch
+      expect(flushes).toHaveLength(0);
+
+      // Simulate frame
+      rafCalls[0](performance.now());
+
+      expect(flushes).toHaveLength(1);
+      expect(flushes[0]).toEqual(["a", "b"]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("cancel() calls cancelAnimationFrame for a pending rAF", async () => {
+    const cancel = vi.fn();
+    vi.stubGlobal("requestAnimationFrame", vi.fn(() => 42));
+    vi.stubGlobal("cancelAnimationFrame", cancel);
+
+    try {
+      const s = createPatchScheduler<string>(() => {});
+      s.schedule(["a"]);
+      s.cancel();
+      expect(cancel).toHaveBeenCalledWith(42);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("a subsequent flush cycle works after the first one completes", async () => {
+    const flushes: string[][] = [];
+    const s = createPatchScheduler<string>((b) => flushes.push([...b]), { useRaf: false });
+
+    s.schedule(["a"]);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(flushes).toHaveLength(1);
+
+    s.schedule(["b"]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(flushes).toHaveLength(2);
+    expect(flushes[1]).toEqual(["b"]);
+  });
+});

--- a/src/shared/lib/patch-scheduler.ts
+++ b/src/shared/lib/patch-scheduler.ts
@@ -1,0 +1,58 @@
+/**
+ * Coalesces rapid successive calls into a single flush per animation frame.
+ *
+ * WHY: when many reactive writers target the same derived state in quick
+ * succession (Dexie delta hooks + optimistic UI patches + flushWriteBuffer),
+ * each write produces its own reactive commit and its own render. That shows
+ * up as flicker — especially when downstream layout is isolated via
+ * `contain: strict`. Batching multiple updates into one frame collapses the
+ * cascade to a single render.
+ */
+export interface PatchScheduler<T> {
+  /** Append items to the pending batch; schedule a flush if one isn't already pending. */
+  schedule(items: readonly T[]): void;
+  /** Cancel the pending flush and drop any queued items. */
+  cancel(): void;
+}
+
+export interface PatchSchedulerOptions {
+  /** Override rAF detection — useful for forcing microtask fallback in tests. */
+  useRaf?: boolean;
+}
+
+export function createPatchScheduler<T>(
+  flush: (batch: T[]) => void,
+  opts: PatchSchedulerOptions = {},
+): PatchScheduler<T> {
+  const useRaf = opts.useRaf ?? (typeof requestAnimationFrame !== "undefined");
+  let pending: T[] = [];
+  let rafId: number | null = null;
+
+  const run = () => {
+    rafId = null;
+    if (pending.length === 0) return;
+    const batch = pending;
+    pending = [];
+    flush(batch);
+  };
+
+  return {
+    schedule(items) {
+      if (items.length === 0) return;
+      pending.push(...items);
+      if (rafId !== null) return;
+      if (useRaf) {
+        rafId = requestAnimationFrame(run);
+      } else {
+        // Non-browser env (tests, SSR): microtask keeps batching within a tick.
+        rafId = 1;
+        queueMicrotask(run);
+      }
+    },
+    cancel() {
+      if (rafId !== null && useRaf) cancelAnimationFrame(rafId);
+      rafId = null;
+      pending = [];
+    },
+  };
+}

--- a/src/shared/ui/avatar/Avatar.vue
+++ b/src/shared/ui/avatar/Avatar.vue
@@ -58,24 +58,28 @@ const imgError = ref(false);
 
 const fixedSrc = computed(() => normalizePocketnetImageUrl(props.src));
 
-const showFallback = computed(() => !props.src || imgError.value);
+const hasImage = computed(() => !!props.src && !imgError.value);
 </script>
 
 <template>
   <div
     :class="sizeClass"
-    class="flex shrink-0 items-center justify-center overflow-hidden rounded-full"
-    :style="showFallback ? { backgroundColor: avatarColor } : {}"
+    class="relative flex shrink-0 items-center justify-center overflow-hidden rounded-full"
+    :style="{ backgroundColor: avatarColor }"
     role="img"
     :aria-label="props.name || 'User avatar'"
   >
+    <!-- Initials are always rendered underneath the image so the tile never
+         shows a blank frame while the image is loading (e.g. right after
+         RecycleScroller recycles the row under a new src). Image covers
+         initials once it paints. -->
+    <span class="font-medium text-white">{{ initials }}</span>
     <img
-      v-if="!showFallback"
+      v-if="hasImage"
       :src="fixedSrc"
       :alt="props.name"
-      class="h-full w-full object-cover"
+      class="absolute inset-0 h-full w-full object-cover"
       @error="imgError = true"
     />
-    <span v-else class="font-medium text-white">{{ initials }}</span>
   </div>
 </template>


### PR DESCRIPTION
## Problem

Users reported visible flicker in the chat list on clicks (opening a chat, mark-as-read) and avatar flicker while the list updated.

## Root causes

Several overlapping issues compounded the flicker:

1. **Cascaded `_sortedRoomsRef` mutations** — `setActiveRoom` fired 2–3 back-to-back `patchSortedRooms` calls: optimistic in-memory patch → Dexie `clearUnread` → `observeRoomChanges` hook in the next microtask → another patch. Each one produced a new array reference, `RecycleScroller` saw a new `items` prop per tick, and the renders stacked.
2. **ContactList skeleton** — `v-if="filteredRooms.length === 0 && chatStore.isSyncing"` reacted to `syncState === 'RECONNECTING'`. Every WebSocket reconnect flashed the skeleton over an already-populated list.
3. **Global `contain: strict` on item-view** — introduced in the recent "contain strict" commit. It applied to *every* vertical `RecycleScroller`, but `--recycle-item-size` was only set in `ContactList`. Other lists got `contain: size` with no explicit height → visual glitches.
4. **`transition-colors` on the chat row** — 150ms color fade on active-room change read as mildly blinking.
5. **`UserAvatar` flipped between a gray placeholder div and `Avatar`** via `v-if="isVisible"`. After `RecycleScroller` recycled a row, `isVisible` reset to `false` for a frame → gray circle flash.
6. **`Avatar` blank tile while image loads** — `v-if="!showFallback"` toggled between `<img>` and `<span>initials`. If the image wasn't cached, a transparent frame showed up before paint.

## Changes

### Chat list
- `patchSortedRooms` is coalesced through `requestAnimationFrame` with per-`roomId` dedup (multiple changes to the same room within a frame collapse to a final state). Direct `_sortedRoomsRef.value` writes (fullRebuild / fallback / cleanup) cancel the pending batch so stale patches can't overwrite fresh state.
- Removed the `v-if="filteredRooms.length === 0 && isSyncing"` skeleton in `ContactList`. The empty state and the single top-level `ChatSidebar` skeleton remain.
- CSS relaxed from `contain: strict` + `height: var(--recycle-item-size)` to `contain: layout paint`.
- Dropped `transition-colors` from the chat-row `<button>`.

### Avatars
- `UserAvatar`: removed the `v-if="isVisible"` swap. `Avatar` renders unconditionally; `IntersectionObserver` is kept only for lazy `loadUserIfMissing`.
- `Avatar`: initials always render as a colored background tile; `<img>` is layered on top via `absolute inset-0` and covers the initials once it paints. If the image is missing or errors, the initials stay visible — no empty frame.

### Infrastructure
- `src/shared/lib/patch-scheduler.ts` — reusable `createPatchScheduler<T>(flush)` utility with rAF coalescing and a microtask fallback for tests/SSR.
- `src/shared/lib/__tests__/patch-scheduler.test.ts` — 7 unit tests (coalesce, cancel, schedule-after-cancel, no-op on empty, rAF path, `cancelAnimationFrame` on pending rAF, repeat cycles).

## Test plan

- [x] `npx vitest run` — **912 passed**, 4 pre-existing failures (openBastyonProfile native, parseVideoUrl peertube, canBeEncrypt `.every()`, all outside the files touched here).
- [x] `vue-tsc --noEmit` — no errors in any modified file.
- [ ] Manual browser verification:
  - [ ] Click an unread chat — no flicker
  - [ ] Toggle network off/on — list stays stable across reconnects
  - [ ] Scroll the sidebar — no placeholder flash on avatars
  - [ ] Open a chat whose profile isn't loaded yet — initials show first, image fades in