### PR TITLE
fix(contacts): remove blank stripes between chats in the sidebar

### DIFF
--- a/src/entities/chat/lib/room-visibility.test.ts
+++ b/src/entities/chat/lib/room-visibility.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { makeRoom, makeMsg } from "@/test-utils";
+import { hasDisplayableContent, filterRoomsForTab } from "./room-visibility";
+import type { ChatRoom } from "@/entities/chat/model/types";
+
+describe("hasDisplayableContent", () => {
+  it("returns true when room has a lastMessage", () => {
+    const room = makeRoom({ lastMessage: makeMsg({ timestamp: 100 }), name: "", updatedAt: 0 });
+    expect(hasDisplayableContent(room)).toBe(true);
+  });
+
+  it("returns true when room has updatedAt > 0 (even without name or message)", () => {
+    const room = makeRoom({ name: "", lastMessage: undefined, updatedAt: 1_700_000_000_000 });
+    expect(hasDisplayableContent(room)).toBe(true);
+  });
+
+  it("returns true when room has a real name (no message, no updatedAt)", () => {
+    const room = makeRoom({ name: "Work chat", lastMessage: undefined, updatedAt: 0 });
+    expect(hasDisplayableContent(room)).toBe(true);
+  });
+
+  it("returns true for a Matrix-ID-like name (unresolved but still renderable)", () => {
+    // Unresolved names render as skeletons — they should not be filtered out.
+    const room = makeRoom({ name: "!abc:server", lastMessage: undefined, updatedAt: 0 });
+    expect(hasDisplayableContent(room)).toBe(true);
+  });
+
+  it('returns false when name="-" and no message and no updatedAt (empty placeholder)', () => {
+    const room = makeRoom({ name: "-", lastMessage: undefined, updatedAt: 0 });
+    expect(hasDisplayableContent(room)).toBe(false);
+  });
+
+  it("returns false when name is empty and no message and no updatedAt", () => {
+    const room = makeRoom({ name: "", lastMessage: undefined, updatedAt: 0 });
+    expect(hasDisplayableContent(room)).toBe(false);
+  });
+
+  it("returns false when name is whitespace and no message and no updatedAt", () => {
+    const room = makeRoom({ name: "   ", lastMessage: undefined, updatedAt: 0 });
+    expect(hasDisplayableContent(room)).toBe(false);
+  });
+
+  it("returns true for an invite with updatedAt set", () => {
+    const room = makeRoom({ membership: "invite", name: "-", lastMessage: undefined, updatedAt: 1_700_000_000_000 });
+    expect(hasDisplayableContent(room)).toBe(true);
+  });
+
+  it('returns true when updatedAt > 0 even if name="-" (updatedAt short-circuits)', () => {
+    // This locks the current semantics: `updatedAt` is a strong enough signal on its own.
+    // `filterRoomsForTab` is what actually excludes invite placeholders from the "all" tab.
+    const room = makeRoom({ name: "-", lastMessage: undefined, updatedAt: 1_700_000_000_000 });
+    expect(hasDisplayableContent(room)).toBe(true);
+  });
+});
+
+describe("filterRoomsForTab", () => {
+  const joined1 = makeRoom({ id: "!j1:s", membership: "join", isGroup: false, name: "Alice", lastMessage: makeMsg({ timestamp: 100 }) });
+  const joined2 = makeRoom({ id: "!j2:s", membership: "join", isGroup: true, name: "Team", lastMessage: makeMsg({ timestamp: 200 }) });
+  const joinedEmpty = makeRoom({ id: "!je:s", membership: "join", isGroup: false, name: "-", lastMessage: undefined, updatedAt: 0 });
+  const invite1 = makeRoom({ id: "!i1:s", membership: "invite", isGroup: false, name: "Invite1", lastMessage: undefined, updatedAt: 1000 });
+  const inviteEmpty = makeRoom({ id: "!ie:s", membership: "invite", isGroup: false, name: "-", lastMessage: undefined, updatedAt: 0 });
+
+  const all: ChatRoom[] = [joined1, joined2, joinedEmpty, invite1, inviteEmpty];
+
+  it('"all" tab hides invites and empty rooms', () => {
+    const filtered = filterRoomsForTab(all, "all");
+    expect(filtered.map(r => r.id)).toEqual(["!j1:s", "!j2:s"]);
+  });
+
+  it('"personal" tab hides groups, invites, and empty rooms', () => {
+    const filtered = filterRoomsForTab(all, "personal");
+    expect(filtered.map(r => r.id)).toEqual(["!j1:s"]);
+  });
+
+  it('"groups" tab hides non-groups, invites, and empty rooms', () => {
+    const filtered = filterRoomsForTab(all, "groups");
+    expect(filtered.map(r => r.id)).toEqual(["!j2:s"]);
+  });
+
+  it('"invites" tab keeps ALL invites (even empty ones — user needs to accept/decline)', () => {
+    const filtered = filterRoomsForTab(all, "invites");
+    expect(filtered.map(r => r.id).sort()).toEqual(["!i1:s", "!ie:s"]);
+  });
+
+  it("preserves input order (does not sort)", () => {
+    const a = makeRoom({ id: "!a:s", lastMessage: makeMsg({ timestamp: 100 }) });
+    const b = makeRoom({ id: "!b:s", lastMessage: makeMsg({ timestamp: 200 }) });
+    const c = makeRoom({ id: "!c:s", lastMessage: makeMsg({ timestamp: 50 }) });
+    expect(filterRoomsForTab([a, b, c], "all").map(r => r.id)).toEqual(["!a:s", "!b:s", "!c:s"]);
+  });
+});

--- a/src/entities/chat/lib/room-visibility.ts
+++ b/src/entities/chat/lib/room-visibility.ts
@@ -1,0 +1,51 @@
+import type { ChatRoom } from "@/entities/chat/model/types";
+
+export type ContactListTab = "all" | "personal" | "groups" | "invites" | "channels";
+
+/**
+ * Whether a room has ANY content worth rendering.
+ *
+ * Purpose: prevent blank 68px slots in the virtual list.
+ * `RecycleScroller` reserves a fixed-height slot per item, so an item with no
+ * name, no `lastMessage`, and `updatedAt=0` renders as an empty stripe —
+ * visually identical to a hole between real chats. This guard drops those
+ * placeholder rooms (they survive in Dexie for eventual hydration but are
+ * not something the user can act on yet).
+ *
+ * A room is displayable if any of the following hold:
+ *   - it has a `lastMessage` (timeline content is available);
+ *   - it has a non-zero `updatedAt` (even an empty invite has an origin ts);
+ *   - it has a non-empty name (even an unresolved Matrix ID is a skeleton hint).
+ */
+export function hasDisplayableContent(room: ChatRoom): boolean {
+  if (room.lastMessage) return true;
+  if ((room.updatedAt ?? 0) > 0) return true;
+  const name = room.name?.trim() ?? "";
+  if (name === "" || name === "-") return false;
+  return true;
+}
+
+/**
+ * Filter `rooms` for a given sidebar tab.
+ *
+ * Rules:
+ *   - "all": hide invites (they live on the dedicated Invites tab) and hide
+ *     empty placeholder rooms. This removes the blank stripes between chats.
+ *   - "personal": 1:1 chats, joined membership only, displayable content.
+ *   - "groups": group chats, joined membership only, displayable content.
+ *   - "invites": ALL invites (even empty ones — the user still needs to
+ *     accept/decline them). No displayability filter.
+ *   - "channels": no room filter (channels live in a separate store).
+ */
+export function filterRoomsForTab(rooms: ChatRoom[], tab: ContactListTab): ChatRoom[] {
+  if (tab === "invites") {
+    return rooms.filter(r => r.membership === "invite");
+  }
+  if (tab === "channels") {
+    return [];
+  }
+  const base = rooms.filter(r => r.membership !== "invite" && hasDisplayableContent(r));
+  if (tab === "personal") return base.filter(r => !r.isGroup);
+  if (tab === "groups") return base.filter(r => r.isGroup);
+  return base;
+}

--- a/src/features/contacts/ui/ContactList.vue
+++ b/src/features/contacts/ui/ContactList.vue
@@ -11,6 +11,7 @@ import { formatRelativeTime } from "@/shared/lib/format";
 import { stripMentionAddresses, stripBastyonLinks } from "@/shared/lib/message-format";
 import { hexDecode, hexEncode } from "@/shared/lib/matrix/functions";
 import { cleanMatrixIds, resolveSystemText, isUnresolvedName } from "@/entities/chat/lib/chat-helpers";
+import { filterRoomsForTab } from "@/entities/chat/lib/room-visibility";
 import { useFormatPreview } from "@/shared/lib/utils/format-preview";
 import { getRoomTitleForUI, getMessagePreviewForUI, type DisplayResult } from "@/entities/chat";
 import { useLongPress } from "@/shared/lib/gestures";
@@ -425,13 +426,16 @@ const allFilteredRooms = computed<UnifiedItem[]>(() => {
     return item;
   };
 
-  if (props.filter === "personal") return rooms.filter(r => !r.isGroup && r.membership !== "invite").map(toItem);
-  if (props.filter === "groups") return rooms.filter(r => r.isGroup && r.membership !== "invite").map(toItem);
-  if (props.filter === "invites") return rooms.filter(r => r.membership === "invite").map(toItem);
+  if (props.filter === "personal") return filterRoomsForTab(rooms, "personal").map(toItem);
+  if (props.filter === "groups") return filterRoomsForTab(rooms, "groups").map(toItem);
+  if (props.filter === "invites") return filterRoomsForTab(rooms, "invites").map(toItem);
 
   // "all": merge-sort rooms + channels (both already sorted by time desc).
   // O(n+m) instead of O((n+m) log(n+m)).
-  const roomItems: UnifiedItem[] = rooms.map(toItem);
+  // Invites and empty placeholder rooms are filtered out here to prevent
+  // blank stripes in RecycleScroller (each slot reserves ITEM_HEIGHT even
+  // when its content is empty). Invites live on the dedicated Invites tab.
+  const roomItems: UnifiedItem[] = filterRoomsForTab(rooms, "all").map(toItem);
   const channelItems: UnifiedItem[] = channelStore.channels
     .map(c => ({ ...c, _key: `ch:${c.address}` }))
     .sort((a, b) => getItemTimestamp(b) - getItemTimestamp(a));


### PR DESCRIPTION
## Summary

Убирает пустые 68-пиксельные «дыры» между карточками чатов в сайдбаре. На скриншотах пользователей с большим числом приглашений (1998+ invites) между реальными чатами на вкладке **All** зияли многосотпиксельные пробелы — `RecycleScroller` резервировал `ITEM_HEIGHT=68` на каждый элемент `allFilteredRooms`, а invites без sender-info рендерились как невидимые stripes.

Что сделано:

- Новый helper `src/entities/chat/lib/room-visibility.ts` с чистыми функциями `hasDisplayableContent(room)` и `filterRoomsForTab(rooms, tab)`.
- Вкладка **All** теперь **не содержит invites** (они только на отдельной вкладке Invites) и отбрасывает полностью пустые placeholder-комнаты.
- Вкладки **Personal** / **Groups** дополнительно отбрасывают пустые placeholder-комнаты.
- Вкладка **Invites** по-прежнему показывает ВСЕ invites (включая «пустые») — чтобы пользователь мог accept/decline.
- `src/features/contacts/ui/ContactList.vue` переиспользует новый helper в `allFilteredRooms`.

Счётчик `1998` на табе Invites не затронут — он считается из `sortedRooms` в store, не из `allFilteredRooms`.

## Why

Пользователь видел на Android большие пустые промежутки в списке чатов (между `Chitaytedetyamknigi` и `Mihik` — ~7 пустых слотов, между `Pkoin Exchange App` и `XPAHUTEJLb` — ещё больше). Корень — invites с `origin_server_ts` попадали в «All» вкладку, сортировались между живыми чатами и рендерились без контента. Предыдущий патч `ba4981c` (flicker + `contain: layout paint`) адресовал мерцание, но не дыры. Этот фикс разделяет invites на отдельную вкладку на UX-уровне.

## Test plan

- [x] 14 unit-тестов в `room-visibility.test.ts` — все зелёные.
- [x] Code review (superpowers:code-reviewer): CRITICAL=0, HIGH=0, APPROVE. 2 MEDIUM находки — locked test case добавлен, invite-count badge проверен (не затронут).
- [x] Type check затронутых файлов (`ContactList.vue`, `room-visibility.ts`) — без ошибок.
- [ ] Собрать Android build и визуально убедиться на скриншотах пользователя, что дыр больше нет.
- [ ] Regression: проверить, что joined room без `lastMessage`, но с name, остаётся видимой во вкладках All / Personal / Groups.
- [ ] Regression: проверить вкладку Invites — все 1998 приглашений на месте.