### PR TITLE
fix(bug-report): delay status sheet by 2 days, drop version trigger

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -226,41 +226,25 @@ const {
   resetState: resetBugStatus,
 } = useBugReportStatus();
 
-let pendingBugCheckVersion: string | null = null;
+let pendingBugCheck = false;
 
-async function runBugStatusCheck() {
+function runBugStatusCheck() {
   if (!authStore.address) return;
-  let version = "web";
-  if (isNative) {
-    try {
-      const { App } = await import("@capacitor/app");
-      const info = await App.getInfo();
-      version = info.version ?? "native";
-    } catch {
-      version = "native";
-    }
-  } else if ((window as any).electronAPI?.getVersion) {
-    try {
-      version = await (window as any).electronAPI.getVersion();
-    } catch {
-      version = "electron";
-    }
-  }
-  if (!shouldCheckOnBoot(version)) return;
+  if (!shouldCheckOnBoot()) return;
   loadBugIssues(authStore.address);
   if (bugStatusIssues.value.length > 0) {
-    pendingBugCheckVersion = version;
+    pendingBugCheck = true;
     openBugStatusSheet();
   } else {
-    markBootCheckCompleted(version);
+    markBootCheckCompleted();
   }
 }
 
 function handleBugStatusSheetClose() {
   closeBugStatusSheet();
-  if (pendingBugCheckVersion) {
-    markBootCheckCompleted(pendingBugCheckVersion);
-    pendingBugCheckVersion = null;
+  if (pendingBugCheck) {
+    markBootCheckCompleted();
+    pendingBugCheck = false;
   }
 }
 
@@ -270,9 +254,11 @@ watch(
   (addr) => {
     if (addr && !bugStatusCheckTriggered) {
       bugStatusCheckTriggered = true;
-      runBugStatusCheck().catch((e) =>
-        console.warn("[App] bug status check failed:", e),
-      );
+      try {
+        runBugStatusCheck();
+      } catch (e) {
+        console.warn("[App] bug status check failed:", e);
+      }
     }
   },
   { immediate: true },

--- a/src/features/bug-report/model/__tests__/use-bug-report-status.test.ts
+++ b/src/features/bug-report/model/__tests__/use-bug-report-status.test.ts
@@ -7,7 +7,6 @@ import {
 import { trackCreatedIssue } from '@/shared/lib/bug-report';
 
 const APP_NAME = 'forta-chat';
-const VERSION_KEY = `${APP_NAME}:bug-report-status:last-version`;
 const CHECKED_AT_KEY = `${APP_NAME}:bug-report-status:last-checked-at`;
 
 beforeEach(() => {
@@ -24,43 +23,35 @@ afterEach(() => {
 });
 
 describe('shouldCheckOnBoot', () => {
-  it('returns true on first run (no metadata stored)', () => {
-    expect(shouldCheckOnBoot('1.0.0')).toBe(true);
+  it('returns true on first run (no timestamp stored)', () => {
+    expect(shouldCheckOnBoot()).toBe(true);
   });
 
-  it('returns true when app version changed', () => {
-    localStorage.setItem(VERSION_KEY, JSON.stringify('1.0.0'));
-    localStorage.setItem(CHECKED_AT_KEY, JSON.stringify(Date.now()));
-    expect(shouldCheckOnBoot('1.1.0')).toBe(true);
-  });
-
-  it('returns false when version same and <3 days since last check', () => {
-    localStorage.setItem(VERSION_KEY, JSON.stringify('1.0.0'));
+  it('returns false when <2 days elapsed since last check', () => {
     const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000;
     localStorage.setItem(CHECKED_AT_KEY, JSON.stringify(oneDayAgo));
-    expect(shouldCheckOnBoot('1.0.0')).toBe(false);
+    expect(shouldCheckOnBoot()).toBe(false);
   });
 
-  it('returns true when >3 days since last check', () => {
-    localStorage.setItem(VERSION_KEY, JSON.stringify('1.0.0'));
-    const fourDaysAgo = Date.now() - 4 * 24 * 60 * 60 * 1000;
-    localStorage.setItem(CHECKED_AT_KEY, JSON.stringify(fourDaysAgo));
-    expect(shouldCheckOnBoot('1.0.0')).toBe(true);
+  it('returns true when >2 days elapsed since last check', () => {
+    const threeDaysAgo = Date.now() - 3 * 24 * 60 * 60 * 1000;
+    localStorage.setItem(CHECKED_AT_KEY, JSON.stringify(threeDaysAgo));
+    expect(shouldCheckOnBoot()).toBe(true);
   });
 
-  it('treats empty version string as first run', () => {
-    expect(shouldCheckOnBoot('')).toBe(true);
+  it('returns false right after markBootCheckCompleted (app update should not re-trigger)', () => {
+    markBootCheckCompleted();
+    expect(shouldCheckOnBoot()).toBe(false);
   });
 });
 
 describe('markBootCheckCompleted', () => {
-  it('persists version + timestamp', () => {
-    markBootCheckCompleted('1.2.3');
-    expect(JSON.parse(localStorage.getItem(VERSION_KEY)!)).toBe('1.2.3');
+  it('persists timestamp', () => {
+    markBootCheckCompleted();
     expect(typeof JSON.parse(localStorage.getItem(CHECKED_AT_KEY)!)).toBe(
       'number',
     );
-    expect(shouldCheckOnBoot('1.2.3')).toBe(false);
+    expect(shouldCheckOnBoot()).toBe(false);
   });
 });
 

--- a/src/features/bug-report/model/use-bug-report-status.ts
+++ b/src/features/bug-report/model/use-bug-report-status.ts
@@ -23,11 +23,11 @@ const REPO_URL = 'https://github.com/greenShirtMystery/forta-bugs/issues';
 
 // ─── Boot-trigger policy ───────────────────────────────────────────────
 // The sheet is auto-opened after login when the user has locally-tracked
-// reports AND at least one of: new app version since last check, or
-// >3 days elapsed since last check. Purely local — no network involved.
-const VERSION_KEY = `${APP_NAME}:bug-report-status:last-version`;
+// reports AND >2 days elapsed since last check. Version changes do NOT
+// trigger the sheet — after an update the user needs time to actually use
+// the new build before being asked whether their bug is resolved.
 const CHECKED_AT_KEY = `${APP_NAME}:bug-report-status:last-checked-at`;
-const INTERVAL_MS = 3 * 24 * 60 * 60 * 1000;
+const INTERVAL_MS = 2 * 24 * 60 * 60 * 1000;
 
 function readLS<T>(key: string): T | null {
   try {
@@ -38,18 +38,13 @@ function readLS<T>(key: string): T | null {
   }
 }
 
-export function shouldCheckOnBoot(currentVersion: string): boolean {
-  if (!currentVersion) return true;
-  const storedVersion = readLS<string>(VERSION_KEY);
-  if (!storedVersion) return true;
-  if (storedVersion !== currentVersion) return true;
+export function shouldCheckOnBoot(): boolean {
   const lastCheckedAt = readLS<number>(CHECKED_AT_KEY);
   if (typeof lastCheckedAt !== 'number') return true;
   return Date.now() - lastCheckedAt > INTERVAL_MS;
 }
 
-export function markBootCheckCompleted(currentVersion: string): void {
-  localStorage.setItem(VERSION_KEY, JSON.stringify(currentVersion));
+export function markBootCheckCompleted(): void {
   localStorage.setItem(CHECKED_AT_KEY, JSON.stringify(Date.now()));
 }
 


### PR DESCRIPTION
## Summary

- Bug-report status sheet no longer re-opens immediately after every app update.
- Only trigger left is time-since-last-check, shortened from 3 days to 2 days.
- Removed the `currentVersion` parameter and Capacitor/Electron version fetch in `App.vue`.

## Why

The sheet asked users "is your bug resolved?" as soon as they opened the updated app. They had no time to actually use the new build, and post-update regressions could slip by unnoticed because the prompt fired before any real usage. Two days is enough to cover the typical messenger flows (chats, calls, sharing, notifications) while still keeping the original bug report fresh in the reporter's memory.

## Changes

- `src/features/bug-report/model/use-bug-report-status.ts` — drop `VERSION_KEY`, make `shouldCheckOnBoot()` / `markBootCheckCompleted()` parameterless, `INTERVAL_MS` 3d → 2d.
- `src/app/App.vue` — remove Capacitor/Electron version detection, simplify to synchronous flow, `pendingBugCheckVersion` → `pendingBugCheck: boolean`.
- `src/features/bug-report/model/__tests__/use-bug-report-status.test.ts` — new coverage for "no re-trigger right after `markBootCheckCompleted`" (the exact post-update regression this PR fixes) + updated interval assertions.

## Test plan

- [x] `npm run test -- --run src/features/bug-report src/shared/lib/bug-report` — 45/45 pass
- [x] Type-check clean in touched files (`vue-tsc --noEmit` clean for App.vue + use-bug-report-status.*)
- [ ] Manual: install an older build, submit a bug, upgrade the app — sheet should NOT open on the next launch. Wait 2 days → sheet opens.
- [ ] Manual: close/reopen an issue from the sheet still works (no regression on `markUnresolved` / `closeUserIssue`).