### PR TITLE
fix(sync): pass clientId as txnId in file/edit/transfer op handlers

### DIFF
--- a/src/entities/matrix/model/matrix-client.ts
+++ b/src/entities/matrix/model/matrix-client.ts
@@ -550,11 +550,17 @@ export class MatrixClientService {
     return this.chatsReady;
   }
 
-  /** Send text message. Returns server event_id. */
-  async sendText(roomId: string, text: string): Promise<string> {
+  /** Send text message. `txnId` is the Matrix transaction ID used for
+   *  idempotency — passing a stable ID (e.g. LocalMessage.clientId) lets the
+   *  server deduplicate retries / multi-tab races into a single event. */
+  async sendText(roomId: string, text: string, txnId?: string): Promise<string> {
     if (!this.client) throw new Error("Client not initialized");
     const content = sdk.ContentHelpers.makeTextMessage(text);
-    const res = await this.client.sendMessage(roomId, content);
+    const res = txnId !== undefined
+      // matrix-js-sdk routes sendEvent through the same txnId dedup path that
+      // sendMessage uses, so we can go through sendEvent when we have an ID.
+      ? await this.client.sendEvent(roomId, "m.room.message", content, txnId)
+      : await this.client.sendMessage(roomId, content);
     return (res as { event_id: string }).event_id;
   }
 

--- a/src/shared/lib/local-db/__tests__/sync-engine-txnid.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-txnid.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Regression tests: every SyncEngine op handler that sends a Matrix event MUST
+ * pass `op.clientId` as the txnId so the homeserver dedupes duplicate sends
+ * (multi-tab races, network retries). Bug: `syncSendFile`, `syncEditMessage`,
+ * and `syncSendTransfer` used to drop the txnId argument, so two tabs running
+ * the same op could produce two server events and two visible bubbles — the
+ * transfer case was the most painful because that's money.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Dexie from "dexie";
+import "fake-indexeddb/auto";
+import { SyncEngine } from "../sync-engine";
+import type { PendingOperation, LocalMessage, LocalRoom } from "../schema";
+
+// --- Mocks -------------------------------------------------------------------
+
+const mockMatrix = {
+  sendEncryptedText: vi.fn<
+    (roomId: string, content: unknown, txnId?: string) => Promise<string>
+  >(async () => "$server_event_id"),
+  sendText: vi.fn<(roomId: string, text: string, txnId?: string) => Promise<string>>(
+    async () => "$server_event_id",
+  ),
+  sendReaction: vi.fn<(roomId: string, eventId: string, emoji: string) => Promise<string>>(
+    async () => "$reaction_id",
+  ),
+  redactEvent: vi.fn<(roomId: string, eventId: string) => Promise<void>>(async () => undefined),
+  sendPollStart: vi.fn<(roomId: string, content: unknown) => Promise<string>>(
+    async () => "$poll_id",
+  ),
+  sendPollResponse: vi.fn<(roomId: string, content: unknown) => Promise<void>>(
+    async () => undefined,
+  ),
+  uploadContentMxc: vi.fn<(blob: Blob) => Promise<string>>(async () => "mxc://server/file"),
+};
+
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: () => mockMatrix,
+}));
+
+// --- Test DB -----------------------------------------------------------------
+
+class TestDb extends Dexie {
+  messages!: Dexie.Table<LocalMessage, number>;
+  rooms!: Dexie.Table<LocalRoom, string>;
+  pendingOps!: Dexie.Table<PendingOperation, number>;
+  attachments!: Dexie.Table<
+    {
+      id?: number;
+      localBlob?: Blob;
+      size?: number;
+      status?: string;
+      messageLocalId?: number;
+    },
+    number
+  >;
+  users!: Dexie.Table<{ address: string }, string>;
+  syncState!: Dexie.Table<{ key: string; value: string | number }, string>;
+  decryptionQueue!: Dexie.Table<{ id?: number; status: string }, number>;
+  listenedMessages!: Dexie.Table<{ messageId: string }, string>;
+
+  constructor(name: string) {
+    super(name, { indexedDB, IDBKeyRange });
+    this.version(1).stores({
+      messages:
+        "++localId, eventId, clientId, [roomId+timestamp], [roomId+status], senderId",
+      rooms: "id, updatedAt, membership, isDeleted",
+      pendingOps: "++id, [roomId+createdAt], status",
+      attachments: "++id, messageLocalId, status",
+      users: "address, updatedAt",
+      syncState: "key",
+      decryptionQueue: "++id, status",
+      listenedMessages: "messageId",
+    });
+  }
+}
+
+// --- Helpers -----------------------------------------------------------------
+
+interface Harness {
+  db: TestDb;
+  engine: SyncEngine;
+  messageRepo: {
+    confirmSent: ReturnType<typeof vi.fn>;
+    updateStatus: ReturnType<typeof vi.fn>;
+    getByEventId: ReturnType<typeof vi.fn>;
+    updateReactions: ReturnType<typeof vi.fn>;
+    getByClientId: ReturnType<typeof vi.fn>;
+  };
+  roomRepo: { updateRoom: ReturnType<typeof vi.fn> };
+  getRoomCrypto: ReturnType<typeof vi.fn>;
+}
+
+function makeHarness(name: string, opts: { encrypted: boolean }): Harness {
+  const db = new TestDb(name);
+  const messageRepo = {
+    confirmSent: vi.fn(async () => undefined),
+    updateStatus: vi.fn(async () => undefined),
+    getByEventId: vi.fn(async () => undefined),
+    updateReactions: vi.fn(async () => undefined),
+    getByClientId: vi.fn(async () => undefined),
+  };
+  const roomRepo = { updateRoom: vi.fn(async () => undefined) };
+  const roomCrypto = opts.encrypted
+    ? {
+        canBeEncrypt: () => true,
+        encryptEvent: async () => ({
+          msgtype: "m.encrypted",
+          body: "cipher",
+          block: "b",
+          version: 1,
+        }),
+        encryptFile: async (blob: Blob) => ({
+          file: blob,
+          secrets: { keys: "k" },
+        }),
+      }
+    : undefined;
+  const getRoomCrypto = vi.fn(async () => roomCrypto);
+  const engine = new SyncEngine(
+    db as never,
+    messageRepo as never,
+    roomRepo as never,
+    getRoomCrypto as never,
+  );
+  return { db, engine, messageRepo, roomRepo, getRoomCrypto };
+}
+
+async function seedOp(
+  db: TestDb,
+  overrides: Partial<PendingOperation> = {},
+): Promise<number> {
+  return db.pendingOps.add({
+    type: "send_message",
+    roomId: "!room:server",
+    payload: {},
+    status: "pending",
+    retries: 0,
+    maxRetries: 5,
+    createdAt: Date.now(),
+    clientId: "cli_fixed_for_test",
+    ...overrides,
+  } as PendingOperation);
+}
+
+async function waitForProcessed(db: TestDb, timeoutMs = 1500): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const remaining = await db.pendingOps.count();
+    if (remaining === 0) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error("pendingOps queue did not drain in time");
+}
+
+// ---------------------------------------------------------------------------
+// Tests — one per op handler that was previously dropping clientId
+// ---------------------------------------------------------------------------
+
+describe("SyncEngine txnId propagation (regression)", () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await h.db.delete();
+  });
+
+  it("syncSendFile passes op.clientId as the Matrix txnId", async () => {
+    h = makeHarness(`txnid-file-${Date.now()}-${Math.random()}`, { encrypted: true });
+    await h.db.open();
+    // Attachment blob required by syncSendFile
+    const attachmentId = await h.db.attachments.add({
+      messageLocalId: 1,
+      localBlob: new Blob(["hi"], { type: "text/plain" }),
+      size: 2,
+      status: "local",
+    });
+
+    await seedOp(h.db, {
+      type: "send_file",
+      clientId: "cli_file_1",
+      payload: {
+        fileName: "test.txt",
+        mimeType: "text/plain",
+        msgtype: "m.file",
+        attachmentId,
+      },
+    });
+
+    await h.engine.processQueue();
+    await waitForProcessed(h.db);
+
+    expect(mockMatrix.sendEncryptedText).toHaveBeenCalledTimes(1);
+    const [roomId, , txnId] = mockMatrix.sendEncryptedText.mock.calls[0];
+    expect(roomId).toBe("!room:server");
+    expect(txnId).toBe("cli_file_1");
+  });
+
+  it("syncEditMessage passes op.clientId as the Matrix txnId", async () => {
+    h = makeHarness(`txnid-edit-${Date.now()}-${Math.random()}`, { encrypted: true });
+    await h.db.open();
+
+    await seedOp(h.db, {
+      type: "edit_message",
+      clientId: "cli_edit_1",
+      payload: { eventId: "$old_event", newContent: "updated body" },
+    });
+
+    await h.engine.processQueue();
+    await waitForProcessed(h.db);
+
+    expect(mockMatrix.sendEncryptedText).toHaveBeenCalledTimes(1);
+    const [, , txnId] = mockMatrix.sendEncryptedText.mock.calls[0];
+    expect(txnId).toBe("cli_edit_1");
+  });
+
+  it("syncSendTransfer (encrypted) passes op.clientId as the Matrix txnId", async () => {
+    h = makeHarness(`txnid-xfer-enc-${Date.now()}-${Math.random()}`, { encrypted: true });
+    await h.db.open();
+
+    await seedOp(h.db, {
+      type: "send_transfer",
+      clientId: "cli_xfer_enc_1",
+      payload: {
+        txId: "abc123",
+        amount: 1.5,
+        from: "PxAlice",
+        to: "PxBob",
+        message: "thanks",
+      },
+    });
+
+    await h.engine.processQueue();
+    await waitForProcessed(h.db);
+
+    expect(mockMatrix.sendEncryptedText).toHaveBeenCalledTimes(1);
+    const [, , txnId] = mockMatrix.sendEncryptedText.mock.calls[0];
+    expect(txnId).toBe("cli_xfer_enc_1");
+  });
+
+  it("syncSendTransfer (plain) passes op.clientId as the Matrix txnId", async () => {
+    h = makeHarness(`txnid-xfer-plain-${Date.now()}-${Math.random()}`, { encrypted: false });
+    await h.db.open();
+
+    await seedOp(h.db, {
+      type: "send_transfer",
+      clientId: "cli_xfer_plain_1",
+      payload: {
+        txId: "def456",
+        amount: 0.25,
+        from: "PxAlice",
+        to: "PxBob",
+      },
+    });
+
+    await h.engine.processQueue();
+    await waitForProcessed(h.db);
+
+    expect(mockMatrix.sendText).toHaveBeenCalledTimes(1);
+    const [, , txnId] = mockMatrix.sendText.mock.calls[0];
+    expect(txnId).toBe("cli_xfer_plain_1");
+    // And nothing leaked to the encrypted path
+    expect(mockMatrix.sendEncryptedText).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/lib/local-db/sync-engine.ts
+++ b/src/shared/lib/local-db/sync-engine.ts
@@ -313,7 +313,9 @@ export class SyncEngine {
       content.secrets = secrets;
     }
 
-    const serverEventId = await matrixService.sendEncryptedText(op.roomId, content);
+    // Pass op.clientId as the Matrix txnId so the homeserver dedupes
+    // multi-tab/retry sends into a single event (matches syncSendMessage).
+    const serverEventId = await matrixService.sendEncryptedText(op.roomId, content, op.clientId);
     await this.messageRepo.confirmSent(op.clientId, serverEventId);
     await this.roomRepo.updateRoom(op.roomId, {
       lastMessageLocalStatus: "synced" as import("./schema").LocalMessageStatus,
@@ -350,7 +352,9 @@ export class SyncEngine {
       };
     }
 
-    await matrixService.sendEncryptedText(op.roomId, content);
+    // Idempotent edit: use clientId as txnId so an edit is never applied twice
+    // if the user has multiple tabs or a flaky connection causes a retry.
+    await matrixService.sendEncryptedText(op.roomId, content, op.clientId);
   }
 
   private async syncDeleteMessage(op: PendingOperation): Promise<void> {
@@ -445,12 +449,15 @@ export class SyncEngine {
       message: payload.message,
     });
 
+    // Transfers MUST dedupe on retry — a double-send here would mean a
+    // duplicate tip bubble for the recipient. Pass clientId as the Matrix
+    // txnId on both the encrypted and plaintext paths.
     let serverEventId: string;
     if (roomCrypto?.canBeEncrypt()) {
       const encrypted = await roomCrypto.encryptEvent(transferBody);
-      serverEventId = await matrixService.sendEncryptedText(op.roomId, encrypted);
+      serverEventId = await matrixService.sendEncryptedText(op.roomId, encrypted, op.clientId);
     } else {
-      serverEventId = await matrixService.sendText(op.roomId, transferBody);
+      serverEventId = await matrixService.sendText(op.roomId, transferBody, op.clientId);
     }
 
     await this.messageRepo.confirmSent(op.clientId, serverEventId);


### PR DESCRIPTION
## Summary

Three `SyncEngine` op handlers — `syncSendFile`, `syncEditMessage`, and `syncSendTransfer` — dropped the `txnId` argument when calling `matrixService.sendEncryptedText` / `sendText`. `syncSendMessage` already passed it correctly; these three did not.

The homeserver deduplicates events per-sender by `txn_id`. Without it, if two tabs both claim the same pending op and hit the server (IndexedDB transactions don't span connections, so that race is reachable), the server creates **two distinct events**. The most visible case was a duplicated tip/transfer bubble for the recipient — that's money — but edits and file/photo/voice uploads had the same bug.

Flagged during code review on the non-blocking SyncEngine PR (#47); shipped as an isolated follow-up so the scheduler refactor isn't blocked by it.

## Changes

- `matrix-client.ts::sendText` now accepts an optional `txnId`. When provided it routes through `client.sendEvent(roomId, "m.room.message", content, txnId)`; otherwise it falls back to the existing `sendMessage` path. Existing callers continue to work unchanged.
- `sync-engine.ts`: four call sites updated to pass `op.clientId`:
  - `syncSendFile` — photo / voice / file uploads
  - `syncEditMessage` — message edits
  - `syncSendTransfer` (encrypted path)
  - `syncSendTransfer` (plaintext fallback)

## Tests

New regression file `src/shared/lib/local-db/__tests__/sync-engine-txnid.test.ts`, 4 cases all GREEN:

- `syncSendFile` invokes `sendEncryptedText` with the op's `clientId` as the third arg.
- `syncEditMessage` likewise.
- `syncSendTransfer` encrypted path likewise.
- `syncSendTransfer` plaintext path routes to `sendText` with `clientId` and does not touch the encrypted path.

## Verification

- [x] `npm test` — 1055/1065 pass. The 10 failures are identical to the baseline on master (no regressions). +4 new tests.
- [x] Targeted test file: 4/4 pass.
- [ ] Manual Android smoke (follow-up): open forta-chat in two tabs on the same account, send a transfer from one tab — recipient should see exactly one bubble.

## Relationship to PR #47

Independent branch, independent PR. Can merge in either order:
- If #47 merges first: this patch rebases cleanly (only touches handler bodies).
- If this patch merges first: #47 also needs no changes (scheduler refactor doesn't touch handler call sites).