### PR TITLE
fix(navigation): open channels and loading rooms on mobile

### DIFF
--- a/src/pages/chat/ChatPage.vue
+++ b/src/pages/chat/ChatPage.vue
@@ -5,6 +5,7 @@ import SettingsContentPanel from "@/widgets/sidebar/ui/SettingsContentPanel.vue"
 import { GroupCreationPanel } from "@/features/group-creation";
 import { useChatStore } from "@/entities/chat";
 import { useAuthStore } from "@/entities/auth";
+import { useChannelStore } from "@/entities/channel";
 import { useI18n } from "@/shared/lib/i18n";
 import { useSidebarTab } from "@/widgets/sidebar/model/use-sidebar-tab";
 import { useAndroidBackHandler } from "@/shared/lib/composables/use-android-back-handler";
@@ -12,6 +13,7 @@ import { useAudioPlayback } from "@/features/messaging/model/use-audio-playback"
 
 const chatStore = useChatStore();
 const authStore = useAuthStore();
+const channelStore = useChannelStore();
 const { t } = useI18n();
 const { settingsSubView, closeSettingsContent, setTab } = useSidebarTab();
 
@@ -23,14 +25,17 @@ const isMobile = ref(window.innerWidth < 768);
 // (e.g. stale push intent) could push them back into a chat they just exited.
 const userForcedSidebar = ref(false);
 
-// Desktop: both panels always visible. Mobile: show sidebar until we have a
-// concrete activeRoom object — not just an activeRoomId. This prevents an
-// empty "Select a chat" screen when a push intent restores activeRoomId
-// before the rooms list has finished syncing.
+// Desktop: both panels always visible. Mobile: hide the sidebar as soon as
+// there is a content intent — either a room the user selected (even if its
+// object is still hydrating; ChatWindow renders MessageSkeleton) or an active
+// channel (ChatWindow renders ChannelView). Watching activeRoom alone missed
+// both cases and left the user staring at the sidebar on mobile.
 const showSidebar = computed(() => {
   if (!isMobile.value) return true;
   if (userForcedSidebar.value) return true;
-  return !chatStore.activeRoom;
+  if (chatStore.activeRoomId) return false;
+  if (channelStore.activeChannelAddress) return false;
+  return true;
 });
 
 let resizeTimer: ReturnType<typeof setTimeout> | undefined;
@@ -60,36 +65,31 @@ const onSelectRoom = () => {
   userForcedSidebar.value = false;
 };
 
-// When activeRoom actually becomes available (e.g. after rooms sync resolves
-// a pending push-intent roomId), clean up any open panels so ChatWindow
-// shows immediately on mobile.
+// Any external content intent (push notification, deep link, channel open)
+// clears user-forced state and closes overlay panels. We react to both
+// activeRoomId and activeChannelAddress because channels live in a separate
+// store — without this, tapping a channel left the sidebar on top even
+// though ChatWindow was already rendering ChannelView underneath.
 watch(
-  () => chatStore.activeRoom,
-  (room) => {
-    if (room && isMobile.value) {
+  [() => chatStore.activeRoomId, () => channelStore.activeChannelAddress],
+  ([newRoomId, newChannelAddr], [oldRoomId, oldChannelAddr]) => {
+    const roomChanged = newRoomId && newRoomId !== oldRoomId;
+    const channelChanged = newChannelAddr && newChannelAddr !== oldChannelAddr;
+    if (!roomChanged && !channelChanged) return;
+    if (isMobile.value) {
       closeSettingsContent();
       setTab("chats");
-      userForcedSidebar.value = false;
     }
-  },
-);
-
-// Any external nav-intent (push, deep link) clears user-forced state;
-// the activeRoom watcher above will subsequently close panels once the
-// room object resolves. This ensures liveness even if the room never
-// materializes (stale ID, deleted room).
-watch(
-  () => chatStore.activeRoomId,
-  (newId, oldId) => {
-    if (newId && newId !== oldId) {
-      userForcedSidebar.value = false;
-    }
+    userForcedSidebar.value = false;
   },
 );
 
 const onBackToSidebar = () => {
   userForcedSidebar.value = true;
   chatStore.setActiveRoom(null);
+  // Defense-in-depth: ChannelView's own back handler also clears this before
+  // emitting, but we cover the room/empty-state back paths here too. Idempotent.
+  channelStore.clearActiveChannel();
 };
 
 const showGroupCreation = ref(false);

--- a/src/pages/chat/__tests__/ChatPage.test.ts
+++ b/src/pages/chat/__tests__/ChatPage.test.ts
@@ -52,6 +52,21 @@ vi.mock("@/entities/chat", () => ({
   }),
 }));
 
+// ── Mock channel store — ChatPage must react to activeChannelAddress ───
+const fakeActiveChannelAddress = ref<string | null>(null);
+const clearActiveChannelSpy = vi.fn(() => {
+  fakeActiveChannelAddress.value = null;
+});
+
+vi.mock("@/entities/channel", () => ({
+  useChannelStore: () => ({
+    get activeChannelAddress() {
+      return fakeActiveChannelAddress.value;
+    },
+    clearActiveChannel: clearActiveChannelSpy,
+  }),
+}));
+
 // ── Mock auth store (ChatPage only reads from it) ─────────────────
 vi.mock("@/entities/auth", () => ({
   useAuthStore: () => ({
@@ -133,10 +148,12 @@ beforeEach(() => {
   fakeActiveRoomId.value = null;
   fakeRooms.value = [];
   fakeRoomsInitialized.value = false;
+  fakeActiveChannelAddress.value = null;
   settingsSubViewRef.value = null;
   setActiveRoomSpy.mockClear();
   closeSettingsContentSpy.mockClear();
   setTabSpy.mockClear();
+  clearActiveChannelSpy.mockClear();
 });
 
 afterEach(() => {
@@ -151,8 +168,10 @@ const isVisible = (el: HTMLElement | null | undefined): boolean => {
 };
 
 describe("ChatPage — reactive showSidebar", () => {
-  it("shows sidebar on mobile when activeRoomId is set but activeRoom is not loaded", async () => {
-    // Simulate push-intent restoration: activeRoomId set before rooms sync
+  it("hides sidebar on mobile as soon as activeRoomId is set, even before the room object hydrates", async () => {
+    // Push-intent / cold-start: activeRoomId restored before Matrix sync
+    // resolves `rooms`. Before the fix, this kept sidebar on top and the
+    // MessageSkeleton inside ChatWindow was never visible.
     fakeActiveRoomId.value = "!abc:matrix.org";
     fakeRooms.value = []; // room object not available yet
     fakeRoomsInitialized.value = false;
@@ -162,18 +181,17 @@ describe("ChatPage — reactive showSidebar", () => {
 
     const sidebar = wrapper.find('[data-testid="chat-sidebar"]');
     expect(sidebar.exists()).toBe(true);
-    // Must be visible (not hidden by v-show="false")
-    expect(isVisible(sidebar.element as HTMLElement)).toBe(true);
+    expect(isVisible(sidebar.element as HTMLElement)).toBe(false);
 
-    // ChatWindow should NOT be visible — we're still on the list
+    // ChatWindow owns the loading placeholder (MessageSkeleton); must be shown.
     const chatWindow = wrapper.find('[data-testid="chat-window"]');
-    expect(isVisible(chatWindow.element as HTMLElement)).toBe(false);
+    expect(chatWindow.exists()).toBe(true);
+    expect(isVisible(chatWindow.element as HTMLElement)).toBe(true);
 
     wrapper.unmount();
   });
 
-  it("hides sidebar on mobile when activeRoom becomes available", async () => {
-    // Start with push-intent state: id present, room object not yet loaded
+  it("keeps ChatWindow visible after activeRoom finishes hydrating", async () => {
     fakeActiveRoomId.value = "!abc:matrix.org";
     fakeRooms.value = [];
     fakeRoomsInitialized.value = false;
@@ -181,19 +199,57 @@ describe("ChatPage — reactive showSidebar", () => {
     const wrapper = mount(ChatPage, mountOpts);
     await flushPromises();
 
-    // Initially sidebar must be visible because activeRoom is unresolved
     const sidebar = wrapper.find('[data-testid="chat-sidebar"]');
-    expect(isVisible(sidebar.element as HTMLElement)).toBe(true);
+    expect(isVisible(sidebar.element as HTMLElement)).toBe(false);
 
-    // Now rooms finish syncing and the target room appears
     fakeRooms.value = [{ id: "!abc:matrix.org", name: "Test Room" }];
     fakeRoomsInitialized.value = true;
     await flushPromises();
 
-    // Sidebar should now hide and chat window should be visible
     expect(isVisible(sidebar.element as HTMLElement)).toBe(false);
     const chatWindow = wrapper.find('[data-testid="chat-window"]');
     expect(chatWindow.exists()).toBe(true);
+    expect(isVisible(chatWindow.element as HTMLElement)).toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it("hides sidebar on mobile when a channel becomes active (no activeRoomId)", async () => {
+    // Regression: before the fix, opening a channel set
+    // channelStore.activeChannelAddress but ChatPage only watched
+    // chatStore.activeRoom, so sidebar stayed on top and ChannelView
+    // (rendered inside ChatWindow) was never visible.
+    fakeActiveRoomId.value = null;
+    fakeActiveChannelAddress.value = "PEUYuN8J1...";
+
+    const wrapper = mount(ChatPage, mountOpts);
+    await flushPromises();
+
+    const sidebar = wrapper.find('[data-testid="chat-sidebar"]');
+    expect(sidebar.exists()).toBe(true);
+    expect(isVisible(sidebar.element as HTMLElement)).toBe(false);
+
+    const chatWindow = wrapper.find('[data-testid="chat-window"]');
+    expect(chatWindow.exists()).toBe(true);
+    expect(isVisible(chatWindow.element as HTMLElement)).toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it("hides sidebar when a channel becomes active after mount", async () => {
+    // Start on sidebar (no active room, no active channel)
+    const wrapper = mount(ChatPage, mountOpts);
+    await flushPromises();
+
+    const sidebar = wrapper.find('[data-testid="chat-sidebar"]');
+    expect(isVisible(sidebar.element as HTMLElement)).toBe(true);
+
+    // Simulate user tapping a channel — channel store becomes active
+    fakeActiveChannelAddress.value = "PEUYuN8J1...";
+    await flushPromises();
+
+    expect(isVisible(sidebar.element as HTMLElement)).toBe(false);
+    const chatWindow = wrapper.find('[data-testid="chat-window"]');
     expect(isVisible(chatWindow.element as HTMLElement)).toBe(true);
 
     wrapper.unmount();
@@ -218,9 +274,10 @@ describe("ChatPage — reactive showSidebar", () => {
     chatWindow.vm.$emit("back");
     await flushPromises();
 
-    // activeRoomId should be null
+    // activeRoomId should be cleared; also clears any active channel
     expect(setActiveRoomSpy).toHaveBeenCalledWith(null);
     expect(fakeActiveRoomId.value).toBeNull();
+    expect(clearActiveChannelSpy).toHaveBeenCalled();
 
     // Sidebar should now be visible
     sidebar = wrapper.find('[data-testid="chat-sidebar"]');
@@ -269,7 +326,7 @@ describe("ChatPage — reactive showSidebar", () => {
     const wrapper = mount(ChatPage, mountOpts);
     await flushPromises();
 
-    // User backs out to sidebar — userForcedSidebar becomes true internally
+    // User backs out — userForcedSidebar becomes true internally, activeRoomId null
     const chatWindow = wrapper.findComponent({ name: "ChatWindow" });
     expect(chatWindow.exists()).toBe(true);
     chatWindow.vm.$emit("back");
@@ -278,31 +335,61 @@ describe("ChatPage — reactive showSidebar", () => {
     let sidebar = wrapper.find('[data-testid="chat-sidebar"]');
     expect(isVisible(sidebar.element as HTMLElement)).toBe(true);
 
-    // External push intent: a new activeRoomId arrives while rooms[] doesn't
-    // yet contain the target room. Without the new watcher, userForcedSidebar
-    // would stay true and sidebar would remain stuck visible even after the
-    // room materialises below.
+    // External push intent arrives — even before rooms[] contains the target,
+    // ChatWindow must become visible (it will render MessageSkeleton while the
+    // room hydrates). Without resetting userForcedSidebar, sidebar would stay
+    // stuck on top.
     fakeActiveRoomId.value = "!second:matrix.org";
     await flushPromises();
 
-    // Sidebar still visible because activeRoom is undefined (room not in list)
     sidebar = wrapper.find('[data-testid="chat-sidebar"]');
-    expect(isVisible(sidebar.element as HTMLElement)).toBe(true);
+    expect(isVisible(sidebar.element as HTMLElement)).toBe(false);
+    const chatWindowAfter = wrapper.find('[data-testid="chat-window"]');
+    expect(isVisible(chatWindowAfter.element as HTMLElement)).toBe(true);
 
-    // Now the second room materialises in rooms[] — this is the verification:
-    // if userForcedSidebar had stayed true, sidebar would stay visible. With
-    // the watcher reset, showSidebar falls back to !activeRoom and hides.
+    // Room materialises — ChatWindow remains visible (now with real content)
     fakeRooms.value = [
       ...fakeRooms.value,
       { id: "!second:matrix.org", name: "Second Room" },
     ];
     await flushPromises();
 
-    sidebar = wrapper.find('[data-testid="chat-sidebar"]');
+    expect(isVisible(chatWindowAfter.element as HTMLElement)).toBe(true);
     expect(isVisible(sidebar.element as HTMLElement)).toBe(false);
 
-    const chatWindowAfter = wrapper.find('[data-testid="chat-window"]');
-    expect(isVisible(chatWindowAfter.element as HTMLElement)).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("resets userForcedSidebar when an external channel-open occurs", async () => {
+    // Mount on sidebar, user-forced (nothing active yet)
+    const wrapper = mount(ChatPage, mountOpts);
+    await flushPromises();
+
+    // Force sidebar state by invoking back (userForcedSidebar → true)
+    // Then an external actor activates a channel — sidebar must hide.
+    fakeActiveChannelAddress.value = null;
+    // simulate a prior back press by directly tripping the forced-state:
+    // easiest path is the real back emit after a brief activeRoomId flash.
+    fakeActiveRoomId.value = "!temp:matrix.org";
+    fakeRooms.value = [{ id: "!temp:matrix.org", name: "Temp" }];
+    fakeRoomsInitialized.value = true;
+    await flushPromises();
+
+    const chatWindow = wrapper.findComponent({ name: "ChatWindow" });
+    chatWindow.vm.$emit("back");
+    await flushPromises();
+
+    let sidebar = wrapper.find('[data-testid="chat-sidebar"]');
+    expect(isVisible(sidebar.element as HTMLElement)).toBe(true);
+
+    // External channel activation (e.g. deep link)
+    fakeActiveChannelAddress.value = "PEUYuN8J1...";
+    await flushPromises();
+
+    sidebar = wrapper.find('[data-testid="chat-sidebar"]');
+    expect(isVisible(sidebar.element as HTMLElement)).toBe(false);
+    const cw = wrapper.find('[data-testid="chat-window"]');
+    expect(isVisible(cw.element as HTMLElement)).toBe(true);
 
     wrapper.unmount();
   });


### PR DESCRIPTION
## Summary

Follow-up to #43. On mobile, channels and rooms that are still syncing no longer open visually — the sidebar stays on top even though the item is selected in the list. This PR restores the transition for both cases while keeping every behavior #43 introduced.

## What broke

#43 made `showSidebar` react only to `chatStore.activeRoom` (the hydrated room object). Two mobile regressions followed:

- **Channels.** Tapping a channel sets `channelStore.activeChannelAddress` but never populates `chatStore.activeRoom` (channels aren't in `chatStore.rooms`). Sidebar stayed on top; `ChannelView` rendered invisibly underneath.
- **Chats during initial sync.** `setActiveRoom(id)` sets `activeRoomId`, but `activeRoom` stays `undefined` until Matrix sync hydrates rooms. Sidebar stayed on top, and the `MessageSkeleton` fallback that #43 added inside `ChatWindow` was never visible.

On desktop neither is visible because `ChatWindow` is always rendered alongside the sidebar.

## Fix

`src/pages/chat/ChatPage.vue`:

- `showSidebar` now hides as soon as **either** `chatStore.activeRoomId` or `channelStore.activeChannelAddress` is truthy. Desktop branch unchanged; `userForcedSidebar` override preserved.
- The two previous watchers on `activeRoom` and `activeRoomId` merge into one watching `[activeRoomId, activeChannelAddress]`. Resets `userForcedSidebar` on any truthy transition and, on mobile, closes overlay panels (same side effects as #43).
- `onBackToSidebar` also calls `channelStore.clearActiveChannel()` as defense-in-depth for the room/empty-state back paths (`ChannelView`'s own back handler still clears on the channel path).

## Preserved from #43

- User-forced sidebar: manual back keeps sidebar until the next external intent.
- `userForcedSidebar` reset on push-intent / deep-link.
- `MessageSkeleton` loading placeholder inside `ChatWindow` — now actually visible.

## Test plan

- [x] 8/8 ChatPage regression tests pass (6 existing updated, 2 new for channels).
- [x] 3/3 ChatWindow tests pass.
- [x] Full suite: 1071 pass, 10 pre-existing failures unrelated to this change (`parseVideoUrl`, `isUnresolvedName`, `openBastyonProfile` — verified via `git stash`).
- [x] `vite build` succeeds.
- [x] `vue-tsc --noEmit` — only pre-existing errors; touched files are clean.
- [x] Architectural code review — Approve, no blockers.
- [ ] Manual: mobile browser — open a channel, see `ChannelView` slide in.
- [ ] Manual: mobile browser — tap a chat during first-launch sync, see `MessageSkeleton`, then the hydrated chat.
- [ ] Manual: Android device — same two flows, plus hardware back returns to the list.

## Files

- `src/pages/chat/ChatPage.vue` — the fix.
- `src/pages/chat/__tests__/ChatPage.test.ts` — updated + new regression tests.