### PR TITLE
fix(chat-window): render header during room cold-load on mobile

### DIFF
--- a/src/widgets/chat-window/ChatWindow.vue
+++ b/src/widgets/chat-window/ChatWindow.vue
@@ -363,9 +363,11 @@ onUnmounted(() => {
 
 <template>
   <div ref="chatWindowRef" class="safe-bottom relative flex h-full flex-col bg-background-total-theme">
-    <!-- Chat header -->
+    <!-- Chat header — rendered also during isRoomLoading so mobile users keep
+         a back button and "chat is loading" chrome while Matrix hydrates the room. -->
     <div
-      v-if="chatStore.activeRoom && !isChannelView"
+      v-if="(chatStore.activeRoom || isRoomLoading) && !isChannelView"
+      data-testid="chat-header"
       class="flex h-14 shrink-0 items-center gap-3 border-b border-neutral-grad-0 px-3"
     >
       <!-- Back button (mobile) -->
@@ -381,6 +383,7 @@ onUnmounted(() => {
 
       <!-- Room avatar + info (clickable to open info panel) -->
       <button
+        v-if="chatStore.activeRoom"
         class="flex min-w-0 flex-1 cursor-pointer items-center gap-3 text-left"
         :aria-label="activeRoomTitle.text + ' — ' + t('info.title')"
         @click="showInfoPanel = true"
@@ -405,44 +408,58 @@ onUnmounted(() => {
         </div>
       </button>
 
-      <!-- Search button -->
-      <button
-        class="btn-press flex h-11 w-11 items-center justify-center rounded-full text-text-on-main-bg-color transition-colors hover:bg-neutral-grad-0"
-        :title="t('chat.search')"
-        :aria-label="t('chat.search')"
-        @click="showSearch = !showSearch"
+      <!-- Loading placeholder: pulse avatar + pulse title, non-interactive -->
+      <div
+        v-else
+        class="flex min-w-0 flex-1 items-center gap-3"
+        aria-hidden="true"
       >
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" />
-        </svg>
-      </button>
+        <div class="h-8 w-8 shrink-0 animate-pulse rounded-full bg-neutral-grad-2" />
+        <div class="h-4 w-32 animate-pulse rounded bg-neutral-grad-2" />
+      </div>
 
-      <!-- Voice call button (1:1 only) -->
-      <button
-        v-if="!chatStore.activeRoom.isGroup"
-        class="btn-press flex h-11 w-11 items-center justify-center rounded-full text-text-on-main-bg-color transition-colors hover:bg-neutral-grad-0"
-        :title="t('call.voiceCall')"
-        :aria-label="t('call.voiceCall')"
-        @click="startCallFromHeader('voice')"
-      >
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07 19.5 19.5 0 01-6-6 19.79 19.79 0 01-3.07-8.67A2 2 0 014.11 2h3a2 2 0 012 1.72c.127.96.361 1.903.7 2.81a2 2 0 01-.45 2.11L8.09 9.91a16 16 0 006 6l1.27-1.27a2 2 0 012.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0122 16.92z" />
-        </svg>
-      </button>
+      <!-- Action buttons: only shown once the room is hydrated, since they
+           depend on room data (search target, call peer, info panel). -->
+      <template v-if="chatStore.activeRoom">
+        <!-- Search button -->
+        <button
+          class="btn-press flex h-11 w-11 items-center justify-center rounded-full text-text-on-main-bg-color transition-colors hover:bg-neutral-grad-0"
+          :title="t('chat.search')"
+          :aria-label="t('chat.search')"
+          @click="showSearch = !showSearch"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <circle cx="11" cy="11" r="8" /><line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+        </button>
 
-      <!-- Info panel button -->
-      <button
-        class="btn-press flex h-11 w-11 items-center justify-center rounded-full text-text-on-main-bg-color transition-colors hover:bg-neutral-grad-0"
-        :title="t('info.title')"
-        :aria-label="t('info.title')"
-        @click="showInfoPanel = !showInfoPanel"
-      >
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-          <circle cx="12" cy="5" r="2" />
-          <circle cx="12" cy="12" r="2" />
-          <circle cx="12" cy="19" r="2" />
-        </svg>
-      </button>
+        <!-- Voice call button (1:1 only) -->
+        <button
+          v-if="!chatStore.activeRoom.isGroup"
+          class="btn-press flex h-11 w-11 items-center justify-center rounded-full text-text-on-main-bg-color transition-colors hover:bg-neutral-grad-0"
+          :title="t('call.voiceCall')"
+          :aria-label="t('call.voiceCall')"
+          @click="startCallFromHeader('voice')"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07 19.5 19.5 0 01-6-6 19.79 19.79 0 01-3.07-8.67A2 2 0 014.11 2h3a2 2 0 012 1.72c.127.96.361 1.903.7 2.81a2 2 0 01-.45 2.11L8.09 9.91a16 16 0 006 6l1.27-1.27a2 2 0 012.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0122 16.92z" />
+          </svg>
+        </button>
+
+        <!-- Info panel button -->
+        <button
+          class="btn-press flex h-11 w-11 items-center justify-center rounded-full text-text-on-main-bg-color transition-colors hover:bg-neutral-grad-0"
+          :title="t('info.title')"
+          :aria-label="t('info.title')"
+          @click="showInfoPanel = !showInfoPanel"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+            <circle cx="12" cy="5" r="2" />
+            <circle cx="12" cy="12" r="2" />
+            <circle cx="12" cy="19" r="2" />
+          </svg>
+        </button>
+      </template>
 
     </div>
 

--- a/src/widgets/chat-window/__tests__/ChatWindow.test.ts
+++ b/src/widgets/chat-window/__tests__/ChatWindow.test.ts
@@ -260,4 +260,88 @@ describe("ChatWindow — loading vs select-prompt placeholders", () => {
 
     wrapper.unmount();
   });
+
+  it("renders chat header with back button while room is loading so mobile users can exit cold-load state", async () => {
+    // Bug: on mobile during initial Matrix sync, activeRoomId is set but
+    // activeRoom is undefined. The header's v-if required activeRoom, so
+    // MessageSkeleton occupied the full screen with no header and no way back.
+    fakeActiveRoomId.value = "!abc:matrix.org";
+    fakeRooms.value = [];
+    fakeRoomsInitialized.value = false;
+
+    const wrapper = mount(ChatWindow, mountOpts);
+    await flushPromises();
+
+    const header = wrapper.find('[data-testid="chat-header"]');
+    expect(header.exists()).toBe(true);
+
+    const backBtn = header.find('[aria-label="nav.back"]');
+    expect(backBtn.exists()).toBe(true);
+
+    // Skeleton block still renders below the header.
+    const skeleton = wrapper.find('[data-testid="chat-loading"]');
+    expect(skeleton.exists()).toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it("hides action buttons (call/search/info) in header while room is loading because they depend on room data", async () => {
+    fakeActiveRoomId.value = "!abc:matrix.org";
+    fakeRooms.value = [];
+    fakeRoomsInitialized.value = false;
+
+    const wrapper = mount(ChatWindow, mountOpts);
+    await flushPromises();
+
+    const header = wrapper.find('[data-testid="chat-header"]');
+    expect(header.find('[aria-label="chat.search"]').exists()).toBe(false);
+    expect(header.find('[aria-label="call.voiceCall"]').exists()).toBe(false);
+    expect(header.find('[aria-label="info.title"]').exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it("push cold-start: shows header+skeleton (not 'select a chat') when deep link sets activeRoomId before Matrix init", async () => {
+    // Scenario: user taps a push notification on a cold app. The deep link sets
+    // activeRoomId before Matrix has even started syncing. Previously the
+    // header's v-if required activeRoom, and isEmptyState would kick in before
+    // isRoomLoading had all three conditions, leaving the user on a
+    // "select a chat" screen — extra confusing when they just tapped a push.
+    fakeActiveRoomId.value = "!pushed:matrix.org";
+    fakeRooms.value = []; // Matrix hasn't synced yet
+    fakeRoomsInitialized.value = false; // init in-flight
+
+    const wrapper = mount(ChatWindow, mountOpts);
+    await flushPromises();
+
+    // Header is visible so user sees a back button and "chat loading" chrome.
+    const header = wrapper.find('[data-testid="chat-header"]');
+    expect(header.exists()).toBe(true);
+    expect(header.find('[aria-label="nav.back"]').exists()).toBe(true);
+
+    // Loading body is rendered, not the empty "select a chat" prompt.
+    expect(wrapper.find('[data-testid="chat-loading"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="chat-select-prompt"]').exists()).toBe(false);
+
+    wrapper.unmount();
+  });
+
+  it("renders full header with avatar/title/actions once room hydrates", async () => {
+    fakeActiveRoomId.value = "!abc:matrix.org";
+    fakeRooms.value = [
+      { id: "!abc:matrix.org", name: "Alice", isGroup: false, members: [], membership: "join" },
+    ];
+    fakeRoomsInitialized.value = true;
+
+    const wrapper = mount(ChatWindow, mountOpts);
+    await flushPromises();
+
+    const header = wrapper.find('[data-testid="chat-header"]');
+    expect(header.exists()).toBe(true);
+    expect(header.find('[aria-label="nav.back"]').exists()).toBe(true);
+    expect(header.find('[aria-label="chat.search"]').exists()).toBe(true);
+    expect(header.find('[aria-label="info.title"]').exists()).toBe(true);
+
+    wrapper.unmount();
+  });
 });


### PR DESCRIPTION
## Summary

On mobile, cold-loading a chat (first launch, push notification deep link, initial Matrix sync) left `MessageSkeleton` occupying the full viewport with no header and no back button — looking exactly like the app had frozen.

Root cause: header's `v-if` required `chatStore.activeRoom` (the hydrated room object). During `isRoomLoading`, by definition `activeRoom` is `undefined`, so the header collapsed. On mobile `ChatWindow` renders `absolute inset-0`, so there is no external header above it — without the in-component header, the user was stranded.

## What changed

- `ChatWindow.vue` header now renders when `(chatStore.activeRoom || isRoomLoading) && !isChannelView`
- During load: back button stays visible, avatar + title get pulse placeholders (same pattern already used for `activeRoomTitle.state === 'resolving'`)
- Action buttons (search / voice call / info) stay hidden until the room hydrates — they depend on room data
- Added `data-testid="chat-header"` for tests

## Why this shape

- **Option A (minimal diff)** over creating a separate `LoadingHeader` component — reuses the existing pulse placeholder pattern already in the header, avoids duplication
- Guards `chatStore.activeRoom?.avatar` / `.isGroup` via `v-if` wrap rather than `?.` chains, to match the existing style
- Action buttons wrapped in a single `<template v-if="chatStore.activeRoom">` block instead of guarding each individually

## Related

Follows up on [#52](https://github.com/pocketnetteam/forta.chat/pull/52) (open channels and loading rooms on mobile) and [#43](https://github.com/pocketnetteam/forta.chat/pull/43) (reactive showSidebar + MessageSkeleton loading state). Those PRs made `MessageSkeleton` render during cold loads; this PR makes the header render alongside it so the user can exit.

## Test plan

- [x] `ChatWindow.test.ts` — 7 tests pass, 4 new:
  - renders chat header with back button during `isRoomLoading`
  - hides search/call/info action buttons during load
  - full header (avatar/title/actions) after room hydrates
  - push cold-start shows header+skeleton, not "select a chat" empty state
- [x] `vue-tsc --noEmit` — no new type errors in changed files
- [ ] Manual on Android: tap a chat from the list on a cold app launch — header with pulse placeholders visible, back button works, MessageSkeleton below
- [ ] Manual on Android: tap a push notification on a cold app — same behavior, no "select a chat" flash