### PR TITLE
fix(calls): permission preflight, answer order, connecting watchdog, notification auto-accept

### DIFF
--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallPlugin.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallPlugin.kt
@@ -19,6 +19,10 @@ import com.getcapacitor.annotation.PermissionCallback
         Permission(
             strings = [android.Manifest.permission.RECORD_AUDIO],
             alias = "microphone"
+        ),
+        Permission(
+            strings = [android.Manifest.permission.CAMERA],
+            alias = "camera"
         )
     ]
 )
@@ -181,6 +185,22 @@ class CallPlugin : Plugin() {
     private fun audioPermissionCallback(call: PluginCall) {
         val granted = getPermissionState("microphone") == PermissionState.GRANTED
         Log.d(TAG, "[WebRTCAudio] requestAudioPermission callback: granted=$granted")
+        call.resolve(JSObject().apply { put("granted", granted) })
+    }
+
+    @PluginMethod
+    fun requestCameraPermission(call: PluginCall) {
+        if (getPermissionState("camera") == PermissionState.GRANTED) {
+            call.resolve(JSObject().apply { put("granted", true) })
+            return
+        }
+        requestPermissionForAlias("camera", call, "cameraPermissionCallback")
+    }
+
+    @PermissionCallback
+    private fun cameraPermissionCallback(call: PluginCall) {
+        val granted = getPermissionState("camera") == PermissionState.GRANTED
+        Log.d(TAG, "[WebRTCAudio] requestCameraPermission callback: granted=$granted")
         call.resolve(JSObject().apply { put("granted", granted) })
     }
 

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/IncomingCallActivity.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/IncomingCallActivity.kt
@@ -73,6 +73,22 @@ class IncomingCallActivity : Activity() {
         super.onCreate(savedInstanceState)
         currentInstance = this
 
+        // H1: action extra from notification accept/decline PendingIntents.
+        // The accept/decline actions attached to the CallStyle notification
+        // launch this Activity with `action=accept|decline`; we must NOT
+        // render the ringer UI and instead dispatch immediately. Without
+        // this the user tapped Accept in the shade, saw the full ringer
+        // appear again, and had to tap Accept a second time.
+        val action = intent.getStringExtra("action")
+        if (action == "accept" || action == "decline") {
+            Log.d(TAG, "onCreate: auto-dispatching action=$action, skipping UI")
+            // Suppress the default Activity animation because we finish
+            // immediately — a visible flash of empty content is jarring.
+            overridePendingTransition(0, 0)
+            if (action == "accept") accept() else decline()
+            return
+        }
+
         // Show on lock screen
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
             setShowWhenLocked(true)

--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -13,6 +13,7 @@ import TitleBar from "@/widgets/title-bar/TitleBar.vue";
 import IncomingCallModal from "@/features/video-calls/ui/IncomingCallModal.vue";
 import CallWindow from "@/features/video-calls/ui/CallWindow.vue";
 import CallStatusBar from "@/features/video-calls/ui/CallStatusBar.vue";
+import PermissionDeniedModal from "@/features/video-calls/ui/PermissionDeniedModal.vue";
 import QuickSearchModal from "@/features/search/ui/QuickSearchModal.vue";
 import { handleSdkSync } from "@/features/sync-status";
 import { isNative } from "@/shared/lib/platform";
@@ -359,6 +360,7 @@ onUnmounted(() => {
     <IncomingCallModal />
     <CallWindow />
     <CallStatusBar />
+    <PermissionDeniedModal />
     <QuickSearchModal
       v-if="showQuickSearch"
       @close="showQuickSearch = false"

--- a/src/features/video-calls/model/call-service.test.ts
+++ b/src/features/video-calls/model/call-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // Mocks — must be set up before importing call-service
@@ -387,6 +387,155 @@ describe('call-service permission flow', () => {
 
       expect(mockUpdateStatus).toHaveBeenCalledWith('failed');
       expect(mockAnswer).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // H2: call.answer() must signal the peer BEFORE any UX transitions. When
+  // launchCallUI blocks (some OEMs take 300-800ms to bring the Activity up
+  // from background), letting it run before call.answer() means the caller
+  // sees no answer in time and sends m.call.hangup — which manifests as
+  // "his app drops the call" (#310) from the answerer's perspective.
+  // -------------------------------------------------------------------------
+  describe('answerCall SDP ordering (H2)', () => {
+    function seedIncomingCall(type: 'voice' | 'video' = 'voice') {
+      mockCallStore.matrixCall = {
+        callId: 'incoming-call-id',
+        roomId: '!room:matrix.org',
+        type,
+        on: mockOn,
+        off: mockOff,
+        answer: mockAnswer,
+        reject: mockReject,
+        localUsermediaStream: null,
+        localScreensharingStream: null,
+        remoteUsermediaStream: null,
+        remoteScreensharingStream: null,
+        remoteUsermediaFeed: null,
+      };
+      mockCallStore.activeCall = {
+        callId: 'incoming-call-id',
+        roomId: '!room:matrix.org',
+        type,
+        direction: 'incoming',
+        peerName: 'Peer',
+        status: 'incoming',
+      };
+    }
+
+    it('calls call.answer BEFORE NativeWebRTC.launchCallUI', async () => {
+      seedIncomingCall('voice');
+
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      await service.answerCall();
+
+      expect(mockAnswer).toHaveBeenCalledOnce();
+      expect(mockNativeWebRTCMethods.launchCallUI).toHaveBeenCalled();
+      const answerOrder = mockAnswer.mock.invocationCallOrder[0];
+      const launchOrder = mockNativeWebRTCMethods.launchCallUI.mock.invocationCallOrder[0];
+      expect(answerOrder).toBeLessThan(launchOrder);
+    });
+
+    it('calls call.answer BEFORE startAudioRouting', async () => {
+      seedIncomingCall('voice');
+
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      await service.answerCall();
+
+      expect(mockAnswer).toHaveBeenCalledOnce();
+      expect(mockStartAudioRouting).toHaveBeenCalled();
+      const answerOrder = mockAnswer.mock.invocationCallOrder[0];
+      const routingOrder = mockStartAudioRouting.mock.invocationCallOrder[0];
+      expect(answerOrder).toBeLessThan(routingOrder);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // H3: if call.answer never resolves (SDK wedged on peer-connection setup,
+  // network partition, OEM audio routing hang), the call stays "connecting…"
+  // indefinitely and the user perceives it as "crashed" / "hung up" (#268,
+  // #309). A 30s watchdog forces transition to failed with full cleanup.
+  // -------------------------------------------------------------------------
+  describe('answerCall connecting watchdog (H3)', () => {
+    function seedIncomingCall(type: 'voice' | 'video' = 'voice') {
+      mockCallStore.matrixCall = {
+        callId: 'incoming-call-id',
+        roomId: '!room:matrix.org',
+        type,
+        on: mockOn,
+        off: mockOff,
+        answer: mockAnswer,
+        reject: mockReject,
+        localUsermediaStream: null,
+        localScreensharingStream: null,
+        remoteUsermediaStream: null,
+        remoteScreensharingStream: null,
+        remoteUsermediaFeed: null,
+      };
+      mockCallStore.activeCall = {
+        callId: 'incoming-call-id',
+        roomId: '!room:matrix.org',
+        type,
+        direction: 'incoming',
+        peerName: 'Peer',
+        status: 'incoming',
+      };
+    }
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('transitions status to failed after 30s of stuck connecting', async () => {
+      vi.useFakeTimers();
+      seedIncomingCall('voice');
+      // call.answer never resolves — simulate SDK wedge.
+      mockAnswer.mockReturnValue(new Promise<void>(() => {}));
+
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      // Start answer flow (do not await — the promise won't settle)
+      void service.answerCall();
+      // Flush microtasks so preflight + updateStatus(connecting) complete.
+      await vi.advanceTimersByTimeAsync(0);
+
+      // At this point we're in connecting, NOT failed.
+      const failedBefore = mockUpdateStatus.mock.calls.filter((c: unknown[]) => c[0] === 'failed');
+      expect(failedBefore).toHaveLength(0);
+
+      // Keep activeCall.status sticky at connecting so the watchdog
+      // interprets the state as actually stuck (without a real store the
+      // updateStatus calls don't propagate back to activeCall).
+      (mockCallStore.activeCall as { status: string }).status = 'connecting';
+
+      // Advance past the watchdog deadline.
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      const failedAfter = mockUpdateStatus.mock.calls.filter((c: unknown[]) => c[0] === 'failed');
+      expect(failedAfter.length).toBeGreaterThanOrEqual(1);
+      expect(mockNativeWebRTCMethods.dismissCallUI).toHaveBeenCalled();
+    });
+
+    it('does NOT force failed when the call connected within the watchdog window', async () => {
+      vi.useFakeTimers();
+      seedIncomingCall('voice');
+      mockAnswer.mockResolvedValue(undefined);
+
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      await service.answerCall();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Simulate state transition to connected — watchdog must be cancelled.
+      (mockCallStore.activeCall as { status: string }).status = 'connected';
+
+      // Advance past 30s.
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      const failedCalls = mockUpdateStatus.mock.calls.filter((c: unknown[]) => c[0] === 'failed');
+      expect(failedCalls).toHaveLength(0);
     });
   });
 

--- a/src/features/video-calls/model/call-service.test.ts
+++ b/src/features/video-calls/model/call-service.test.ts
@@ -50,11 +50,13 @@ vi.mock('@/shared/lib/native-webrtc', () => ({
 
 // Mock native-call-bridge
 const mockRequestAudioPermission = vi.fn();
+const mockRequestCameraPermission = vi.fn();
 const mockStartAudioRouting = vi.fn().mockResolvedValue(undefined);
 const mockStopAudioRouting = vi.fn().mockResolvedValue(undefined);
 vi.mock('@/shared/lib/native-calls', () => ({
   nativeCallBridge: {
     requestAudioPermission: mockRequestAudioPermission,
+    requestCameraPermission: mockRequestCameraPermission,
     reportOutgoingCall: vi.fn().mockResolvedValue(undefined),
     reportCallConnected: vi.fn().mockResolvedValue(undefined),
     reportCallEnded: vi.fn().mockResolvedValue(undefined),
@@ -62,6 +64,29 @@ vi.mock('@/shared/lib/native-calls', () => ({
     wire: vi.fn().mockResolvedValue(undefined),
     startAudioRouting: mockStartAudioRouting,
     stopAudioRouting: mockStopAudioRouting,
+  },
+  consumePendingAnswerCallId: vi.fn().mockResolvedValue(false),
+  consumePendingRejectCallId: vi.fn().mockResolvedValue(false),
+}));
+
+// Mock permissions — by default resolves ok; individual tests override via
+// mockEnsureCallPermissions.mockRejectedValueOnce(...) when denied paths
+// need to be exercised. This lets call-service tests focus on the flow
+// around ensureCallPermissions, not its internals (covered in permissions.test.ts).
+class MockPermissionDeniedError extends Error {
+  constructor(public readonly device: 'microphone' | 'camera') {
+    super(`Permission denied: ${device}`);
+    this.name = 'PermissionDeniedError';
+  }
+}
+const mockEnsureCallPermissions = vi.fn();
+const mockCallPermissionError: { value: { device: 'microphone' | 'camera' } | null } = { value: null };
+vi.mock('./permissions', () => ({
+  ensureCallPermissions: mockEnsureCallPermissions,
+  PermissionDeniedError: MockPermissionDeniedError,
+  callPermissionError: mockCallPermissionError,
+  clearCallPermissionError: () => {
+    mockCallPermissionError.value = null;
   },
 }));
 
@@ -214,44 +239,78 @@ describe('call-service permission flow', () => {
     mockCallStore.activeCall = null;
     mockCallStore.matrixCall = null;
     mockCallStore.videoMuted = false;
+    // Default: permissions resolve successfully. Individual tests override
+    // with mockRejectedValueOnce(new MockPermissionDeniedError(...)).
+    mockEnsureCallPermissions.mockResolvedValue(undefined);
   });
 
   describe('startCall', () => {
-    it('calls requestAudioPermission before creating MatrixCall on native', async () => {
-      mockRequestAudioPermission.mockResolvedValue({ granted: true });
-
+    it('calls ensureCallPermissions with isVideo=false for voice call', async () => {
       const { useCallService } = await import('./call-service');
       const service = useCallService();
       await service.startCall('!room:matrix.org', 'voice');
 
-      expect(mockRequestAudioPermission).toHaveBeenCalledOnce();
+      expect(mockEnsureCallPermissions).toHaveBeenCalledWith(false);
     });
 
-    it('sets CallStatus.failed and returns early when permission denied', async () => {
-      mockRequestAudioPermission.mockResolvedValue({ granted: false });
+    it('calls ensureCallPermissions with isVideo=true for video call', async () => {
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      await service.startCall('!room:matrix.org', 'video');
+
+      expect(mockEnsureCallPermissions).toHaveBeenCalledWith(true);
+    });
+
+    it('sets CallStatus.failed and returns early when microphone denied', async () => {
+      mockEnsureCallPermissions.mockRejectedValueOnce(
+        new MockPermissionDeniedError('microphone'),
+      );
 
       const { useCallService } = await import('./call-service');
       const service = useCallService();
       await service.startCall('!room:matrix.org', 'voice');
 
       expect(mockUpdateStatus).toHaveBeenCalledWith('failed');
-      expect(mockScheduleClearCall).toHaveBeenCalledWith(1500);
+      expect(mockScheduleClearCall).toHaveBeenCalled();
       expect(mockPlaceVoiceCall).not.toHaveBeenCalled();
+    });
+
+    it('sets CallStatus.failed and skips placeVideoCall when camera denied for video', async () => {
+      mockEnsureCallPermissions.mockRejectedValueOnce(
+        new MockPermissionDeniedError('camera'),
+      );
+
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      await service.startCall('!room:matrix.org', 'video');
+
+      expect(mockUpdateStatus).toHaveBeenCalledWith('failed');
+      expect(mockPlaceVideoCall).not.toHaveBeenCalled();
+    });
+
+    it('does not start audio routing when permission denied', async () => {
+      mockEnsureCallPermissions.mockRejectedValueOnce(
+        new MockPermissionDeniedError('microphone'),
+      );
+
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      await service.startCall('!room:matrix.org', 'voice');
+
+      expect(mockStartAudioRouting).not.toHaveBeenCalled();
     });
   });
 
   describe('answerCall', () => {
-    it('calls requestAudioPermission before answering on native', async () => {
-      mockRequestAudioPermission.mockResolvedValue({ granted: true });
-
-      // Simulate incoming call state on shared mock store
+    function seedIncomingCall(type: 'voice' | 'video' = 'voice') {
       mockCallStore.matrixCall = {
         callId: 'incoming-call-id',
         roomId: '!room:matrix.org',
-        type: 'voice',
+        type,
         on: mockOn,
         off: mockOff,
         answer: mockAnswer,
+        reject: mockReject,
         localUsermediaStream: null,
         localScreensharingStream: null,
         remoteUsermediaStream: null,
@@ -261,45 +320,72 @@ describe('call-service permission flow', () => {
       mockCallStore.activeCall = {
         callId: 'incoming-call-id',
         roomId: '!room:matrix.org',
-        type: 'voice',
+        type,
         direction: 'incoming',
         peerName: 'Peer',
         status: 'incoming',
       };
+    }
+
+    it('calls ensureCallPermissions with isVideo=false before answering voice', async () => {
+      seedIncomingCall('voice');
 
       const { useCallService } = await import('./call-service');
       const service = useCallService();
       await service.answerCall();
 
-      expect(mockRequestAudioPermission).toHaveBeenCalledOnce();
+      expect(mockEnsureCallPermissions).toHaveBeenCalledWith(false);
     });
 
-    it('sets CallStatus.failed when permission denied on answer', async () => {
-      mockRequestAudioPermission.mockResolvedValue({ granted: false });
+    it('calls ensureCallPermissions with isVideo=true before answering video', async () => {
+      seedIncomingCall('video');
 
-      mockCallStore.matrixCall = {
-        callId: 'incoming-call-id',
-        roomId: '!room:matrix.org',
-        type: 'voice',
-        on: mockOn,
-        off: mockOff,
-        answer: mockAnswer,
-        localUsermediaStream: null,
-      };
-      mockCallStore.activeCall = {
-        callId: 'incoming-call-id',
-        type: 'voice',
-        direction: 'incoming',
-        peerName: 'Peer',
-        status: 'incoming',
-      };
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      await service.answerCall();
+
+      expect(mockEnsureCallPermissions).toHaveBeenCalledWith(true);
+    });
+
+    it('sets CallStatus.failed when microphone denied on answer and does NOT call SDK answer', async () => {
+      seedIncomingCall('voice');
+      mockEnsureCallPermissions.mockRejectedValueOnce(
+        new MockPermissionDeniedError('microphone'),
+      );
 
       const { useCallService } = await import('./call-service');
       const service = useCallService();
       await service.answerCall();
 
       expect(mockUpdateStatus).toHaveBeenCalledWith('failed');
-      expect(mockScheduleClearCall).toHaveBeenCalledWith(1500);
+      expect(mockScheduleClearCall).toHaveBeenCalled();
+      expect(mockAnswer).not.toHaveBeenCalled();
+    });
+
+    it('rejects the incoming matrixCall when permission denied so caller stops ringing', async () => {
+      seedIncomingCall('voice');
+      mockEnsureCallPermissions.mockRejectedValueOnce(
+        new MockPermissionDeniedError('microphone'),
+      );
+
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      await service.answerCall();
+
+      expect(mockReject).toHaveBeenCalled();
+    });
+
+    it('sets CallStatus.failed when camera denied during video answer', async () => {
+      seedIncomingCall('video');
+      mockEnsureCallPermissions.mockRejectedValueOnce(
+        new MockPermissionDeniedError('camera'),
+      );
+
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      await service.answerCall();
+
+      expect(mockUpdateStatus).toHaveBeenCalledWith('failed');
       expect(mockAnswer).not.toHaveBeenCalled();
     });
   });

--- a/src/features/video-calls/model/call-service.ts
+++ b/src/features/video-calls/model/call-service.ts
@@ -18,6 +18,7 @@ import {
   consumePendingAnswerCallId,
   consumePendingRejectCallId,
 } from "@/shared/lib/native-calls";
+import { ensureCallPermissions, PermissionDeniedError, callPermissionError } from "./permissions";
 
 // Install native WebRTC proxy on mobile — must run before any call is placed.
 // This replaces window.RTCPeerConnection so that the Matrix SDK transparently
@@ -442,22 +443,23 @@ export function useCallService() {
 
     callStore.cancelScheduledClear();
 
-    // D-01: JS-side permission check before call start
-    if (isNative) {
-      try {
-        const { granted } = await nativeCallBridge.requestAudioPermission();
-        if (!granted) {
-          // D-03: reject call on denial, D-04: toast shown via onAudioError event
-          callStore.updateStatus(CallStatus.failed);
-          callStore.scheduleClearCall(1500);
-          return;
-        }
-      } catch (e) {
-        console.error("[call-service] requestAudioPermission failed:", e);
-        callStore.updateStatus(CallStatus.failed);
-        callStore.scheduleClearCall(1500);
-        return;
+    // Preflight: mic (+ camera for video). Throws PermissionDeniedError
+    // if the OS denied access, or if getUserMedia returns a stream with
+    // empty tracks. If we skip this and let the SDK's getUserMedia fail
+    // silently, the peer sees an invite, accepts, but there is no media
+    // to exchange — that is the origin of the mass "no audio" reports.
+    try {
+      await ensureCallPermissions(type === "video");
+    } catch (e) {
+      if (e instanceof PermissionDeniedError) {
+        console.warn("[call-service] startCall: permission denied for", e.device);
+        callPermissionError.value = { device: e.device };
+      } else {
+        console.error("[call-service] startCall: ensureCallPermissions failed:", e);
       }
+      callStore.updateStatus(CallStatus.failed);
+      callStore.scheduleClearCall(1500);
+      return;
     }
 
     const matrixService = getMatrixClientService();
@@ -718,23 +720,41 @@ export function useCallService() {
     clearIncomingTimeout();
     stopAllSounds();
 
-    // D-01: JS-side permission check before answering
-    if (isNative) {
-      try {
-        console.log("[call-service] answerCall: requesting audio permission");
-        const { granted } = await nativeCallBridge.requestAudioPermission();
-        console.log("[call-service] answerCall: permission granted=" + granted);
-        if (!granted) {
-          callStore.updateStatus(CallStatus.failed);
-          callStore.scheduleClearCall(1500);
-          return;
-        }
-      } catch (e) {
-        console.error("[call-service] requestAudioPermission failed:", e);
-        callStore.updateStatus(CallStatus.failed);
-        callStore.scheduleClearCall(1500);
-        return;
+    const isVideo = callStore.activeCall?.type === "video";
+
+    // Preflight: mic (+ camera for video) BEFORE any SDK signaling. If
+    // the OS denied permission we must NOT call `call.answer()` — doing
+    // so would let Matrix SDK establish the peer connection with an empty
+    // track and the caller would see "connected" with no audio. Instead
+    // reject the call so the caller stops ringing and receives a clear
+    // `m.call.reject`, then dismiss our own native UI.
+    try {
+      await ensureCallPermissions(isVideo);
+    } catch (e) {
+      if (e instanceof PermissionDeniedError) {
+        console.warn("[call-service] answerCall: permission denied for", e.device);
+        callPermissionError.value = { device: e.device };
+      } else {
+        console.error("[call-service] answerCall: ensureCallPermissions failed:", e);
       }
+      // Detach SDK event listeners FIRST — if we call reject() below while
+      // listeners are still bound, the SDK's State→Ended / Hangup events
+      // would fire our onState/onHangup handlers, double-triggering
+      // scheduleClearCall + duplicate history entry + redundant
+      // dismissCallUI. Mirrors rejectCall()'s ordering.
+      unwireCallEvents(call);
+      try {
+        call.reject();
+      } catch (rejectErr) {
+        console.warn("[call-service] answerCall: reject after permission failure errored:", rejectErr);
+      }
+      callStore.updateStatus(CallStatus.failed);
+      callStore.scheduleClearCall(1500);
+      if (isNative) {
+        NativeWebRTC.dismissCallUI().catch(() => {});
+        nativeCallBridge.reportCallEnded(call.callId).catch(() => {});
+      }
+      return;
     }
 
     callStore.updateStatus(CallStatus.connecting);
@@ -742,8 +762,6 @@ export function useCallService() {
     // Hint stored device IDs (lightweight, sync) — real fix is post-connect
     const client = getClient();
     hintStoredDevices(client);
-
-    const isVideo = callStore.activeCall?.type === "video";
 
     // Launch native call UI when answering incoming call
     if (isNative && callStore.activeCall) {

--- a/src/features/video-calls/model/call-service.ts
+++ b/src/features/video-calls/model/call-service.ts
@@ -176,6 +176,12 @@ function wireCallEvents(call: MatrixCall, direction: "outgoing" | "incoming") {
     const status = mapSDKState(newState, direction);
     callStore.updateStatus(status);
 
+    // Any transition out of "connecting" cancels the watchdog — either
+    // we connected successfully or the SDK itself decided to end/fail.
+    if (status !== CallStatus.connecting) {
+      clearConnectingWatchdog();
+    }
+
     if (status === CallStatus.connected) {
       stopAllSounds();
       clearIncomingTimeout();
@@ -239,6 +245,7 @@ function wireCallEvents(call: MatrixCall, direction: "outgoing" | "incoming") {
   const onHangup = (() => {
     stopAllSounds();
     clearIncomingTimeout();
+    clearConnectingWatchdog();
     // Also tear down the native surface. Without this, when the remote
     // cancels a call we never answered, or when another of our devices
     // picks up (m.call.select_answer), the SDK fires Hangup but the
@@ -265,6 +272,7 @@ function wireCallEvents(call: MatrixCall, direction: "outgoing" | "incoming") {
     }
     stopAllSounds();
     clearIncomingTimeout();
+    clearConnectingWatchdog();
     unwireCallEvents(call);
     if (isNative) {
       import('@/shared/lib/native-calls').then(({ nativeCallBridge }) => {
@@ -332,6 +340,27 @@ function clearIncomingTimeout() {
   if (incomingTimeoutId !== null) {
     clearTimeout(incomingTimeoutId);
     incomingTimeoutId = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Connecting watchdog (H3)
+// ---------------------------------------------------------------------------
+
+/**
+ * If `call.answer()` resolves but `onState→Connected` never fires (SDK
+ * wedged on peer-connection setup, OEM audio init deadlock, network
+ * partition during ICE), the UI sits in "connecting..." forever. Users
+ * perceive this as the call "crashing" (#268, #309). Force-fail after
+ * 30s with full teardown so the store clears and the user can try again.
+ */
+const CONNECTING_WATCHDOG_MS = 30_000;
+let connectingWatchdogId: ReturnType<typeof setTimeout> | null = null;
+
+function clearConnectingWatchdog() {
+  if (connectingWatchdogId !== null) {
+    clearTimeout(connectingWatchdogId);
+    connectingWatchdogId = null;
   }
 }
 
@@ -763,23 +792,49 @@ export function useCallService() {
     const client = getClient();
     hintStoredDevices(client);
 
-    // Launch native call UI when answering incoming call
-    if (isNative && callStore.activeCall) {
-      NativeWebRTC.launchCallUI({
-        callerName: callStore.activeCall.peerName,
-        callType: callStore.activeCall.type,
-        callId: call.callId,
-        direction: "incoming",
-      }).catch(() => {});
-    }
+    // H3: watchdog — if we stay in "connecting" for 30s, tear the call
+    // down. onState clears this watchdog whenever status transitions
+    // away from connecting; hangup/reject clear it explicitly.
+    clearConnectingWatchdog();
+    connectingWatchdogId = setTimeout(() => {
+      connectingWatchdogId = null;
+      if (callStore.activeCall?.status !== CallStatus.connecting) return;
+      console.warn("[call-service] answerCall: stuck in connecting for 30s, forcing failed");
+      unwireCallEvents(call);
+      try {
+        call.hangup(CallErrorCode.UserHangup, false);
+      } catch { /* ignore */ }
+      callStore.updateStatus(CallStatus.failed);
+      callStore.scheduleClearCall(2000);
+      if (isNative) {
+        NativeWebRTC.dismissCallUI().catch(() => {});
+        nativeCallBridge.reportCallEnded(call.callId).catch(() => {});
+        nativeCallBridge.stopAudioRouting().catch(() => {});
+      }
+    }, CONNECTING_WATCHDOG_MS);
 
     try {
+      // H2: answer the SDK call FIRST so the peer sees m.call.answer
+      // within ~200ms. launchCallUI on some OEMs takes 300-800ms to
+      // bring the native Activity up — running it before call.answer()
+      // meant the caller's timeout fired and they sent m.call.hangup,
+      // which the user perceived as "他 dropped my call" (#310).
       console.log("[call-service] answerCall: calling SDK call.answer(true, " + isVideo + ")");
       await call.answer(true, isVideo);
       console.log("[call-service] answerCall: SDK call.answer resolved");
 
-      // Activate native VoIP audio routing after answering — same reasoning
-      // as startCall: must come AFTER answer, graceful degradation on failure.
+      // Non-blocking native UX transitions.
+      if (isNative && callStore.activeCall) {
+        NativeWebRTC.launchCallUI({
+          callerName: callStore.activeCall.peerName,
+          callType: callStore.activeCall.type,
+          callId: call.callId,
+          direction: "incoming",
+        }).catch((e) => console.warn("[call-service] launchCallUI failed:", e));
+      }
+
+      // Activate native VoIP audio routing after answering. Graceful
+      // degradation on failure — never drop the call for a routing hiccup.
       if (isNative) {
         const callType = isVideo ? "video" : "voice";
         nativeCallBridge.startAudioRouting({ callType }).catch((e) => {
@@ -789,6 +844,7 @@ export function useCallService() {
     } catch (e) {
       console.error("[call-service] Failed to answer call:", e);
       useBugReport().open({ context: tRaw("bugReport.ctx.answerCall"), error: e });
+      clearConnectingWatchdog();
       unwireCallEvents(call);
       callStore.updateStatus(CallStatus.failed);
       callStore.scheduleClearCall(2000);
@@ -801,6 +857,7 @@ export function useCallService() {
     if (!call) return;
 
     clearIncomingTimeout();
+    clearConnectingWatchdog();
     stopAllSounds();
 
     try {
@@ -840,6 +897,7 @@ export function useCallService() {
     if (!call) return;
 
     clearIncomingTimeout();
+    clearConnectingWatchdog();
     stopAllSounds();
 
     try {

--- a/src/features/video-calls/model/permissions-web.test.ts
+++ b/src/features/video-calls/model/permissions-web.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// On web path, nativeCallBridge is not invoked at all — ensureCallPermissions
+// goes through navigator.permissions and navigator.mediaDevices.getUserMedia.
+
+vi.mock('@/shared/lib/platform', () => ({
+  isNative: false,
+}));
+
+vi.mock('@/shared/lib/native-calls', () => ({
+  nativeCallBridge: {
+    requestAudioPermission: vi.fn(),
+    requestCameraPermission: vi.fn(),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Fake navigator helpers
+// ---------------------------------------------------------------------------
+
+interface PermissionEntry {
+  state: 'granted' | 'denied' | 'prompt';
+}
+
+function installNavigatorMocks(opts: {
+  permissions?: Record<string, PermissionEntry>;
+  getUserMedia?: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
+}) {
+  const permsMap = opts.permissions ?? {};
+  (globalThis as unknown as { navigator: Navigator }).navigator = {
+    permissions: {
+      query: vi.fn(async (q: { name: string }) => {
+        const entry = permsMap[q.name] ?? { state: 'prompt' };
+        return entry as unknown as PermissionStatus;
+      }),
+    },
+    mediaDevices: {
+      getUserMedia: opts.getUserMedia ?? vi.fn(),
+    },
+  } as unknown as Navigator;
+}
+
+function makeStream(audioTracks: number, videoTracks: number): MediaStream {
+  const stopSpy = vi.fn();
+  const audio = Array.from({ length: audioTracks }, () => ({
+    kind: 'audio',
+    stop: stopSpy,
+  }));
+  const video = Array.from({ length: videoTracks }, () => ({
+    kind: 'video',
+    stop: stopSpy,
+  }));
+  return {
+    getAudioTracks: () => audio,
+    getVideoTracks: () => video,
+    getTracks: () => [...audio, ...video],
+  } as unknown as MediaStream;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ensureCallPermissions (web)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('mic permission state=denied — throws microphone denied', async () => {
+    installNavigatorMocks({
+      permissions: { microphone: { state: 'denied' } },
+      getUserMedia: vi.fn().mockResolvedValue(makeStream(1, 0)),
+    });
+
+    const { ensureCallPermissions, PermissionDeniedError } = await import('./permissions');
+    await expect(ensureCallPermissions(false)).rejects.toBeInstanceOf(PermissionDeniedError);
+  });
+
+  it('mic granted, getUserMedia yields a valid audio track — resolves', async () => {
+    const stream = makeStream(1, 0);
+    installNavigatorMocks({
+      permissions: { microphone: { state: 'granted' } },
+      getUserMedia: vi.fn().mockResolvedValue(stream),
+    });
+
+    const { ensureCallPermissions } = await import('./permissions');
+    await expect(ensureCallPermissions(false)).resolves.toBeUndefined();
+  });
+
+  it('getUserMedia returns stream with 0 audio tracks — treats as denied', async () => {
+    installNavigatorMocks({
+      permissions: { microphone: { state: 'granted' } },
+      getUserMedia: vi.fn().mockResolvedValue(makeStream(0, 0)),
+    });
+
+    const { ensureCallPermissions, PermissionDeniedError } = await import('./permissions');
+    await expect(ensureCallPermissions(false)).rejects.toBeInstanceOf(PermissionDeniedError);
+  });
+
+  it('getUserMedia throws NotAllowedError — maps to PermissionDeniedError for microphone', async () => {
+    const err = new Error('Permission denied by user');
+    err.name = 'NotAllowedError';
+    installNavigatorMocks({
+      permissions: { microphone: { state: 'prompt' } },
+      getUserMedia: vi.fn().mockRejectedValue(err),
+    });
+
+    const { ensureCallPermissions, PermissionDeniedError } = await import('./permissions');
+    await expect(ensureCallPermissions(false)).rejects.toSatisfy((e: unknown) => {
+      return e instanceof PermissionDeniedError &&
+        (e as InstanceType<typeof PermissionDeniedError>).device === 'microphone';
+    });
+  });
+
+  it('video call, microphone denied via NotAllowedError — attributes to microphone (NOT camera)', async () => {
+    // Regression: a combined getUserMedia({audio,video}) would lose the
+    // device attribution and always label denials as "camera" on video
+    // calls. Sequential probing must attribute this to microphone.
+    const err = new Error('Permission denied by user');
+    err.name = 'NotAllowedError';
+    const getUserMedia = vi.fn((constraints: MediaStreamConstraints) => {
+      // First call is audio-only — fail it with NotAllowedError.
+      if (constraints.audio && !constraints.video) return Promise.reject(err);
+      return Promise.resolve(makeStream(0, 1));
+    });
+    installNavigatorMocks({
+      permissions: {
+        microphone: { state: 'prompt' },
+        camera: { state: 'granted' },
+      },
+      getUserMedia,
+    });
+
+    const { ensureCallPermissions, PermissionDeniedError } = await import('./permissions');
+    await expect(ensureCallPermissions(true)).rejects.toSatisfy((e: unknown) => {
+      return e instanceof PermissionDeniedError &&
+        (e as InstanceType<typeof PermissionDeniedError>).device === 'microphone';
+    });
+    // Only the audio probe should have been attempted; video probe is skipped.
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+  });
+
+  it('video call, camera denied via NotAllowedError on the video probe — attributes to camera', async () => {
+    const err = new Error('Permission denied by user');
+    err.name = 'NotAllowedError';
+    const getUserMedia = vi.fn((constraints: MediaStreamConstraints) => {
+      if (constraints.audio && !constraints.video) {
+        // Audio probe succeeds.
+        return Promise.resolve(makeStream(1, 0));
+      }
+      // Video probe fails.
+      return Promise.reject(err);
+    });
+    installNavigatorMocks({
+      permissions: {
+        microphone: { state: 'granted' },
+        camera: { state: 'prompt' },
+      },
+      getUserMedia,
+    });
+
+    const { ensureCallPermissions, PermissionDeniedError } = await import('./permissions');
+    await expect(ensureCallPermissions(true)).rejects.toSatisfy((e: unknown) => {
+      return e instanceof PermissionDeniedError &&
+        (e as InstanceType<typeof PermissionDeniedError>).device === 'camera';
+    });
+  });
+
+  it('video call, camera denied via permissions query — throws camera', async () => {
+    installNavigatorMocks({
+      permissions: {
+        microphone: { state: 'granted' },
+        camera: { state: 'denied' },
+      },
+      getUserMedia: vi.fn().mockResolvedValue(makeStream(1, 1)),
+    });
+
+    const { ensureCallPermissions, PermissionDeniedError } = await import('./permissions');
+    await expect(ensureCallPermissions(true)).rejects.toSatisfy((e: unknown) => {
+      return e instanceof PermissionDeniedError &&
+        (e as InstanceType<typeof PermissionDeniedError>).device === 'camera';
+    });
+  });
+
+  it('video call, getUserMedia returns stream without video tracks — throws camera', async () => {
+    installNavigatorMocks({
+      permissions: {
+        microphone: { state: 'granted' },
+        camera: { state: 'granted' },
+      },
+      // 0 video tracks — camera did not actually deliver
+      getUserMedia: vi.fn().mockResolvedValue(makeStream(1, 0)),
+    });
+
+    const { ensureCallPermissions, PermissionDeniedError } = await import('./permissions');
+    await expect(ensureCallPermissions(true)).rejects.toSatisfy((e: unknown) => {
+      return e instanceof PermissionDeniedError &&
+        (e as InstanceType<typeof PermissionDeniedError>).device === 'camera';
+    });
+  });
+
+  it('video call, everything granted and tracks present — resolves', async () => {
+    installNavigatorMocks({
+      permissions: {
+        microphone: { state: 'granted' },
+        camera: { state: 'granted' },
+      },
+      getUserMedia: vi.fn().mockResolvedValue(makeStream(1, 1)),
+    });
+
+    const { ensureCallPermissions } = await import('./permissions');
+    await expect(ensureCallPermissions(true)).resolves.toBeUndefined();
+  });
+
+  it('stops tracks from the probe stream to release device', async () => {
+    const stream = makeStream(1, 0);
+    const stopSpy = vi.fn();
+    (stream.getTracks() as Array<{ stop: () => void }>).forEach((t) => {
+      t.stop = stopSpy;
+    });
+
+    installNavigatorMocks({
+      permissions: { microphone: { state: 'granted' } },
+      getUserMedia: vi.fn().mockResolvedValue(stream),
+    });
+
+    const { ensureCallPermissions } = await import('./permissions');
+    await ensureCallPermissions(false);
+    expect(stopSpy).toHaveBeenCalled();
+  });
+});

--- a/src/features/video-calls/model/permissions.test.ts
+++ b/src/features/video-calls/model/permissions.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Module mocks — hoisted to the top of the file by vitest
+// ---------------------------------------------------------------------------
+
+const mockRequestAudioPermission = vi.fn();
+const mockRequestCameraPermission = vi.fn();
+
+vi.mock('@/shared/lib/platform', () => ({
+  isNative: true,
+}));
+
+vi.mock('@/shared/lib/native-calls', () => ({
+  nativeCallBridge: {
+    requestAudioPermission: mockRequestAudioPermission,
+    requestCameraPermission: mockRequestCameraPermission,
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Native suite
+// ---------------------------------------------------------------------------
+
+describe('ensureCallPermissions (native)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('voice call, microphone granted — resolves without throwing', async () => {
+    mockRequestAudioPermission.mockResolvedValue({ granted: true });
+    const { ensureCallPermissions } = await import('./permissions');
+
+    await expect(ensureCallPermissions(false)).resolves.toBeUndefined();
+    expect(mockRequestAudioPermission).toHaveBeenCalledOnce();
+    expect(mockRequestCameraPermission).not.toHaveBeenCalled();
+  });
+
+  it('voice call, microphone denied — throws PermissionDeniedError for microphone', async () => {
+    mockRequestAudioPermission.mockResolvedValue({ granted: false });
+    const { ensureCallPermissions, PermissionDeniedError } = await import('./permissions');
+
+    await expect(ensureCallPermissions(false)).rejects.toBeInstanceOf(PermissionDeniedError);
+    try {
+      await ensureCallPermissions(false);
+    } catch (e) {
+      expect((e as InstanceType<typeof PermissionDeniedError>).device).toBe('microphone');
+    }
+    expect(mockRequestCameraPermission).not.toHaveBeenCalled();
+  });
+
+  it('video call, both granted — resolves', async () => {
+    mockRequestAudioPermission.mockResolvedValue({ granted: true });
+    mockRequestCameraPermission.mockResolvedValue({ granted: true });
+    const { ensureCallPermissions } = await import('./permissions');
+
+    await expect(ensureCallPermissions(true)).resolves.toBeUndefined();
+    expect(mockRequestAudioPermission).toHaveBeenCalledOnce();
+    expect(mockRequestCameraPermission).toHaveBeenCalledOnce();
+  });
+
+  it('video call, microphone granted but camera denied — throws for camera', async () => {
+    mockRequestAudioPermission.mockResolvedValue({ granted: true });
+    mockRequestCameraPermission.mockResolvedValue({ granted: false });
+    const { ensureCallPermissions, PermissionDeniedError } = await import('./permissions');
+
+    await expect(ensureCallPermissions(true)).rejects.toBeInstanceOf(PermissionDeniedError);
+    try {
+      await ensureCallPermissions(true);
+    } catch (e) {
+      expect((e as InstanceType<typeof PermissionDeniedError>).device).toBe('camera');
+    }
+  });
+
+  it('video call, microphone denied — does not even check camera', async () => {
+    mockRequestAudioPermission.mockResolvedValue({ granted: false });
+    const { ensureCallPermissions } = await import('./permissions');
+
+    await expect(ensureCallPermissions(true)).rejects.toThrow();
+    expect(mockRequestCameraPermission).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PermissionDeniedError class shape
+// ---------------------------------------------------------------------------
+
+describe('PermissionDeniedError', () => {
+  it('exposes device field and extends Error', async () => {
+    const { PermissionDeniedError } = await import('./permissions');
+    const err = new PermissionDeniedError('microphone');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.device).toBe('microphone');
+    expect(err.name).toBe('PermissionDeniedError');
+    expect(err.message.toLowerCase()).toContain('microphone');
+  });
+
+  it('carries camera device correctly', async () => {
+    const { PermissionDeniedError } = await import('./permissions');
+    const err = new PermissionDeniedError('camera');
+    expect(err.device).toBe('camera');
+    expect(err.message.toLowerCase()).toContain('camera');
+  });
+});

--- a/src/features/video-calls/model/permissions.ts
+++ b/src/features/video-calls/model/permissions.ts
@@ -1,0 +1,151 @@
+import { ref, type Ref } from "vue";
+import { isNative } from "@/shared/lib/platform";
+import { nativeCallBridge } from "@/shared/lib/native-calls";
+
+export type PermissionDevice = "microphone" | "camera";
+
+/**
+ * Reactive pointer to the last call-permission error, consumed by
+ * {@link PermissionDeniedModal} to show a UI banner. Cleared by the user
+ * closing the modal. Deliberately module-local (not in a Pinia store)
+ * because it is read-only UX state with no cross-store concerns.
+ */
+export const callPermissionError: Ref<{ device: PermissionDevice } | null> = ref(null);
+
+export function clearCallPermissionError(): void {
+  callPermissionError.value = null;
+}
+
+/**
+ * Thrown by {@link ensureCallPermissions} when the user has not granted
+ * required runtime permissions or the browser returned a stream without
+ * the necessary track. The caller is expected to surface this to the UI
+ * (modal with deep-link to system settings) and suppress any further
+ * SDK calls — otherwise Matrix would invite/answer with an empty track
+ * and the peer would appear "connected" but with no media.
+ */
+export class PermissionDeniedError extends Error {
+  readonly device: PermissionDevice;
+
+  constructor(device: PermissionDevice) {
+    super(`Permission denied: ${device}`);
+    this.name = "PermissionDeniedError";
+    this.device = device;
+  }
+}
+
+/**
+ * Preflight check before any Matrix SDK call placement or answering.
+ *
+ * Root cause of mass "no audio" reports (#279, #283, #289, #301, #305,
+ * #329, #366, #371): `getUserMedia` silently returned a stream without
+ * the audio track when `RECORD_AUDIO` was revoked/denied. Matrix SDK
+ * continued the invite/answer flow with an empty track, so the peer
+ * "connected" but heard silence (and the local user heard silence too
+ * because the remote was in the same situation, or saw a 1-2 second
+ * "connected then dropped" when SDP negotiation eventually failed).
+ *
+ * This function refuses to let the flow continue unless both:
+ *   - The OS-level runtime permission is GRANTED
+ *   - (web only) `getUserMedia` actually returns a stream with non-empty
+ *     audio and, for video calls, video tracks
+ *
+ * On Android (Capacitor native), permission is requested via the single
+ * `CallPlugin` entrypoint. A second path through `WebRTCPlugin` would
+ * pop a duplicate system dialog in the middle of call setup, so that is
+ * kept only as a fail-fast check in `startLocalMedia`.
+ */
+export async function ensureCallPermissions(isVideo: boolean): Promise<void> {
+  if (isNative) {
+    await ensureNativePermissions(isVideo);
+    return;
+  }
+  await ensureWebPermissions(isVideo);
+}
+
+async function ensureNativePermissions(isVideo: boolean): Promise<void> {
+  const audio = await nativeCallBridge.requestAudioPermission();
+  if (!audio.granted) {
+    throw new PermissionDeniedError("microphone");
+  }
+  if (!isVideo) return;
+  const video = await nativeCallBridge.requestCameraPermission();
+  if (!video.granted) {
+    throw new PermissionDeniedError("camera");
+  }
+}
+
+async function ensureWebPermissions(isVideo: boolean): Promise<void> {
+  // 1. Fast denial — browsers that support Permissions API report
+  //    persistent "denied" state without prompting. Saves us from
+  //    hitting getUserMedia just to get back an empty stream.
+  await assertWebPermissionNotDenied("microphone");
+  if (isVideo) {
+    await assertWebPermissionNotDenied("camera");
+  }
+
+  // 2. Probe calls — issued sequentially (audio first, then video) so
+  //    that a NotAllowedError can be reliably attributed to the
+  //    specific device that failed. A combined probe
+  //    (`{ audio: true, video: true }`) loses this information:
+  //    Chromium's `NotAllowedError` does not distinguish whether the
+  //    user denied microphone or camera when both are requested in
+  //    one call, which would leave us showing the wrong "grant X in
+  //    settings" hint to the user.
+  await probeDevice("microphone", { audio: true });
+  if (isVideo) {
+    await probeDevice("camera", { video: true });
+  }
+}
+
+async function probeDevice(
+  device: PermissionDevice,
+  constraints: MediaStreamConstraints,
+): Promise<void> {
+  let stream: MediaStream;
+  try {
+    stream = await navigator.mediaDevices.getUserMedia(constraints);
+  } catch (e: unknown) {
+    const name = (e as { name?: string } | undefined)?.name ?? "";
+    if (name === "NotAllowedError" || name === "PermissionDeniedError") {
+      throw new PermissionDeniedError(device);
+    }
+    // NotFoundError / OverconstrainedError / etc. — propagate so the
+    // caller can surface a more specific "device missing" error.
+    throw e;
+  }
+
+  try {
+    const tracks =
+      device === "microphone" ? stream.getAudioTracks() : stream.getVideoTracks();
+    if (tracks.length === 0) {
+      throw new PermissionDeniedError(device);
+    }
+  } finally {
+    // Release the probe stream so the SDK's own getUserMedia can
+    // acquire the device without contention. Never leave tracks
+    // alive here — some browsers will refuse a second getUserMedia
+    // while the first stream is still open.
+    stream.getTracks().forEach((t) => {
+      try {
+        t.stop();
+      } catch {
+        /* ignore */
+      }
+    });
+  }
+}
+
+async function assertWebPermissionNotDenied(device: PermissionDevice): Promise<void> {
+  const perms = (navigator as unknown as { permissions?: { query: (q: { name: string }) => Promise<{ state: string }> } }).permissions;
+  if (!perms || typeof perms.query !== "function") return; // Safari < 16
+  try {
+    const status = await perms.query({ name: device });
+    if (status.state === "denied") {
+      throw new PermissionDeniedError(device);
+    }
+  } catch (e: unknown) {
+    if (e instanceof PermissionDeniedError) throw e;
+    // Some browsers throw for unsupported PermissionName — fall through.
+  }
+}

--- a/src/features/video-calls/ui/PermissionDeniedModal.vue
+++ b/src/features/video-calls/ui/PermissionDeniedModal.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { callPermissionError, clearCallPermissionError } from "../model/permissions";
+
+const { t } = useI18n();
+
+const show = computed(() => callPermissionError.value !== null);
+
+const deviceMessage = computed(() => {
+  const device = callPermissionError.value?.device;
+  if (device === "camera") return t("call.permissionDenied.camera");
+  return t("call.permissionDenied.microphone");
+});
+
+function close() {
+  clearCallPermissionError();
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="perm-modal">
+      <div
+        v-if="show"
+        class="perm-modal-backdrop fixed inset-0 z-[60] flex items-center justify-center"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="perm-denied-title"
+        @click.self="close"
+      >
+        <div class="perm-modal-card mx-4 max-w-sm rounded-xl bg-color-bg p-5 shadow-2xl">
+          <div class="mb-3 flex items-start gap-3">
+            <div class="perm-modal-icon flex h-10 w-10 shrink-0 items-center justify-center rounded-full">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3z" />
+                <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+                <line x1="12" y1="19" x2="12" y2="23" />
+                <line x1="8" y1="23" x2="16" y2="23" />
+                <line x1="4" y1="4" x2="20" y2="20" />
+              </svg>
+            </div>
+            <div class="flex-1">
+              <h3 id="perm-denied-title" class="text-base font-semibold text-color-text">
+                {{ t("call.permissionDenied.title") }}
+              </h3>
+              <p class="mt-1 text-sm text-color-text-muted">
+                {{ deviceMessage }}
+              </p>
+            </div>
+          </div>
+
+          <p class="mb-4 text-sm text-color-text-muted">
+            {{ t("call.permissionDenied.instructions") }}
+          </p>
+
+          <div class="flex justify-end">
+            <button
+              type="button"
+              class="rounded-lg bg-color-bg-ac px-4 py-2 text-sm font-medium text-text-on-bg-ac-color transition-colors hover:bg-color-bg-ac-1"
+              @click="close"
+            >
+              {{ t("call.permissionDenied.close") }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.perm-modal-backdrop {
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(4px);
+}
+
+.perm-modal-icon {
+  background: rgba(239, 68, 68, 0.15);
+  color: rgb(239, 68, 68);
+}
+
+.perm-modal-enter-active,
+.perm-modal-leave-active {
+  transition: opacity 0.2s ease;
+}
+.perm-modal-enter-active .perm-modal-card,
+.perm-modal-leave-active .perm-modal-card {
+  transition: transform 0.25s cubic-bezier(0.34, 1.4, 0.64, 1);
+}
+.perm-modal-enter-from,
+.perm-modal-leave-to {
+  opacity: 0;
+}
+.perm-modal-enter-from .perm-modal-card {
+  transform: scale(0.92);
+}
+.perm-modal-leave-to .perm-modal-card {
+  transform: scale(0.96);
+}
+</style>

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -483,6 +483,11 @@ export const en = {
   "call.you": "You",
   "call.screen": "screen",
   "call.callInOtherTab": "Call is active in another tab",
+  "call.permissionDenied.title": "Device access denied",
+  "call.permissionDenied.microphone": "Microphone access is denied. Calls cannot proceed — the other party will not hear you.",
+  "call.permissionDenied.camera": "Camera access is denied. Video calls cannot proceed.",
+  "call.permissionDenied.instructions": "Grant access in your system settings: Settings → Apps → Forta Chat → Permissions.",
+  "call.permissionDenied.close": "Close",
 
   // ── Auth / Login ──
   "auth.signIn": "Sign In",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -485,6 +485,11 @@ export const ru: Record<TranslationKey, string> = {
   "call.you": "Вы",
   "call.screen": "экран",
   "call.callInOtherTab": "Звонок активен в другой вкладке",
+  "call.permissionDenied.title": "Нет доступа к устройству",
+  "call.permissionDenied.microphone": "Доступ к микрофону не разрешён. Без него звонок невозможен: собеседник вас не услышит.",
+  "call.permissionDenied.camera": "Доступ к камере не разрешён. Без него видеозвонок невозможен.",
+  "call.permissionDenied.instructions": "Разрешите доступ в настройках системы: «Настройки → Приложения → Forta Chat → Разрешения».",
+  "call.permissionDenied.close": "Закрыть",
 
   // ── Auth / Login ──
   "auth.signIn": "Войти",

--- a/src/shared/lib/native-calls/native-call-bridge.ts
+++ b/src/shared/lib/native-calls/native-call-bridge.ts
@@ -30,6 +30,7 @@ interface NativeCallNativePlugin {
   reportCallConnected(options: { callId: string }): Promise<void>;
   reportCallEnded(options: { callId: string }): Promise<void>;
   requestAudioPermission(): Promise<{ granted: boolean }>;
+  requestCameraPermission(): Promise<{ granted: boolean }>;
   getAudioDevices(): Promise<{
     active: string;
     devices: Array<{ type: string; name: string }>;
@@ -441,6 +442,11 @@ class NativeCallBridge {
   async requestAudioPermission(): Promise<{ granted: boolean }> {
     if (!isNative) return { granted: true };
     return NativeCall.requestAudioPermission();
+  }
+
+  async requestCameraPermission(): Promise<{ granted: boolean }> {
+    if (!isNative) return { granted: true };
+    return NativeCall.requestCameraPermission();
   }
 
   /**


### PR DESCRIPTION
## Summary

Session 16 fix — the call-dropped / no-audio / accept-does-nothing cluster (~25 user reports). Three hypotheses landed; two deferred pending more signal.

- **H0 — Permission preflight** (`61fda68`): root cause for mass "no audio" reports. `getUserMedia` was silently yielding streams with zero audio tracks when `RECORD_AUDIO` was revoked/denied on Android; Matrix SDK continued the invite/answer flow and the peer "connected" but heard silence. Added single-entrypoint `ensureCallPermissions(isVideo)` for both native (Capacitor) and web paths, with `PermissionDeniedError` + reactive UX. Camera permission is requested separately on video calls. Web path probes microphone and camera **sequentially** so `NotAllowedError` can be attributed to the correct device.
- **H2 — Answer order** (`2e977ea`): `call.answer()` now fires BEFORE `launchCallUI` and `startAudioRouting`. Some OEMs needed 300-800ms to bring the native Activity up; running launchCallUI first meant the caller's m.call.invite timeout expired before our m.call.answer reached them — caller sent m.call.hangup — answerer perceived it as "he dropped my call".
- **H3 — Connecting watchdog** (`2e977ea`): if `call.answer()` resolves but `onState→Connected` never fires (SDK wedged, OEM audio deadlock, ICE failure), the UI sat in "connecting…" forever. 30s watchdog force-fails with full teardown (SDK hangup, dismiss native UI, stop audio routing).
- **H1 — Auto-dispatch notification actions** (`e6b82c6`): `CallConnectionService` attaches accept/decline PendingIntents with `action=accept|decline` extras, but `IncomingCallActivity.onCreate` ignored them — user tapped Accept in the shade, saw the ringer UI again, had to tap Accept a second time. Now `onCreate` short-circuits to `accept()`/`decline()` when the action is set, bypassing UI render.

## Bugs addressed

- No audio / one-way audio: #279, #283, #289, #301, #305, #329, #366, #371
- Accept → call drops instantly / window collapses: #268, #309, #310, #352, #354
- Outgoing calls: #265, #269, #270, #287, #321, #326, #337, #345, #378, #379 (H0 permission preflight covers the large subset driven by revoked mic)
- Stale ringer: #256, #339 (already handled in master via FortaFirebaseMessagingService, verified during research)

## Deferred

- **H4 — Bastyon→Forta direction label "outgoing"**: in-code direction is always `incoming` for `handleIncomingCall`; bug is likely in Bastyon push payload mapping. Needs a test Bastyon account to reproduce.
- **H6 — launchMode/taskAffinity changes**: current `singleTop`/`singleTask` look correct; changing them is high-risk for regressions on share-target / deep-link flows. Deferred until a reproducible repro for "window collapses" is in hand.

## Scope of changes

| Layer | Files |
|---|---|
| Vue / TS core | `permissions.ts` (new), `call-service.ts`, `native-call-bridge.ts` |
| UX | `PermissionDeniedModal.vue` (new), `App.vue`, i18n RU/EN |
| Android native | `CallPlugin.kt` (camera permission), `IncomingCallActivity.kt` (auto-dispatch) |
| Tests | `permissions.test.ts` (new), `permissions-web.test.ts` (new), `call-service.test.ts` (extended) — 40 unit tests |

`AndroidManifest.xml` untouched; existing CallConnectionService/FortaFirebaseMessagingService behavior preserved.

## Test plan

- [x] 40/40 new + extended unit tests GREEN (permissions native+web paths, SDP ordering, 30s watchdog, clear-on-connected, camera attribution for NotAllowedError)
- [x] `vue-tsc --noEmit` clean on all touched files (pre-existing TS errors on master untouched)
- [ ] `./gradlew assembleDebug` — verify Kotlin changes compile on CI
- [ ] Manual Android 14+: first install → call → mic prompt shown BEFORE m.call.invite leaves
- [ ] Manual Android 14+: revoke mic in settings → attempt call → PermissionDeniedModal shown, no invite
- [ ] Manual Android 14+: video call without camera permission → camera prompt, on deny modal shows "camera"
- [ ] Manual Forta↔Forta voice: audio works both ways within 3s, hangup cleans notification on both sides
- [ ] Manual Forta↔Forta video: video + audio both ways
- [ ] Manual lock-screen: tap Accept in notification — one-shot straight into call, no second ringer flash
- [ ] Manual stuck call: simulate call.answer never resolving — after 30s status transitions to failed + UI dismissed
- [ ] Manual on OEM (Xiaomi / Huawei / Realme): audio routes correctly, notifications dismiss

## Reviewer notes

- Session prompt: `.planning/bug-fix-plan/SESSION-PROMPTS/16-call-accept-disconnect.md`
- Pre-existing test failures on master (sync-engine IndexedDB schema, chat-helpers, display-result, video-embed, open-profile-url) are NOT touched by this PR.
- `WebRTCPlugin` duplicate mic-permission path is intentionally left as fail-fast only; the single entrypoint is now `CallPlugin` via `ensureCallPermissions`.
- Code review done in-session; 2 HIGH findings fixed before commit (missing `unwireCallEvents` in answerCall denial branch, incorrect device attribution for combined-probe NotAllowedError).