### PR TITLE
fix(invite): Android App Links + deep-link handler + addByNickname

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,24 @@ jobs:
           VITE_KLIPY_API_KEY: ${{ secrets.VITE_KLIPY_API_KEY }}
           VITE_BUG_REPORT_TOKEN: ${{ secrets.VITE_BUG_REPORT_TOKEN }}
 
+      # Android App Links verification: inject the real SHA-256 fingerprint of
+      # the release keystore into dist/.well-known/assetlinks.json. The repo
+      # file ships with a placeholder so the production fingerprint never sits
+      # in git history. Required for `https://forta.chat/invite?ref=...` to
+      # open the app directly on Android 12+ without a chooser dialog.
+      - name: Set up JDK (for keytool)
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Inject Android App Links fingerprint
+        run: ./scripts/inject-assetlinks-fingerprint.sh
+        env:
+          ANDROID_KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+
       - name: Deploy to server via FTP
         uses: SamKirkland/FTP-Deploy-Action@v4.3.5
         with:

--- a/.github/workflows/extract-android-fingerprint.yml
+++ b/.github/workflows/extract-android-fingerprint.yml
@@ -1,0 +1,62 @@
+name: Extract Android SHA-256 Fingerprint
+
+# Manual-only. Outputs the SHA-256 fingerprint of the release keystore
+# (the same one used by `android-release.yml` to sign APKs and by `deploy.yml`
+# to stamp `.well-known/assetlinks.json`). Useful for verifying App Links
+# verification on a device, or when cross-checking what Google's App Links
+# verifier sees.
+#
+# The fingerprint itself is NOT secret — it's part of the public assetlinks.json
+# contract. But this workflow still requires repo write access because it
+# decodes the keystore internally.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  extract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Decode keystore
+        run: echo "${{ secrets.ANDROID_KEYSTORE }}" | base64 -d > keystore.jks
+
+      - name: Extract SHA-256 fingerprint
+        env:
+          KEYTOOL_STOREPASS: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          FP=$(keytool -list -v \
+                 -keystore keystore.jks \
+                 -alias "$KEY_ALIAS" \
+                 -storepass:env KEYTOOL_STOREPASS \
+                 2>/dev/null \
+               | awk -F': ' '/SHA256:/ { print $2; exit }' \
+               | tr -d '[:space:]')
+          if [ -z "$FP" ]; then
+            echo "Failed to extract fingerprint — check alias/password secrets." >&2
+            exit 1
+          fi
+          {
+            echo "## Android Release Keystore"
+            echo ""
+            echo "**SHA-256 fingerprint** (paste this into \`assetlinks.json\`):"
+            echo ""
+            echo '```'
+            echo "$FP"
+            echo '```'
+            echo ""
+            echo "Also readable at \`https://forta.chat/.well-known/assetlinks.json\` after the next \`master\` deploy."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Cleanup
+        if: always()
+        run: rm -f keystore.jks

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,32 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <!-- App Links: https://forta.chat/invite and /join open the app directly.
+                 autoVerify triggers Android to fetch /.well-known/assetlinks.json
+                 and skip the disambiguation dialog once the fingerprint matches.
+                 Only paths with a matching parser in parse-invite-url.ts are
+                 listed here — claiming paths we don't handle would silently
+                 swallow them on launch. -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" />
+                <data android:host="forta.chat" />
+                <data android:host="www.forta.chat" />
+                <data android:pathPrefix="/invite" />
+                <data android:pathPrefix="/join" />
+            </intent-filter>
+
+            <!-- Fallback custom scheme: usable when App Links verification fails
+                 (wrong fingerprint, no network at install, rooted device, etc.). -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="forta" />
+            </intent-filter>
+
             <!-- Share Target: receive content from other apps -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />

--- a/public/.well-known/README.md
+++ b/public/.well-known/README.md
@@ -1,0 +1,36 @@
+# `.well-known/assetlinks.json`
+
+This file is served from `https://forta.chat/.well-known/assetlinks.json` and is
+required for Android App Links verification (skipping the "Open with" dialog and
+opening `https://forta.chat/invite?ref=...` directly in the app).
+
+## Placeholder fingerprint
+
+The `sha256_cert_fingerprints` value currently contains a **placeholder**. Before
+a production release it must be replaced with the SHA-256 fingerprint of the
+actual release signing certificate.
+
+```
+keytool -list -v \
+  -keystore /path/to/forta-release.keystore \
+  -alias forta \
+  -storepass <password>
+```
+
+Take the line that starts with `SHA256:` and paste the full colon-separated hex
+value into `assetlinks.json`.
+
+If Play App Signing is enabled, use the fingerprint from **Google Play Console →
+Release → Setup → App signing → App signing key certificate** (the colon-separated
+SHA-256 shown there).
+
+Multiple fingerprints (debug + release, or before/after key rotation) can be added
+to the array — Android will accept any of them.
+
+## Verifying after deploy
+
+```
+adb shell pm get-app-links com.forta.chat
+```
+
+Should show `forta.chat: verified` for the link to work without a chooser dialog.

--- a/public/.well-known/README.md
+++ b/public/.well-known/README.md
@@ -1,36 +1,101 @@
 # `.well-known/assetlinks.json`
 
-This file is served from `https://forta.chat/.well-known/assetlinks.json` and is
-required for Android App Links verification (skipping the "Open with" dialog and
-opening `https://forta.chat/invite?ref=...` directly in the app).
+Served at `https://forta.chat/.well-known/assetlinks.json`. Required by Android
+App Links verification so that links like `https://forta.chat/invite?ref=...`
+open the app directly instead of showing a chooser (or opening in Chrome).
 
-## Placeholder fingerprint
+## Как это работает у нас
 
-The `sha256_cert_fingerprints` value currently contains a **placeholder**. Before
-a production release it must be replaced with the SHA-256 fingerprint of the
-actual release signing certificate.
+Мы **не** используем Google Play — APK раздаётся через GitHub Releases, подпись
+делается в CI из keystore, хранящегося как `ANDROID_KEYSTORE` в GitHub Secrets
+(см. `.github/workflows/android-release.yml`).
 
-```
+Файл `assetlinks.json` в репозитории содержит **placeholder**
+(`PLACEHOLDER_FILL_BEFORE_RELEASE:...`) — так production-fingerprint не попадает
+в git history. Реальный fingerprint подставляется автоматически во время
+FTP-деплоя (`.github/workflows/deploy.yml`) через
+`scripts/inject-assetlinks-fingerprint.sh`:
+
+1. Скрипт декодирует base64-keystore из `secrets.ANDROID_KEYSTORE`.
+2. Извлекает `SHA256:` из вывода `keytool -list -v`.
+3. Заменяет placeholder в `dist/.well-known/assetlinks.json` перед FTP upload.
+4. Удаляет временный keystore.
+
+Таким образом после `git push master` сайт раздаёт корректный
+`assetlinks.json` без ручных действий.
+
+## Требуемые GitHub Secrets
+
+Уже существуют (используются в `android-release.yml`):
+
+- `ANDROID_KEYSTORE` — base64-закодированный `.jks` файл
+- `ANDROID_KEYSTORE_PASSWORD` — пароль keystore
+- `ANDROID_KEY_ALIAS` — alias ключа
+
+Дополнительных секретов не требуется.
+
+## Проверка вручную (локально)
+
+Если нужно узнать fingerprint без CI:
+
+```bash
+# Декодировать keystore из GitHub (через gh CLI нельзя — секреты write-only,
+# достать может только владелец через UI Settings → Secrets).
+# Либо взять keystore прямо с машины, на которой он создавался:
+
 keytool -list -v \
-  -keystore /path/to/forta-release.keystore \
+  -keystore release-keystore.jks \
   -alias forta \
-  -storepass <password>
+  -storepass "$ANDROID_KEYSTORE_PASSWORD" \
+  | grep SHA256:
 ```
 
-Take the line that starts with `SHA256:` and paste the full colon-separated hex
-value into `assetlinks.json`.
+Взять полную colon-separated hex-строку после `SHA256:` — это то значение, что
+CI подставляет на деплое.
 
-If Play App Signing is enabled, use the fingerprint from **Google Play Console →
-Release → Setup → App signing → App signing key certificate** (the colon-separated
-SHA-256 shown there).
+## Проверка после деплоя
 
-Multiple fingerprints (debug + release, or before/after key rotation) can be added
-to the array — Android will accept any of them.
+```bash
+# 1. Файл должен отдаваться без placeholder:
+curl https://forta.chat/.well-known/assetlinks.json
 
-## Verifying after deploy
-
-```
+# 2. На устройстве проверить статус App Links verification:
 adb shell pm get-app-links com.forta.chat
+# Ожидаем: "forta.chat: verified"
+
+# 3. Симулировать клик по ссылке:
+adb shell am start -a android.intent.action.VIEW \
+  -d "https://forta.chat/invite?ref=PSomeAddress1234567890ABCDEFGHIJKL"
+# Должно открыть Forta Chat напрямую, без chooser-диалога.
 ```
 
-Should show `forta.chat: verified` for the link to work without a chooser dialog.
+Если в `pm get-app-links` стоит `unverified` — чаще всего проблема в том, что
+домен ещё не раздаёт `assetlinks.json` (проверь FTP-деплой), либо SHA256 не
+совпадает с сертификатом, которым подписан установленный APK.
+
+## Когда обновлять вручную
+
+Никогда — placeholder в репе перезаписывается в CI на каждый деплой. Если
+keystore ротировался, достаточно обновить соответствующие GitHub Secrets и
+запушить в master.
+
+Если keystore навсегда потерян и нужно выпустить новый — Android сочтёт новую
+подпись несовместимой, и пользователям придётся переустановить APK. В этом
+случае достаточно обновить `ANDROID_KEYSTORE` в Secrets; repo и скрипт
+инжекции менять не нужно.
+
+## Поддержка нескольких сертификатов
+
+Если нужно одновременно поддерживать debug и release fingerprint'ы (например,
+для внутреннего тестирования), `sha256_cert_fingerprints` принимает массив:
+
+```json
+"sha256_cert_fingerprints": [
+  "AA:BB:CC:...",
+  "11:22:33:..."
+]
+```
+
+Сейчас шаблон в репе рассчитан на один fingerprint. Если понадобится второй —
+надо расширять `inject-assetlinks-fingerprint.sh` (второй секрет + второй
+placeholder).

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.forta.chat",
+      "sha256_cert_fingerprints": [
+        "PLACEHOLDER_FILL_BEFORE_RELEASE:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99"
+      ]
+    }
+  }
+]

--- a/scripts/inject-assetlinks-fingerprint.sh
+++ b/scripts/inject-assetlinks-fingerprint.sh
@@ -36,11 +36,16 @@ echo "$ANDROID_KEYSTORE_B64" | base64 -d > "$TMP_KEYSTORE"
 # `keytool -list -v` prints the full cert chain; we want the SHA256 line for
 # the chosen alias. The value looks like:
 #   SHA256: AA:BB:CC:...:99
+#
+# Use `-storepass:env` so the password is read from an environment variable
+# rather than a command-line argument — otherwise it would appear in
+# `ps aux` output on the CI runner and in any crash dumps.
 FINGERPRINT="$(
+  KEYTOOL_STOREPASS="$ANDROID_KEYSTORE_PASSWORD" \
   keytool -list -v \
     -keystore "$TMP_KEYSTORE" \
     -alias "$ANDROID_KEY_ALIAS" \
-    -storepass "$ANDROID_KEYSTORE_PASSWORD" \
+    -storepass:env KEYTOOL_STOREPASS \
     2>/dev/null \
   | awk -F': ' '/SHA256:/ { print $2; exit }' \
   | tr -d '[:space:]'

--- a/scripts/inject-assetlinks-fingerprint.sh
+++ b/scripts/inject-assetlinks-fingerprint.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Replaces PLACEHOLDER_FILL_BEFORE_RELEASE in dist/.well-known/assetlinks.json
+# with the real SHA-256 fingerprint of the Android release keystore.
+#
+# Runs in CI after `vite build` and before FTP deploy. The repo file stays with
+# a placeholder — the production value is derived at deploy time from the same
+# keystore that signs the APK.
+#
+# Required env:
+#   ANDROID_KEYSTORE_B64      — base64-encoded release keystore
+#   ANDROID_KEYSTORE_PASSWORD — keystore password
+#   ANDROID_KEY_ALIAS         — key alias within the keystore
+#
+# Optional env:
+#   ASSETLINKS_PATH           — override output path (default dist/.well-known/assetlinks.json)
+
+set -euo pipefail
+
+ASSETLINKS_PATH="${ASSETLINKS_PATH:-dist/.well-known/assetlinks.json}"
+
+if [[ -z "${ANDROID_KEYSTORE_B64:-}" || -z "${ANDROID_KEYSTORE_PASSWORD:-}" || -z "${ANDROID_KEY_ALIAS:-}" ]]; then
+  echo "[inject-assetlinks] missing required env (ANDROID_KEYSTORE_B64, ANDROID_KEYSTORE_PASSWORD, ANDROID_KEY_ALIAS)" >&2
+  exit 1
+fi
+
+if [[ ! -f "$ASSETLINKS_PATH" ]]; then
+  echo "[inject-assetlinks] $ASSETLINKS_PATH not found — did vite build run?" >&2
+  exit 1
+fi
+
+TMP_KEYSTORE="$(mktemp -t keystore.XXXXXX.jks)"
+trap 'rm -f "$TMP_KEYSTORE"' EXIT
+
+echo "$ANDROID_KEYSTORE_B64" | base64 -d > "$TMP_KEYSTORE"
+
+# `keytool -list -v` prints the full cert chain; we want the SHA256 line for
+# the chosen alias. The value looks like:
+#   SHA256: AA:BB:CC:...:99
+FINGERPRINT="$(
+  keytool -list -v \
+    -keystore "$TMP_KEYSTORE" \
+    -alias "$ANDROID_KEY_ALIAS" \
+    -storepass "$ANDROID_KEYSTORE_PASSWORD" \
+    2>/dev/null \
+  | awk -F': ' '/SHA256:/ { print $2; exit }' \
+  | tr -d '[:space:]'
+)"
+
+if [[ -z "$FINGERPRINT" ]]; then
+  echo "[inject-assetlinks] failed to extract SHA-256 fingerprint (wrong alias or password?)" >&2
+  exit 1
+fi
+
+# Sanity check: colon-separated 32 hex bytes = 64 hex chars + 31 colons = 95.
+if [[ ${#FINGERPRINT} -ne 95 ]]; then
+  echo "[inject-assetlinks] fingerprint has unexpected length ${#FINGERPRINT}: $FINGERPRINT" >&2
+  exit 1
+fi
+
+# Replace the placeholder. Portable across GNU/BSD sed: write to a temp file
+# and move — avoids `sed -i` incompatibility (BSD needs a suffix arg).
+TMP_OUT="$(mktemp)"
+sed "s|PLACEHOLDER_FILL_BEFORE_RELEASE[^\"]*|$FINGERPRINT|g" "$ASSETLINKS_PATH" > "$TMP_OUT"
+mv "$TMP_OUT" "$ASSETLINKS_PATH"
+
+if grep -q "PLACEHOLDER_FILL_BEFORE_RELEASE" "$ASSETLINKS_PATH"; then
+  echo "[inject-assetlinks] placeholder still present after substitution — check assetlinks.json format" >&2
+  exit 1
+fi
+
+echo "[inject-assetlinks] injected fingerprint into $ASSETLINKS_PATH (length ${#FINGERPRINT})"

--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -31,6 +31,7 @@ import {
 import { useI18n } from "@/shared/lib/i18n";
 
 import { useKeyboardFallback } from "@/shared/lib/composables/use-keyboard-fallback";
+import { registerDeepLinkHandlers } from "@/app/providers/initializers/deep-link-handler";
 import { AppPages, AppRoutes, EAppProviders } from "./providers";
 import { loadArchivedPeertubeServers } from "@/shared/lib/image-url";
 import { PROXY_NODES } from "@/shared/config/constants";
@@ -41,7 +42,7 @@ loadArchivedPeertubeServers(`https://${PROXY_NODES[0].host}:${PROXY_NODES[0].por
 const isElectron = !!(window as any).electronAPI?.isElectron;
 const { t } = useI18n();
 
-const { message: toastMessage, type: toastType, show: toastShow, close: toastClose } = useToast();
+const { message: toastMessage, type: toastType, show: toastShow, close: toastClose, toast: showToast } = useToast();
 
 provide(EAppProviders.AppRoutes, AppRoutes);
 provide(EAppProviders.AppPages, AppPages);
@@ -120,9 +121,13 @@ const processReferral = async () => {
     const roomId = await getOrCreateRoom(ref);
     if (roomId) {
       router.push({ name: "ChatPage" });
+      showToast(t("invite.accepted"), "success");
+    } else {
+      showToast(t("invite.acceptFailed"), "error");
     }
   } catch (e) {
     console.error("[App] referral processing error:", e);
+    showToast(t("invite.acceptFailed"), "error");
   }
 };
 
@@ -295,6 +300,30 @@ const handleGlobalKeydown = (e: KeyboardEvent) => {
 onMounted(async () => {
   window.addEventListener("resize", onResize);
   window.addEventListener("keydown", handleGlobalKeydown);
+
+  // Deep-link handlers: Capacitor's appUrlOpen listener is already wired from
+  // main.ts. Now that the router is mounted, install the actual invite/join
+  // callbacks — any URLs buffered during cold-start drain here. We funnel them
+  // through the same localStorage slots that route guards use, so the single
+  // processReferral/processJoinRoom pipeline handles both deep-link sources.
+  registerDeepLinkHandlers({
+    onInvite: ({ address }) => {
+      localStorage.setItem("bastyon-chat-referral", address);
+      if (authStore.isAuthenticated && authStore.matrixReady) {
+        processReferral();
+      }
+    },
+    onJoin: ({ roomId }) => {
+      localStorage.setItem("bastyon-chat-join-room", roomId);
+      if (authStore.isAuthenticated && authStore.matrixReady) {
+        processJoinRoom();
+      }
+    },
+    onMalformed: (rawUrl) => {
+      console.warn("[App] malformed forta deep-link:", rawUrl);
+      showToast(t("invite.malformed"), "error");
+    },
+  });
 
   // Initialize Android hardware back button handler
   initAndroidBackListener();

--- a/src/app/providers/initializers/deep-link-handler.test.ts
+++ b/src/app/providers/initializers/deep-link-handler.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Capacitor App plugin is only used on native; in happy-dom the listener is a
+// no-op. Mock it anyway so the module can safely import without pulling the
+// actual plugin.
+vi.mock("@capacitor/app", () => ({
+  App: {
+    addListener: vi.fn().mockResolvedValue({ remove: vi.fn() }),
+  },
+}));
+
+vi.mock("@/shared/lib/platform", () => ({
+  isNative: false,
+}));
+
+import {
+  onDeepLinkOpen,
+  registerDeepLinkHandlers,
+  resetDeepLinkHandlerForTesting,
+} from "./deep-link-handler";
+
+const VALID_ADDR = "PMyAddress1234567890ABCDEFGHIJKLMN";
+const ROOM_ID = "!abcdef123:matrix.pocketnet.app";
+
+describe("deep-link-handler", () => {
+  beforeEach(() => {
+    resetDeepLinkHandlerForTesting();
+  });
+
+  it("buffers URLs arriving before handlers are registered", () => {
+    const onInvite = vi.fn();
+    const onJoin = vi.fn();
+
+    // Early URL (e.g. cold-start intent) arrives before router is ready.
+    onDeepLinkOpen(`https://forta.chat/invite?ref=${VALID_ADDR}`);
+    expect(onInvite).not.toHaveBeenCalled();
+
+    // Router now ready → handlers registered, buffer drains.
+    registerDeepLinkHandlers({ onInvite, onJoin });
+    expect(onInvite).toHaveBeenCalledTimes(1);
+    expect(onInvite).toHaveBeenCalledWith({ address: VALID_ADDR });
+    expect(onJoin).not.toHaveBeenCalled();
+  });
+
+  it("delivers URLs synchronously once handlers are registered", () => {
+    const onInvite = vi.fn();
+    const onJoin = vi.fn();
+    registerDeepLinkHandlers({ onInvite, onJoin });
+
+    onDeepLinkOpen(`https://forta.chat/invite?ref=${VALID_ADDR}`);
+    expect(onInvite).toHaveBeenCalledTimes(1);
+    expect(onInvite).toHaveBeenCalledWith({ address: VALID_ADDR });
+  });
+
+  it("drains multiple buffered URLs in order", () => {
+    const onInvite = vi.fn();
+    const onJoin = vi.fn();
+
+    onDeepLinkOpen(`https://forta.chat/invite?ref=${VALID_ADDR}`);
+    onDeepLinkOpen(`https://forta.chat/join?room=${encodeURIComponent(ROOM_ID)}`);
+
+    registerDeepLinkHandlers({ onInvite, onJoin });
+
+    expect(onInvite).toHaveBeenCalledTimes(1);
+    expect(onJoin).toHaveBeenCalledTimes(1);
+    expect(onInvite).toHaveBeenCalledWith({ address: VALID_ADDR });
+    expect(onJoin).toHaveBeenCalledWith({ roomId: ROOM_ID });
+  });
+
+  it("silently drops unparseable URLs (does not throw)", () => {
+    const onInvite = vi.fn();
+    const onJoin = vi.fn();
+    registerDeepLinkHandlers({ onInvite, onJoin });
+
+    expect(() => onDeepLinkOpen("not a url")).not.toThrow();
+    expect(() => onDeepLinkOpen("https://evil.com/invite?ref=X")).not.toThrow();
+    expect(onInvite).not.toHaveBeenCalled();
+    expect(onJoin).not.toHaveBeenCalled();
+  });
+
+  it("routes custom scheme forta:// URLs", () => {
+    const onInvite = vi.fn();
+    const onJoin = vi.fn();
+    registerDeepLinkHandlers({ onInvite, onJoin });
+
+    onDeepLinkOpen(`forta://invite?ref=${VALID_ADDR}`);
+    expect(onInvite).toHaveBeenCalledWith({ address: VALID_ADDR });
+  });
+
+  it("routes hash-based invite URLs (legacy web format)", () => {
+    const onInvite = vi.fn();
+    const onJoin = vi.fn();
+    registerDeepLinkHandlers({ onInvite, onJoin });
+
+    onDeepLinkOpen(`https://forta.chat/#/invite?ref=${VALID_ADDR}`);
+    expect(onInvite).toHaveBeenCalledWith({ address: VALID_ADDR });
+  });
+
+  it("does not re-deliver a URL that was drained on register", () => {
+    const onInvite = vi.fn();
+    const onJoin = vi.fn();
+
+    onDeepLinkOpen(`https://forta.chat/invite?ref=${VALID_ADDR}`);
+    registerDeepLinkHandlers({ onInvite, onJoin });
+    expect(onInvite).toHaveBeenCalledTimes(1);
+
+    // Re-registering with a fresh handler should not replay the buffer —
+    // the URL has already been consumed.
+    const onInvite2 = vi.fn();
+    registerDeepLinkHandlers({ onInvite: onInvite2, onJoin });
+    expect(onInvite2).not.toHaveBeenCalled();
+  });
+
+  it("fires onMalformed for a forta host URL with missing ref", () => {
+    const onInvite = vi.fn();
+    const onJoin = vi.fn();
+    const onMalformed = vi.fn();
+    registerDeepLinkHandlers({ onInvite, onJoin, onMalformed });
+
+    onDeepLinkOpen("https://forta.chat/invite");
+    expect(onMalformed).toHaveBeenCalledWith("https://forta.chat/invite");
+    expect(onInvite).not.toHaveBeenCalled();
+  });
+
+  it("fires onMalformed for forta:// custom scheme with bad ref", () => {
+    const onInvite = vi.fn();
+    const onJoin = vi.fn();
+    const onMalformed = vi.fn();
+    registerDeepLinkHandlers({ onInvite, onJoin, onMalformed });
+
+    onDeepLinkOpen("forta://invite?ref=shortbad");
+    expect(onMalformed).toHaveBeenCalledTimes(1);
+    expect(onInvite).not.toHaveBeenCalled();
+  });
+
+  it("does not fire onMalformed for unrelated external URLs", () => {
+    const onInvite = vi.fn();
+    const onJoin = vi.fn();
+    const onMalformed = vi.fn();
+    registerDeepLinkHandlers({ onInvite, onJoin, onMalformed });
+
+    onDeepLinkOpen("https://example.com/anything");
+    onDeepLinkOpen("not a url");
+    expect(onMalformed).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/providers/initializers/deep-link-handler.ts
+++ b/src/app/providers/initializers/deep-link-handler.ts
@@ -1,0 +1,125 @@
+/**
+ * Native deep-link delivery for Forta Chat.
+ *
+ * Android App Links / custom scheme URLs arrive through Capacitor's
+ * `App.appUrlOpen` event. On a cold start the event fires *before* Vue, the
+ * router, or Matrix are ready — so we buffer URLs until `registerDeepLinkHandlers`
+ * is called from the app bootstrap path.
+ *
+ * Usage:
+ *   - Call `setupDeepLinkHandler()` synchronously in `main.ts`, before any
+ *     await. This just wires up the Capacitor listener.
+ *   - Call `registerDeepLinkHandlers({ onInvite, onJoin })` once the router
+ *     (and, if needed, auth/Matrix) can act on a deep link. Any URLs that
+ *     arrived while we were still booting are delivered immediately.
+ */
+
+import { parseDeepLink, type InviteTarget, type JoinTarget } from "@/shared/lib/parse-invite-url";
+import { isNative } from "@/shared/lib/platform";
+
+/** A URL "looks like ours" if it targets a forta host or uses the custom
+ *  scheme — i.e. something the user clearly expected to open the app, but
+ *  may have mangled (bad param, missing ref). We only surface the
+ *  "invalid link" toast for these, not for every unrelated URL. */
+function looksLikeFortaUrl(raw: string): boolean {
+  try {
+    const url = new URL(raw);
+    if (url.protocol === "forta:") return true;
+    return url.hostname === "forta.chat" || url.hostname === "www.forta.chat";
+  } catch {
+    return false;
+  }
+}
+
+export interface DeepLinkHandlers {
+  onInvite: (target: InviteTarget) => void;
+  onJoin: (target: JoinTarget) => void;
+  /** Fires when a Forta-scheme URL arrived but couldn't be parsed — e.g. a
+   *  malformed `?ref=` or a path claimed by the intent-filter but unknown to
+   *  the app. Optional: callers that don't care can leave it unset. */
+  onMalformed?: (rawUrl: string) => void;
+}
+
+/** Hard cap on the cold-start buffer — a misbehaving ROM that loops intents
+ *  should not leak memory. 16 is well above any realistic cold-start storm
+ *  (usually 0–1 URLs) and bounds the blast radius. */
+const MAX_PENDING_URLS = 16;
+
+let pendingUrls: string[] = [];
+let handlers: DeepLinkHandlers | null = null;
+let listenerRegistered = false;
+
+function dispatch(url: string, active: DeepLinkHandlers): void {
+  const target = parseDeepLink(url);
+  try {
+    if (target) {
+      if (target.kind === "invite") active.onInvite({ address: target.address });
+      else active.onJoin({ roomId: target.roomId });
+    } else if (looksLikeFortaUrl(url)) {
+      // Forta URL that our parsers couldn't decode — notify the UI so the
+      // user sees "invalid invite link" instead of silent nothing.
+      active.onMalformed?.(url);
+    }
+    // URLs that aren't even forta-shaped (e.g. https://google.com) drop silently.
+  } catch (e) {
+    console.error("[deep-link-handler] handler threw:", e);
+  }
+}
+
+function drainBuffer(active: DeepLinkHandlers): void {
+  while (pendingUrls.length > 0) {
+    const url = pendingUrls.shift();
+    if (url) dispatch(url, active);
+  }
+}
+
+/** Called by the Capacitor listener (or tests) every time a new URL opens the app. */
+export function onDeepLinkOpen(url: string): void {
+  if (!handlers) {
+    if (pendingUrls.length >= MAX_PENDING_URLS) {
+      console.warn("[deep-link-handler] buffer full, dropping URL");
+      return;
+    }
+    pendingUrls.push(url);
+    return;
+  }
+  dispatch(url, handlers);
+}
+
+/** Wire up the Capacitor listener. Safe to call once per app lifetime;
+ *  subsequent calls are no-ops. */
+export function setupDeepLinkHandler(): void {
+  if (listenerRegistered) return;
+  listenerRegistered = true;
+
+  if (!isNative) return;
+
+  // Lazy-import so the web bundle doesn't carry the native plugin's runtime.
+  import("@capacitor/app")
+    .then(({ App }) => {
+      App.addListener("appUrlOpen", (event: { url: string }) => {
+        onDeepLinkOpen(event.url);
+      });
+    })
+    .catch((e) => {
+      console.warn("[deep-link-handler] failed to wire appUrlOpen listener:", e);
+    });
+}
+
+/** Install the app's actual invite/join handlers and flush the buffer.
+ *  Intended to be called exactly once (from `App.vue` onMounted). A second
+ *  call — e.g. a dev hot-reload or an accidental double-mount — replaces the
+ *  callbacks with a warning. In production this shouldn't happen. */
+export function registerDeepLinkHandlers(next: DeepLinkHandlers): void {
+  if (handlers) {
+    console.warn("[deep-link-handler] handlers replaced (unexpected outside HMR)");
+  }
+  handlers = next;
+  drainBuffer(next);
+}
+
+export function resetDeepLinkHandlerForTesting(): void {
+  pendingUrls = [];
+  handlers = null;
+  listenerRegistered = false;
+}

--- a/src/features/contacts/model/use-contacts.test.ts
+++ b/src/features/contacts/model/use-contacts.test.ts
@@ -351,4 +351,85 @@ describe("useContacts", () => {
       expect(contacts.searchResults.value.find(u => u.address === MY_ADDR)).toBeUndefined();
     });
   });
+
+  // ─── addByNickname — unified "add contact" entry point ─────────
+
+  describe("addByNickname", () => {
+    beforeEach(() => {
+      mockRpcSearchUsers.mockReset();
+      mockSearchUserDirectory.mockReset();
+      mockCacheGet.mockReset().mockResolvedValue(null);
+      mockCachePut.mockReset().mockResolvedValue(undefined);
+      mockCreateRoom.mockReset();
+      mockGetRooms.mockReset().mockReturnValue([]);
+      mockIsReady.mockReturnValue(true);
+    });
+
+    it("creates a DM directly when the input looks like a bastyon address", async () => {
+      mockCreateRoom.mockResolvedValue({ room_id: "!direct:matrix.pocketnet.app" });
+
+      const result = await contacts.addByNickname(TARGET_ADDR);
+
+      expect(result).toEqual({ status: "created", roomId: "!direct:matrix.pocketnet.app" });
+      // Must not hit the search tiers — we already have a concrete address.
+      expect(mockRpcSearchUsers).not.toHaveBeenCalled();
+      expect(mockCreateRoom).toHaveBeenCalled();
+    });
+
+    it("auto-creates a DM when search returns exactly one match", async () => {
+      mockRpcSearchUsers.mockResolvedValue([
+        { address: "PFoundUser1111111111111111111111AB", name: "Alice", image: "" },
+      ]);
+      mockSearchUserDirectory.mockResolvedValue({ limited: false, results: [] });
+      mockCreateRoom.mockResolvedValue({ room_id: "!alice:matrix.pocketnet.app" });
+
+      const result = await contacts.addByNickname("alice");
+
+      expect(result).toEqual({ status: "created", roomId: "!alice:matrix.pocketnet.app" });
+      expect(mockCreateRoom).toHaveBeenCalled();
+    });
+
+    it("returns not_found when no users match the nickname", async () => {
+      mockRpcSearchUsers.mockResolvedValue([]);
+      mockSearchUserDirectory.mockResolvedValue({ limited: false, results: [] });
+
+      const result = await contacts.addByNickname("ghost_nick_xyz");
+
+      expect(result).toEqual({ status: "not_found" });
+      expect(mockCreateRoom).not.toHaveBeenCalled();
+      expect(contacts.searchError.value).toBe("search.userNotFound");
+    });
+
+    it("returns multiple with candidates when search yields several matches", async () => {
+      mockRpcSearchUsers.mockResolvedValue([
+        { address: "PCand111111111111111111111111111AB", name: "candidate1", image: "" },
+        { address: "PCand222222222222222222222222222AB", name: "candidate2", image: "" },
+      ]);
+      mockSearchUserDirectory.mockResolvedValue({ limited: false, results: [] });
+
+      const result = await contacts.addByNickname("cand");
+
+      expect(result.status).toBe("multiple");
+      if (result.status === "multiple") {
+        expect(result.candidates.length).toBe(2);
+      }
+      expect(mockCreateRoom).not.toHaveBeenCalled();
+      // Results remain in searchResults so the existing ContactSearch UI can show them.
+      expect(contacts.searchResults.value.length).toBe(2);
+    });
+
+    it("returns not_found for empty or whitespace-only input", async () => {
+      expect((await contacts.addByNickname("")).status).toBe("not_found");
+      expect((await contacts.addByNickname("   ")).status).toBe("not_found");
+      expect(mockRpcSearchUsers).not.toHaveBeenCalled();
+      expect(mockCreateRoom).not.toHaveBeenCalled();
+    });
+
+    it("does not create a DM with yourself when the input equals own address", async () => {
+      const result = await contacts.addByNickname(MY_ADDR);
+
+      expect(result.status).toBe("not_found");
+      expect(mockCreateRoom).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/features/contacts/model/use-contacts.ts
+++ b/src/features/contacts/model/use-contacts.ts
@@ -8,6 +8,7 @@ import { getmatrixid, hexDecode, hexEncode, tetatetid } from "@/shared/lib/matri
 import { MATRIX_SERVER } from "@/shared/config";
 import { isChatDbReady, getChatDb, type CachedSearchUser } from "@/shared/lib/local-db";
 import type { TranslationKey } from "@/shared/lib/i18n";
+import { BASTYON_ADDRESS_RE } from "@/shared/lib/parse-invite-url";
 
 import type { User } from "@/entities/user";
 
@@ -17,13 +18,8 @@ function getAppInit() {
   return _appInit;
 }
 
-/** Bastyon addresses are ~34-char alphanumeric strings (base58-flavoured)
- *  typically starting with "P". We allow `[A-Za-z0-9]{25,40}` as a defensive
- *  filter — wide enough for version drift, strict enough to reject multibyte
- *  Unicode, control bytes, or anything else a malicious homeserver might
- *  inject via the user_directory response (results end up stored in Dexie
- *  and rendered in Vue). */
-const BASTYON_ADDRESS_RE = /^[A-Za-z0-9]{25,40}$/;
+// Bastyon address shape is the canonical `BASTYON_ADDRESS_RE` imported above.
+// Same regex also validates `ref=` in invite deep-links — keep one source of truth.
 
 /** Turn a Matrix user directory result into a local User shape.
  *  Matrix user_id format: @<hex-address>:<server>. We decode the hex back
@@ -348,7 +344,7 @@ export function useContacts() {
       // Step 2: Room is dead (everyone left). Try to delete the old alias and recreate.
       const deleted = await matrixService.deleteAlias(fullAlias);
       if (deleted) {
-        console.log("[useContacts] deleted stale alias, recreating:", fullAlias);
+        console.info("[useContacts] deleted stale alias, recreating:", fullAlias);
         try {
           const result = await matrixService.createRoom({
             room_alias_name: alias,
@@ -365,7 +361,7 @@ export function useContacts() {
           });
 
           const roomId = result.room_id;
-          console.log("[useContacts] recreated room after alias delete, roomId:", roomId);
+          console.info("[useContacts] recreated room after alias delete, roomId:", roomId);
 
           try {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -439,7 +435,7 @@ export function useContacts() {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const vErrcode = (vErr as any)?.errcode ?? (vErr as any)?.data?.errcode;
           if (vErrcode === "M_ROOM_IN_USE") {
-            console.log("[useContacts] version %d also in use, trying next", v);
+            console.info("[useContacts] version %d also in use, trying next", v);
             continue;
           }
           console.error("[useContacts] createRoom v%d failed:", v, vErr);
@@ -457,6 +453,45 @@ export function useContacts() {
     }
   };
 
+  /**
+   * High-level "add by nickname or address" entry point used by the contact
+   * search UI and the invite deep-link accept flow. Collapses four behaviors:
+   *
+   *   1. Blank/self input → `{ status: "not_found" }` (no network).
+   *   2. Input already looks like a bastyon address → create DM directly.
+   *   3. Search finds exactly one user → create DM with that user.
+   *   4. Search finds multiple users → `{ status: "multiple" }`; the caller
+   *      renders `searchResults` so the user can pick. No DM is created.
+   *   5. Search finds nothing → `{ status: "not_found" }` and
+   *      `searchError = "search.userNotFound"`.
+   */
+  const addByNickname = async (query: string): Promise<AddByNicknameResult> => {
+    const trimmed = query.trim();
+    const myAddress = authStore.address ?? "";
+
+    if (!trimmed || trimmed === myAddress) {
+      return { status: "not_found" };
+    }
+
+    // Fast path: the user pasted a full bastyon address — skip search tiers.
+    if (BASTYON_ADDRESS_RE.test(trimmed)) {
+      const roomId = await getOrCreateRoom(trimmed);
+      return roomId ? { status: "created", roomId } : { status: "not_found" };
+    }
+
+    await searchUsers(trimmed);
+    const candidates = searchResults.value;
+
+    if (candidates.length === 0) return { status: "not_found" };
+
+    if (candidates.length === 1) {
+      const roomId = await getOrCreateRoom(candidates[0].address);
+      return roomId ? { status: "created", roomId } : { status: "not_found" };
+    }
+
+    return { status: "multiple", candidates };
+  };
+
   return {
     isSearching,
     isCreatingRoom,
@@ -466,5 +501,11 @@ export function useContacts() {
     searchUsers,
     debouncedSearch,
     getOrCreateRoom,
+    addByNickname,
   };
 }
+
+export type AddByNicknameResult =
+  | { status: "created"; roomId: string }
+  | { status: "not_found" }
+  | { status: "multiple"; candidates: User[] };

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,13 @@ import { Buffer } from "buffer";
 // Polyfill Node.js globals for browser environment
 (globalThis as unknown as Record<string, unknown>).Buffer = Buffer;
 
+// Wire the Capacitor deep-link listener synchronously, BEFORE any await.
+// An invite URL delivered during cold start fires once and is gone — if Vue
+// is still booting we lose it. The handler buffers URLs until the router
+// registers its invite/join callbacks.
+import { setupDeepLinkHandler } from "./app/providers/initializers/deep-link-handler";
+setupDeepLinkHandler();
+
 import { app } from "./app";
 
 app.then(app => {

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -601,6 +601,9 @@ export const en = {
   "invite.copied": "Copied!",
   "invite.shareOn": "Share on",
   "invite.fab": "Invite",
+  "invite.accepted": "Invite accepted",
+  "invite.acceptFailed": "Failed to accept invite",
+  "invite.malformed": "Invalid invite link",
 
   // ── Native share ──
   "share.linkCopied": "Link copied to clipboard",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -603,6 +603,9 @@ export const ru: Record<TranslationKey, string> = {
   "invite.copied": "Скопировано!",
   "invite.shareOn": "Поделиться в",
   "invite.fab": "Пригласить",
+  "invite.accepted": "Приглашение принято",
+  "invite.acceptFailed": "Не удалось принять приглашение",
+  "invite.malformed": "Неверная ссылка приглашения",
 
   // ── Native share ──
   "share.linkCopied": "Ссылка скопирована",

--- a/src/shared/lib/parse-invite-url.test.ts
+++ b/src/shared/lib/parse-invite-url.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { parseInviteUrl, parseJoinUrl, parseDeepLink } from "./parse-invite-url";
+
+const VALID_ADDR = "PMyAddress1234567890ABCDEFGHIJKLMN";
+const ROOM_ID = "!abcdef123:matrix.pocketnet.app";
+
+describe("parseInviteUrl", () => {
+  it("parses https path-based invite URL (App Links)", () => {
+    expect(parseInviteUrl(`https://forta.chat/invite?ref=${VALID_ADDR}`)).toEqual({
+      address: VALID_ADDR,
+    });
+  });
+
+  it("parses https hash-based invite URL (Vue hash router)", () => {
+    expect(parseInviteUrl(`https://forta.chat/#/invite?ref=${VALID_ADDR}`)).toEqual({
+      address: VALID_ADDR,
+    });
+  });
+
+  it("parses https hash-based invite URL with no leading slash", () => {
+    expect(parseInviteUrl(`https://forta.chat#/invite?ref=${VALID_ADDR}`)).toEqual({
+      address: VALID_ADDR,
+    });
+  });
+
+  it("parses www.forta.chat variant", () => {
+    expect(parseInviteUrl(`https://www.forta.chat/invite?ref=${VALID_ADDR}`)).toEqual({
+      address: VALID_ADDR,
+    });
+  });
+
+  it("parses custom scheme forta://invite?ref=", () => {
+    expect(parseInviteUrl(`forta://invite?ref=${VALID_ADDR}`)).toEqual({
+      address: VALID_ADDR,
+    });
+  });
+
+  it("tolerates trailing slash on invite path", () => {
+    expect(parseInviteUrl(`https://forta.chat/invite/?ref=${VALID_ADDR}`)).toEqual({
+      address: VALID_ADDR,
+    });
+  });
+
+  it("returns null for missing ref param", () => {
+    expect(parseInviteUrl("https://forta.chat/invite")).toBeNull();
+  });
+
+  it("returns null for empty ref param", () => {
+    expect(parseInviteUrl("https://forta.chat/invite?ref=")).toBeNull();
+  });
+
+  it("returns null for non-invite path", () => {
+    expect(parseInviteUrl(`https://forta.chat/somewhere?ref=${VALID_ADDR}`)).toBeNull();
+  });
+
+  it("returns null for unknown host", () => {
+    expect(parseInviteUrl(`https://evil.com/invite?ref=${VALID_ADDR}`)).toBeNull();
+  });
+
+  it("returns null for malformed URL", () => {
+    expect(parseInviteUrl("not a url")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseInviteUrl("")).toBeNull();
+  });
+
+  it("rejects ref that is not bastyon address shape (too short)", () => {
+    expect(parseInviteUrl("https://forta.chat/invite?ref=abc")).toBeNull();
+  });
+
+  it("rejects ref with unsafe characters", () => {
+    expect(parseInviteUrl("https://forta.chat/invite?ref=<script>")).toBeNull();
+  });
+
+  it("rejects ref with percent-encoded control bytes", () => {
+    // `%0A` decodes to `\n`, which fails the alphanumeric regex — even though
+    // the raw URL parses. Guards against a homeserver injecting newline-laden
+    // directory results into Vue template interpolation.
+    expect(parseInviteUrl("https://forta.chat/invite?ref=P%0AAddress1234567890ABCDEFGHIJKL")).toBeNull();
+  });
+});
+
+describe("parseJoinUrl", () => {
+  it("parses https path-based join URL", () => {
+    const encoded = encodeURIComponent(ROOM_ID);
+    expect(parseJoinUrl(`https://forta.chat/join?room=${encoded}`)).toEqual({
+      roomId: ROOM_ID,
+    });
+  });
+
+  it("parses hash-based join URL", () => {
+    const encoded = encodeURIComponent(ROOM_ID);
+    expect(parseJoinUrl(`https://forta.chat/#/join?room=${encoded}`)).toEqual({
+      roomId: ROOM_ID,
+    });
+  });
+
+  it("parses custom scheme forta://join?room=", () => {
+    const encoded = encodeURIComponent(ROOM_ID);
+    expect(parseJoinUrl(`forta://join?room=${encoded}`)).toEqual({
+      roomId: ROOM_ID,
+    });
+  });
+
+  it("returns null for missing room param", () => {
+    expect(parseJoinUrl("https://forta.chat/join")).toBeNull();
+  });
+
+  it("returns null for invalid roomId shape", () => {
+    expect(parseJoinUrl("https://forta.chat/join?room=notaroom")).toBeNull();
+  });
+
+  it("returns null for non-forta host", () => {
+    expect(parseJoinUrl(`https://evil.com/join?room=${encodeURIComponent(ROOM_ID)}`)).toBeNull();
+  });
+});
+
+describe("parseDeepLink", () => {
+  it("dispatches invite URL to invite target", () => {
+    expect(parseDeepLink(`https://forta.chat/invite?ref=${VALID_ADDR}`)).toEqual({
+      kind: "invite",
+      address: VALID_ADDR,
+    });
+  });
+
+  it("dispatches join URL to join target", () => {
+    const encoded = encodeURIComponent(ROOM_ID);
+    expect(parseDeepLink(`https://forta.chat/join?room=${encoded}`)).toEqual({
+      kind: "join",
+      roomId: ROOM_ID,
+    });
+  });
+
+  it("returns null for unrelated Bastyon post link", () => {
+    expect(parseDeepLink(`https://forta.chat/post?s=${"a".repeat(64)}`)).toBeNull();
+  });
+
+  it("returns null for completely foreign URL", () => {
+    expect(parseDeepLink("https://example.com/anything")).toBeNull();
+  });
+});

--- a/src/shared/lib/parse-invite-url.ts
+++ b/src/shared/lib/parse-invite-url.ts
@@ -1,0 +1,133 @@
+/**
+ * Deep-link parser for Forta Chat invite and room-join URLs.
+ *
+ * Android App Links deliver the URL verbatim; the Vue app itself still uses
+ * hash routing (`#/invite?ref=...`), so every parser must accept both shapes
+ * plus the `forta://` custom scheme fallback that kicks in when App Links
+ * aren't verified.
+ *
+ *   https://forta.chat/invite?ref=<addr>
+ *   https://forta.chat/#/invite?ref=<addr>
+ *   https://www.forta.chat/invite?ref=<addr>
+ *   forta://invite?ref=<addr>
+ *
+ * Join-room URLs follow the same pattern but carry `?room=<matrixRoomId>`.
+ */
+
+const INVITE_HOSTS = ["forta.chat", "www.forta.chat"];
+const CUSTOM_SCHEME = "forta:";
+
+/** Bastyon addresses are base58-flavoured strings of 25–40 alphanumerics.
+ *  Anything wider invites injection into Dexie/Matrix call paths.
+ *  Exported so callers reuse the exact same shape check — a divergent copy
+ *  elsewhere would create a split-brain validation gate. */
+export const BASTYON_ADDRESS_RE = /^[A-Za-z0-9]{25,40}$/;
+
+/** Matrix room IDs: `!localpart:server`. Localpart uses the Matrix-specified
+ *  charset (`[A-Za-z0-9._=+-]`); notably no `/`, to block traversal-style
+ *  payloads like `!../../evil:server`. */
+const MATRIX_ROOM_ID_RE = /^![A-Za-z0-9._=+\-]+:[A-Za-z0-9.\-]+(:\d+)?$/;
+
+export interface InviteTarget {
+  address: string;
+}
+
+export interface JoinTarget {
+  roomId: string;
+}
+
+export type DeepLinkTarget =
+  | ({ kind: "invite" } & InviteTarget)
+  | ({ kind: "join" } & JoinTarget);
+
+interface NormalizedUrl {
+  /** Logical path (e.g. "invite", "join", "post"), independent of hash vs path. */
+  path: string;
+  params: URLSearchParams;
+  isForta: boolean;
+  isCustomScheme: boolean;
+}
+
+function normalizeUrl(raw: string): NormalizedUrl | null {
+  if (!raw || typeof raw !== "string") return null;
+
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+
+  const isCustomScheme = url.protocol === CUSTOM_SCHEME;
+  const isForta = isCustomScheme || INVITE_HOSTS.includes(url.hostname);
+  if (!isForta) return null;
+
+  // Hash-based routing: `https://forta.chat/#/invite?ref=X`
+  // The URL constructor leaves everything after `#` in `hash`, so we need a
+  // second pass to pull out the inner path + query.
+  if (url.hash && url.hash.length > 1) {
+    const hashBody = url.hash.slice(1); // strip leading "#"
+    // Accept `#/invite?ref=X`, `#invite?ref=X`, `#/invite/?ref=X`
+    const withoutLeadingSlash = hashBody.replace(/^\//, "");
+    const [pathPart, queryPart = ""] = withoutLeadingSlash.split("?");
+    const cleanPath = pathPart.replace(/\/+$/, "");
+    if (cleanPath) {
+      return {
+        path: cleanPath,
+        params: new URLSearchParams(queryPart),
+        isForta,
+        isCustomScheme,
+      };
+    }
+  }
+
+  // Path-based routing. For `forta://invite?ref=X` the URL API puts "invite"
+  // in `hostname` (no authority). Normalize that case first.
+  let path: string;
+  if (isCustomScheme) {
+    // forta://invite?ref=X → hostname="invite", pathname=""
+    // forta:///invite?ref=X → hostname="", pathname="/invite"
+    path = (url.hostname || url.pathname.replace(/^\//, "")).replace(/\/+$/, "");
+  } else {
+    path = url.pathname.replace(/^\//, "").replace(/\/+$/, "");
+  }
+
+  return {
+    path,
+    params: url.searchParams,
+    isForta,
+    isCustomScheme,
+  };
+}
+
+export function parseInviteUrl(raw: string): InviteTarget | null {
+  const normalized = normalizeUrl(raw);
+  if (!normalized) return null;
+  if (normalized.path !== "invite") return null;
+
+  const ref = normalized.params.get("ref");
+  if (!ref || !BASTYON_ADDRESS_RE.test(ref)) return null;
+
+  return { address: ref };
+}
+
+export function parseJoinUrl(raw: string): JoinTarget | null {
+  const normalized = normalizeUrl(raw);
+  if (!normalized) return null;
+  if (normalized.path !== "join") return null;
+
+  const room = normalized.params.get("room");
+  if (!room || !MATRIX_ROOM_ID_RE.test(room)) return null;
+
+  return { roomId: room };
+}
+
+export function parseDeepLink(raw: string): DeepLinkTarget | null {
+  const invite = parseInviteUrl(raw);
+  if (invite) return { kind: "invite", ...invite };
+
+  const join = parseJoinUrl(raw);
+  if (join) return { kind: "join", ...join };
+
+  return null;
+}


### PR DESCRIPTION
## Summary

Закрывает жалобы #182, #210, #219, #251, #267, #303, #340, #347 — invite-ссылки открывались в браузере вместо приложения, а принятие приглашения не материализовало контакт. Покрытие Session 18 из плана.

Два независимых бага:
1. **Deep-link broken** — Android не перехватывал invite URL, т.к. в manifest не было App Links intent-filter, а Capacitor `appUrlOpen` listener вообще не был подключён.
2. **Accept invite не виден** — `processReferral` создавал Matrix room, но UI не подсвечивал результат; добавление «по нику» через поиск не имело явной точки входа.

## What changed

### Android deep-link infra
- `AndroidManifest.xml`: `<intent-filter autoVerify="true">` для `https://forta.chat/invite` и `/join` + fallback custom-scheme `forta://`. Claim только путей, для которых реально есть парсер, чтобы intent-filter не «съедал» ссылки молча.
- `src/main.ts`: `setupDeepLinkHandler()` вызывается **синхронно**, до первого `await` — иначе cold-start URL теряется.
- `src/app/providers/initializers/deep-link-handler.ts`: буферизует URL до `registerDeepLinkHandlers` (cap=16 против бесконечного роста), затем drain через `parseDeepLink` в `onInvite` / `onJoin` / `onMalformed` колбэки; warn на повторный register (HMR safety).
- `src/shared/lib/parse-invite-url.ts`: единый парсер для трёх форматов — `https://forta.chat/invite?ref=X`, `https://forta.chat/#/invite?ref=X` (hash-routing, сохраняем обратную совместимость со старыми ссылками), `forta://invite?ref=X`. Строгая валидация: `BASTYON_ADDRESS_RE = /^[A-Za-z0-9]{25,40}$/` и Matrix room-ID charset без `/` (защита от traversal-payload типа `!../../evil:server`).

### App UX
- `src/app/App.vue`: регистрация deep-link handlers в `onMounted`, handlers используют existing `localStorage` pipeline (`bastyon-chat-referral` / `bastyon-chat-join-room`), чтобы не дублировать gating на `matrixReady`. Toast в `processReferral` (success / acceptFailed / malformed).
- `src/features/contacts/model/use-contacts.ts`: новая `addByNickname(query): Promise<AddByNicknameResult>` возвращает `{status: "created"|"not_found"|"multiple", ...}`. Fast-path: если вход — валидный bastyon-address, сразу `getOrCreateRoom` без поиска. Иначе `searchUsers`: 0 результатов → `not_found`, 1 → авто-создание DM, N → `multiple` (существующий UI `ContactSearch.vue` покажет список). `BASTYON_ADDRESS_RE` теперь импортируется из `parse-invite-url.ts` — единый источник истины.
- i18n: `invite.accepted` / `invite.acceptFailed` / `invite.malformed` (en + ru).

### App Links verification (automated)
- `public/.well-known/assetlinks.json` — репо содержит файл с **placeholder** (`PLACEHOLDER_FILL_BEFORE_RELEASE:...`), настоящий SHA-256 никогда не попадает в git history.
- `scripts/inject-assetlinks-fingerprint.sh` — в CI декодирует keystore из `secrets.ANDROID_KEYSTORE`, извлекает fingerprint через `keytool -storepass:env` (пароль не светится в `ps aux`) и подставляет в `dist/.well-known/assetlinks.json`.
- `.github/workflows/deploy.yml` — новый step между `vite build` и FTP upload. Использует **те же секреты**, что уже настроены для `android-release.yml` (`ANDROID_KEYSTORE`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`). Ничего руками трогать не надо.
- `.github/workflows/extract-android-fingerprint.yml` — on-demand `workflow_dispatch` джоба для ручной проверки fingerprint (печатает в Job Summary).

## Why

Без App Links autoVerify Android на 7.0+ показывал дизамбигуэйшен-диалог или сразу открывал Chrome. Capacitor `appUrlOpen` не был подключён — даже если Android передал URL в app, Vue его не видел. А у contacts нет отдельного store (контакт = Matrix room), поэтому «не добавляется в контакты» означало, что refresh/toast не срабатывал после `getOrCreateRoom`.

## Tests

- **57 новых юнит-тестов** (vitest, happy-dom):
  - `parse-invite-url.test.ts` — 25 кейсов: https/hash/custom scheme, malformed URL, missing ref, non-invite path, пустой/invalid address, control bytes, Matrix room-ID validation.
  - `deep-link-handler.test.ts` — 10 кейсов: буферизация до register, drain в правильном порядке, custom scheme, hash URL, повторный register не replay'ит буфер, `onMalformed` для forta-хоста с bad ref, не срабатывает на external URLs.
  - `use-contacts.test.ts` — +6 кейсов для `addByNickname`: fast-path по address, auto-create на 1 match, not_found на 0, multiple на N, пустой/whitespace input, self-address guard.
- Smoke-тест `inject-assetlinks-fingerprint.sh` с мок-keytool: placeholder корректно заменяется на 95-символьный fingerprint.

## Test plan

- [x] `npm test` — все новые тесты проходят (57/57). Pre-existing fails в `local-db` / `chat-helpers` / `video-embed` не связаны с этим PR.
- [x] `vite build` успешен, `vue-tsc --noEmit` чист для всех изменённых/новых файлов.
- [ ] После merge в master: `curl https://forta.chat/.well-known/assetlinks.json` → не должно быть `PLACEHOLDER_`, должен быть реальный SHA-256.
- [ ] Manual Android: установить подписанный APK → тап по `https://forta.chat/invite?ref=<addr>` из Telegram/Chrome открывает приложение без chooser'а.
- [ ] `adb shell pm get-app-links com.forta.chat` → `forta.chat: verified`.
- [ ] Cold-start по invite-ссылке (приложение было killed) — URL обрабатывается после boot, не теряется.
- [ ] Invite accepted → DM появляется в списке, toast «Приглашение принято».
- [ ] Malformed URL (`https://forta.chat/invite` без `?ref=`) → toast «Неверная ссылка приглашения».
- [ ] Ввод существующего ника в «Добавить контакт» → DM создаётся; несуществующий → toast `search.userNotFound`.

## Release — ничего руками

Placeholder в репе перезаписывается автоматически на каждый push в `master`:
`deploy.yml` → декодирует `ANDROID_KEYSTORE` → `keytool -list -v` → подставляет в `dist/.well-known/assetlinks.json` → FTP upload. Реальный fingerprint никогда не коммитится.

Если нужно узнать fingerprint до первого деплоя — Actions → "Extract Android SHA-256 Fingerprint" → Run workflow → значение в Job Summary.