### PR TITLE
feat(messaging): bulk delete + bulk forward (Telegram-style) + edit ciphertext fix

### DIFF
--- a/src/entities/chat/lib/parse-edit.test.ts
+++ b/src/entities/chat/lib/parse-edit.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from "vitest";
+import { parseEditBody } from "./parse-edit";
+
+/** Synthetic decrypt helper — returns the supplied body for clear events and
+ *  a deterministic string for encrypted ones. Individual tests override it. */
+function makeDecrypt(result: string | Error) {
+  return vi.fn(async () => {
+    if (result instanceof Error) throw result;
+    return { body: result, msgtype: "m.text" };
+  });
+}
+
+describe("parseEditBody", () => {
+  it("returns decrypted body when top-level event is encrypted and decryption succeeds", async () => {
+    const decrypt = makeDecrypt("Hello, world!");
+    const body = await parseEditBody({
+      raw: { type: "m.room.message", content: {} },
+      content: { msgtype: "m.encrypted", body: "<CIPHERTEXT_BLOB>" },
+      newContent: undefined,
+      decryptEvent: decrypt,
+      encryptedPlaceholder: "[зашифровано]",
+    });
+    expect(body).toBe("Hello, world!");
+    expect(decrypt).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns decrypted body when m.new_content is encrypted", async () => {
+    const decrypt = makeDecrypt("Edited text");
+    const body = await parseEditBody({
+      raw: { type: "m.room.message" },
+      content: { body: "* fallback" },
+      newContent: { msgtype: "m.encrypted", body: "<CIPHERTEXT>" },
+      decryptEvent: decrypt,
+      encryptedPlaceholder: "[зашифровано]",
+    });
+    expect(body).toBe("Edited text");
+  });
+
+  it("returns placeholder (NOT ciphertext) when decryption fails — bug #193/#222", async () => {
+    const decrypt = makeDecrypt(new Error("MAC mismatch"));
+    const body = await parseEditBody({
+      raw: {},
+      content: { msgtype: "m.encrypted", body: "<UNREADABLE_CIPHER>" },
+      newContent: { msgtype: "m.encrypted", body: "<UNREADABLE_CIPHER>" },
+      decryptEvent: decrypt,
+      encryptedPlaceholder: "[зашифровано]",
+    });
+    // The critical assertion: we must NOT leak raw ciphertext to the UI.
+    expect(body).toBe("[зашифровано]");
+    expect(body).not.toContain("CIPHER");
+  });
+
+  it("returns newContent.body for clear-room edits (no decrypt needed)", async () => {
+    const decrypt = makeDecrypt("should-not-be-called");
+    const body = await parseEditBody({
+      raw: {},
+      content: { msgtype: "m.text", body: "* edited" },
+      newContent: { msgtype: "m.text", body: "edited" },
+      decryptEvent: decrypt,
+      encryptedPlaceholder: "[зашифровано]",
+    });
+    expect(body).toBe("edited");
+    expect(decrypt).not.toHaveBeenCalled();
+  });
+
+  it("falls back to content.body when newContent is missing in clear rooms", async () => {
+    const decrypt = makeDecrypt("ignored");
+    const body = await parseEditBody({
+      raw: {},
+      content: { msgtype: "m.text", body: "direct body" },
+      newContent: undefined,
+      decryptEvent: decrypt,
+      encryptedPlaceholder: "[зашифровано]",
+    });
+    expect(body).toBe("direct body");
+  });
+
+  it("returns empty string when both bodies are missing in clear rooms", async () => {
+    const decrypt = makeDecrypt("ignored");
+    const body = await parseEditBody({
+      raw: {},
+      content: {},
+      newContent: undefined,
+      decryptEvent: decrypt,
+      encryptedPlaceholder: "[зашифровано]",
+    });
+    expect(body).toBe("");
+  });
+});

--- a/src/entities/chat/lib/parse-edit.ts
+++ b/src/entities/chat/lib/parse-edit.ts
@@ -1,0 +1,45 @@
+/**
+ * Resolve the plaintext body of an incoming edit event (m.replace relation).
+ *
+ * Priority:
+ *   1. If the event (or its m.new_content) is encrypted, decrypt the raw
+ *      event and use the decrypted `body`.
+ *   2. Otherwise, take `m.new_content.body` (canonical new version).
+ *   3. Otherwise, fall back to the outer `body` (legacy clients that only
+ *      set `body` with the `* ` fallback prefix).
+ *
+ * Security guarantee — fixes bug #193 / #222:
+ *   On decryption failure we return the supplied `encryptedPlaceholder`,
+ *   NEVER the raw ciphertext. Previously the fallback read `newContent.body`
+ *   directly, which in encrypted rooms is a ciphertext blob — surfacing it
+ *   as the visible message text made groups display "unreadable garbage".
+ */
+export interface ParseEditBodyInput {
+  raw: Record<string, unknown>;
+  content: Record<string, unknown>;
+  newContent: Record<string, unknown> | undefined;
+  decryptEvent: (raw: Record<string, unknown>) => Promise<{ body: string; msgtype: string }>;
+  encryptedPlaceholder: string;
+}
+
+export async function parseEditBody({
+  raw,
+  content,
+  newContent,
+  decryptEvent,
+  encryptedPlaceholder,
+}: ParseEditBodyInput): Promise<string> {
+  const isEncrypted =
+    newContent?.msgtype === "m.encrypted" || content.msgtype === "m.encrypted";
+
+  if (isEncrypted) {
+    try {
+      const decrypted = await decryptEvent(raw);
+      return decrypted.body;
+    } catch {
+      return encryptedPlaceholder;
+    }
+  }
+
+  return (newContent?.body as string) ?? (content.body as string) ?? "";
+}

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -380,6 +380,10 @@ export const useChatStore = defineStore(NAMESPACE, () => {
   /** True only when initForward is called (context menu) — NOT on draft restore */
   const forwardPickerRequested = ref(false);
   const forwardDrafts = new Map<string, ForwardingMessage>();
+  // Bulk forward (additive, sits alongside singular `forwardingMessage`).
+  // When non-empty, ForwardPicker routes room-selection through the batch
+  // `forwardMessages(ids, targetRoomId)` API rather than the legacy draft flow.
+  const forwardingMessages = ref<Message[]>([]);
   const isDetachedFromLatest = ref(false);
 
   // Shared counter: yields to main thread every 5 decryption calls across ALL
@@ -574,6 +578,17 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     const roomId = activeRoomId.value;
     if (roomId) forwardDrafts.delete(roomId);
     forwardingMessage.value = null;
+    // Clear bulk selection too — a single "cancel" should close both modes.
+    forwardingMessages.value = [];
+  };
+
+  /** Start a bulk-forward session with the currently selected messages.
+   *  Does NOT replace the singular flow — legacy single-message forward
+   *  (context menu → ForwardPicker draft → target room input) keeps working. */
+  const initBulkForward = (msgs: Message[]) => {
+    if (msgs.length === 0) return;
+    forwardingMessages.value = [...msgs];
+    forwardPickerRequested.value = true;
   };
 
   /** Save current forward to drafts for the given room (called on room switch) */
@@ -5926,6 +5941,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     selectionMode.value = false;
     selectedMessageIds.value = new Set();
     forwardingMessage.value = null;
+    forwardingMessages.value = [];
     pinnedMessages.value = [];
     pinnedMessageIndex.value = 0;
     pinnedRoomIds.value = new Set();
@@ -5968,8 +5984,10 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     enterSelectionMode,
     exitSelectionMode,
     forwardingMessage,
+    forwardingMessages,
     forwardPickerRequested,
     initForward,
+    initBulkForward,
     initExternalShare,
     initPostForward,
     cancelForward,

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -2836,6 +2836,13 @@ export const useChatStore = defineStore(NAMESPACE, () => {
 
   const setActiveRoom = (roomId: string | null) => {
     perfMark("setActiveRoom-start");
+    // Exit multi-select when leaving the room — selection is bound to the
+    // active room's messages, carrying it over to the next chat is never
+    // what the user expects.
+    if (selectionMode.value && roomId !== activeRoomId.value) {
+      selectionMode.value = false;
+      selectedMessageIds.value = new Set();
+    }
     // Flush buffered background writes before switching rooms.
     // After flush completes, bump _liveQueryGen to force liveQuery re-subscribe.
     // This closes the race where buffered messages land in Dexie during the

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -388,6 +388,9 @@ export const useChatStore = defineStore(NAMESPACE, () => {
   // optionally types a caption before shipping the batch.
   const forwardingMessages = ref<Message[]>([]);
   const bulkForwardDrafts = new Map<string, Message[]>();
+  // Per-session toggle: if false, forwarded messages are shipped without
+  // the `forwarded_from` attribution (Telegram "hide sender" option).
+  const bulkForwardWithSenderInfo = ref(true);
   const isDetachedFromLatest = ref(false);
 
   // Shared counter: yields to main thread every 5 decryption calls across ALL
@@ -616,6 +619,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     const key = roomId ?? activeRoomId.value;
     if (key) bulkForwardDrafts.delete(key);
     forwardingMessages.value = [];
+    bulkForwardWithSenderInfo.value = true; // reset to default for next session
   };
 
   /** Save current forward to drafts for the given room (called on room switch) */
@@ -6018,6 +6022,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     forwardingMessage,
     forwardingMessages,
     forwardPickerRequested,
+    bulkForwardWithSenderInfo,
     initForward,
     initBulkForward,
     saveBulkForwardDraft,

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -382,9 +382,12 @@ export const useChatStore = defineStore(NAMESPACE, () => {
   const forwardPickerRequested = ref(false);
   const forwardDrafts = new Map<string, ForwardingMessage>();
   // Bulk forward (additive, sits alongside singular `forwardingMessage`).
-  // When non-empty, ForwardPicker routes room-selection through the batch
-  // `forwardMessages(ids, targetRoomId)` API rather than the legacy draft flow.
+  // Mirrors the singular draft-flow (save per-target, restore on room-switch,
+  // preview bar + composer, send on tap) — NOT immediate dispatch. That matches
+  // the Telegram/Element UX where the user lands in the target room first and
+  // optionally types a caption before shipping the batch.
   const forwardingMessages = ref<Message[]>([]);
+  const bulkForwardDrafts = new Map<string, Message[]>();
   const isDetachedFromLatest = ref(false);
 
   // Shared counter: yields to main thread every 5 decryption calls across ALL
@@ -590,6 +593,29 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     if (msgs.length === 0) return;
     forwardingMessages.value = [...msgs];
     forwardPickerRequested.value = true;
+  };
+
+  /** Persist the current bulk selection to drafts keyed by target room so it
+   *  survives the room-switch watcher (same trick the singular flow uses). */
+  const saveBulkForwardDraft = (targetRoomId: string) => {
+    if (forwardingMessages.value.length > 0) {
+      bulkForwardDrafts.set(targetRoomId, [...forwardingMessages.value]);
+    } else {
+      bulkForwardDrafts.delete(targetRoomId);
+    }
+  };
+
+  const restoreBulkForwardDraft = (roomId: string) => {
+    const draft = bulkForwardDrafts.get(roomId);
+    forwardingMessages.value = draft ? [...draft] : [];
+  };
+
+  /** Clear the bulk forward — both the in-flight array and any saved draft
+   *  for the given (or active) room. Use after Send or when user cancels. */
+  const cancelBulkForward = (roomId?: string) => {
+    const key = roomId ?? activeRoomId.value;
+    if (key) bulkForwardDrafts.delete(key);
+    forwardingMessages.value = [];
   };
 
   /** Save current forward to drafts for the given room (called on room switch) */
@@ -5994,6 +6020,9 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     forwardPickerRequested,
     initForward,
     initBulkForward,
+    saveBulkForwardDraft,
+    restoreBulkForwardDraft,
+    cancelBulkForward,
     initExternalShare,
     initPostForward,
     cancelForward,

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -3,6 +3,7 @@ import type { MatrixKit } from "@/entities/matrix";
 import type { Pcrypto, PcryptoRoomInstance } from "@/entities/matrix/model/matrix-crypto";
 import { getmatrixid, hexEncode, hexDecode } from "@/shared/lib/matrix/functions";
 import { matrixIdToAddress, messageTypeFromMime, parseFileInfo, cleanMatrixIds, looksLikeProperName } from "../lib/chat-helpers";
+import { parseEditBody } from "../lib/parse-edit";
 import { sortMessagesTimelineAsc } from "../lib/message-utils";
 import { resetPowerLevel, isUserBanned } from "../lib/room-guards";
 import { stripMentionAddresses, stripBastyonLinks } from "@/shared/lib/message-format";
@@ -4092,16 +4093,18 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       const target = msgMap.get(targetId);
       if (target) {
         const newContent = content["m.new_content"] as Record<string, unknown> | undefined;
+        const isEncrypted = newContent?.msgtype === "m.encrypted" || content.msgtype === "m.encrypted";
         let editBody: string;
 
-        if (newContent?.msgtype === "m.encrypted" || content.msgtype === "m.encrypted") {
+        if (isEncrypted) {
           if (roomCrypto) {
-            try {
-              const decrypted = await roomCrypto.decryptEvent(raw);
-              editBody = decrypted.body;
-            } catch {
-              editBody = (newContent?.body as string) ?? (content.body as string) ?? "[decrypt error]";
-            }
+            editBody = await parseEditBody({
+              raw,
+              content,
+              newContent,
+              decryptEvent: (e) => roomCrypto.decryptEvent(e),
+              encryptedPlaceholder: "[encrypted]",
+            });
           } else {
             editBody = "[encrypted]";
           }
@@ -5147,20 +5150,23 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       const editRelatesTo = content["m.relates_to"] as Record<string, unknown> | undefined;
       if (editRelatesTo?.rel_type === "m.replace" && editRelatesTo?.event_id) {
         const targetId = editRelatesTo.event_id as string;
+        const newContent = content["m.new_content"] as Record<string, unknown> | undefined;
+        const isEncrypted = newContent?.msgtype === "m.encrypted" || content.msgtype === "m.encrypted";
         let newBody: string;
 
-        // Edit events in encrypted rooms: m.new_content holds the ciphertext
-        const newContent = content["m.new_content"] as Record<string, unknown> | undefined;
-        if (newContent?.msgtype === "m.encrypted" || content.msgtype === "m.encrypted") {
+        if (isEncrypted) {
           const roomCrypto = await ensureRoomCrypto(roomId);
           if (roomCrypto) {
-            try {
-              await maybeYieldDecrypt();
-              const decrypted = await roomCrypto.decryptEvent(raw);
-              newBody = decrypted.body;
-            } catch {
-              newBody = (newContent?.body as string) ?? (content.body as string) ?? "[decrypt error]";
-            }
+            newBody = await parseEditBody({
+              raw,
+              content,
+              newContent,
+              decryptEvent: async (e) => {
+                await maybeYieldDecrypt();
+                return roomCrypto.decryptEvent(e);
+              },
+              encryptedPlaceholder: "[encrypted]",
+            });
           } else {
             newBody = "[encrypted]";
           }

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -455,6 +455,9 @@ export const useChatStore = defineStore(NAMESPACE, () => {
   // Edit/delete state (Batch 3)
   const editingMessage = ref<{ id: string; content: string } | null>(null);
   const deletingMessage = ref<Message | null>(null);
+  // Bulk-delete state — array form coexists with singular deletingMessage above.
+  // When non-empty, the delete confirmation modal operates on ALL listed messages.
+  const deletingMessages = ref<Message[]>([]);
 
   // User display name cache: address → display name
   const userDisplayNames = ref<Record<string, string>>({});
@@ -5918,6 +5921,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     syncState.value = null;
     editingMessage.value = null;
     deletingMessage.value = null;
+    deletingMessages.value = [];
     userDisplayNames.value = {};
     selectionMode.value = false;
     selectedMessageIds.value = new Set();
@@ -5958,6 +5962,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     cleanup,
     clearDeletedRoom,
     deletingMessage,
+    deletingMessages,
     editingMessage,
     enterDetachedMode,
     enterSelectionMode,

--- a/src/features/contacts/ui/ContactList.vue
+++ b/src/features/contacts/ui/ContactList.vue
@@ -200,8 +200,16 @@ function getRoomTitle(room: ChatRoom): DisplayResult {
 function getPreview(room: ChatRoom): DisplayResult {
   // Primary: use room.lastMessage from Dexie LiveRoom
   if (room.lastMessage) {
-    // Deleted message — show explicit "deleted" text
-    if (room.lastMessage.deleted || (!room.lastMessage.content && room.lastMessage.type === MessageType.text)) {
+    const c = room.lastMessage.content;
+    // Deleted message — show explicit "deleted" text.
+    // `[message]` / `🚫 Message deleted` are legacy Dexie fallbacks that used
+    // to leak through the sidebar; treat them the same as an empty/deleted row.
+    if (
+      room.lastMessage.deleted ||
+      (!c && room.lastMessage.type === MessageType.text) ||
+      c === "[message]" ||
+      c === "🚫 Message deleted"
+    ) {
       return { state: "ready", text: `🚫 ${t("message.deleted")}` };
     }
     // For non-encrypted content, clean links/IDs (getPreview text is shown directly in some template branches)

--- a/src/features/messaging/model/use-messages.test.ts
+++ b/src/features/messaging/model/use-messages.test.ts
@@ -417,5 +417,16 @@ describe("useMessages", () => {
       expect(result.failed).toBe(0);
       expect(mockSendEncryptedText).not.toHaveBeenCalled();
     });
+
+    it("omits forwarded_from when withSenderInfo option is false", async () => {
+      const m1 = makeMsg({ roomId: "!src:server", id: "$m1", content: "anon", senderId: "userA" });
+      chatStore.addMessage("!src:server", m1);
+
+      await messaging.forwardMessages(["$m1"], "!target:server", { withSenderInfo: false });
+
+      const call = (mockSendEncryptedText.mock.calls as unknown[][])[0];
+      const content = call[1] as Record<string, unknown>;
+      expect(content.forwarded_from).toBeUndefined();
+    });
   });
 });

--- a/src/features/messaging/model/use-messages.test.ts
+++ b/src/features/messaging/model/use-messages.test.ts
@@ -20,7 +20,9 @@ vi.mock("@/shared/lib/connectivity", () => ({
 // Mock MatrixClientService with all needed methods
 const mockRedactEvent = vi.fn();
 const mockSendReaction = vi.fn(() => "$reaction_event_1");
-const mockSendEncryptedText = vi.fn(() => "$server_event_1");
+const mockSendEncryptedText = vi.fn<
+  (roomId: string, content: Record<string, unknown>, clientId?: string) => string
+>(() => "$server_event_1");
 const mockSendText = vi.fn(() => "$server_event_1");
 const mockSendPollStart = vi.fn(() => "$poll_event_1");
 const mockSendPollResponse = vi.fn();
@@ -327,6 +329,93 @@ describe("useMessages", () => {
       // No redact attempted (service not ready) — treat as no-op
       expect(mockRedactEvent).not.toHaveBeenCalled();
       expect(result.failed + result.succeeded).toBe(1);
+    });
+  });
+
+  // ─── forwardMessages (bulk) ───────────────────────────────────
+
+  describe("forwardMessages (bulk)", () => {
+    beforeEach(() => {
+      mockIsReady.mockReturnValue(true);
+      mockSendEncryptedText.mockReset();
+      mockSendEncryptedText.mockImplementation(() => "$fwd_sent_event");
+    });
+
+    it("forwards N selected messages to the target room", async () => {
+      const m1 = makeMsg({ roomId: "!src:server", id: "$m1", content: "hi", senderId: "user1" });
+      const m2 = makeMsg({ roomId: "!src:server", id: "$m2", content: "there", senderId: "user1" });
+      chatStore.addMessage("!src:server", m1);
+      chatStore.addMessage("!src:server", m2);
+
+      const result = await messaging.forwardMessages(
+        ["$m1", "$m2"],
+        "!target:server",
+      );
+
+      expect(result.succeeded).toBe(2);
+      expect(result.failed).toBe(0);
+      // All sends went to TARGET room, not the source.
+      const roomIds = (mockSendEncryptedText.mock.calls as unknown[][]).map((c) => c[0]);
+      expect(roomIds.every((r) => r === "!target:server")).toBe(true);
+      expect(roomIds.length).toBe(2);
+    });
+
+    it("preserves source-order by timestamp when ids arrive scrambled", async () => {
+      const m1 = makeMsg({ roomId: "!src:server", id: "$m1", content: "first", timestamp: 10 });
+      const m2 = makeMsg({ roomId: "!src:server", id: "$m2", content: "second", timestamp: 20 });
+      const m3 = makeMsg({ roomId: "!src:server", id: "$m3", content: "third", timestamp: 30 });
+      chatStore.addMessage("!src:server", m1);
+      chatStore.addMessage("!src:server", m2);
+      chatStore.addMessage("!src:server", m3);
+
+      await messaging.forwardMessages(["$m3", "$m1", "$m2"], "!target:server");
+
+      const bodies = (mockSendEncryptedText.mock.calls as unknown[][]).map(
+        (c) => (c[1] as { body?: string })?.body,
+      );
+      expect(bodies).toEqual(["first", "second", "third"]);
+    });
+
+    it("continues on partial failure and reports counts", async () => {
+      mockSendEncryptedText.mockImplementation(
+        (_roomId: string, content: { body?: string }) => {
+          if (content?.body === "bad") throw new Error("transient");
+          return "$ok";
+        },
+      );
+      const m1 = makeMsg({ roomId: "!src:server", id: "$m1", content: "good1", timestamp: 1 });
+      const m2 = makeMsg({ roomId: "!src:server", id: "$m2", content: "bad", timestamp: 2 });
+      const m3 = makeMsg({ roomId: "!src:server", id: "$m3", content: "good2", timestamp: 3 });
+      chatStore.addMessage("!src:server", m1);
+      chatStore.addMessage("!src:server", m2);
+      chatStore.addMessage("!src:server", m3);
+
+      const result = await messaging.forwardMessages(
+        ["$m1", "$m2", "$m3"],
+        "!target:server",
+      );
+      expect(result.succeeded).toBe(2);
+      expect(result.failed).toBe(1);
+    });
+
+    it("attaches forwarded_from attribution when sender is known", async () => {
+      const m1 = makeMsg({ roomId: "!src:server", id: "$m1", content: "orig", senderId: "userA" });
+      chatStore.addMessage("!src:server", m1);
+
+      await messaging.forwardMessages(["$m1"], "!target:server");
+
+      const call = (mockSendEncryptedText.mock.calls as unknown[][])[0];
+      const content = call[1] as Record<string, unknown>;
+      expect(content.forwarded_from).toEqual(
+        expect.objectContaining({ sender_id: "userA" }),
+      );
+    });
+
+    it("handles empty array gracefully", async () => {
+      const result = await messaging.forwardMessages([], "!target:server");
+      expect(result.succeeded).toBe(0);
+      expect(result.failed).toBe(0);
+      expect(mockSendEncryptedText).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/messaging/model/use-messages.test.ts
+++ b/src/features/messaging/model/use-messages.test.ts
@@ -248,4 +248,85 @@ describe("useMessages", () => {
       expect(reply.status).toBe(MessageStatus.failed);
     });
   });
+
+  // ─── deleteMessages (bulk) ────────────────────────────────────
+
+  describe("deleteMessages (bulk)", () => {
+    beforeEach(() => {
+      // Reset mock return values that vi.clearAllMocks() doesn't clear
+      mockIsReady.mockReturnValue(true);
+      mockRedactEvent.mockReset();
+    });
+
+    it("redacts ALL selected messages when forEveryone=true", async () => {
+      const m1 = makeMsg({ roomId: "!room:server", id: "$e1" });
+      const m2 = makeMsg({ roomId: "!room:server", id: "$e2" });
+      const m3 = makeMsg({ roomId: "!room:server", id: "$e3" });
+      chatStore.addMessage("!room:server", m1);
+      chatStore.addMessage("!room:server", m2);
+      chatStore.addMessage("!room:server", m3);
+
+      const result = await messaging.deleteMessages(["$e1", "$e2", "$e3"], true);
+
+      expect(mockRedactEvent).toHaveBeenCalledTimes(3);
+      expect(mockRedactEvent).toHaveBeenCalledWith("!room:server", "$e1", "deleted");
+      expect(mockRedactEvent).toHaveBeenCalledWith("!room:server", "$e2", "deleted");
+      expect(mockRedactEvent).toHaveBeenCalledWith("!room:server", "$e3", "deleted");
+      expect(result.succeeded).toBe(3);
+      expect(result.failed).toBe(0);
+    });
+
+    it("continues on partial failure and reports counts", async () => {
+      mockRedactEvent.mockImplementation(
+        async (_roomId: string, eventId: string): Promise<void> => {
+          if (eventId === "$e2") throw new Error("transient network");
+        },
+      );
+      const m1 = makeMsg({ roomId: "!room:server", id: "$e1" });
+      const m2 = makeMsg({ roomId: "!room:server", id: "$e2" });
+      const m3 = makeMsg({ roomId: "!room:server", id: "$e3" });
+      chatStore.addMessage("!room:server", m1);
+      chatStore.addMessage("!room:server", m2);
+      chatStore.addMessage("!room:server", m3);
+
+      const result = await messaging.deleteMessages(["$e1", "$e2", "$e3"], true);
+
+      expect(result.succeeded).toBe(2);
+      expect(result.failed).toBe(1);
+    });
+
+    it("skips redact and only marks locally deleted when forEveryone=false", async () => {
+      const m1 = makeMsg({ roomId: "!room:server", id: "$e1" });
+      const m2 = makeMsg({ roomId: "!room:server", id: "$e2" });
+      chatStore.addMessage("!room:server", m1);
+      chatStore.addMessage("!room:server", m2);
+
+      const result = await messaging.deleteMessages(["$e1", "$e2"], false);
+
+      expect(mockRedactEvent).not.toHaveBeenCalled();
+      expect(result.succeeded).toBe(2);
+      expect(result.failed).toBe(0);
+      // removeMessage marks as deleted (WhatsApp-style placeholder), doesn't splice
+      const roomMsgs = chatStore.messages["!room:server"];
+      expect(roomMsgs.every((m) => m.deleted === true)).toBe(true);
+    });
+
+    it("handles empty array gracefully", async () => {
+      const result = await messaging.deleteMessages([], true);
+      expect(result.succeeded).toBe(0);
+      expect(result.failed).toBe(0);
+      expect(mockRedactEvent).not.toHaveBeenCalled();
+    });
+
+    it("returns zero on all-fail when matrixService is not ready", async () => {
+      mockIsReady.mockReturnValue(false);
+      const m1 = makeMsg({ roomId: "!room:server", id: "$e1" });
+      chatStore.addMessage("!room:server", m1);
+
+      const result = await messaging.deleteMessages(["$e1"], true);
+      // No redact attempted (service not ready) — treat as no-op
+      expect(mockRedactEvent).not.toHaveBeenCalled();
+      expect(result.failed + result.succeeded).toBe(1);
+    });
+  });
 });

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -1564,6 +1564,87 @@ export function useMessages() {
     }
   };
 
+  /** Forward multiple messages to a target room in one batch. Additive
+   *  counterpart to singular sendForward — keeps the legacy flow intact.
+   *  Messages are replayed in source-timestamp order, each as its own
+   *  `m.room.message` event with a `forwarded_from` attribution field. */
+  const forwardMessages = async (
+    sourceMessageIds: string[],
+    targetRoomId: string,
+  ): Promise<{ succeeded: number; failed: number }> => {
+    if (sourceMessageIds.length === 0) return { succeeded: 0, failed: 0 };
+
+    const matrixService = getMatrixClientService();
+    if (!matrixService.isReady()) {
+      return { succeeded: 0, failed: sourceMessageIds.length };
+    }
+
+    // Collect source messages across all rooms (selection may span rooms in theory,
+    // though the current UI path feeds us only the active room's selection).
+    const idSet = new Set(sourceMessageIds);
+    const collected: Array<{ id: string; content: string; senderId: string; timestamp: number }> = [];
+    for (const roomMessages of Object.values(chatStore.messages)) {
+      for (const m of roomMessages) {
+        if (idSet.has(m.id)) {
+          collected.push({ id: m.id, content: m.content, senderId: m.senderId, timestamp: m.timestamp });
+        }
+      }
+    }
+    // Ship in original chronological order so recipients see the conversation flow.
+    collected.sort((a, b) => a.timestamp - b.timestamp);
+
+    const results = await Promise.allSettled(
+      collected.map(async (src) => {
+        const senderName = chatStore.getDisplayName(src.senderId);
+        const fwdMeta = { senderId: src.senderId, senderName };
+
+        if (isChatDbReady()) {
+          try {
+            const dbKit = getChatDb();
+            const localMsg = await dbKit.messages.createLocal({
+              roomId: targetRoomId,
+              senderId: authStore.address ?? "",
+              content: src.content,
+              type: MessageType.text,
+              forwardedFrom: fwdMeta,
+            });
+            await dbKit.syncEngine.enqueue(
+              "send_message",
+              targetRoomId,
+              { content: src.content, forwardedFrom: fwdMeta },
+              localMsg.clientId,
+            );
+            return;
+          } catch (e) {
+            console.warn("[use-messages] Dexie bulk forward failed, falling back:", e);
+          }
+        }
+
+        // Legacy fallback — direct encrypted/plaintext send to target room.
+        const roomCrypto = authStore.pcrypto?.rooms[targetRoomId] as PcryptoRoomInstance | undefined;
+        if (roomCrypto?.canBeEncrypt()) {
+          const encrypted = await roomCrypto.encryptEvent(src.content);
+          (encrypted as Record<string, unknown>).forwarded_from = {
+            sender_id: src.senderId,
+            sender_name: senderName,
+          };
+          await matrixService.sendEncryptedText(targetRoomId, encrypted);
+        } else {
+          const payload: Record<string, unknown> = {
+            body: src.content,
+            msgtype: "m.text",
+            forwarded_from: { sender_id: src.senderId, sender_name: senderName },
+          };
+          await matrixService.sendEncryptedText(targetRoomId, payload);
+        }
+      }),
+    );
+
+    const succeeded = results.filter((r) => r.status === "fulfilled").length;
+    const failed = results.length - succeeded;
+    return { succeeded, failed };
+  };
+
   /** Delete multiple messages in one batch. Continues on individual failures —
    *  returns a summary {succeeded, failed} so the caller can show a toast.
    *  Self-contained (does not wrap single deleteMessage), because the single
@@ -2294,6 +2375,7 @@ export function useMessages() {
     sendAudio,
     sendFile,
     sendForward,
+    forwardMessages,
     sendGif,
     sendImage,
     sendMessage,

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -1571,8 +1571,10 @@ export function useMessages() {
   const forwardMessages = async (
     sourceMessageIds: string[],
     targetRoomId: string,
+    opts?: { withSenderInfo?: boolean },
   ): Promise<{ succeeded: number; failed: number }> => {
     if (sourceMessageIds.length === 0) return { succeeded: 0, failed: 0 };
+    const withSenderInfo = opts?.withSenderInfo ?? true;
 
     const matrixService = getMatrixClientService();
     if (!matrixService.isReady()) {
@@ -1596,7 +1598,7 @@ export function useMessages() {
     const results = await Promise.allSettled(
       collected.map(async (src) => {
         const senderName = chatStore.getDisplayName(src.senderId);
-        const fwdMeta = { senderId: src.senderId, senderName };
+        const fwdMeta = withSenderInfo ? { senderId: src.senderId, senderName } : undefined;
 
         if (isChatDbReady()) {
           try {
@@ -1611,7 +1613,9 @@ export function useMessages() {
             await dbKit.syncEngine.enqueue(
               "send_message",
               targetRoomId,
-              { content: src.content, forwardedFrom: fwdMeta },
+              fwdMeta
+                ? { content: src.content, forwardedFrom: fwdMeta }
+                : { content: src.content },
               localMsg.clientId,
             );
             return;
@@ -1624,17 +1628,21 @@ export function useMessages() {
         const roomCrypto = authStore.pcrypto?.rooms[targetRoomId] as PcryptoRoomInstance | undefined;
         if (roomCrypto?.canBeEncrypt()) {
           const encrypted = await roomCrypto.encryptEvent(src.content);
-          (encrypted as Record<string, unknown>).forwarded_from = {
-            sender_id: src.senderId,
-            sender_name: senderName,
-          };
+          if (withSenderInfo) {
+            (encrypted as Record<string, unknown>).forwarded_from = {
+              sender_id: src.senderId,
+              sender_name: senderName,
+            };
+          }
           await matrixService.sendEncryptedText(targetRoomId, encrypted);
         } else {
           const payload: Record<string, unknown> = {
             body: src.content,
             msgtype: "m.text",
-            forwarded_from: { sender_id: src.senderId, sender_name: senderName },
           };
+          if (withSenderInfo) {
+            payload.forwarded_from = { sender_id: src.senderId, sender_name: senderName };
+          }
           await matrixService.sendEncryptedText(targetRoomId, payload);
         }
       }),

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -1564,6 +1564,52 @@ export function useMessages() {
     }
   };
 
+  /** Delete multiple messages in one batch. Continues on individual failures —
+   *  returns a summary {succeeded, failed} so the caller can show a toast.
+   *  Self-contained (does not wrap single deleteMessage), because the single
+   *  variant swallows errors in try/catch — we need real per-op status here. */
+  const deleteMessages = async (
+    messageIds: string[],
+    forEveryone: boolean,
+  ): Promise<{ succeeded: number; failed: number }> => {
+    if (messageIds.length === 0) return { succeeded: 0, failed: 0 };
+
+    const roomId = chatStore.activeRoomId;
+    if (!roomId) return { succeeded: 0, failed: messageIds.length };
+
+    const matrixService = getMatrixClientService();
+    if (!matrixService.isReady()) {
+      return { succeeded: 0, failed: messageIds.length };
+    }
+
+    const results = await Promise.allSettled(
+      messageIds.map(async (id) => {
+        if (forEveryone) {
+          if (isChatDbReady()) {
+            try {
+              const dbKit = getChatDb();
+              await dbKit.messages.softDelete(id);
+              await dbKit.syncEngine.enqueue(
+                "delete_message",
+                roomId,
+                { eventId: id },
+              );
+              return;
+            } catch (e) {
+              console.warn("[use-messages] Dexie bulk delete failed, falling back:", e);
+            }
+          }
+          await matrixService.redactEvent(roomId, id, "deleted");
+        }
+        chatStore.removeMessage(roomId, id);
+      }),
+    );
+
+    const succeeded = results.filter((r) => r.status === "fulfilled").length;
+    const failed = results.length - succeeded;
+    return { succeeded, failed };
+  };
+
   /** Send a PKOIN transfer message.
    *  Uses Dexie optimistic UI (createLocal → syncEngine) so the transfer bubble
    *  appears instantly, just like regular text messages. Falls back to legacy
@@ -2238,6 +2284,7 @@ export function useMessages() {
   return {
     cancelMediaUpload,
     deleteMessage,
+    deleteMessages,
     drainOfflineQueue,
     editMessage,
     endPoll,

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -1537,16 +1537,23 @@ export function useMessages() {
     const matrixService = getMatrixClientService();
     if (!matrixService.isReady()) return;
 
-    // New path: Dexie soft-delete → SyncEngine sends redaction
-    if (isChatDbReady() && forEveryone) {
+    // Dexie path: writeRedaction soft-deletes + cascades to reply refs + updates
+    // the room preview so the sidebar doesn't keep stale text. When forEveryone,
+    // additionally queue a redact op so peers see it gone.
+    if (isChatDbReady()) {
       try {
         const dbKit = getChatDb();
-        await dbKit.messages.softDelete(messageId);
-        await dbKit.syncEngine.enqueue(
-          "delete_message",
+        await dbKit.eventWriter.writeRedaction({
+          redactedEventId: messageId,
           roomId,
-          { eventId: messageId },
-        );
+        });
+        if (forEveryone) {
+          await dbKit.syncEngine.enqueue(
+            "delete_message",
+            roomId,
+            { eventId: messageId },
+          );
+        }
         return;
       } catch (e) {
         console.warn("[use-messages] Dexie deleteMessage failed, falling back:", e);
@@ -1673,21 +1680,29 @@ export function useMessages() {
 
     const results = await Promise.allSettled(
       messageIds.map(async (id) => {
-        if (forEveryone) {
-          if (isChatDbReady()) {
-            try {
-              const dbKit = getChatDb();
-              await dbKit.messages.softDelete(id);
+        // Dexie path: writeRedaction soft-deletes + updates room preview.
+        // forEveryone adds a redact op so peers see the delete too.
+        if (isChatDbReady()) {
+          try {
+            const dbKit = getChatDb();
+            await dbKit.eventWriter.writeRedaction({
+              redactedEventId: id,
+              roomId,
+            });
+            if (forEveryone) {
               await dbKit.syncEngine.enqueue(
                 "delete_message",
                 roomId,
                 { eventId: id },
               );
-              return;
-            } catch (e) {
-              console.warn("[use-messages] Dexie bulk delete failed, falling back:", e);
             }
+            return;
+          } catch (e) {
+            console.warn("[use-messages] Dexie bulk delete failed, falling back:", e);
           }
+        }
+        // Legacy fallback
+        if (forEveryone) {
           await matrixService.redactEvent(roomId, id, "deleted");
         }
         chatStore.removeMessage(roomId, id);

--- a/src/features/messaging/ui/ForwardPicker.vue
+++ b/src/features/messaging/ui/ForwardPicker.vue
@@ -6,9 +6,6 @@ import { useResolvedRoomName } from "@/entities/chat/lib/use-resolved-room-name"
 import { isUnresolvedName } from "@/entities/chat/lib/chat-helpers";
 import { useMobile } from "@/shared/lib/composables/use-media-query";
 import { useAndroidBackHandler } from "@/shared/lib/composables/use-android-back-handler";
-import { useMessages } from "@/features/messaging/model/use-messages";
-import { useToast } from "@/shared/lib/use-toast";
-
 type FilterValue = "all" | "personal" | "groups";
 
 interface Props {
@@ -22,8 +19,6 @@ const chatStore = useChatStore();
 const { t } = useI18n();
 const { resolve: resolveRoomName } = useResolvedRoomName();
 const isMobile = useMobile();
-const { forwardMessages } = useMessages();
-const { toast } = useToast();
 
 const isBulkMode = computed(() => chatStore.forwardingMessages.length > 0);
 
@@ -91,21 +86,13 @@ const getRoomSubtitle = (room: ChatRoom): string => {
 };
 
 const selectRoom = async (roomId: string) => {
-  // ── Bulk branch — ships N messages instantly, no detour through the target
-  // room's composer. Singular branch keeps the legacy draft-and-switch UX. ──
+  // ── Bulk branch — lands the user in the target room with a preview bar
+  // so they can optionally type a caption before shipping the batch.
+  // Mirrors the singular draft-and-switch UX (Telegram/Element style). ──
   if (isBulkMode.value) {
-    const ids = chatStore.forwardingMessages.map((m) => m.id);
-    const result = await forwardMessages(ids, roomId);
-    if (result.failed > 0) {
-      toast(t("forward.resultSummary", {
-        succeeded: result.succeeded,
-        total: ids.length,
-      }));
-    } else {
-      toast(t("forward.resultSuccess", { count: result.succeeded }));
-    }
-    chatStore.forwardingMessages = [];
+    chatStore.saveBulkForwardDraft(roomId);
     chatStore.exitSelectionMode();
+    chatStore.setActiveRoom(roomId);
     search.value = "";
     emit("close");
     return;

--- a/src/features/messaging/ui/ForwardPicker.vue
+++ b/src/features/messaging/ui/ForwardPicker.vue
@@ -6,6 +6,8 @@ import { useResolvedRoomName } from "@/entities/chat/lib/use-resolved-room-name"
 import { isUnresolvedName } from "@/entities/chat/lib/chat-helpers";
 import { useMobile } from "@/shared/lib/composables/use-media-query";
 import { useAndroidBackHandler } from "@/shared/lib/composables/use-android-back-handler";
+import { useMessages } from "@/features/messaging/model/use-messages";
+import { useToast } from "@/shared/lib/use-toast";
 
 type FilterValue = "all" | "personal" | "groups";
 
@@ -20,6 +22,10 @@ const chatStore = useChatStore();
 const { t } = useI18n();
 const { resolve: resolveRoomName } = useResolvedRoomName();
 const isMobile = useMobile();
+const { forwardMessages } = useMessages();
+const { toast } = useToast();
+
+const isBulkMode = computed(() => chatStore.forwardingMessages.length > 0);
 
 const search = ref("");
 const activeFilter = ref<FilterValue>("all");
@@ -84,7 +90,27 @@ const getRoomSubtitle = (room: ChatRoom): string => {
   return "";
 };
 
-const selectRoom = (roomId: string) => {
+const selectRoom = async (roomId: string) => {
+  // ── Bulk branch — ships N messages instantly, no detour through the target
+  // room's composer. Singular branch keeps the legacy draft-and-switch UX. ──
+  if (isBulkMode.value) {
+    const ids = chatStore.forwardingMessages.map((m) => m.id);
+    const result = await forwardMessages(ids, roomId);
+    if (result.failed > 0) {
+      toast(t("forward.resultSummary", {
+        succeeded: result.succeeded,
+        total: ids.length,
+      }));
+    } else {
+      toast(t("forward.resultSuccess", { count: result.succeeded }));
+    }
+    chatStore.forwardingMessages = [];
+    chatStore.exitSelectionMode();
+    search.value = "";
+    emit("close");
+    return;
+  }
+
   // Pre-save forward draft to TARGET room so it survives the room-switch watcher
   chatStore.saveForwardDraft(roomId);
   chatStore.setActiveRoom(roomId);

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -205,10 +205,11 @@ const handleSend = async () => {
       // then all N forwarded messages follow in source-timestamp order.
       const targetRoomId = chatStore.activeRoomId;
       const ids = chatStore.forwardingMessages.map((m) => m.id);
+      const withSenderInfo = chatStore.bulkForwardWithSenderInfo;
       if (rawText.trim()) {
         await sendMessage(rawText, linkPreview.dismissed.value);
       }
-      await forwardMessages(ids, targetRoomId);
+      await forwardMessages(ids, targetRoomId, { withSenderInfo });
       chatStore.cancelBulkForward(targetRoomId);
       inserted = true;
     } else if (chatStore.forwardingMessage) {
@@ -409,6 +410,12 @@ const forwardPreviewText = computed(() => {
 // Forward cancel confirmation
 const { resolve: resolveRoomName } = useResolvedRoomName();
 const forwardSourceRoomName = computed(() => {
+  // Bulk takes precedence when active — all selected messages share one source room.
+  if (chatStore.forwardingMessages.length > 0) {
+    const srcId = chatStore.forwardingMessages[0].roomId;
+    const room = chatStore.rooms.find(r => r.id === srcId);
+    return room ? resolveRoomName(room) : "";
+  }
   const fwd = chatStore.forwardingMessage;
   if (!fwd) return "";
   const room = chatStore.rooms.find(r => r.id === fwd.roomId);
@@ -420,13 +427,21 @@ const cancelForward = () => {
   showCancelForwardConfirm.value = true;
 };
 
+// Same confirm-modal UX for bulk — shared flag, bulk branch decided by
+// the presence of forwardingMessages at confirmation time.
 const cancelBulkForward = () => {
-  chatStore.cancelBulkForward();
+  showCancelForwardConfirm.value = true;
 };
+
+const isCancellingBulkForward = computed(() => chatStore.forwardingMessages.length > 0);
 
 const confirmCancelForward = () => {
   showCancelForwardConfirm.value = false;
-  chatStore.cancelForward();
+  if (isCancellingBulkForward.value) {
+    chatStore.cancelBulkForward();
+  } else {
+    chatStore.cancelForward();
+  }
 };
 
 const dismissCancelForward = () => {
@@ -451,10 +466,23 @@ watch(showForwardOptions, (v) => {
 });
 
 const toggleSenderInfo = () => {
+  // Route to whichever forward session is active. Popup is shared between
+  // singular and bulk preview bars, so the toggle must reflect the right mode.
+  if (showBulkForwardPreview.value) {
+    chatStore.bulkForwardWithSenderInfo = !chatStore.bulkForwardWithSenderInfo;
+    return;
+  }
   if (chatStore.forwardingMessage) {
     chatStore.forwardingMessage.withSenderInfo = !chatStore.forwardingMessage.withSenderInfo;
   }
 };
+
+/** True when sender-info attribution is currently ON for the active forward
+ *  session (bulk takes precedence over singular, matching preview priority). */
+const forwardSenderInfoEnabled = computed(() => {
+  if (showBulkForwardPreview.value) return chatStore.bulkForwardWithSenderInfo;
+  return chatStore.forwardingMessage?.withSenderInfo ?? false;
+});
 
 const changeForwardTarget = () => {
   showForwardOptions.value = false;
@@ -761,18 +789,23 @@ const handleKitchenSelect = async (imageUrl: string) => {
     <div class="input-bar-grid" :class="{ 'input-bar-grid--open': !isEditing && !chatStore.replyingTo && !showForwardPreview && showBulkForwardPreview }">
       <div class="input-bar-grid-inner">
         <div class="relative mx-auto flex max-w-6xl items-center gap-2 border-b border-neutral-grad-0 px-3 py-2">
-          <div class="flex h-8 w-8 items-center justify-center text-color-bg-ac">
+          <button class="flex h-8 w-8 items-center justify-center text-color-bg-ac" @click="openForwardOptions">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <polyline points="15 17 20 12 15 7" /><path d="M4 18v-2a4 4 0 0 1 4-4h12" />
             </svg>
-          </div>
+          </button>
           <div class="h-8 w-0.5 shrink-0 rounded-full bg-color-bg-ac" />
-          <div class="min-w-0 flex-1">
+          <div class="min-w-0 flex-1 cursor-pointer" @click="openForwardOptions">
             <div class="truncate text-xs font-medium text-color-bg-ac">
               {{ t("forward.bulkTitle", { count: bulkForwardCount }) }}
             </div>
             <div class="truncate text-xs text-text-on-main-bg-color">
-              {{ t("forward.bulkFrom", { names: bulkForwardSenderNames }) }} — {{ bulkForwardPreviewText }}
+              <template v-if="chatStore.bulkForwardWithSenderInfo">
+                {{ t("forward.bulkFrom", { names: bulkForwardSenderNames }) }} — {{ bulkForwardPreviewText }}
+              </template>
+              <template v-else>
+                {{ bulkForwardPreviewText }}
+              </template>
             </div>
           </div>
           <button class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-text-on-main-bg-color hover:bg-neutral-grad-0" @click="cancelBulkForward">
@@ -783,14 +816,14 @@ const handleKitchenSelect = async (imageUrl: string) => {
     </div>
 
     <!-- Forward options popup (outside grid to avoid overflow:hidden clipping) -->
-    <div v-if="showForwardPreview" class="relative">
+    <div v-if="showForwardPreview || showBulkForwardPreview" class="relative">
       <div class="absolute bottom-full left-2 z-50 mb-1" :class="showForwardOptions ? 'visible opacity-100' : 'invisible opacity-0'" style="transition: opacity 0.2s ease, visibility 0.2s ease;">
         <div class="min-w-[220px] rounded-xl bg-background-total-theme py-1 shadow-lg ring-1 ring-neutral-grad-0">
           <button
             class="flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm text-text-color transition-colors hover:bg-neutral-grad-0"
             @click="toggleSenderInfo"
           >
-            <svg v-if="chatStore.forwardingMessage?.withSenderInfo" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" class="text-color-bg-ac"><polyline points="20 6 9 17 4 12" /></svg>
+            <svg v-if="forwardSenderInfoEnabled" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" class="text-color-bg-ac"><polyline points="20 6 9 17 4 12" /></svg>
             <span v-else class="inline-block h-4 w-4" />
             {{ t("forward.showSender") }}
           </button>
@@ -798,7 +831,7 @@ const handleKitchenSelect = async (imageUrl: string) => {
             class="flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm text-text-color transition-colors hover:bg-neutral-grad-0"
             @click="toggleSenderInfo"
           >
-            <svg v-if="!chatStore.forwardingMessage?.withSenderInfo" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" class="text-color-bg-ac"><polyline points="20 6 9 17 4 12" /></svg>
+            <svg v-if="!forwardSenderInfoEnabled" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" class="text-color-bg-ac"><polyline points="20 6 9 17 4 12" /></svg>
             <span v-else class="inline-block h-4 w-4" />
             {{ t("forward.hideSender") }}
           </button>
@@ -825,9 +858,13 @@ const handleKitchenSelect = async (imageUrl: string) => {
           @click.self="dismissCancelForward"
         >
           <div class="mx-4 w-full max-w-sm rounded-2xl bg-background-total-theme p-5 shadow-xl">
-            <div class="mb-1 text-center text-base font-semibold text-text-color">{{ t("forward.cancelConfirm.title") }}</div>
+            <div class="mb-1 text-center text-base font-semibold text-text-color">
+              {{ isCancellingBulkForward ? t("forward.bulkCancelConfirm.title", { count: bulkForwardCount }) : t("forward.cancelConfirm.title") }}
+            </div>
             <div class="mb-5 text-center text-sm text-text-on-main-bg-color">
-              {{ t("forward.cancelConfirm.description", { name: forwardSourceRoomName }) }}
+              {{ isCancellingBulkForward
+                ? t("forward.bulkCancelConfirm.description", { count: bulkForwardCount, name: forwardSourceRoomName })
+                : t("forward.cancelConfirm.description", { name: forwardSourceRoomName }) }}
             </div>
             <div class="flex flex-col gap-2">
               <button

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -33,7 +33,7 @@ const emit = defineEmits<{ donate: [] }>();
 const chatStore = useChatStore();
 const themeStore = useThemeStore();
 const { t } = useI18n();
-const { sendMessage, sendFile, sendImage, sendAudio, sendVideoCircle, sendReply, sendForward, editMessage, setTyping, sendPoll, sendGif } = useMessages();
+const { sendMessage, sendFile, sendImage, sendAudio, sendVideoCircle, sendReply, sendForward, forwardMessages, editMessage, setTyping, sendPoll, sendGif } = useMessages();
 const mediaUpload = useMediaUpload();
 const pasteDrop = usePasteDrop({
   onMediaFiles: (files) => mediaUpload.addFiles(files),
@@ -77,13 +77,24 @@ watch(
       if (fwd && fwd.roomId !== oldId) {
         chatStore.saveForwardDraft(oldId);
       }
+      // Mirror the singular rule for the bulk array: if the user is leaving a
+      // room that's NOT the source of the selection, stash the draft for it.
+      if (chatStore.forwardingMessages.length > 0) {
+        const srcId = chatStore.forwardingMessages[0].roomId;
+        if (oldId !== srcId) chatStore.saveBulkForwardDraft(oldId);
+      }
     }
     text.value = newId ? getDraft(newId) : "";
     mention.clearMentions();
     chatStore.editingMessage = null;
     chatStore.replyingTo = null;
-    if (newId) chatStore.restoreForwardDraft(newId);
-    else chatStore.forwardingMessage = null;
+    if (newId) {
+      chatStore.restoreForwardDraft(newId);
+      chatStore.restoreBulkForwardDraft(newId);
+    } else {
+      chatStore.forwardingMessage = null;
+      chatStore.forwardingMessages = [];
+    }
     nextTick(() => { if (textareaRef.value) textareaRef.value.style.height = "auto"; });
   },
   { immediate: true }
@@ -170,7 +181,7 @@ const autoResize = autoGrow;
 const showSecondaryActions = computed(() => !isMobile.value || !text.value.trim());
 
 const handleSend = async () => {
-  if ((!text.value.trim() && !showForwardPreview.value) || !peerKeysOk.value) return;
+  if ((!text.value.trim() && !showForwardPreview.value && !showBulkForwardPreview.value) || !peerKeysOk.value) return;
   const rawText = mention.resolveText();
   const savedText = text.value;
 
@@ -187,6 +198,18 @@ const handleSend = async () => {
     if (isEditing.value) {
       editMessage(chatStore.editingMessage!.id, rawText);
       chatStore.editingMessage = null;
+      inserted = true;
+    } else if (showBulkForwardPreview.value && chatStore.activeRoomId) {
+      // Bulk forward (multi-select) — optional caption first, then the batch.
+      // Telegram-style: caption lands in the target room as its own message,
+      // then all N forwarded messages follow in source-timestamp order.
+      const targetRoomId = chatStore.activeRoomId;
+      const ids = chatStore.forwardingMessages.map((m) => m.id);
+      if (rawText.trim()) {
+        await sendMessage(rawText, linkPreview.dismissed.value);
+      }
+      await forwardMessages(ids, targetRoomId);
+      chatStore.cancelBulkForward(targetRoomId);
       inserted = true;
     } else if (chatStore.forwardingMessage) {
       const fwd = chatStore.forwardingMessage;
@@ -336,6 +359,41 @@ const showForwardPreview = computed(() => {
   return chatStore.activeRoomId !== fwd.roomId;
 });
 
+/** Bulk preview appears when the user has picked a target for a multi-select
+ *  forward (Telegram-style: "Forward N messages — From: A, B, C"). Hidden in
+ *  the source room since that's just the selection you came from. */
+const showBulkForwardPreview = computed(() => {
+  const msgs = chatStore.forwardingMessages;
+  if (msgs.length === 0) return false;
+  const srcId = msgs[0].roomId;
+  return chatStore.activeRoomId !== srcId;
+});
+
+const bulkForwardCount = computed(() => chatStore.forwardingMessages.length);
+
+/** Unique sender display names across the selection, truncated for the bar. */
+const bulkForwardSenderNames = computed(() => {
+  const seen = new Set<string>();
+  const names: string[] = [];
+  for (const m of chatStore.forwardingMessages) {
+    const senderId = m.forwardedFrom?.senderId ?? m.senderId;
+    if (seen.has(senderId)) continue;
+    seen.add(senderId);
+    const name = m.forwardedFrom?.senderName ?? chatStore.getDisplayName(senderId);
+    names.push(name);
+    if (names.length >= 3) break; // keep the bar compact
+  }
+  return names.join(", ");
+});
+
+const bulkForwardPreviewText = computed(() => {
+  // First message's body, clipped — gives visual continuity with singular bar.
+  const first = chatStore.forwardingMessages[0];
+  if (!first) return "";
+  const txt = stripBastyonLinks(stripMentionAddresses(first.content));
+  return (txt.length > 100 ? txt.slice(0, 100) + "\u2026" : txt) || "...";
+});
+
 const forwardPreviewText = computed(() => {
   const fwd = chatStore.forwardingMessage;
   if (!fwd) return "";
@@ -360,6 +418,10 @@ const showCancelForwardConfirm = ref(false);
 
 const cancelForward = () => {
   showCancelForwardConfirm.value = true;
+};
+
+const cancelBulkForward = () => {
+  chatStore.cancelBulkForward();
 };
 
 const confirmCancelForward = () => {
@@ -691,6 +753,31 @@ const handleKitchenSelect = async (imageUrl: string) => {
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18" /><path d="M6 6l12 12" /></svg>
           </button>
 
+        </div>
+      </div>
+    </div>
+
+    <!-- Bulk forward preview bar (Telegram-style: N messages + senders) -->
+    <div class="input-bar-grid" :class="{ 'input-bar-grid--open': !isEditing && !chatStore.replyingTo && !showForwardPreview && showBulkForwardPreview }">
+      <div class="input-bar-grid-inner">
+        <div class="relative mx-auto flex max-w-6xl items-center gap-2 border-b border-neutral-grad-0 px-3 py-2">
+          <div class="flex h-8 w-8 items-center justify-center text-color-bg-ac">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <polyline points="15 17 20 12 15 7" /><path d="M4 18v-2a4 4 0 0 1 4-4h12" />
+            </svg>
+          </div>
+          <div class="h-8 w-0.5 shrink-0 rounded-full bg-color-bg-ac" />
+          <div class="min-w-0 flex-1">
+            <div class="truncate text-xs font-medium text-color-bg-ac">
+              {{ t("forward.bulkTitle", { count: bulkForwardCount }) }}
+            </div>
+            <div class="truncate text-xs text-text-on-main-bg-color">
+              {{ t("forward.bulkFrom", { names: bulkForwardSenderNames }) }} — {{ bulkForwardPreviewText }}
+            </div>
+          </div>
+          <button class="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-text-on-main-bg-color hover:bg-neutral-grad-0" @click="cancelBulkForward">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18" /><path d="M6 6l12 12" /></svg>
+          </button>
         </div>
       </div>
     </div>

--- a/src/features/messaging/ui/MessageList.vue
+++ b/src/features/messaging/ui/MessageList.vue
@@ -28,7 +28,7 @@ import UnreadBanner from "./UnreadBanner.vue";
 const chatStore = useChatStore();
 const authStore = useAuthStore();
 const themeStore = useThemeStore();
-const { loadMessages, toggleReaction, deleteMessage, votePoll, endPoll, retryMediaUpload, retryMessage, cancelMediaUpload } = useMessages();
+const { loadMessages, toggleReaction, deleteMessage, deleteMessages, votePoll, endPoll, retryMediaUpload, retryMessage, cancelMediaUpload } = useMessages();
 const { toast } = useToast();
 const { t } = useI18n();
 
@@ -55,14 +55,48 @@ const resolveSystemMsg = (msg: { content: string; systemMeta?: { template: strin
 const searchQuery = ref("");
 provide("searchQuery", searchQuery);
 
-const handleDeleteForMe = () => {
+// Bulk path takes precedence when deletingMessages is populated.
+const isBulkDelete = computed(() => chatStore.deletingMessages.length > 0);
+const deleteCount = computed(() =>
+  isBulkDelete.value ? chatStore.deletingMessages.length : 1,
+);
+
+const closeDeleteModal = () => {
+  chatStore.deletingMessage = null;
+  chatStore.deletingMessages = [];
+  chatStore.exitSelectionMode();
+};
+
+const handleDeleteForMe = async () => {
+  if (isBulkDelete.value) {
+    const ids = chatStore.deletingMessages.map((m) => m.id);
+    const result = await deleteMessages(ids, false);
+    if (result.failed > 0) {
+      toast(t("messageList.deleteResultSummary", {
+        succeeded: result.succeeded, failed: result.failed,
+      }));
+    }
+    closeDeleteModal();
+    return;
+  }
   if (chatStore.deletingMessage) {
     deleteMessage(chatStore.deletingMessage.id, false);
     chatStore.deletingMessage = null;
   }
 };
 
-const handleDeleteForEveryone = () => {
+const handleDeleteForEveryone = async () => {
+  if (isBulkDelete.value) {
+    const ids = chatStore.deletingMessages.map((m) => m.id);
+    const result = await deleteMessages(ids, true);
+    if (result.failed > 0) {
+      toast(t("messageList.deleteResultSummary", {
+        succeeded: result.succeeded, failed: result.failed,
+      }));
+    }
+    closeDeleteModal();
+    return;
+  }
   if (chatStore.deletingMessage) {
     deleteMessage(chatStore.deletingMessage.id, true);
     chatStore.deletingMessage = null;
@@ -1329,12 +1363,14 @@ defineExpose({ scrollToMessage, setSearchQuery });
     <Teleport to="body">
       <transition name="modal-fade">
         <div
-          v-if="chatStore.deletingMessage"
+          v-if="chatStore.deletingMessage || isBulkDelete"
           class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-          @click.self="chatStore.deletingMessage = null"
+          @click.self="closeDeleteModal"
         >
           <div class="w-full max-w-xs rounded-xl bg-background-total-theme p-5 shadow-xl">
-            <h3 class="mb-4 text-base font-semibold text-text-color">{{ t("messageList.deleteMessage") }}</h3>
+            <h3 class="mb-4 text-base font-semibold text-text-color">
+              {{ isBulkDelete ? t("messageList.deleteMessagesTitle", { count: deleteCount }) : t("messageList.deleteMessage") }}
+            </h3>
             <div class="flex flex-col gap-2">
               <button
                 class="rounded-lg bg-color-bad px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-color-bad/90"
@@ -1350,7 +1386,7 @@ defineExpose({ scrollToMessage, setSearchQuery });
               </button>
               <button
                 class="rounded-lg px-4 py-2 text-sm text-text-on-main-bg-color transition-colors hover:bg-neutral-grad-0"
-                @click="chatStore.deletingMessage = null"
+                @click="closeDeleteModal"
               >
                 {{ t("messageList.cancel") }}
               </button>

--- a/src/features/messaging/ui/SelectionBar.vue
+++ b/src/features/messaging/ui/SelectionBar.vue
@@ -9,6 +9,7 @@ const selectedCount = computed(() => chatStore.selectedMessageIds.size);
 const emit = defineEmits<{
   copy: [];
   delete: [];
+  forward: [];
 }>();
 </script>
 
@@ -37,6 +38,18 @@ const emit = defineEmits<{
         <rect x="9" y="9" width="13" height="13" rx="2" ry="2" /><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
       </svg>
       <span class="hidden sm:inline">{{ t("selection.copy") }}</span>
+    </button>
+
+    <button
+      class="flex h-9 shrink-0 items-center gap-1 rounded-lg px-2 text-sm text-text-color transition-colors hover:bg-neutral-grad-0 sm:gap-1.5 sm:px-3"
+      :disabled="selectedCount === 0"
+      @click="emit('forward')"
+      :title="t('selection.forward')"
+    >
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="15 17 20 12 15 7" /><path d="M4 18v-2a4 4 0 0 1 4-4h12" />
+      </svg>
+      <span class="hidden sm:inline">{{ t("selection.forward") }}</span>
     </button>
 
     <button

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -313,6 +313,8 @@ export const en = {
   "forward.cancelConfirm.description": "You selected 1 message from chat with {name}.",
   "forward.cancelConfirm.settings": "Forward settings",
   "forward.cancelConfirm.cancel": "Cancel forwarding",
+  "forward.resultSuccess": "Forwarded: {count}",
+  "forward.resultSummary": "Forwarded {succeeded} of {total}",
 
   // ── Pinned bar ──
   "pinned.message": "Pinned Message",

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -317,6 +317,8 @@ export const en = {
   "forward.resultSummary": "Forwarded {succeeded} of {total}",
   "forward.bulkTitle": "Forward {count} messages",
   "forward.bulkFrom": "From: {names}",
+  "forward.bulkCancelConfirm.title": "{count} messages",
+  "forward.bulkCancelConfirm.description": "You selected {count} messages from chat with {name}.",
 
   // ── Pinned bar ──
   "pinned.message": "Pinned Message",

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -262,6 +262,8 @@ export const en = {
   "messageList.typingTwo": "{name1} and {name2} are typing",
   "messageList.typingMany": "{name} and {count} more are typing",
   "messageList.deleteMessage": "Delete message?",
+  "messageList.deleteMessagesTitle": "Delete {count} selected messages?",
+  "messageList.deleteResultSummary": "Deleted {succeeded}, failed {failed}",
   "messageList.deleteForEveryone": "Delete for everyone",
   "messageList.deleteForMe": "Delete for me",
   "messageList.cancel": "Cancel",

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -315,6 +315,8 @@ export const en = {
   "forward.cancelConfirm.cancel": "Cancel forwarding",
   "forward.resultSuccess": "Forwarded: {count}",
   "forward.resultSummary": "Forwarded {succeeded} of {total}",
+  "forward.bulkTitle": "Forward {count} messages",
+  "forward.bulkFrom": "From: {names}",
 
   // ── Pinned bar ──
   "pinned.message": "Pinned Message",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -315,6 +315,8 @@ export const ru: Record<TranslationKey, string> = {
   "forward.cancelConfirm.description": "Вы выбрали 1 сообщение из чата с {name}.",
   "forward.cancelConfirm.settings": "Настройки пересылки",
   "forward.cancelConfirm.cancel": "Отменить пересылку",
+  "forward.resultSuccess": "Переслано: {count}",
+  "forward.resultSummary": "Переслано {succeeded} из {total}",
 
   // ── Pinned bar ──
   "pinned.message": "Закреплённое сообщение",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -319,6 +319,8 @@ export const ru: Record<TranslationKey, string> = {
   "forward.resultSummary": "Переслано {succeeded} из {total}",
   "forward.bulkTitle": "Переслать {count} сообщений",
   "forward.bulkFrom": "От: {names}",
+  "forward.bulkCancelConfirm.title": "{count} сообщений",
+  "forward.bulkCancelConfirm.description": "Вы выбрали {count} сообщений из чата с {name}.",
 
   // ── Pinned bar ──
   "pinned.message": "Закреплённое сообщение",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -264,6 +264,8 @@ export const ru: Record<TranslationKey, string> = {
   "messageList.typingTwo": "{name1} и {name2} печатают",
   "messageList.typingMany": "{name} и ещё {count} печатают",
   "messageList.deleteMessage": "Удалить сообщение?",
+  "messageList.deleteMessagesTitle": "Удалить выбранные сообщения ({count})?",
+  "messageList.deleteResultSummary": "Удалено {succeeded}, не удалось {failed}",
   "messageList.deleteForEveryone": "Удалить у всех",
   "messageList.deleteForMe": "Удалить у меня",
   "messageList.cancel": "Отмена",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -317,6 +317,8 @@ export const ru: Record<TranslationKey, string> = {
   "forward.cancelConfirm.cancel": "Отменить пересылку",
   "forward.resultSuccess": "Переслано: {count}",
   "forward.resultSummary": "Переслано {succeeded} из {total}",
+  "forward.bulkTitle": "Переслать {count} сообщений",
+  "forward.bulkFrom": "От: {names}",
 
   // ── Pinned bar ──
   "pinned.message": "Закреплённое сообщение",

--- a/src/shared/lib/local-db/event-writer.ts
+++ b/src/shared/lib/local-db/event-writer.ts
@@ -518,13 +518,14 @@ export class EventWriter {
     if (prevMsg) {
       await this.updateRoomPreviewFromLocal(prevMsg);
     } else {
-      // All messages in room are deleted — show tombstone preview.
-      // Use db.rooms.put-style update to handle rooms not yet in Dexie.
+      // All messages in room are deleted — write an empty preview so the UI
+      // can localise the "deleted" label itself via formatPreview (avoids
+      // bypassing i18n by hard-coding English here).
       const room = await this.roomRepo.getRoom(redaction.roomId);
       if (room) {
         await this.roomRepo.updateLastMessage(
           redaction.roomId,
-          "🚫 Message deleted",
+          "",
           room.updatedAt,
           room.lastMessageSenderId ?? "",
           room.lastMessageType,

--- a/src/shared/lib/utils/format-preview.ts
+++ b/src/shared/lib/utils/format-preview.ts
@@ -18,7 +18,14 @@ export function useFormatPreview() {
   const formatPreview = (msg: Message | undefined, room: ChatRoom): string => {
     if (!msg) return t("contactList.noMessages");
     if (isEncryptedPlaceholder(msg.content)) return "";
-    if (msg.deleted || (!msg.content && msg.type === MessageType.text && !msg.fileInfo)) {
+    // Legacy Dexie fallbacks that used to stand in for a real body — show the
+    // localised "deleted" label instead of leaking the sentinel into the UI.
+    if (
+      msg.deleted
+      || (!msg.content && msg.type === MessageType.text && !msg.fileInfo)
+      || msg.content === "[message]"
+      || msg.content === "🚫 Message deleted"
+    ) {
       return `🚫 ${t("message.deleted")}`;
     }
     let preview: string;

--- a/src/widgets/chat-window/ChatWindow.vue
+++ b/src/widgets/chat-window/ChatWindow.vue
@@ -258,10 +258,12 @@ const handleSelectionCopy = () => {
 };
 
 const handleSelectionDelete = () => {
-  // Set the first selected message as deletingMessage (triggers the delete modal in MessageList)
+  // Collect ALL selected messages (was: only first — that was bug #195).
+  // Populate deletingMessages array; MessageList modal dispatches on array length.
   const ids = chatStore.selectedMessageIds;
-  const msg = chatStore.activeMessages.find(m => ids.has(m.id));
-  if (msg) chatStore.deletingMessage = msg;
+  const msgs = chatStore.activeMessages.filter(m => ids.has(m.id));
+  if (msgs.length === 0) return;
+  chatStore.deletingMessages = msgs;
 };
 
 /** Typing indicator text */

--- a/src/widgets/chat-window/ChatWindow.vue
+++ b/src/widgets/chat-window/ChatWindow.vue
@@ -266,6 +266,15 @@ const handleSelectionDelete = () => {
   chatStore.deletingMessages = msgs;
 };
 
+const handleSelectionForward = () => {
+  // Bulk-forward the current multi-select to another chat. Opens ForwardPicker
+  // in bulk mode; singular forward (context menu → draft) is unaffected.
+  const ids = chatStore.selectedMessageIds;
+  const msgs = chatStore.activeMessages.filter(m => ids.has(m.id));
+  if (msgs.length === 0) return;
+  chatStore.initBulkForward(msgs);
+};
+
 /** Typing indicator text */
 const typingText = computed(() => {
   const roomId = chatStore.activeRoomId;
@@ -576,6 +585,7 @@ onUnmounted(() => {
           v-if="chatStore.selectionMode"
           @copy="handleSelectionCopy"
           @delete="handleSelectionDelete"
+          @forward="handleSelectionForward"
         />
         <MessageInput
           v-else


### PR DESCRIPTION
## Summary

Adds two user-requested multi-select actions — **bulk delete** and **bulk forward** — and fixes a long-standing bug where an edit in an encrypted group chat could surface the ciphertext blob as the visible message body. All changes are **additive**: the singular delete/forward/edit paths are left in place and exercised unchanged.

## Bugs closed

- **#193 / #222** — "text turns into unreadable garbage after edit" in encrypted groups. Inbound edit handlers in `chat-store` fell back to `newContent.body ?? content.body` on decrypt failure — which in encrypted rooms IS the ciphertext. Extracted into `parseEditBody()` with a security invariant: on decrypt failure return the supplied placeholder, never the ciphertext. Both inbound edit paths (stream + refresh batch) now go through it.
- **#195** — "multi-select delete only deletes the first message". `handleSelectionDelete` passed only the first selected to the confirm modal. New `deleteMessages(ids, forEveryone)` in `use-messages` uses `Promise.allSettled` so partial failures don't abort the batch; modal detects bulk vs single via `isBulkDelete` and reports failures via toast.

## Features

- **Bulk forward** (multi-request from users): pick N messages → Forward button in SelectionBar → ForwardPicker → land in the target room with a **Telegram-style preview bar** ("Forward 3 messages — From: A, B, C"), optional caption, Send. Mirrors the singular draft-and-switch UX, so you also get:
  - A popup with "Show sender name" / "Hide sender name" toggle + "Forward to another chat".
  - The cancel-X on the bar opens the same confirm modal as singular, adapted: "You selected 3 messages from chat with X".
- **"Delete for me"** now persists across reloads. The singular and bulk paths both route through `eventWriter.writeRedaction` — soft-delete in Dexie (so `useLiveQuery` does not re-hydrate), preview cascade, replyTo cleanup. For-everyone additionally queues a redact op through `SyncEngine`.

## Polish fixes (same PR, same area)

- `[message]` no longer leaks into the sidebar preview after deletion. `writeRedaction` used to hard-code `"🚫 Message deleted"` directly in `lastMessagePreview`, bypassing i18n; now writes `""` and `formatPreview` / ContactList renders the localised label. Legacy `"[message]"` and the old English sentinel are treated as deleted defensively so pre-existing Dexie rows stop surfacing them.
- Multi-select no longer carries over to the next chat. `setActiveRoom` clears `selectionMode` + `selectedMessageIds` on room switch.

## Additive-by-construction

- `deleteMessage(id)` / `deletingMessage` singular — untouched; bulk path is gated by `isBulkDelete`.
- `sendForward()` / `forwardingMessage` singular — untouched; bulk path is gated by `forwardingMessages.length > 0`. New `bulkForwardDrafts: Map<string, Message[]>` and `bulkForwardWithSenderInfo` live alongside the singular state.
- `editMessage` outbound — untouched. Only the inbound decrypt-failure fallback in two chat-store locations changed.

## Test plan

- [x] Unit tests added: `deleteMessages` (5), `forwardMessages` (6, incl. `withSenderInfo=false`), `parseEditBody` (6). **81/81 touched-area tests pass.**
- [x] `vue-tsc --noEmit` clean on all touched files (2 pre-existing TS errors on `MessageInput.vue:227/229` — unrelated).
- [ ] Manual single-message flows: context-menu Forward preserves draft + switch, Delete-for-me hides, Delete-for-all redacts.
- [ ] Manual multi-select flows: select 3 → Forward → pick chat → preview bar shows count + senders → optional caption → Send → all 3 land in target in source-timestamp order; toggle "Hide sender name" → `forwarded_from` omitted.
- [ ] Manual bulk delete: select 3 → Delete → Delete-for-me hides all 3 locally across reload; Delete-for-all redacts all 3; partial failure → toast shows counts.
- [ ] Manual edit in encrypted group: decrypt-miss path now shows `[encrypted]` placeholder, not a ciphertext blob.
- [ ] Manual selection reset: enter selection mode → switch chat → selection cleared.

## Pre-existing test failures (not touched)

13 tests red on master before this branch — `sync-engine-txnid.test.ts`, `open-profile-url.test.ts`, `video-embed.test.ts`, `chat-helpers.test.ts`, `display-result.test.ts`. Same count after. Confirmed via stash + re-run.