### PR TITLE
fix(preview): stop mislabelling calls as deleted in chat list

### DIFF
--- a/src/features/contacts/ui/ContactList.vue
+++ b/src/features/contacts/ui/ContactList.vue
@@ -201,13 +201,12 @@ function getPreview(room: ChatRoom): DisplayResult {
   // Primary: use room.lastMessage from Dexie LiveRoom
   if (room.lastMessage) {
     const c = room.lastMessage.content;
-    // Deleted message — show explicit "deleted" text.
-    // `[message]` / `🚫 Message deleted` are legacy Dexie fallbacks that used
-    // to leak through the sidebar; treat them the same as an empty/deleted row.
+    // Explicit deletion markers only. `"[message]"` is a generic "preview
+    // unavailable" sentinel (see format-preview.ts), not a deletion marker —
+    // treating it as deleted here used to mislabel call/media events.
     if (
       room.lastMessage.deleted ||
       (!c && room.lastMessage.type === MessageType.text) ||
-      c === "[message]" ||
       c === "🚫 Message deleted"
     ) {
       return { state: "ready", text: `🚫 ${t("message.deleted")}` };

--- a/src/shared/lib/utils/format-preview.test.ts
+++ b/src/shared/lib/utils/format-preview.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia } from "pinia";
+import { createTestingPinia } from "@pinia/testing";
+import { makeMsg, makeRoom } from "@/test-utils";
+import { MessageType, MessageStatus } from "@/entities/chat";
+
+// Auth store mock — formatPreview reads `address` for "You:" prefix in groups.
+vi.mock("@/entities/auth", () => ({
+  useAuthStore: vi.fn(() => ({ address: "PMe000000000000000000000000000001" })),
+}));
+
+// Matrix service mock — chat-store touches it at init.
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: vi.fn(() => ({
+    getUserId: () => "@me:server",
+    getRoom: () => ({ selfMembership: "join" }),
+    sendReadReceipt: vi.fn(async () => true),
+    kit: {
+      client: { getUserId: () => "@me:server" },
+      isTetatetChat: vi.fn(() => true),
+      getRoomMembers: vi.fn(() => []),
+    },
+  })),
+}));
+
+import { useFormatPreview } from "./format-preview";
+
+describe("useFormatPreview", () => {
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }));
+    // English locale is default in happy-dom (navigator.language = "en-US").
+  });
+
+  describe("call event previews (regression: BAST bug — shown as deleted)", () => {
+    // Real-world shape: event-writer stores "[message]" as lastMessagePreview
+    // when getPreviewText returned empty for a system event. chat-store rebuilds
+    // lastMessage with content="[message]" but preserves callInfo + systemMeta.
+    // formatPreview must render the call label via systemMeta, not "deleted".
+    it("renders voice-call preview from systemMeta even when content is the [message] sentinel", () => {
+      const { formatPreview } = useFormatPreview();
+      const room = makeRoom({ isGroup: false });
+      const msg = makeMsg({
+        content: "[message]",
+        type: MessageType.system,
+        callInfo: { callType: "voice", missed: false, duration: 42 },
+        systemMeta: { template: "system.voiceCall", senderAddr: "PCaller00000000000000000000000001" },
+      });
+
+      const result = formatPreview(msg, room);
+
+      expect(result).toBe("📞 Voice call");
+      expect(result).not.toContain("deleted");
+    });
+
+    it("renders video-call preview from systemMeta with 📹 icon", () => {
+      const { formatPreview } = useFormatPreview();
+      const room = makeRoom({ isGroup: false });
+      const msg = makeMsg({
+        content: "[message]",
+        type: MessageType.system,
+        callInfo: { callType: "video", missed: false, duration: 120 },
+        systemMeta: { template: "system.videoCall", senderAddr: "PCaller00000000000000000000000001" },
+      });
+
+      expect(formatPreview(msg, room)).toBe("📹 Video call");
+    });
+
+    it("renders missed-call preview without mislabeling as deleted", () => {
+      const { formatPreview } = useFormatPreview();
+      const room = makeRoom({ isGroup: false });
+      const msg = makeMsg({
+        content: "[message]",
+        type: MessageType.system,
+        callInfo: { callType: "voice", missed: true },
+        systemMeta: { template: "system.missedVoiceCall", senderAddr: "PCaller00000000000000000000000001" },
+      });
+
+      expect(formatPreview(msg, room)).toBe("📞 Missed voice call");
+    });
+
+    it("still renders call preview when content is empty string", () => {
+      const { formatPreview } = useFormatPreview();
+      const room = makeRoom({ isGroup: false });
+      const msg = makeMsg({
+        content: "",
+        type: MessageType.system,
+        callInfo: { callType: "voice", missed: false, duration: 10 },
+        systemMeta: { template: "system.voiceCall", senderAddr: "PCaller00000000000000000000000001" },
+      });
+
+      expect(formatPreview(msg, room)).toBe("📞 Voice call");
+    });
+  });
+
+  describe("system message without meta (edge case)", () => {
+    // If a system event arrives without systemMeta.template and without callInfo
+    // (e.g. legacy/unknown event), [message] should normalise to empty and the
+    // switch's system branch should return an empty preview — never "deleted".
+    it("returns empty (not deleted) for system msg with [message] content and no meta", () => {
+      const { formatPreview } = useFormatPreview();
+      const room = makeRoom({ isGroup: false });
+      const msg = makeMsg({ content: "[message]", type: MessageType.system });
+
+      const result = formatPreview(msg, room);
+
+      expect(result).not.toContain("deleted");
+      expect(result).toBe("");
+    });
+  });
+
+  describe("media placeholder fallback (regression: [message] → deleted)", () => {
+    it("renders photo fallback when image content is the [message] sentinel", () => {
+      const { formatPreview } = useFormatPreview();
+      const room = makeRoom({ isGroup: false });
+      const msg = makeMsg({
+        content: "[message]",
+        type: MessageType.image,
+        fileInfo: { name: "img.jpg", type: "image/jpeg", size: 1, url: "x" },
+        status: MessageStatus.sent,
+      });
+
+      expect(formatPreview(msg, room)).toBe("📷 Photo");
+    });
+  });
+
+  describe("deletion markers (preserve existing behavior)", () => {
+    it("renders 'deleted' when msg.deleted is true", () => {
+      const { formatPreview } = useFormatPreview();
+      const room = makeRoom({ isGroup: false });
+      const msg = makeMsg({ content: "whatever", deleted: true });
+
+      expect(formatPreview(msg, room)).toBe("🚫 This message was deleted");
+    });
+
+    it("renders 'deleted' for the explicit legacy literal marker", () => {
+      const { formatPreview } = useFormatPreview();
+      const room = makeRoom({ isGroup: false });
+      const msg = makeMsg({ content: "🚫 Message deleted" });
+
+      expect(formatPreview(msg, room)).toBe("🚫 This message was deleted");
+    });
+
+    it("renders 'deleted' for empty text with no fileInfo (legacy pattern)", () => {
+      const { formatPreview } = useFormatPreview();
+      const room = makeRoom({ isGroup: false });
+      const msg = makeMsg({ content: "", type: MessageType.text });
+
+      expect(formatPreview(msg, room)).toBe("🚫 This message was deleted");
+    });
+  });
+});

--- a/src/shared/lib/utils/format-preview.ts
+++ b/src/shared/lib/utils/format-preview.ts
@@ -18,38 +18,43 @@ export function useFormatPreview() {
   const formatPreview = (msg: Message | undefined, room: ChatRoom): string => {
     if (!msg) return t("contactList.noMessages");
     if (isEncryptedPlaceholder(msg.content)) return "";
-    // Legacy Dexie fallbacks that used to stand in for a real body — show the
-    // localised "deleted" label instead of leaking the sentinel into the UI.
-    if (
-      msg.deleted
-      || (!msg.content && msg.type === MessageType.text && !msg.fileInfo)
-      || msg.content === "[message]"
-      || msg.content === "🚫 Message deleted"
-    ) {
+    // Explicit deletion markers: the redaction flag plus the legacy English
+    // literal body that the old pipeline stored for redacted text messages.
+    if (msg.deleted || msg.content === "🚫 Message deleted") {
+      return `🚫 ${t("message.deleted")}`;
+    }
+    // `"[message]"` is a generic "preview unavailable" sentinel written by
+    // event-writer when getPreviewText returned empty (e.g. call events whose
+    // real label lives in systemMeta/callInfo, not in content). Normalise it
+    // to empty so type-specific branches produce the proper icon+label rather
+    // than mislabelling the message as deleted.
+    const content = msg.content === "[message]" ? "" : msg.content;
+    // Empty-body text with no attachment is the legacy "deleted text" pattern.
+    if (!content && msg.type === MessageType.text && !msg.fileInfo) {
       return `🚫 ${t("message.deleted")}`;
     }
     let preview: string;
     switch (msg.type) {
       case MessageType.image:
-        preview = msg.content && msg.content !== "[photo]" ? `📷 ${msg.content}` : "📷 " + t("message.photo");
+        preview = content && content !== "[photo]" ? `📷 ${content}` : "📷 " + t("message.photo");
         break;
       case MessageType.video:
-        preview = msg.content && msg.content !== "[video]" ? `🎬 ${msg.content}` : "🎬 " + t("message.video");
+        preview = content && content !== "[video]" ? `🎬 ${content}` : "🎬 " + t("message.video");
         break;
       case MessageType.audio:
-        preview = msg.content && msg.content !== "[voice message]" ? `🎤 ${msg.content}` : "🎤 " + t("message.voiceMessage");
+        preview = content && content !== "[voice message]" ? `🎤 ${content}` : "🎤 " + t("message.voiceMessage");
         break;
       case MessageType.videoCircle:
-        preview = msg.content && msg.content !== "[video message]" ? `🎬 ${msg.content}` : "🎬 " + t("message.videoMessage");
+        preview = content && content !== "[video message]" ? `🎬 ${content}` : "🎬 " + t("message.videoMessage");
         break;
       case MessageType.file:
-        preview = `📎 ${msg.content || t("message.file")}`;
+        preview = `📎 ${content || t("message.file")}`;
         break;
       case MessageType.poll:
         preview = `📊 ${msg.pollInfo?.question || t("message.poll")}`;
         break;
       case MessageType.transfer:
-        preview = `💸 ${msg.transferInfo ? `${msg.transferInfo.amount} PKOIN` : (msg.content || t("message.transfer"))}`;
+        preview = `💸 ${msg.transferInfo ? `${msg.transferInfo.amount} PKOIN` : (content || t("message.transfer"))}`;
         break;
       case MessageType.system: {
         let sysText: string;
@@ -66,7 +71,7 @@ export function useFormatPreview() {
             msg.systemMeta.extra,
           );
         } else {
-          sysText = cleanMatrixIds(msg.content);
+          sysText = cleanMatrixIds(content);
         }
         // Guard: never show raw hex/address/Matrix-ID strings in chat list preview
         if (/[a-f0-9]{16,}/i.test(sysText) || /![a-zA-Z0-9]+:/.test(sysText)) {
@@ -79,7 +84,7 @@ export function useFormatPreview() {
         return sysText;
       }
       default:
-        preview = msg.content || "";
+        preview = content || "";
     }
     preview = stripMentionAddresses(preview);
     preview = stripBastyonLinks(preview);


### PR DESCRIPTION
## Summary
- `"[message]"` is a generic "preview unavailable" sentinel written by event-writer when `getPreviewText` returned empty — it is **not** a deletion marker.
- `useFormatPreview` and `ContactList.vue#getPreview` treated it as deleted, so call events (type=system, empty content, meta in `callInfo`/`systemMeta`) rendered as "🚫 Сообщение удалено" instead of "📞 Голосовой звонок".
- Fix: normalise the sentinel to an empty string on entry so the type-specific switch branches produce the correct icon+label. Real deletion markers (`msg.deleted`, literal `"🚫 Message deleted"`, empty text body w/o fileInfo) stay untouched.

## Test plan
- [x] 9 new unit tests in `format-preview.test.ts` (voice/video/missed calls with and without the sentinel, image fallback, system-without-meta edge case, all three deletion paths)
- [x] 87/87 pass across `src/features/contacts`, `src/shared/lib/utils`, `src/entities/chat/model/chat-store.test.ts`
- [x] `vue-tsc`: 44 pre-existing errors, diff vs master empty — zero new type errors introduced
- [ ] Manual smoke: make a voice/video/missed call, confirm sidebar shows "📞 Voice call" / "📹 Video call" / "📞 Missed voice call" instead of "Message deleted"