### PR TITLE
fix(call-permissions): make permission denied modal visible

### DIFF
--- a/src/features/video-calls/ui/PermissionDeniedModal.vue
+++ b/src/features/video-calls/ui/PermissionDeniedModal.vue
@@ -28,7 +28,7 @@ function close() {
         aria-labelledby="perm-denied-title"
         @click.self="close"
       >
-        <div class="perm-modal-card mx-4 max-w-sm rounded-xl bg-color-bg p-5 shadow-2xl">
+        <div class="perm-modal-card mx-4 max-w-sm rounded-xl bg-background-main p-5 shadow-2xl">
           <div class="mb-3 flex items-start gap-3">
             <div class="perm-modal-icon flex h-10 w-10 shrink-0 items-center justify-center rounded-full">
               <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -40,16 +40,16 @@ function close() {
               </svg>
             </div>
             <div class="flex-1">
-              <h3 id="perm-denied-title" class="text-base font-semibold text-color-text">
+              <h3 id="perm-denied-title" class="text-base font-semibold text-text-color">
                 {{ t("call.permissionDenied.title") }}
               </h3>
-              <p class="mt-1 text-sm text-color-text-muted">
+              <p class="mt-1 text-sm text-text-on-main-bg-color">
                 {{ deviceMessage }}
               </p>
             </div>
           </div>
 
-          <p class="mb-4 text-sm text-color-text-muted">
+          <p class="mb-4 text-sm text-text-on-main-bg-color">
             {{ t("call.permissionDenied.instructions") }}
           </p>
 


### PR DESCRIPTION
## Summary

- `PermissionDeniedModal.vue` used Tailwind classes that do not exist in `tailwind.config.js` (`bg-color-bg`, `text-color-text`, `text-color-text-muted`). The card rendered transparent with default-black text, so the "grant microphone permission" prompt was unreadable.
- Swapped to the real theme tokens already used across the app (`bg-background-main`, `text-text-color`, `text-text-on-main-bg-color`).

## Why it matters

The same modal fires in two places:

1. Outgoing call: `call-service.ts` `startCall()` → `ensureCallPermissions()` → sets `callPermissionError`.
2. **Incoming call accepted without `RECORD_AUDIO`:** `call-service.ts` `answerCall()` does the same preflight before `call.answer()`. Users who tap "accept" while mic permission is revoked saw nothing useful — which is the primary case reported in-session.

The preflight and rejection logic are already correct; only the modal rendering was broken. No logic changes.

## Test plan

- [x] `npm run test -- src/features/video-calls/model/permissions.test.ts src/features/video-calls/model/permissions-web.test.ts` — 17/17 passed
- [ ] Manual: trigger an outgoing call with mic denied → modal is opaque, title and instructions readable on both themes
- [ ] Manual: revoke mic permission, receive an incoming call, tap accept → modal shown, call is rejected cleanly (no silent "connected" state)