### PR TITLE
fix(video): preserve playback state on remount + call peer aspect

### DIFF
--- a/src/features/messaging/ui/MediaViewer.vue
+++ b/src/features/messaging/ui/MediaViewer.vue
@@ -4,6 +4,7 @@ import type { Message } from "@/entities/chat";
 import { useChatStore, MessageType } from "@/entities/chat";
 import { useFileDownload } from "../model/use-file-download";
 import { useAndroidBackHandler } from "@/shared/lib/composables/use-android-back-handler";
+import { useVideoStatePreservation } from "@/shared/lib/composables/use-video-state-preservation";
 
 interface Props {
   show: boolean;
@@ -44,6 +45,15 @@ const currentUrl = computed(() => {
   const key = currentMessage.value._key || currentMessage.value.id;
   return getState(key).objectUrl;
 });
+
+const videoRef = ref<HTMLVideoElement | null>(null);
+const currentVideoId = computed(() => {
+  const msg = currentMessage.value;
+  if (!msg || msg.type !== MessageType.video) return null;
+  return msg._key || msg.id;
+});
+
+useVideoStatePreservation(videoRef, currentVideoId, { dontResumePlay: true });
 
 const resetTransform = () => {
   scale.value = 1;
@@ -162,8 +172,10 @@ watch(currentMessage, async (msg) => {
           />
           <video
             v-else-if="currentUrl && currentMessage.type === 'video'"
+            ref="videoRef"
             :src="currentUrl"
             controls
+            playsinline
             class="max-h-full max-w-full"
           />
           <div v-else class="flex items-center justify-center">

--- a/src/features/messaging/ui/MessageBubble.vue
+++ b/src/features/messaging/ui/MessageBubble.vue
@@ -4,6 +4,7 @@ import { useChatStore, MessageStatus, MessageType } from "@/entities/chat";
 import { formatTime } from "@/shared/lib/format";
 import { stripMentionAddresses, stripBastyonLinks } from "@/shared/lib/message-format";
 import { useFileDownload } from "../model/use-file-download";
+import { useVideoStatePreservation } from "@/shared/lib/composables/use-video-state-preservation";
 import MessageContent from "./MessageContent.vue";
 import MessageStatusIcon from "./MessageStatusIcon.vue";
 import PollCard from "./PollCard.vue";
@@ -183,6 +184,9 @@ const hasFileInfo = computed(() => !!props.message.fileInfo);
 // and images show an infinite spinner.
 const fileCacheKey = computed(() => props.message._key || props.message.id);
 const fileState = computed(() => getState(fileCacheKey.value));
+
+const inlineVideoRef = ref<HTMLVideoElement | null>(null);
+useVideoStatePreservation(inlineVideoRef, fileCacheKey, { dontResumePlay: true });
 
 /** Telegram-style sender colors (same palette as Avatar) */
 const SENDER_COLORS = ["#E17076", "#FAA774", "#A695E7", "#7BC862", "#6EC9CB", "#65AADD", "#EE7AAE"];
@@ -552,7 +556,7 @@ const replyPreviewSender = computed(() => {
           </div>
         </div>
         <div class="relative">
-          <video v-if="fileState.objectUrl" :src="fileState.objectUrl" controls class="block max-h-[360px] max-w-full" preload="metadata" />
+          <video v-if="fileState.objectUrl" ref="inlineVideoRef" :src="fileState.objectUrl" controls playsinline class="block max-h-[360px] max-w-full" preload="metadata" />
           <div v-else-if="fileState.loading" class="flex h-48 w-64 items-center justify-center bg-neutral-grad-0">
             <div class="contain-strict h-8 w-8 animate-spin rounded-full border-2 border-color-bg-ac border-t-transparent" />
           </div>

--- a/src/features/messaging/ui/VideoCirclePlayer.vue
+++ b/src/features/messaging/ui/VideoCirclePlayer.vue
@@ -2,6 +2,7 @@
 import { ref, computed, onMounted, onUnmounted, watch } from "vue";
 import type { Message } from "@/entities/chat";
 import { useFileDownload } from "../model/use-file-download";
+import { useVideoStatePreservation } from "@/shared/lib/composables/use-video-state-preservation";
 
 interface Props {
   message: Message;
@@ -47,6 +48,8 @@ const displayTime = computed(() => {
 });
 
 const videoSrc = computed(() => fileState.value.objectUrl);
+
+useVideoStatePreservation(videoEl, fileCacheKey, { dontResumePlay: true });
 
 let observer: IntersectionObserver | null = null;
 

--- a/src/features/video-calls/ui/CallWindow.vue
+++ b/src/features/video-calls/ui/CallWindow.vue
@@ -184,6 +184,7 @@ function makeTile(
   audioOff: boolean,
   isScreen: boolean,
   mirror: boolean,
+  isLocal: boolean,
 ): TileData {
   return {
     id,
@@ -193,7 +194,11 @@ function makeTile(
     videoOff,
     audioOff,
     muted: true,
-    objectFit: isScreen ? "contain" : "cover",
+    // Local camera stays `cover` so PiP/self-view fills without bars; remote
+    // peer streams use `contain` to avoid cropping when peer camera aspect
+    // doesn't match the container (e.g. landscape peer in portrait phone →
+    // "only top visible" bug).
+    objectFit: isScreen ? "contain" : isLocal ? "cover" : "contain",
     mirror,
   };
 }
@@ -211,6 +216,7 @@ const allTiles = computed<TileData[]>(() => {
       callStore.audioMuted,
       false,
       true,
+      true,
     ),
   );
 
@@ -221,6 +227,7 @@ const allTiles = computed<TileData[]>(() => {
       peerName.value,
       peerAddress.value,
       callStore.remoteVideoMuted,
+      false,
       false,
       false,
       false,
@@ -238,6 +245,7 @@ const allTiles = computed<TileData[]>(() => {
         false,
         true,
         false,
+        true,
       ),
     );
   }
@@ -252,6 +260,7 @@ const allTiles = computed<TileData[]>(() => {
         false,
         false,
         true,
+        false,
         false,
       ),
     );
@@ -566,12 +575,14 @@ const isAnyScreenSharing = computed(
             key="simple"
             class="flex flex-1"
           >
-            <!-- Remote fullscreen -->
+            <!-- Remote fullscreen. object-fit: contain so peer camera aspect
+                 is preserved (fixes "huge peer video, only top visible" bug
+                 when peer camera is landscape and local container portrait). -->
             <VideoTile
               :stream="callStore.remoteStream"
               :video-off="callStore.remoteVideoMuted"
               :address="peerAddress"
-              object-fit="cover"
+              object-fit="contain"
               muted
               class="h-full w-full !rounded-none"
             />

--- a/src/features/video-calls/ui/__tests__/VideoTile.test.ts
+++ b/src/features/video-calls/ui/__tests__/VideoTile.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import VideoTile from '../VideoTile.vue';
+
+vi.stubGlobal('useI18n', () => ({ t: (k: string) => k }));
+
+// UserAvatar is auto-imported; stub it so tests don't need the full auth module.
+vi.mock('@/entities/user', () => ({
+  UserAvatar: { name: 'UserAvatar', template: '<div class="mock-avatar" />' },
+}));
+
+describe('VideoTile', () => {
+  beforeEach(() => {
+    vi.stubGlobal('useI18n', () => ({ t: (k: string) => k }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.stubGlobal('useI18n', () => ({ t: (k: string) => k }));
+  });
+
+  it('applies object-contain class when objectFit is "contain"', () => {
+    const wrapper = mount(VideoTile, {
+      props: {
+        stream: null,
+        objectFit: 'contain',
+      },
+    });
+    const video = wrapper.find('video');
+    expect(video.exists()).toBe(true);
+    expect(video.classes()).toContain('object-contain');
+    expect(video.classes()).not.toContain('object-cover');
+  });
+
+  it('applies object-cover class when objectFit is "cover"', () => {
+    const wrapper = mount(VideoTile, {
+      props: {
+        stream: null,
+        objectFit: 'cover',
+      },
+    });
+    const video = wrapper.find('video');
+    expect(video.classes()).toContain('object-cover');
+    expect(video.classes()).not.toContain('object-contain');
+  });
+
+  it('mirrors the video when mirror prop is true (local self-view)', () => {
+    const wrapper = mount(VideoTile, {
+      props: {
+        stream: null,
+        mirror: true,
+      },
+    });
+    const video = wrapper.find('video');
+    expect(video.classes()).toContain('scale-x-[-1]');
+  });
+
+  it('does not mirror when mirror is false', () => {
+    const wrapper = mount(VideoTile, {
+      props: {
+        stream: null,
+        mirror: false,
+      },
+    });
+    const video = wrapper.find('video');
+    expect(video.classes()).not.toContain('scale-x-[-1]');
+  });
+});

--- a/src/shared/lib/composables/use-video-state-preservation.test.ts
+++ b/src/shared/lib/composables/use-video-state-preservation.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ref, effectScope, nextTick } from "vue";
+import {
+  useVideoStatePreservation,
+  _resetVideoStateCache,
+  _getCacheSize,
+} from "./use-video-state-preservation";
+
+// ---------------------------------------------------------------------------
+// Mock HTMLVideoElement with real event dispatching
+// ---------------------------------------------------------------------------
+function createMockVideoEl(overrides: Partial<HTMLVideoElement> = {}) {
+  const listeners = new Map<string, Set<EventListener>>();
+
+  const el = {
+    readyState: 0,
+    currentTime: 0,
+    duration: 100,
+    paused: true,
+    volume: 1,
+    muted: false,
+    play: vi.fn(() => Promise.resolve()),
+    pause: vi.fn(),
+    addEventListener: vi.fn((event: string, handler: EventListener) => {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)!.add(handler);
+    }),
+    removeEventListener: vi.fn((event: string, handler: EventListener) => {
+      listeners.get(event)?.delete(handler);
+    }),
+    _emit(event: string) {
+      listeners.get(event)?.forEach((handler) => handler(new Event(event)));
+    },
+    ...overrides,
+  };
+  return el as unknown as HTMLVideoElement & {
+    _emit: (event: string) => void;
+    play: ReturnType<typeof vi.fn>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock lifecycle hooks — collect callbacks, fire manually in tests
+// ---------------------------------------------------------------------------
+const mountedCallbacks: Array<() => void> = [];
+const disposeCallbacks: Array<() => void> = [];
+
+vi.mock("vue", async () => {
+  const actual = await vi.importActual<typeof import("vue")>("vue");
+  return {
+    ...actual,
+    onMounted: (cb: () => void) => mountedCallbacks.push(cb),
+    onScopeDispose: (cb: () => void) => disposeCallbacks.push(cb),
+  };
+});
+
+function simulateMount() {
+  mountedCallbacks.forEach((cb) => cb());
+}
+
+function simulateUnmount() {
+  disposeCallbacks.forEach((cb) => cb());
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("useVideoStatePreservation", () => {
+  beforeEach(() => {
+    mountedCallbacks.length = 0;
+    disposeCallbacks.length = 0;
+    _resetVideoStateCache();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    if (vi.isFakeTimers()) {
+      vi.runOnlyPendingTimers();
+    }
+    vi.useRealTimers();
+  });
+
+  it("saves currentTime on unmount", () => {
+    const el = createMockVideoEl({ currentTime: 42, paused: false });
+    const videoRef = ref<HTMLVideoElement | null>(el);
+
+    useVideoStatePreservation(videoRef, "msg-1");
+    simulateMount();
+    simulateUnmount();
+
+    // Re-mount a fresh element, should restore currentTime=42
+    mountedCallbacks.length = 0;
+    disposeCallbacks.length = 0;
+
+    const el2 = createMockVideoEl({ readyState: 1, duration: 100 });
+    const videoRef2 = ref<HTMLVideoElement | null>(el2);
+
+    useVideoStatePreservation(videoRef2, "msg-1");
+    simulateMount();
+
+    expect(el2.currentTime).toBe(42);
+  });
+
+  it("restores paused state and triggers play when previously playing", async () => {
+    const el = createMockVideoEl({ currentTime: 10, paused: false });
+    const videoRef = ref<HTMLVideoElement | null>(el);
+
+    useVideoStatePreservation(videoRef, "msg-play");
+    simulateMount();
+    simulateUnmount();
+
+    mountedCallbacks.length = 0;
+    disposeCallbacks.length = 0;
+    const el2 = createMockVideoEl({ readyState: 1, duration: 100 });
+    const videoRef2 = ref<HTMLVideoElement | null>(el2);
+
+    useVideoStatePreservation(videoRef2, "msg-play");
+    simulateMount();
+
+    expect(el2.play).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call play if previously paused", () => {
+    const el = createMockVideoEl({ currentTime: 15, paused: true });
+    const videoRef = ref<HTMLVideoElement | null>(el);
+
+    useVideoStatePreservation(videoRef, "msg-paused");
+    simulateMount();
+    simulateUnmount();
+
+    mountedCallbacks.length = 0;
+    disposeCallbacks.length = 0;
+    const el2 = createMockVideoEl({ readyState: 1, duration: 100 });
+    const videoRef2 = ref<HTMLVideoElement | null>(el2);
+
+    useVideoStatePreservation(videoRef2, "msg-paused");
+    simulateMount();
+
+    expect(el2.play).not.toHaveBeenCalled();
+    expect(el2.currentTime).toBe(15);
+  });
+
+  it("waits for loadedmetadata if readyState is 0", () => {
+    const el = createMockVideoEl({ currentTime: 30 });
+    const videoRef = ref<HTMLVideoElement | null>(el);
+    useVideoStatePreservation(videoRef, "msg-loading");
+    simulateMount();
+    simulateUnmount();
+
+    mountedCallbacks.length = 0;
+    disposeCallbacks.length = 0;
+    const el2 = createMockVideoEl({ readyState: 0, duration: 100 });
+    const videoRef2 = ref<HTMLVideoElement | null>(el2);
+
+    useVideoStatePreservation(videoRef2, "msg-loading");
+    simulateMount();
+
+    // Before metadata, currentTime remains at default
+    expect(el2.currentTime).toBe(0);
+
+    // After metadata loads, state should restore
+    el2._emit("loadedmetadata");
+    expect(el2.currentTime).toBe(30);
+  });
+
+  it("preserves volume and muted state", () => {
+    const el = createMockVideoEl({ currentTime: 5, volume: 0.3, muted: true });
+    const videoRef = ref<HTMLVideoElement | null>(el);
+    useVideoStatePreservation(videoRef, "msg-audio");
+    simulateMount();
+    simulateUnmount();
+
+    mountedCallbacks.length = 0;
+    disposeCallbacks.length = 0;
+    const el2 = createMockVideoEl({ readyState: 1, duration: 100 });
+    const videoRef2 = ref<HTMLVideoElement | null>(el2);
+    useVideoStatePreservation(videoRef2, "msg-audio");
+    simulateMount();
+
+    expect(el2.volume).toBe(0.3);
+    expect(el2.muted).toBe(true);
+  });
+
+  it("does not restore for a different id", () => {
+    const el = createMockVideoEl({ currentTime: 50, paused: true });
+    const videoRef = ref<HTMLVideoElement | null>(el);
+    useVideoStatePreservation(videoRef, "msg-A");
+    simulateMount();
+    simulateUnmount();
+
+    mountedCallbacks.length = 0;
+    disposeCallbacks.length = 0;
+    const el2 = createMockVideoEl({ readyState: 1, duration: 100 });
+    const videoRef2 = ref<HTMLVideoElement | null>(el2);
+    useVideoStatePreservation(videoRef2, "msg-B");
+    simulateMount();
+
+    expect(el2.currentTime).toBe(0);
+  });
+
+  it("guards against NaN and out-of-range currentTime", () => {
+    const el = createMockVideoEl({ currentTime: NaN, paused: true });
+    const videoRef = ref<HTMLVideoElement | null>(el);
+    useVideoStatePreservation(videoRef, "msg-nan");
+    simulateMount();
+    simulateUnmount();
+
+    mountedCallbacks.length = 0;
+    disposeCallbacks.length = 0;
+    const el2 = createMockVideoEl({ readyState: 1, duration: 100 });
+    const videoRef2 = ref<HTMLVideoElement | null>(el2);
+    useVideoStatePreservation(videoRef2, "msg-nan");
+    simulateMount();
+
+    // NaN sanitized to 0 — no harmful write
+    expect(el2.currentTime).toBe(0);
+  });
+
+  it("auto-saves periodically while playing (saveInterval>0)", () => {
+    const el = createMockVideoEl({ currentTime: 0, paused: false });
+    const videoRef = ref<HTMLVideoElement | null>(el);
+
+    useVideoStatePreservation(videoRef, "msg-auto", { saveIntervalMs: 1000 });
+    simulateMount();
+
+    // Advance currentTime then fire timer
+    el.currentTime = 10;
+    vi.advanceTimersByTime(1000);
+
+    simulateUnmount();
+
+    mountedCallbacks.length = 0;
+    disposeCallbacks.length = 0;
+    const el2 = createMockVideoEl({ readyState: 1, duration: 100 });
+    const videoRef2 = ref<HTMLVideoElement | null>(el2);
+    useVideoStatePreservation(videoRef2, "msg-auto");
+    simulateMount();
+
+    expect(el2.currentTime).toBe(10);
+  });
+
+  it("caps cache size to prevent unbounded growth in long sessions", () => {
+    // Saturate cache with >200 entries; oldest should be evicted.
+    for (let i = 0; i < 250; i++) {
+      const el = createMockVideoEl({ currentTime: i, paused: true });
+      const videoRef = ref<HTMLVideoElement | null>(el);
+      useVideoStatePreservation(videoRef, `msg-${i}`);
+      simulateMount();
+      simulateUnmount();
+      mountedCallbacks.length = 0;
+      disposeCallbacks.length = 0;
+    }
+    expect(_getCacheSize()).toBeLessThanOrEqual(200);
+
+    // The oldest entry (msg-0) should have been evicted.
+    const freshEl = createMockVideoEl({ readyState: 1, duration: 1000 });
+    const freshRef = ref<HTMLVideoElement | null>(freshEl);
+    useVideoStatePreservation(freshRef, "msg-0");
+    simulateMount();
+    expect(freshEl.currentTime).toBe(0); // evicted → not restored
+
+    // A recent entry (msg-249) should still be restorable.
+    mountedCallbacks.length = 0;
+    disposeCallbacks.length = 0;
+    const recentEl = createMockVideoEl({ readyState: 1, duration: 1000 });
+    const recentRef = ref<HTMLVideoElement | null>(recentEl);
+    useVideoStatePreservation(recentRef, "msg-249");
+    simulateMount();
+    expect(recentEl.currentTime).toBe(249); // still in cache
+  });
+
+  it("saves on swap when videoRef changes mid-lifecycle", async () => {
+    // Use real fake timers to unblock nextTick scheduling
+    vi.useRealTimers();
+
+    const firstEl = createMockVideoEl({ currentTime: 12, paused: true });
+    const videoRef = ref<HTMLVideoElement | null>(firstEl);
+
+    const scope = effectScope();
+    scope.run(() => useVideoStatePreservation(videoRef, "msg-swap"));
+    simulateMount();
+
+    // Swap to a different element (e.g., user navigates to next media).
+    const secondEl = createMockVideoEl({ readyState: 1, duration: 100 });
+    videoRef.value = secondEl as unknown as HTMLVideoElement;
+
+    // watch(videoRef) has flush 'pre' by default; await nextTick to flush.
+    await nextTick();
+
+    // Second element should restore previous state.
+    expect(secondEl.currentTime).toBe(12);
+
+    scope.stop();
+  });
+
+  it("skips resume play when dontResumePlay is set", () => {
+    const el = createMockVideoEl({ currentTime: 5, paused: false });
+    const videoRef = ref<HTMLVideoElement | null>(el);
+    useVideoStatePreservation(videoRef, "msg-no-resume", { dontResumePlay: true });
+    simulateMount();
+    simulateUnmount();
+
+    mountedCallbacks.length = 0;
+    disposeCallbacks.length = 0;
+    const el2 = createMockVideoEl({ readyState: 1, duration: 100 });
+    const videoRef2 = ref<HTMLVideoElement | null>(el2);
+    useVideoStatePreservation(videoRef2, "msg-no-resume", { dontResumePlay: true });
+    simulateMount();
+
+    expect(el2.play).not.toHaveBeenCalled();
+    expect(el2.currentTime).toBe(5);
+  });
+});

--- a/src/shared/lib/composables/use-video-state-preservation.ts
+++ b/src/shared/lib/composables/use-video-state-preservation.ts
@@ -1,0 +1,156 @@
+import { onMounted, onScopeDispose, watch, type Ref } from "vue";
+
+export interface PreservedVideoState {
+  currentTime: number;
+  paused: boolean;
+  volume: number;
+  muted: boolean;
+}
+
+/**
+ * LRU-capped cache. The app is a messenger with potentially thousands of
+ * video-containing messages; an unbounded Map would grow forever as the user
+ * scrolls. 200 entries is ~8 KB and covers any realistic rotation/re-mount
+ * window.
+ */
+const STATE_CACHE_CAP = 200;
+const stateCache = new Map<string, PreservedVideoState>();
+
+function cachePut(key: string, value: PreservedVideoState): void {
+  if (stateCache.has(key)) stateCache.delete(key);
+  stateCache.set(key, value);
+  if (stateCache.size > STATE_CACHE_CAP) {
+    const oldest = stateCache.keys().next().value;
+    if (oldest !== undefined) stateCache.delete(oldest);
+  }
+}
+
+/** Exported for test cleanup only. */
+export function _resetVideoStateCache() {
+  stateCache.clear();
+}
+
+/** Exported for tests. */
+export function _getCacheSize() {
+  return stateCache.size;
+}
+
+function sanitizeTime(value: number | undefined | null): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return 0;
+  return value;
+}
+
+function sanitizeVolume(value: number | undefined | null): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 1;
+  return Math.max(0, Math.min(1, value));
+}
+
+export interface UseVideoStatePreservationOptions {
+  /** Periodically persist state while playing (ms). Set to 0 to disable. */
+  saveIntervalMs?: number;
+  /** Skip restoring paused=false (i.e. never auto-play on remount). */
+  dontResumePlay?: boolean;
+}
+
+/**
+ * Preserves video playback state across remounts keyed by `id`.
+ * Android WebView can re-layout and virtual scrollers can recycle nodes on
+ * rotation, which resets currentTime. Restoring the cached state on
+ * `loadedmetadata` avoids the jarring reset.
+ */
+export function useVideoStatePreservation(
+  videoRef: Ref<HTMLVideoElement | null>,
+  id: Ref<string | null> | string,
+  options: UseVideoStatePreservationOptions = {},
+) {
+  const { saveIntervalMs = 1000, dontResumePlay = false } = options;
+
+  function currentId(): string | null {
+    if (typeof id === "string") return id;
+    return id.value;
+  }
+
+  function saveStateFrom(el: HTMLVideoElement | null) {
+    const key = currentId();
+    if (!el || !key) return;
+    cachePut(key, {
+      currentTime: sanitizeTime(el.currentTime),
+      paused: el.paused,
+      volume: sanitizeVolume(el.volume),
+      muted: !!el.muted,
+    });
+  }
+
+  function saveState() {
+    saveStateFrom(videoRef.value);
+  }
+
+  function restoreState() {
+    const el = videoRef.value;
+    const key = currentId();
+    if (!el || !key) return;
+    const saved = stateCache.get(key);
+    if (!saved) return;
+
+    try {
+      if (saved.currentTime > 0 && saved.currentTime < (el.duration || Infinity)) {
+        el.currentTime = saved.currentTime;
+      }
+      if (Number.isFinite(saved.volume)) el.volume = saved.volume;
+      el.muted = saved.muted;
+      if (!saved.paused && !dontResumePlay) {
+        void el.play().catch(() => {
+          // Autoplay may be blocked; stay paused silently.
+        });
+      }
+    } catch {
+      // Safari can throw if element is not ready; ignore.
+    }
+  }
+
+  function attachRestoreHandler(el: HTMLVideoElement) {
+    if (el.readyState >= 1) {
+      restoreState();
+    } else {
+      const handler = () => {
+        el.removeEventListener("loadedmetadata", handler);
+        restoreState();
+      };
+      el.addEventListener("loadedmetadata", handler);
+    }
+  }
+
+  let saveTimer: ReturnType<typeof setInterval> | null = null;
+
+  function startAutoSave() {
+    if (saveIntervalMs <= 0 || saveTimer) return;
+    saveTimer = setInterval(saveState, saveIntervalMs);
+  }
+
+  function stopAutoSave() {
+    if (saveTimer) {
+      clearInterval(saveTimer);
+      saveTimer = null;
+    }
+  }
+
+  onMounted(() => {
+    const el = videoRef.value;
+    if (el) attachRestoreHandler(el);
+    startAutoSave();
+  });
+
+  watch(videoRef, (el, prev) => {
+    // Save from the outgoing element explicitly — videoRef.value is already
+    // the new element when this callback fires, so we can't use saveState().
+    if (prev) saveStateFrom(prev);
+    if (el) attachRestoreHandler(el);
+  });
+
+  onScopeDispose(() => {
+    saveState();
+    stopAutoSave();
+  });
+
+  return { saveState, restoreState };
+}


### PR DESCRIPTION
## Summary

- **#183, #190** — Видео больше не сбрасывается при ремаунте (поворот/recycle виртуал-скроллера). Новый composable `useVideoStatePreservation` кэширует `currentTime`/`paused`/`volume`/`muted` по стабильному id и восстанавливает на `loadedmetadata`.
- **#323** — Peer video в звонке больше не обрезается/не раздувается. Remote-камера теперь рендерится c `object-fit: contain`; локальная камера остаётся `cover` чтобы PiP/self-view заполняли без полос.

## Что изменилось

- `src/shared/lib/composables/use-video-state-preservation.ts` (новый) — composable с LRU-кэшом на 200 записей (предотвращает утечку памяти в длинных сессиях с тысячами видео-сообщений). Опция `dontResumePlay` чтобы rotate не триггерил неожиданный autoplay.
- Подключён к `MediaViewer.vue`, `VideoCirclePlayer.vue` и inline `<video>` в `MessageBubble.vue`. Везде добавлен `playsinline`.
- `src/features/video-calls/ui/CallWindow.vue` — `makeTile()` расширен параметром `isLocal`. Remote-camera в simple-video layout теперь использует `object-fit="contain"`.

## Что было рассмотрено и отклонено (не root cause)

- **#304, #328** «не грузится видео в каналах» — каналы используют iframe YouTube/PeerTube через `VideoPlayer.vue`, не native `<video>`. `use-channel-video` / mxc-resolver из плана не нужны.
- `use-orientation` composable из плана — такого композабла в репо нет, `orientationchange` listener'ов нет. MainActivity.xml уже содержит `configChanges="orientation|..."` — WebView не пересоздаётся, поэтому рутинного ремаунта видео от поворота не происходит. Composable остаётся полезным как защита от виртуал-скроллера.

## Тесты

- 11 unit-тестов для `useVideoStatePreservation`: save/restore currentTime, paused-state, volume/muted, NaN guard, LRU cap, mid-lifecycle videoRef swap, `dontResumePlay`, autoSaveInterval.
- 4 теста для `VideoTile` на маппинг объектов props → classes (contain/cover/mirror).

## Test plan

- [ ] Android: открыть видео в чате → rotate portrait↔landscape → видео продолжает играть с того же кадра.
- [ ] Android: открыть галерею (MediaViewer), свайпать между видео → каждое возобновляется с сохранённой позиции.
- [ ] Android: video-звонок с peer у которого портретная камера → на portrait phone пир не обрезан сверху, видно полностью.
- [ ] Android: video-звонок на landscape phone → пир по-прежнему занимает полный экран без растяжения.
- [ ] Local self-view в PiP → остаётся `cover`, без чёрных полос.