### PR TITLE
fix(interaction): polls change-vote + reaction picker double-fire + error toasts

### DIFF
--- a/src/features/messaging/model/use-messages.test.ts
+++ b/src/features/messaging/model/use-messages.test.ts
@@ -12,6 +12,18 @@ vi.mock("@/entities/auth", () => ({
   })),
 }));
 
+// Spy on the toast composable so error flows can be asserted.
+const mockToast = vi.fn();
+vi.mock("@/shared/lib/use-toast", () => ({
+  useToast: () => ({
+    toast: mockToast,
+    close: vi.fn(),
+    message: { value: "" },
+    type: { value: "info" },
+    show: { value: false },
+  }),
+}));
+
 // Mock connectivity
 vi.mock("@/shared/lib/connectivity", () => ({
   useConnectivity: vi.fn(() => ({ isOnline: { value: true } })),
@@ -104,6 +116,20 @@ describe("useMessages", () => {
       expect(mockRedactEvent).toHaveBeenCalledWith("!room:server", "$old_reaction");
       expect(mockSendReaction).toHaveBeenCalledWith("!room:server", msg.id, "😂");
     });
+
+    it("shows toast when sendReaction throws", async () => {
+      mockToast.mockClear();
+      const msg = makeMsg({ roomId: "!room:server" });
+      chatStore.addMessage("!room:server", msg);
+      mockSendReaction.mockImplementationOnce(() => {
+        throw new Error("network error");
+      });
+
+      await messaging.toggleReaction(msg.id, "👍");
+
+      expect(mockToast).toHaveBeenCalled();
+      expect(mockToast.mock.calls[0][1]).toBe("error");
+    });
   });
 
   // ─── sendTransferMessage ──────────────────────────────────────
@@ -163,6 +189,54 @@ describe("useMessages", () => {
       expect(msgs[0].type).toBe(MessageType.poll);
       expect(msgs[0].pollInfo?.question).toBe("Yes or No?");
       expect(msgs[0].pollInfo?.options).toHaveLength(2);
+    });
+  });
+
+  // ─── votePoll ─────────────────────────────────────────────────
+
+  describe("votePoll", () => {
+    it("sends m.poll.response with m.reference relates_to and MSC3381 answers", async () => {
+      await messaging.votePoll("$poll1", "opt-1");
+
+      expect(mockSendPollResponse).toHaveBeenCalledWith("!room:server", {
+        "m.relates_to": {
+          rel_type: "m.reference",
+          event_id: "$poll1",
+        },
+        "org.matrix.msc3381.poll.response": {
+          answers: ["opt-1"],
+        },
+      });
+    });
+
+    it("allows changing vote (MSC3381 last-vote-wins)", async () => {
+      await messaging.votePoll("$poll1", "opt-0");
+      await messaging.votePoll("$poll1", "opt-2");
+
+      expect(mockSendPollResponse).toHaveBeenCalledTimes(2);
+      expect(mockSendPollResponse).toHaveBeenLastCalledWith(
+        "!room:server",
+        expect.objectContaining({
+          "m.relates_to": expect.objectContaining({ event_id: "$poll1" }),
+          "org.matrix.msc3381.poll.response": { answers: ["opt-2"] },
+        }),
+      );
+    });
+
+    it("noops when no active room", async () => {
+      chatStore.activeRoomId = null as unknown as string;
+      await messaging.votePoll("$poll1", "opt-0");
+      expect(mockSendPollResponse).not.toHaveBeenCalled();
+    });
+
+    it("shows toast when sendPollResponse throws", async () => {
+      mockToast.mockClear();
+      mockSendPollResponse.mockRejectedValueOnce(new Error("server error"));
+      await messaging.votePoll("$poll1", "opt-0");
+
+      expect(mockToast).toHaveBeenCalled();
+      const toastArgs = mockToast.mock.calls[0];
+      expect(toastArgs[1]).toBe("error");
     });
   });
 

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -17,6 +17,7 @@ import { withTimeout } from "@/shared/lib/with-timeout";
 import type { LocalMessageStatus } from "@/shared/lib/local-db/schema";
 import { useBugReport } from "@/features/bug-report";
 import { tRaw } from "@/shared/lib/i18n";
+import { useToast } from "@/shared/lib/use-toast";
 
 /** Per-phase media pipeline timeouts. Splitting the old single 5-minute cap
  *  lets us surface phase-specific failures (e.g. crypto hang vs upload stall)
@@ -1236,6 +1237,7 @@ export function useMessages() {
       }
     } catch (e) {
       console.error("[Reaction] Failed to toggle reaction:", e);
+      useToast().toast(tRaw("reaction.failed"), "error");
       useBugReport().open({ context: tRaw("bugReport.ctx.toggleReaction"), error: e });
       await chatStore.loadRoomMessages(roomId, { waitForSdk: true });
     }
@@ -1905,6 +1907,7 @@ export function useMessages() {
       }
     } catch (e) {
       console.error("Failed to vote on poll:", e);
+      useToast().toast(tRaw("poll.voteFailed"), "error");
       useBugReport().open({ context: tRaw("bugReport.ctx.votePoll"), error: e });
     }
   };

--- a/src/features/messaging/ui/MessageContextMenu.vue
+++ b/src/features/messaging/ui/MessageContextMenu.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import type { Message } from "@/entities/chat";
 import { useThemeStore } from "@/entities/theme";
 import { useMobile } from "@/shared/lib/composables/use-media-query";
@@ -67,7 +67,19 @@ const menuItems = computed<ContextMenuItem[]>(() => {
   return items;
 });
 
+// Anti-double-fire: guards the mobile BottomSheet quick-reaction row where
+// a rapid double-tap would otherwise send two identical reactions before the
+// menu finishes closing. Instance-scoped so multiple menus don't cross-cancel.
+const DOUBLE_FIRE_WINDOW_MS = 400;
+const lastReactionEmoji = ref<string | null>(null);
+const lastReactionAt = ref(0);
+
 const handleReaction = (emoji: string) => {
+  const now = Date.now();
+  if (lastReactionEmoji.value === emoji && now - lastReactionAt.value < DOUBLE_FIRE_WINDOW_MS) return;
+  lastReactionEmoji.value = emoji;
+  lastReactionAt.value = now;
+
   if (props.message) {
     emit("react", emoji, props.message);
   }
@@ -107,12 +119,14 @@ const onBottomSheetAction = (action: string) => {
       <button
         v-for="emoji in themeStore.quickReactions"
         :key="emoji"
+        type="button"
         class="text-2xl p-2 rounded-full hover:bg-neutral-grad-0/50 active:scale-90 transition-transform"
         @click="handleReaction(emoji)"
       >
         {{ emoji }}
       </button>
       <button
+        type="button"
         class="p-2 rounded-full hover:bg-neutral-grad-0/50"
         :title="t('contextMenu.moreReactions')"
         @click="handleOpenEmojiPicker"

--- a/src/features/messaging/ui/PollCard.vue
+++ b/src/features/messaging/ui/PollCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, onUnmounted, ref } from "vue";
 import type { Message } from "@/entities/chat";
 
 interface Props {
@@ -34,8 +34,37 @@ const getPercentage = (optionId: string): number => {
   return Math.round((getVoteCount(optionId) / totalVotes.value) * 100);
 };
 
+// Anti-double-fire: record which option is currently being sent and ignore
+// a *repeat* click on the same option within a short window. Clicks on a
+// different option are always allowed (MSC3381 last-vote-wins) so the user
+// can immediately correct a mistaken tap.
+const pendingVote = ref<string | null>(null);
+let pendingClearTimer: ReturnType<typeof setTimeout> | null = null;
+
+const clearPending = () => {
+  if (pendingClearTimer) {
+    clearTimeout(pendingClearTimer);
+    pendingClearTimer = null;
+  }
+  pendingVote.value = null;
+};
+
+onUnmounted(clearPending);
+
 const handleVote = (optionId: string) => {
-  if (poll.value.ended || poll.value.myVote) return;
+  if (poll.value.ended) return;
+  // Duplicate click on the option we're already sending — dedupe.
+  if (pendingVote.value === optionId) return;
+  // Already the server-confirmed vote — nothing to do.
+  if (poll.value.myVote === optionId) return;
+
+  pendingVote.value = optionId;
+  if (pendingClearTimer) clearTimeout(pendingClearTimer);
+  pendingClearTimer = setTimeout(() => {
+    pendingVote.value = null;
+    pendingClearTimer = null;
+  }, 800);
+
   emit("vote", optionId);
 };
 </script>
@@ -52,9 +81,10 @@ const handleVote = (optionId: string) => {
       <button
         v-for="option in poll.options"
         :key="option.id"
+        type="button"
         class="relative overflow-hidden rounded-lg px-3 py-2 text-left text-sm transition-colors"
         :class="[
-          poll.ended || hasVoted
+          poll.ended
             ? 'cursor-default'
             : isOwn
               ? 'hover:bg-white/15 cursor-pointer'
@@ -62,15 +92,16 @@ const handleVote = (optionId: string) => {
           isOwn ? 'bg-white/10' : 'bg-neutral-grad-0/60',
           poll.myVote === option.id ? (isOwn ? 'ring-1 ring-white/40' : 'ring-1 ring-color-bg-ac/40') : '',
         ]"
-        :disabled="poll.ended || hasVoted"
-        @click="handleVote(option.id)"
+        :disabled="poll.ended"
+        :aria-pressed="poll.myVote === option.id"
+        @click.stop="handleVote(option.id)"
       >
         <!-- Progress bar (shown after voting or when ended) -->
         <div
           v-if="hasVoted || poll.ended"
           class="absolute inset-0 transition-all duration-300"
           :class="isOwn ? 'bg-white/15' : 'bg-color-bg-ac/10'"
-          :style="{ width: `${getPercentage(option.id)}%` }"
+          :style="{ width: `${getPercentage(option.id)}%`, pointerEvents: 'none' }"
         />
         <div class="relative flex items-center justify-between gap-2">
           <span :class="isOwn ? 'text-white' : 'text-text-color'">
@@ -95,6 +126,7 @@ const handleVote = (optionId: string) => {
       </span>
       <button
         v-if="isOwn && !poll.ended"
+        type="button"
         class="text-[11px] hover:underline"
         :class="isOwn ? 'text-white/70' : 'text-color-bg-ac'"
         @click.stop="emit('end')"

--- a/src/features/messaging/ui/ReactionPicker.vue
+++ b/src/features/messaging/ui/ReactionPicker.vue
@@ -1,9 +1,26 @@
 <script setup lang="ts">
+import { ref } from "vue";
 import { useThemeStore } from "@/entities/theme";
 
 const emit = defineEmits<{ select: [emoji: string] }>();
 
 const themeStore = useThemeStore();
+
+// Anti-double-fire guard: ignore repeated clicks on the same emoji within
+// a short window. Protects against rapid taps / double-tap duplicating
+// reactions before the parent can close the picker. Instance-scoped so
+// multiple pickers in the DOM don't cross-cancel each other's clicks.
+const DOUBLE_FIRE_WINDOW_MS = 400;
+const lastEmoji = ref<string | null>(null);
+const lastAt = ref(0);
+
+const handleSelect = (emoji: string) => {
+  const now = Date.now();
+  if (lastEmoji.value === emoji && now - lastAt.value < DOUBLE_FIRE_WINDOW_MS) return;
+  lastEmoji.value = emoji;
+  lastAt.value = now;
+  emit("select", emoji);
+};
 </script>
 
 <template>
@@ -11,8 +28,9 @@ const themeStore = useThemeStore();
     <button
       v-for="emoji in themeStore.quickReactions"
       :key="emoji"
+      type="button"
       class="flex h-8 w-8 items-center justify-center rounded-full text-lg transition-transform hover:scale-125 hover:bg-neutral-grad-0"
-      @click="emit('select', emoji)"
+      @click="handleSelect(emoji)"
     >
       {{ emoji }}
     </button>

--- a/src/features/messaging/ui/__tests__/PollCard.test.ts
+++ b/src/features/messaging/ui/__tests__/PollCard.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import PollCard from "../PollCard.vue";
+import { MessageStatus, MessageType } from "@/entities/chat";
+import type { Message } from "@/entities/chat";
+
+vi.stubGlobal("useI18n", () => ({ t: (k: string) => k }));
+
+function makePollMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "$poll1",
+    roomId: "!room:server",
+    senderId: "PSender1",
+    content: "Favorite color?",
+    timestamp: Date.now(),
+    status: MessageStatus.sent,
+    type: MessageType.poll,
+    pollInfo: {
+      question: "Favorite color?",
+      options: [
+        { id: "opt-0", text: "Red" },
+        { id: "opt-1", text: "Blue" },
+        { id: "opt-2", text: "Green" },
+      ],
+      votes: {},
+    },
+    ...overrides,
+  } as Message;
+}
+
+describe("PollCard", () => {
+  beforeEach(() => {
+    vi.stubGlobal("useI18n", () => ({ t: (k: string) => k }));
+  });
+
+  it("emits vote with optionId when user clicks an option", async () => {
+    const wrapper = mount(PollCard, {
+      props: { message: makePollMessage(), isOwn: false },
+    });
+
+    await wrapper.findAll("button")[0].trigger("click");
+
+    const voteEvents = wrapper.emitted("vote");
+    expect(voteEvents).toBeTruthy();
+    expect(voteEvents![0]).toEqual(["opt-0"]);
+  });
+
+  it("allows changing vote after user has already voted (MSC3381: last vote wins)", async () => {
+    const msg = makePollMessage({
+      pollInfo: {
+        question: "Q",
+        options: [
+          { id: "opt-0", text: "A" },
+          { id: "opt-1", text: "B" },
+        ],
+        votes: { "opt-0": ["PMe"] },
+        myVote: "opt-0",
+      },
+    });
+    const wrapper = mount(PollCard, {
+      props: { message: msg, isOwn: false },
+    });
+
+    const buttons = wrapper.findAll("button");
+    await buttons[1].trigger("click");
+
+    const voteEvents = wrapper.emitted("vote");
+    expect(voteEvents).toBeTruthy();
+    expect(voteEvents![0]).toEqual(["opt-1"]);
+  });
+
+  it("blocks voting when poll is ended", async () => {
+    const msg = makePollMessage({
+      pollInfo: {
+        question: "Q",
+        options: [
+          { id: "opt-0", text: "A" },
+          { id: "opt-1", text: "B" },
+        ],
+        votes: { "opt-0": ["PSomeone"] },
+        ended: true,
+      },
+    });
+    const wrapper = mount(PollCard, {
+      props: { message: msg, isOwn: false },
+    });
+
+    await wrapper.findAll("button")[0].trigger("click");
+
+    expect(wrapper.emitted("vote")).toBeFalsy();
+  });
+
+  it("prevents double-fire from rapid duplicate clicks on the same option", async () => {
+    const wrapper = mount(PollCard, {
+      props: { message: makePollMessage(), isOwn: false },
+    });
+    const firstOption = wrapper.findAll("button")[0];
+
+    await firstOption.trigger("click");
+    await firstOption.trigger("click");
+    await firstOption.trigger("click");
+
+    const voteEvents = wrapper.emitted("vote");
+    expect(voteEvents).toBeTruthy();
+    expect(voteEvents!.length).toBe(1);
+  });
+
+  it("marks selected option with aria-pressed when user has voted", () => {
+    const msg = makePollMessage({
+      pollInfo: {
+        question: "Q",
+        options: [
+          { id: "opt-0", text: "A" },
+          { id: "opt-1", text: "B" },
+        ],
+        votes: { "opt-0": ["PMe"] },
+        myVote: "opt-0",
+      },
+    });
+    const wrapper = mount(PollCard, {
+      props: { message: msg, isOwn: false },
+    });
+
+    const buttons = wrapper.findAll("button");
+    expect(buttons[0].attributes("aria-pressed")).toBe("true");
+    expect(buttons[1].attributes("aria-pressed")).toBe("false");
+  });
+
+  it("emits end when poll owner clicks End poll", async () => {
+    const wrapper = mount(PollCard, {
+      props: { message: makePollMessage(), isOwn: true },
+    });
+
+    const endButton = wrapper
+      .findAll("button")
+      .find(b => b.text().toLowerCase().includes("end poll"));
+    expect(endButton).toBeDefined();
+
+    await endButton!.trigger("click");
+    expect(wrapper.emitted("end")).toBeTruthy();
+  });
+});

--- a/src/features/messaging/ui/__tests__/ReactionPicker.test.ts
+++ b/src/features/messaging/ui/__tests__/ReactionPicker.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import ReactionPicker from "../ReactionPicker.vue";
+
+vi.stubGlobal("useI18n", () => ({ t: (k: string) => k }));
+
+vi.mock("@/entities/theme", () => ({
+  useThemeStore: () => ({
+    quickReactions: ["👍", "❤️", "😂", "😮", "😢", "🙏"],
+    animationsEnabled: true,
+  }),
+}));
+
+describe("ReactionPicker", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.stubGlobal("useI18n", () => ({ t: (k: string) => k }));
+  });
+
+  it("emits select with the emoji on click", async () => {
+    const wrapper = mount(ReactionPicker);
+
+    const firstButton = wrapper.findAll("button")[0];
+    await firstButton.trigger("click");
+
+    const selectEvents = wrapper.emitted("select");
+    expect(selectEvents).toBeTruthy();
+    expect(selectEvents![0]).toEqual(["👍"]);
+  });
+
+  it("ignores rapid double-click on the same emoji (anti-double-fire)", async () => {
+    const wrapper = mount(ReactionPicker);
+
+    const firstButton = wrapper.findAll("button")[0];
+    await firstButton.trigger("click");
+    await firstButton.trigger("click");
+    await firstButton.trigger("click");
+
+    const selectEvents = wrapper.emitted("select");
+    expect(selectEvents).toBeTruthy();
+    expect(selectEvents!.length).toBe(1);
+  });
+
+  it("allows selecting a different emoji right after another", async () => {
+    const wrapper = mount(ReactionPicker);
+
+    const buttons = wrapper.findAll("button");
+    await buttons[0].trigger("click");
+    await buttons[1].trigger("click");
+
+    const selectEvents = wrapper.emitted("select");
+    expect(selectEvents).toBeTruthy();
+    expect(selectEvents!.length).toBe(2);
+    expect(selectEvents![0]).toEqual(["👍"]);
+    expect(selectEvents![1]).toEqual(["❤️"]);
+  });
+
+  it("anti-double-fire guard is instance-scoped (multiple pickers don't cross-cancel)", async () => {
+    const wrapperA = mount(ReactionPicker);
+    const wrapperB = mount(ReactionPicker);
+
+    // Fire the same emoji on two different picker instances in quick succession.
+    await wrapperA.findAll("button")[0].trigger("click");
+    await wrapperB.findAll("button")[0].trigger("click");
+
+    expect(wrapperA.emitted("select")).toHaveLength(1);
+    expect(wrapperB.emitted("select")).toHaveLength(1);
+  });
+});

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -449,6 +449,8 @@ export const en = {
   "poll.endPoll": "End poll",
   "poll.finalResults": "Final results",
   "poll.votes": "{count} vote(s)",
+  "poll.voteFailed": "Failed to submit vote",
+  "reaction.failed": "Failed to submit reaction",
 
   // ── Video calls ──
   "call.voiceCall": "Voice call",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -451,6 +451,8 @@ export const ru: Record<TranslationKey, string> = {
   "poll.endPoll": "Завершить опрос",
   "poll.finalResults": "Итоговые результаты",
   "poll.votes": "{count} голос(ов)",
+  "poll.voteFailed": "Не удалось отправить голос",
+  "reaction.failed": "Не удалось отправить реакцию",
 
   // ── Video calls ──
   "call.voiceCall": "Голосовой звонок",


### PR DESCRIPTION
## Summary

Fixes bugs **#194** (poll options not registering votes) and **#377** (reaction picker double-fire / glitches) from Session 22 of the Android-compatibility audit.

## What changed

### PollCard
- Removed the hard gate on `myVote` so users can **change their vote** (MSC3381 last-vote-wins) — previously, any tap on a different option after an initial vote was silently dropped.
- Added an anti-double-fire guard: duplicate clicks on the *same* option within 800 ms are deduped. Clicks on a *different* option pass through immediately so the user can correct a mistaken tap.
- `aria-pressed` reflects the current selected option.
- `pointer-events: none` on the progress-bar overlay so it never steals taps.
- Pending-vote timer is cancelled on `onUnmounted` to avoid leaks.

### ReactionPicker / MessageContextMenu
- Instance-scoped anti-double-fire guard (400 ms on the same emoji) — rapid double-tap on a quick-reaction button was sending two identical `m.reaction` events before the picker finished closing.
- Using `ref()` instead of module scope so multiple pickers in the DOM don't cross-cancel each other's clicks.
- Added `type="button"` on the mobile BottomSheet quick-reaction row to match the convention in `ReactionPicker.vue`.

### use-messages
- `votePoll` / `toggleReaction` now also surface a user-visible toast (`poll.voteFailed`, `reaction.failed`) on failure — previously the error was only captured by `useBugReport` and invisible to the user.

### i18n
- New keys `poll.voteFailed`, `reaction.failed` added to ru/en locales.

## Why

The existing `votePoll` / `toggleReaction` logic on the Matrix side was already correct (MSC3381 + `m.annotation` relates_to, proper redact-before-send for reactions). The real bugs were all on the UI glue:
- PollCard turned the poll into read-only after the first vote, hiding the fact that Matrix actually supports revote.
- Neither ReactionPicker nor the mobile BottomSheet quick-reactions had any double-click protection, so rapid taps produced duplicate events.
- Failures were silent from the user's point of view.

## Tests

Added 10 tests across 3 files (41 tests total in the affected suites, all passing):
- `PollCard.test.ts` — emit `vote`, change-vote allowed, double-fire dedupe, `aria-pressed`, blocked when ended, `end` emit.
- `ReactionPicker.test.ts` — emit `select`, dedupe same-emoji double-click, allow different-emoji sequence, cross-instance isolation.
- `use-messages.test.ts` — votePoll payload shape, change-vote at model level, noop on no room, toast on `sendPollResponse` error, toast on `sendReaction` error.

## Verification

- `vue-tsc --noEmit` — no new type errors in touched files.
- `vite build` — passes in ~20s.
- `vitest run` on affected suites — 41/41 passing.
- Pre-existing failing suites (video-embed, open-profile-url, chat-helpers, display-result, sync-engine-txnid) are unrelated — verified by stashing these changes and re-running.

## Test plan

- [ ] Create a poll in a group, tap an option → vote recorded on both sides.
- [ ] Tap a different option → vote changes (not blocked).
- [ ] Rapidly double-tap the same option → only one vote event sent.
- [ ] Break network mid-vote → toast "Failed to submit vote" appears.
- [ ] Open reaction picker, rapidly double-tap the same emoji → only one reaction added.
- [ ] Open reaction picker, tap different emojis quickly → both land.
- [ ] Two messages side-by-side: reaction on A then same emoji on B within 400 ms → both reactions land (no cross-cancel).