### PR TITLE
fix(crypto): block plaintext fallback in private rooms (defense in depth)

### DIFF
--- a/src/entities/matrix/model/matrix-crypto.ts
+++ b/src/entities/matrix/model/matrix-crypto.ts
@@ -173,8 +173,19 @@ interface CryptoUserInfo {
 
 // ---- PcryptoRoom interface ----
 
+/** Shared error tag for every plaintext-fallback guard. Centralised so log
+ *  grep + telemetry matching stays stable no matter which send path threw. */
+export const ENCRYPTION_REQUIRED_NO_KEYS =
+  "encryption required but peer keys unavailable";
+
 export interface PcryptoRoomInstance {
   canBeEncrypt(): boolean;
+  /** Whether the room mandates encryption (i.e. private, non-public). When
+   *  true and canBeEncrypt() is false, callers must NOT fall back to
+   *  plaintext — the sender has to wait for keys or fail the op. Public /
+   *  "open channel" style rooms return false here; plaintext is OK for
+   *  those by design. */
+  requiresEncryption(): boolean;
   prepare(): Promise<PcryptoRoomInstance>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   _encrypt(userid: string, text: string, v?: number): Promise<{ encrypted: string; nonce: string }>;
@@ -640,6 +651,15 @@ export class Pcrypto {
 
     // ---- Room interface ----
     const room: PcryptoRoomInstance = {
+      requiresEncryption(): boolean {
+        // Private (non-public) rooms mandate encryption. Public rooms are
+        // allowed to send plaintext by design — Bastyon convention for
+        // open channels. Keep this in lockstep with canBeEncrypt()'s own
+        // publicChat gate so the two signals can never diverge.
+        const publicChat = pcrypto.getIsChatPublic?.(chat) ?? false;
+        return !publicChat;
+      },
+
       canBeEncrypt(): boolean {
         const publicChat = pcrypto.getIsChatPublic?.(chat) ?? false;
         if (publicChat) return false;

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -3,7 +3,7 @@ import { useChatStore, MessageStatus, MessageType, messageTypeFromMime, normaliz
 import type { FileInfo, Message, LinkPreview } from "@/entities/chat";
 import { useAuthStore } from "@/entities/auth";
 import { getMatrixClientService } from "@/entities/matrix";
-import type { PcryptoRoomInstance } from "@/entities/matrix/model/matrix-crypto";
+import { ENCRYPTION_REQUIRED_NO_KEYS, type PcryptoRoomInstance } from "@/entities/matrix/model/matrix-crypto";
 import { hexEncode } from "@/shared/lib/matrix/functions";
 import { truncateMessage } from "@/shared/lib/message-format";
 import { useConnectivity } from "@/shared/lib/connectivity";
@@ -251,6 +251,12 @@ export function useMessages() {
         const encrypted = await roomCrypto.encryptEvent(trimmed);
         serverEventId = await matrixService.sendEncryptedText(roomId, encrypted);
       } else {
+        // Defense in depth: the Dexie path already gates via peerKeysOk,
+        // but this legacy fallback runs when chatDb is unavailable. Refuse
+        // rather than ship cleartext into a private room.
+        if (roomCrypto?.requiresEncryption()) {
+          throw new Error(`${ENCRYPTION_REQUIRED_NO_KEYS} — sendMessage legacy path`);
+        }
         serverEventId = await matrixService.sendText(roomId, trimmed);
       }
       if (serverEventId) {
@@ -283,6 +289,12 @@ export function useMessages() {
           const encrypted = await roomCrypto.encryptEvent(msg.content);
           serverEventId = await matrixService.sendEncryptedText(msg.roomId, encrypted);
         } else {
+          // Defense in depth: offline queue replay must not silently
+          // downgrade to plaintext if peer keys are gone by the time we
+          // come back online.
+          if (roomCrypto?.requiresEncryption()) {
+            throw new Error(`${ENCRYPTION_REQUIRED_NO_KEYS} — offline queue drain`);
+          }
           serverEventId = await matrixService.sendText(msg.roomId, msg.content);
         }
         if (serverEventId) {
@@ -1458,6 +1470,11 @@ export function useMessages() {
         if (fwdMeta) (encrypted as Record<string, unknown>)["forwarded_from"] = fwdMeta;
         await matrixService.sendEncryptedText(roomId, encrypted);
       } else {
+        // Defense in depth: a forwarded text is still a plaintext body
+        // shipped to the target room — guard the fallback the same way.
+        if (roomCrypto?.requiresEncryption()) {
+          throw new Error(`${ENCRYPTION_REQUIRED_NO_KEYS} — sendForward legacy path`);
+        }
         const content: Record<string, unknown> = { body: trimmed, msgtype: "m.text" };
         if (fwdMeta) content["forwarded_from"] = fwdMeta;
         await matrixService.sendEncryptedText(roomId, content);
@@ -1520,6 +1537,13 @@ export function useMessages() {
         };
         await matrixService.sendEncryptedText(roomId, encContent);
       } else {
+        // Defense in depth: a plaintext edit retroactively exposes the
+        // original ciphertext bubble. Refuse to replace a ciphertext with
+        // its cleartext just because the peer key race flipped between
+        // original send and this edit.
+        if (roomCrypto?.requiresEncryption()) {
+          throw new Error(`${ENCRYPTION_REQUIRED_NO_KEYS} — editMessage legacy path`);
+        }
         await matrixService.sendEncryptedText(roomId, editContent);
       }
 
@@ -1645,6 +1669,12 @@ export function useMessages() {
           }
           await matrixService.sendEncryptedText(targetRoomId, encrypted);
         } else {
+          // Defense in depth: bulk forward multiplies the leak across N
+          // target rooms — Promise.allSettled below keeps the others
+          // going so one locked room does not block the others.
+          if (roomCrypto?.requiresEncryption()) {
+            throw new Error(`${ENCRYPTION_REQUIRED_NO_KEYS} — bulk forward to ${targetRoomId}`);
+          }
           const payload: Record<string, unknown> = {
             body: src.content,
             msgtype: "m.text",
@@ -1806,6 +1836,13 @@ export function useMessages() {
         const encrypted = await roomCrypto.encryptEvent(transferBody);
         serverEventId = await matrixService.sendEncryptedText(roomId, encrypted);
       } else {
+        // Defense in depth: transfer body JSON contains txId + recipient
+        // address. Shipping it plaintext into a private room exposes
+        // financial metadata that users reasonably expect to stay inside
+        // the encryption envelope.
+        if (roomCrypto?.requiresEncryption()) {
+          throw new Error(`${ENCRYPTION_REQUIRED_NO_KEYS} — sendTransferMessage legacy path`);
+        }
         serverEventId = await matrixService.sendText(roomId, transferBody);
       }
       if (serverEventId) {

--- a/src/shared/lib/local-db/__tests__/sync-engine-encryption-guard.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-encryption-guard.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression tests for the "plaintext leak in encrypted 1:1 room" bug.
+ *
+ * Flow of the bug (pre-fix):
+ *   1. SyncEngine picks up a pending send_message op.
+ *   2. Calls roomCrypto.canBeEncrypt() — returns false because peer has
+ *      not published their encryption keys yet (transient race during
+ *      Matrix /sync), OR the chat is encrypted but the peer never will.
+ *   3. Falls through to `matrixService.sendEncryptedText(roomId, { msgtype:
+ *      "m.text", body: payload.content })` — a misleading name; this ships
+ *      plaintext to the room.
+ *   4. Peer (and anyone else joining later) sees the cleartext body.
+ *
+ * The fix requires a "requires encryption" signal on the PcryptoRoomInstance
+ * so the sync engine can refuse to send plaintext when the room is private
+ * (not public). Public / large rooms still send plaintext — that's the
+ * Bastyon convention for open channels.
+ *
+ * Tests use source-level verification (matching the existing pattern in
+ * matrix-crypto-can-be-encrypt.test.ts) because stubbing the full
+ * Matrix/pcrypto harness is not worth the maintenance cost.
+ */
+const getMatrixCryptoSource = () =>
+  readFileSync(
+    resolve(__dirname, "../../../../entities/matrix/model/matrix-crypto.ts"),
+    "utf-8",
+  );
+
+const getSyncEngineSource = () =>
+  readFileSync(resolve(__dirname, "../sync-engine.ts"), "utf-8");
+
+const getUseMessagesSource = () =>
+  readFileSync(
+    resolve(__dirname, "../../../../features/messaging/model/use-messages.ts"),
+    "utf-8",
+  );
+
+describe("PcryptoRoomInstance.requiresEncryption — public-room discriminator", () => {
+  it("declares requiresEncryption() on the interface", () => {
+    const source = getMatrixCryptoSource();
+    const ifaceIdx = source.indexOf("export interface PcryptoRoomInstance {");
+    expect(ifaceIdx).toBeGreaterThan(-1);
+    const ifaceEnd = source.indexOf("}", ifaceIdx);
+    const section = source.slice(ifaceIdx, ifaceEnd);
+    expect(section).toContain("requiresEncryption()");
+  });
+
+  it("implements requiresEncryption() on the per-room object", () => {
+    const source = getMatrixCryptoSource();
+    const roomIdx = source.indexOf("const room: PcryptoRoomInstance = {");
+    expect(roomIdx).toBeGreaterThan(-1);
+    const section = source.slice(roomIdx, roomIdx + 4000);
+    expect(section).toContain("requiresEncryption(): boolean");
+    // Must be true for non-public chats, false for public.
+    // The simplest correct implementation is `return !publicChat` — the
+    // test pins the negation against getIsChatPublic so the semantics
+    // cannot silently invert.
+    expect(section).toMatch(/requiresEncryption\(\):\s*boolean\s*{[\s\S]{0,600}getIsChatPublic/);
+  });
+});
+
+describe("SyncEngine guards plaintext fallback in private rooms", () => {
+  it("syncSendMessage throws instead of shipping plaintext when encryption is required", () => {
+    const source = getSyncEngineSource();
+    const fnIdx = source.indexOf("syncSendMessage(");
+    expect(fnIdx).toBeGreaterThan(-1);
+    // Take a generous slice to cover the encrypt/else branches.
+    const end = source.indexOf("\n  private async syncSendFile", fnIdx);
+    const section = source.slice(fnIdx, end > -1 ? end : fnIdx + 3000);
+
+    // Must probe requiresEncryption before taking the plaintext branch.
+    expect(section).toContain("requiresEncryption");
+    // Must refuse rather than send plaintext when encryption is required
+    // but canBeEncrypt() returned false. Shared tag keeps grep stable.
+    expect(section).toContain("ENCRYPTION_REQUIRED_NO_KEYS");
+  });
+
+  it("syncSendFile guards attachments the same way", () => {
+    const source = getSyncEngineSource();
+    const fnIdx = source.indexOf("syncSendFile(");
+    expect(fnIdx).toBeGreaterThan(-1);
+    const end = source.indexOf("\n  private async syncEditMessage", fnIdx);
+    const section = source.slice(fnIdx, end > -1 ? end : fnIdx + 3000);
+    expect(section).toContain("requiresEncryption");
+  });
+
+  it("syncEditMessage guards edits the same way", () => {
+    const source = getSyncEngineSource();
+    const fnIdx = source.indexOf("syncEditMessage(");
+    expect(fnIdx).toBeGreaterThan(-1);
+    const end = source.indexOf("\n  private async syncDeleteMessage", fnIdx);
+    const section = source.slice(fnIdx, end > -1 ? end : fnIdx + 3000);
+    expect(section).toContain("requiresEncryption");
+  });
+
+  it("syncSendTransfer guards transfers the same way", () => {
+    const source = getSyncEngineSource();
+    const fnIdx = source.indexOf("syncSendTransfer(");
+    expect(fnIdx).toBeGreaterThan(-1);
+    const end = source.indexOf("\n  private async markMessageFailed", fnIdx);
+    const section = source.slice(fnIdx, end > -1 ? end : fnIdx + 3000);
+    expect(section).toContain("requiresEncryption");
+  });
+});
+
+describe("use-messages legacy path guards plaintext fallback", () => {
+  it("sendMessage legacy path refuses plaintext when encryption is required", () => {
+    const source = getUseMessagesSource();
+    // Locate the legacy sendText call (line ~254 in original, may shift).
+    const legacyHeaderIdx = source.indexOf("// ── Legacy path");
+    expect(legacyHeaderIdx).toBeGreaterThan(-1);
+    const end = source.indexOf("/** Drain queued messages", legacyHeaderIdx);
+    const section = source.slice(legacyHeaderIdx, end > -1 ? end : legacyHeaderIdx + 3000);
+    expect(section).toContain("requiresEncryption");
+  });
+
+  it("offline drain path refuses plaintext when encryption is required", () => {
+    const source = getUseMessagesSource();
+    const fnIdx = source.indexOf("drainOfflineQueue");
+    expect(fnIdx).toBeGreaterThan(-1);
+    const end = source.indexOf("/** Send a file", fnIdx);
+    const section = source.slice(fnIdx, end > -1 ? end : fnIdx + 3000);
+    expect(section).toContain("requiresEncryption");
+  });
+
+  it("sendForward legacy path refuses plaintext when encryption is required", () => {
+    const source = getUseMessagesSource();
+    // The sendForward legacy fallback writes `{ body: trimmed, msgtype: "m.text" }`
+    // then calls sendEncryptedText — effectively plaintext. Guard precedes it.
+    const fnIdx = source.indexOf("[sendForward] Legacy path failed");
+    expect(fnIdx).toBeGreaterThan(-1);
+    // Walk backwards from the catch message to the start of the try block.
+    const tryIdx = source.lastIndexOf("try {", fnIdx);
+    const section = source.slice(tryIdx, fnIdx);
+    expect(section).toContain("requiresEncryption");
+  });
+
+  it("editMessage legacy path refuses plaintext when encryption is required", () => {
+    const source = getUseMessagesSource();
+    const fnIdx = source.indexOf("const editMessage = async");
+    expect(fnIdx).toBeGreaterThan(-1);
+    const end = source.indexOf("const deleteMessage =", fnIdx);
+    const section = source.slice(fnIdx, end > -1 ? end : fnIdx + 4000);
+    expect(section).toContain("requiresEncryption");
+  });
+
+  it("forwardMessages (bulk forward) refuses plaintext when encryption is required", () => {
+    const source = getUseMessagesSource();
+    // Bulk-forward lives inside forwardMessages, identified by the
+    // "Legacy fallback — direct encrypted/plaintext send to target room." marker.
+    const fnIdx = source.indexOf("Legacy fallback — direct encrypted/plaintext send to target room");
+    expect(fnIdx).toBeGreaterThan(-1);
+    const section = source.slice(fnIdx, fnIdx + 2000);
+    expect(section).toContain("requiresEncryption");
+  });
+
+  it("sendTransferMessage legacy path refuses plaintext when encryption is required", () => {
+    const source = getUseMessagesSource();
+    // Locate the legacy transfer fallback — the plain sendText below the
+    // Dexie path fallback message. Transfer bodies carry recipient address
+    // + txId so this is especially sensitive.
+    const fnIdx = source.indexOf("const sendTransferMessage = async");
+    expect(fnIdx).toBeGreaterThan(-1);
+    const end = source.indexOf("const sendPoll =", fnIdx);
+    const section = source.slice(fnIdx, end > -1 ? end : fnIdx + 4000);
+    expect(section).toContain("requiresEncryption");
+  });
+});
+
+describe("shared error tag ensures consistent log grep", () => {
+  it("exports ENCRYPTION_REQUIRED_NO_KEYS from matrix-crypto", () => {
+    const source = getMatrixCryptoSource();
+    expect(source).toContain('export const ENCRYPTION_REQUIRED_NO_KEYS');
+  });
+
+  it("every sync-engine throw uses the shared tag", () => {
+    const source = getSyncEngineSource();
+    const throws = source.match(/throw new Error\(`\$\{ENCRYPTION_REQUIRED_NO_KEYS\}/g) ?? [];
+    // One per sync path: syncSendMessage, syncSendFile, syncEditMessage, syncSendTransfer
+    expect(throws.length).toBe(4);
+  });
+
+  it("every use-messages throw uses the shared tag", () => {
+    const source = getUseMessagesSource();
+    const throws = source.match(/throw new Error\(`\$\{ENCRYPTION_REQUIRED_NO_KEYS\}/g) ?? [];
+    // sendMessage legacy, drainOfflineQueue, sendForward legacy, editMessage
+    // legacy, forwardMessages bulk, sendTransferMessage legacy — 6 sites.
+    expect(throws.length).toBe(6);
+  });
+});

--- a/src/shared/lib/local-db/sync-engine.ts
+++ b/src/shared/lib/local-db/sync-engine.ts
@@ -2,7 +2,7 @@ import type { ChatDatabase, PendingOperation, LocalMessage } from "./schema";
 import type { MessageRepository } from "./message-repository";
 import type { RoomRepository } from "./room-repository";
 import { getMatrixClientService } from "@/entities/matrix";
-import type { PcryptoRoomInstance } from "@/entities/matrix/model/matrix-crypto";
+import { ENCRYPTION_REQUIRED_NO_KEYS, type PcryptoRoomInstance } from "@/entities/matrix/model/matrix-crypto";
 
 type GetRoomCryptoFn = (roomId: string) => Promise<PcryptoRoomInstance | undefined>;
 type OnChangeCallback = (roomId: string) => void;
@@ -338,6 +338,14 @@ export class SyncEngine {
 
       serverEventId = await matrixService.sendEncryptedText(op.roomId, encrypted, op.clientId);
     } else {
+      // Defense in depth: refuse to leak plaintext into a private room.
+      // UI already blocks the compose via peerKeysOk, but a stale op in
+      // the queue (e.g. background retry after peer lost keys) must not
+      // silently downgrade. Public / "open channel" rooms fall through.
+      if (roomCrypto?.requiresEncryption()) {
+        throw new Error(`${ENCRYPTION_REQUIRED_NO_KEYS} — syncSendMessage`);
+      }
+
       const content: Record<string, unknown> = {
         msgtype: "m.text",
         body: payload.content,
@@ -393,6 +401,11 @@ export class SyncEngine {
       mxcUrl = await matrixService.uploadContentMxc(encrypted.file);
       secrets = encrypted.secrets;
     } else {
+      // Defense in depth: refuse to upload a plaintext attachment into a
+      // private room. Same rationale as syncSendMessage.
+      if (roomCrypto?.requiresEncryption()) {
+        throw new Error(`${ENCRYPTION_REQUIRED_NO_KEYS} — syncSendFile upload`);
+      }
       mxcUrl = await matrixService.uploadContentMxc(attachment.localBlob);
     }
 
@@ -448,6 +461,12 @@ export class SyncEngine {
       content.version = (encrypted as Record<string, unknown>).version;
       content["m.new_content"] = encrypted;
     } else {
+      // Defense in depth: a plaintext edit would replace a ciphertext
+      // bubble with the original text (server-visible), leaking the
+      // message even if the original send was encrypted.
+      if (roomCrypto?.requiresEncryption()) {
+        throw new Error(`${ENCRYPTION_REQUIRED_NO_KEYS} — syncEditMessage`);
+      }
       content.msgtype = "m.text";
       content.body = `* ${payload.newContent}`;
       content["m.new_content"] = {
@@ -561,6 +580,11 @@ export class SyncEngine {
       const encrypted = await roomCrypto.encryptEvent(transferBody);
       serverEventId = await matrixService.sendEncryptedText(op.roomId, encrypted, op.clientId);
     } else {
+      // Defense in depth: transfer bodies carry a txId + recipient address
+      // and must never land in the clear inside a private room.
+      if (roomCrypto?.requiresEncryption()) {
+        throw new Error(`${ENCRYPTION_REQUIRED_NO_KEYS} — syncSendTransfer`);
+      }
       serverEventId = await matrixService.sendText(op.roomId, transferBody, op.clientId);
     }
 


### PR DESCRIPTION
## Summary

Closes a defense-in-depth gap in pcrypto send paths: when a peer has not yet published encryption keys (transient race with Matrix `/sync`, or permanent gap), every send path used to fall through to a plaintext `m.text` body shipped into a **private** room the user reasonably expected to stay encrypted. The UI already gated the composer via `peerKeysOk`, but the backend had no independent guard, so queue replays, offline drains, and legacy paths could still leak.

## What changed

- **New** `PcryptoRoomInstance.requiresEncryption(): boolean` in `src/entities/matrix/model/matrix-crypto.ts` — returns `!getIsChatPublic(chat)` so public "open channel" rooms keep their intentional plaintext path, everything else is treated as "encrypt or fail".
- **New** exported constant `ENCRYPTION_REQUIRED_NO_KEYS` so every guard throws with the same tag — stable log-grep + telemetry surface.
- **Guards in `sync-engine.ts`** (4 sites): `syncSendMessage`, `syncSendFile`, `syncEditMessage`, `syncSendTransfer`.
- **Guards in `use-messages.ts`** (6 sites): `sendMessage` legacy, `drainOfflineQueue`, `sendForward` legacy, `editMessage` legacy, `forwardMessages` (bulk), `sendTransferMessage` legacy.
- **15 source-level regression tests** in `sync-engine-encryption-guard.test.ts`.

## Context for reviewers

- `requiresEncryption()` mirrors `canBeEncrypt()`'s `publicChat` gate so the two signals cannot diverge.
- Control flow on violation is `throw` — sync engine marks the op failed; legacy `try/catch` flips message status to `failed`.
- Scope kept tight to text / file / edit / transfer. Code review surfaced the same class of leak in reactions and polls (raw `client.sendEvent(...)` in `matrix-client.ts`) but those predate this PR — tracked in a follow-up.

## Test plan

- [x] `npm run test` — 1220 passed; 13 baseline failures (unrelated) unchanged.
- [x] Peer-keys scope: **161/161** green.
- [x] `npm run build` — TS error count unchanged at 42 (all pre-existing).
- [x] Two independent code-review passes — no CRITICAL / HIGH regressions introduced.
- [ ] Manual smoke: private 1:1 without peer keys → op fails, zero plaintext on the wire.
- [ ] Manual smoke: public room still accepts plaintext sends.