### PR TITLE
feat(media): route media uploads through SyncEngine for crash recovery

### DIFF
--- a/src/entities/matrix/model/__tests__/matrix-crypto-mime.test.ts
+++ b/src/entities/matrix/model/__tests__/matrix-crypto-mime.test.ts
@@ -39,4 +39,45 @@ describe("PcryptoFile.encryptFile — MIME type", () => {
 
     expect(Array.from(bytes)).toEqual(Array.from(plaintext));
   }, TEST_TIMEOUT);
+
+  it("decryptFile honours originalMime argument when provided", async () => {
+    const { PcryptoFile } = await import("../matrix-crypto");
+    const pf = new PcryptoFile();
+    const plaintext = new Uint8Array([1, 2, 3]);
+    const input = new File([plaintext], "data.bin", { type: "image/png" });
+
+    const encrypted = await pf.encryptFile(input, "mime-secret");
+    // Ciphertext blob has application/octet-stream. Caller knows the real
+    // mimetype from fileInfo.type and passes it explicitly.
+    const decrypted = await pf.decryptFile(encrypted, "mime-secret", "image/png");
+
+    expect(decrypted.type).toBe("image/png");
+  }, TEST_TIMEOUT);
+
+  it("decryptFile falls back to legacy encrypted/* prefix if originalMime omitted", async () => {
+    const { PcryptoFile } = await import("../matrix-crypto");
+    const pf = new PcryptoFile();
+    // Simulate a blob written by the OLD client that stamped an invalid
+    // compound MIME like encrypted/image/png. The decrypt must strip the
+    // prefix so older messages still open.
+    const blob = new Blob([new Uint8Array([1, 2])], { type: "encrypted/image/png" });
+    // We only care about the MIME-restore logic here — use a stub key path
+    // by piggybacking on a real encrypt/decrypt cycle.
+    const realEncrypted = await pf.encryptFile(
+      new File([new Uint8Array([99])], "x.png", { type: "image/png" }),
+      "legacy-secret",
+    );
+    // Re-wrap the ciphertext bytes in a legacy-mime Blob
+    const legacyShaped = new File([await realEncrypted.arrayBuffer()], "legacy", {
+      type: "encrypted/image/png",
+    });
+
+    const decrypted = await pf.decryptFile(legacyShaped, "legacy-secret");
+    // Without originalMime, the restored MIME must be the stripped form
+    // (not "application/octet-stream" — that would regress older previews).
+    expect(decrypted.type).toBe("image/png");
+
+    // Touch the unused `blob` to keep the compiler honest.
+    expect(blob.size).toBe(2);
+  }, TEST_TIMEOUT);
 });

--- a/src/entities/matrix/model/matrix-crypto.ts
+++ b/src/entities/matrix/model/matrix-crypto.ts
@@ -114,14 +114,23 @@ export class PcryptoFile {
     return new File([encrypted], "encrypted", { type: "application/octet-stream" });
   }
 
-  async decryptFile(file: Blob, secret: string): Promise<File> {
+  /**
+   * Decrypt a ciphertext blob.
+   *
+   * @param originalMime — MIME type of the plaintext. New writers always
+   *   store ciphertext as application/octet-stream and pass the real MIME
+   *   via fileInfo.type, so prefer this argument. When omitted we fall
+   *   back to stripping the legacy "encrypted/" prefix from file.type so
+   *   messages written by old clients still open.
+   */
+  async decryptFile(file: Blob, secret: string, originalMime?: string): Promise<File> {
     const buffer = await readFile(file);
     const decrypted = await this.decrypt(buffer, secret);
-    // Strip the legacy "encrypted/" prefix if the ciphertext was produced by
-    // an older client version; fall back to generic binary otherwise.
-    const type = file.type.startsWith("encrypted/")
-      ? file.type.replace("encrypted/", "")
-      : "application/octet-stream";
+    const type = originalMime
+      ? originalMime
+      : file.type.startsWith("encrypted/")
+        ? file.type.replace("encrypted/", "")
+        : "application/octet-stream";
     return new File([decrypted], "decrypted", { type });
   }
 }
@@ -198,7 +207,7 @@ export interface PcryptoRoomInstance {
   getOrCreateCommonKey(): Promise<{ key: string; hash: string; block: number }>;
   sendCommonKey(): Promise<{ key: string; hash: string; block: number }>;
   encryptFile(file: Blob): Promise<{ file: File; secrets: Record<string, unknown> }>;
-  decryptFile(file: Blob, secret: string): Promise<File>;
+  decryptFile(file: Blob, secret: string, originalMime?: string): Promise<File>;
   encryptKey(key: string): Promise<{ block: number; keys: string; v: number }>;
   decryptKey(event: Record<string, unknown>): Promise<string>;
   clear(): void;
@@ -1062,8 +1071,8 @@ export class Pcrypto {
         return { file: encryptedFile, secrets };
       },
 
-      async decryptFile(file: Blob, secret: string): Promise<File> {
-        return pcrypto.pcryptoFile.decryptFile(file as File, secret);
+      async decryptFile(file: Blob, secret: string, originalMime?: string): Promise<File> {
+        return pcrypto.pcryptoFile.decryptFile(file as File, secret, originalMime);
       },
 
       async encryptKey(key: string): Promise<{ block: number; keys: string; v: number }> {

--- a/src/features/messaging/model/__tests__/decrypt-queue.test.ts
+++ b/src/features/messaging/model/__tests__/decrypt-queue.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Sequential decrypt queue — serialises expensive file decryption across
+ * concurrent download calls. On old Android WebViews (Android 7/8 Xiaomi)
+ * running decryptFile on 10 inbound images at once saturates the CPU and
+ * the main thread freezes for tens of seconds. Running them one-at-a-time
+ * keeps the UI responsive.
+ *
+ * Mirrors bastyon-chat's `decryptFileQueue` / `f.processArray` pattern
+ * (pcrypto.js:1256-1273).
+ */
+import { describe, it, expect } from "vitest";
+import { enqueueDecrypt } from "../decrypt-queue";
+
+describe("enqueueDecrypt — sequential execution", () => {
+  it("runs tasks one at a time even when scheduled concurrently", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const makeTask = (ms: number, tag: string) => async () => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, ms));
+      inFlight--;
+      return tag;
+    };
+
+    const p1 = enqueueDecrypt(makeTask(20, "a"));
+    const p2 = enqueueDecrypt(makeTask(20, "b"));
+    const p3 = enqueueDecrypt(makeTask(20, "c"));
+
+    const results = await Promise.all([p1, p2, p3]);
+    expect(results).toEqual(["a", "b", "c"]);
+    // Parallel execution would yield maxInFlight >= 2; sequential caps at 1.
+    expect(maxInFlight).toBe(1);
+  });
+
+  it("preserves enqueue order under rapid scheduling", async () => {
+    const order: number[] = [];
+    const tasks = Array.from({ length: 5 }, (_, i) => async () => {
+      // Slight per-task delay so out-of-order resolution would surface.
+      await new Promise((r) => setTimeout(r, 5));
+      order.push(i);
+      return i;
+    });
+    const results = await Promise.all(tasks.map((t) => enqueueDecrypt(t)));
+    expect(results).toEqual([0, 1, 2, 3, 4]);
+    expect(order).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it("survives a failing task without poisoning the queue", async () => {
+    const p1 = enqueueDecrypt<string>(async () => {
+      throw new Error("boom");
+    });
+    await expect(p1).rejects.toThrow("boom");
+
+    // Follow-up task must still execute.
+    const p2 = enqueueDecrypt<string>(async () => "ok");
+    await expect(p2).resolves.toBe("ok");
+  });
+});

--- a/src/features/messaging/model/decrypt-queue.ts
+++ b/src/features/messaging/model/decrypt-queue.ts
@@ -1,0 +1,26 @@
+/**
+ * Sequential queue for file-decrypt tasks.
+ *
+ * Running decryptFile on many inbound attachments concurrently saturates
+ * the CPU on older Android WebViews (observed freezes on Xiaomi Android 7
+ * and similar low-end devices, see bug reports #306, #370). Serialising
+ * the work keeps the main thread responsive — decryption on one file
+ * usually finishes fast enough that the user-perceived lag is fine.
+ *
+ * Mirrors bastyon-chat's `decryptFileQueue` / `f.processArray` pattern
+ * (src/application/pcrypto.js:1256-1273).
+ */
+
+let tail: Promise<unknown> = Promise.resolve();
+
+/** Enqueue `task` behind every previously-enqueued decrypt task. Returns
+ *  a promise that resolves/rejects with the task's result. Failures do
+ *  NOT poison the chain — the next enqueue runs regardless. */
+export function enqueueDecrypt<T>(task: () => Promise<T>): Promise<T> {
+  const run = tail.then(task, task);
+  // Swallow rejections on the shared tail so a failure doesn't pollute
+  // the chain. Consumers still see the rejection via the returned
+  // promise (`run`), which is not the same object.
+  tail = run.catch(() => undefined);
+  return run;
+}

--- a/src/features/messaging/model/use-file-download.ts
+++ b/src/features/messaging/model/use-file-download.ts
@@ -6,6 +6,7 @@ import { hexEncode } from "@/shared/lib/matrix/functions";
 import { isNative, isElectron } from "@/shared/lib/platform";
 import { useBugReport } from "@/features/bug-report";
 import { tRaw } from "@/shared/lib/i18n";
+import { enqueueDecrypt } from "./decrypt-queue";
 
 interface FileDownloadState {
   loading: boolean;
@@ -62,25 +63,32 @@ async function fetchWithTimeout(url: string, signal?: AbortSignal): Promise<Resp
 }
 
 /** Download and optionally decrypt a file from the Matrix server.
- *  Retries up to MAX_RETRIES times on transient failures (network, crypto not ready). */
+ *  Retries up to MAX_RETRIES times on transient failures (network, crypto not ready).
+ *
+ *  @param signal — optional external AbortSignal. When this signal aborts
+ *                  the in-flight fetch is torn down immediately and no
+ *                  further retry attempts are made. */
 async function downloadAndDecrypt(
   fileInfo: FileInfo,
   roomId: string,
   senderId: string,
   timestamp: number,
+  signal?: AbortSignal,
 ): Promise<Blob> {
   if (!fileInfo.url) throw new Error("No file URL");
+  if (signal?.aborted) throw new DOMException("Download cancelled", "AbortError");
 
   let lastError: unknown;
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    if (signal?.aborted) throw new DOMException("Download cancelled", "AbortError");
     if (attempt > 0) {
       await new Promise((r) => setTimeout(r, RETRY_DELAYS[attempt - 1] ?? 6000));
     }
 
     try {
       // Download the file (with hard timeout to avoid indefinite MIUI/Tor stalls)
-      const response = await fetchWithTimeout(fileInfo.url);
+      const response = await fetchWithTimeout(fileInfo.url, signal);
       if (!response.ok) {
         const err = new Error(`Download failed: ${response.status}`);
         // Mark non-retriable codes so the catch block below can throw immediately
@@ -112,13 +120,22 @@ async function downloadAndDecrypt(
         };
 
         const decryptKey = await roomCrypto.decryptKey(event);
-        const decryptedFile = await roomCrypto.decryptFile(blob, decryptKey);
+        // Serialise decryption: parallel decryptFile calls on low-end
+        // Android WebViews saturate the CPU and freeze the UI.
+        // Pass the declared plaintext MIME so new ciphertexts (stored as
+        // application/octet-stream) restore with the right type instead
+        // of falling through to a generic binary fallback.
+        const decryptedFile = await enqueueDecrypt(() =>
+          roomCrypto.decryptFile(blob, decryptKey, fileInfo.type),
+        );
         blob = decryptedFile;
       }
 
       return blob;
     } catch (e) {
       lastError = e;
+      // User cancel is terminal — no retries.
+      if (e instanceof DOMException && e.name === "AbortError") throw e;
       // Don't retry on permanent errors (missing URL, 4xx client errors)
       if (e instanceof Error) {
         if (e.message === "No file URL") throw e;
@@ -234,8 +251,11 @@ export function useFileDownload() {
     return states.value[eventId];
   };
 
-  /** Download (and decrypt if needed) a file message */
-  const download = async (message: Message) => {
+  /** Download (and decrypt if needed) a file message.
+   *  @param signal — optional AbortSignal. Callers that want the download
+   *                  to stop when their scope unmounts (e.g. MediaGrid on
+   *                  chat switch) should pass `onScopeDispose`-tied signal. */
+  const download = async (message: Message, signal?: AbortSignal) => {
     if (!message.fileInfo) return null;
 
     // Use _key (stable clientId) if available, otherwise fall back to id.
@@ -261,6 +281,7 @@ export function useFileDownload() {
         message.roomId,
         message.senderId,
         message.timestamp,
+        signal,
       );
       const mimeType = message.fileInfo.type || "application/octet-stream";
       const typedBlob = new Blob([blob], { type: mimeType });
@@ -272,6 +293,11 @@ export function useFileDownload() {
 
       return url;
     } catch (e) {
+      // User-initiated cancel is not an error for bug reporting — just bail.
+      if (e instanceof DOMException && e.name === "AbortError") {
+        state.error = null;
+        return null;
+      }
       console.error("[use-file-download] download error:", e);
       useBugReport().open({ context: tRaw("bugReport.ctx.fileDownload"), error: e });
       state.error = String(e);

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -336,195 +336,51 @@ export function useMessages() {
 
     const localBlobUrl = URL.createObjectURL(file);
 
-    // Dexie-first path: insert into Dexie immediately, upload async
-    if (isChatDbReady()) {
-      try {
-        const dbKit = getChatDb();
-        const localMsg = await dbKit.messages.createLocal({
-          roomId,
-          senderId: authStore.address ?? "",
-          content: file.name,
-          type: msgType,
-          fileInfo: {
-            name: file.name,
-            type: mime,
-            size: file.size,
-            url: localBlobUrl,
-          },
-          localBlobUrl,
-          uploadProgress: 0,
-        });
-
-        // Async upload pipeline (with abort support)
-        (async () => {
-          const controller = registerUploadAbort(localMsg.clientId);
-          const { signal } = controller;
-
-          try {
-            const checkAbort = () => {
-              if (signal.aborted) throw new DOMException("Upload cancelled", "AbortError");
-            };
-
-            // Phase 1: Encrypt (fast, fails loudly if crypto is stuck)
-            checkAbort();
-            await dbKit.db.messages.where("clientId").equals(localMsg.clientId)
-              .modify({ uploadPhase: "encrypting" });
-
-            const roomCrypto = authStore.pcrypto?.rooms[roomId] as PcryptoRoomInstance | undefined;
-
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const fileInfo: Record<string, any> = {
-              name: file.name,
-              type: mime,
-              size: file.size,
-            };
-
-            let fileToUpload: Blob = file;
-
-            if (roomCrypto?.canBeEncrypt()) {
-              const encrypted = await withTimeout(
-                roomCrypto.encryptFile(file),
-                ENCRYPT_TIMEOUT_MS,
-                "File encrypt",
-              );
-              fileInfo.secrets = encrypted.secrets;
-              fileToUpload = encrypted.file;
-            }
-
-            // Phase 2: Upload (long timeout — large files on slow networks)
-            checkAbort();
-            await dbKit.db.messages.where("clientId").equals(localMsg.clientId)
-              .modify({ uploadPhase: "uploading" });
-
-            const onProgress = makeThrottledProgress((percent) => {
-              dbKit.messages.updateUploadProgress(localMsg.clientId, percent);
-            });
-            const url = await withTimeout(
-              matrixService.uploadContent(fileToUpload, onProgress, signal),
-              UPLOAD_TIMEOUT_MS,
-              "File upload",
-            );
-            fileInfo.url = url;
-
-            // Phase 3: Send event (short — just a Matrix PUT)
-            checkAbort();
-            await dbKit.db.messages.where("clientId").equals(localMsg.clientId)
-              .modify({ uploadPhase: "sending_event", uploadProgress: 100 });
-
-            const body = JSON.stringify(fileInfo);
-            const serverEventId = await withTimeout(
-              matrixService.sendEncryptedText(roomId, {
-                body,
-                msgtype: "m.file",
-              }, localMsg.clientId),
-              SEND_EVENT_TIMEOUT_MS,
-              "File send event",
-            );
-
-            const serverFileInfo: FileInfo = {
-              name: file.name,
-              type: mime,
-              size: file.size,
-              url,
-              ...(fileInfo.secrets ? { secrets: fileInfo.secrets } : {}),
-            };
-            await dbKit.messages.confirmMediaSent(localMsg.clientId, serverEventId, serverFileInfo, roomId);
-
-            invalidateDownloadCache(localMsg.clientId);
-            setTimeout(() => URL.revokeObjectURL(localBlobUrl), 5000);
-          } catch (e) {
-            if (e instanceof DOMException && e.name === "AbortError") {
-              await handleUploadCancelled(dbKit, localMsg.clientId, localBlobUrl);
-            } else {
-              console.error("Failed to send file (Dexie path):", e);
-              // Only mark failed if not already confirmed (race: timeout fires after confirmMediaSent)
-              const current = await dbKit.messages.getByClientId(localMsg.clientId);
-              if (current && current.status !== "synced") {
-                await dbKit.db.messages.where("clientId").equals(localMsg.clientId).modify({
-                  status: "failed" as LocalMessageStatus,
-                  uploadProgress: undefined,
-                  uploadPhase: undefined,
-                });
-              }
-            }
-          } finally {
-            unregisterUploadAbort(localMsg.clientId);
-          }
-        })();
-
-        return;
-      } catch (e) {
-        console.warn("[use-messages] Dexie sendFile failed, falling back to legacy:", e);
-      }
+    if (!isChatDbReady()) {
+      // Without Dexie we have no crash-safe queue — dropping the send is
+      // safer than leaking a never-completing toast on a dead pipeline.
+      console.error("[use-messages] sendFile: chat DB not ready");
+      URL.revokeObjectURL(localBlobUrl);
+      return;
     }
 
-    // Legacy path
-    sendFileLegacy(file, roomId, mime, msgType, localBlobUrl, matrixService);
-  };
-
-  /** Legacy sendFile — fallback when Dexie is not ready */
-  const sendFileLegacy = async (
-    file: File,
-    roomId: string,
-    fileMime: string,
-    msgType: MessageType,
-    localBlobUrl: string,
-    matrixService: ReturnType<typeof getMatrixClientService>,
-  ) => {
-    const tempId = `msg_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
-    const message: Message = {
-      id: tempId,
+    const dbKit = getChatDb();
+    const localMsg = await dbKit.messages.createLocal({
       roomId,
       senderId: authStore.address ?? "",
       content: file.name,
-      timestamp: Date.now(),
-      status: MessageStatus.sending,
       type: msgType,
       fileInfo: {
         name: file.name,
-        type: fileMime,
+        type: mime,
         size: file.size,
         url: localBlobUrl,
       },
-    };
-    chatStore.addMessage(roomId, message);
+      localBlobUrl,
+      uploadProgress: 0,
+    });
 
-    try {
-      const roomCrypto = authStore.pcrypto?.rooms[roomId] as PcryptoRoomInstance | undefined;
+    // Persist blob so SyncEngine.syncSendFile can resume after a crash.
+    const attachmentId = await dbKit.db.attachments.add({
+      messageLocalId: localMsg.localId!,
+      fileName: file.name,
+      mimeType: mime,
+      size: file.size,
+      localBlob: file,
+      status: "local",
+    });
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const fileInfo: Record<string, any> = {
-        name: file.name,
-        type: fileMime,
-        size: file.size,
-      };
-
-      let fileToUpload: Blob = file;
-
-      if (roomCrypto?.canBeEncrypt()) {
-        const encrypted = await roomCrypto.encryptFile(file);
-        fileInfo.secrets = encrypted.secrets;
-        fileToUpload = encrypted.file;
-      }
-
-      const url = await matrixService.uploadContent(fileToUpload);
-      fileInfo.url = url;
-
-      const body = JSON.stringify(fileInfo);
-      const serverEventId = await matrixService.sendEncryptedText(roomId, {
-        body,
+    await dbKit.syncEngine.enqueue(
+      "send_file",
+      roomId,
+      {
+        fileName: file.name,
+        mimeType: mime,
         msgtype: "m.file",
-      });
-
-      if (serverEventId) {
-        chatStore.updateMessageIdAndStatus(roomId, tempId, serverEventId, MessageStatus.sent);
-      } else {
-        chatStore.updateMessageStatus(roomId, tempId, MessageStatus.sent);
-      }
-    } catch (e) {
-      console.error("Failed to send file:", e);
-      chatStore.updateMessageStatus(roomId, tempId, MessageStatus.failed);
-    }
+        attachmentId,
+      },
+      localMsg.clientId,
+    );
   };
 
   /** Send an image message (m.image event — compatible with bastyon-chat) */
@@ -536,167 +392,24 @@ export function useMessages() {
     if (!matrixService.isReady()) return;
 
     const dimensions = await getImageDimensions(file);
+    const imageMime = resolveMime(file);
     const localBlobUrl = URL.createObjectURL(file);
 
-    // Dexie-first path
-    if (isChatDbReady()) {
-      try {
-        const dbKit = getChatDb();
-        const localMsg = await dbKit.messages.createLocal({
-          roomId,
-          senderId: authStore.address ?? "",
-          content: options.caption || file.name,
-          type: MessageType.image,
-          fileInfo: {
-            name: file.name,
-            type: file.type,
-            size: file.size,
-            url: localBlobUrl,
-            w: dimensions.w,
-            h: dimensions.h,
-            caption: options.caption,
-            captionAbove: options.captionAbove,
-          },
-          localBlobUrl,
-          uploadProgress: 0,
-        });
-
-        // Async upload pipeline (with abort support)
-        (async () => {
-          const controller = registerUploadAbort(localMsg.clientId);
-          const { signal } = controller;
-
-          try {
-            const checkAbort = () => {
-              if (signal.aborted) throw new DOMException("Upload cancelled", "AbortError");
-            };
-
-            const imageMime = resolveMime(file);
-
-            // Phase 1: Encrypt
-            checkAbort();
-            await dbKit.db.messages.where("clientId").equals(localMsg.clientId)
-              .modify({ uploadPhase: "encrypting" });
-
-            const roomCrypto = authStore.pcrypto?.rooms[roomId] as PcryptoRoomInstance | undefined;
-            let fileToUpload: Blob = file;
-            let secrets: Record<string, unknown> | undefined;
-
-            if (roomCrypto?.canBeEncrypt()) {
-              const encrypted = await withTimeout(
-                roomCrypto.encryptFile(file),
-                ENCRYPT_TIMEOUT_MS,
-                "Image encrypt",
-              );
-              secrets = encrypted.secrets;
-              fileToUpload = encrypted.file;
-            }
-
-            // Phase 2: Upload
-            checkAbort();
-            await dbKit.db.messages.where("clientId").equals(localMsg.clientId)
-              .modify({ uploadPhase: "uploading" });
-
-            const onProgress = makeThrottledProgress((percent) => {
-              dbKit.messages.updateUploadProgress(localMsg.clientId, percent);
-            });
-            const url = await withTimeout(
-              matrixService.uploadContent(fileToUpload, onProgress, signal),
-              UPLOAD_TIMEOUT_MS,
-              "Image upload",
-            );
-
-            // Phase 3: Send event
-            checkAbort();
-            await dbKit.db.messages.where("clientId").equals(localMsg.clientId)
-              .modify({ uploadPhase: "sending_event", uploadProgress: 100 });
-
-            const content: Record<string, unknown> = {
-              body: options.caption || "Image",
-              msgtype: "m.image",
-              url,
-              info: {
-                w: dimensions.w,
-                h: dimensions.h,
-                mimetype: imageMime,
-                size: file.size,
-                ...(secrets ? { secrets } : {}),
-                ...(options.caption ? { caption: options.caption } : {}),
-                ...(options.captionAbove != null ? { captionAbove: options.captionAbove } : {}),
-              },
-            };
-
-            const serverEventId = await withTimeout(
-              matrixService.sendEncryptedText(roomId, content, localMsg.clientId),
-              SEND_EVENT_TIMEOUT_MS,
-              "Image send event",
-            );
-
-            const serverFileInfo: FileInfo = {
-              name: file.name,
-              type: imageMime,
-              size: file.size,
-              url,
-              w: dimensions.w,
-              h: dimensions.h,
-              caption: options.caption,
-              captionAbove: options.captionAbove,
-              ...(secrets ? { secrets: secrets as FileInfo["secrets"] } : {}),
-            };
-            await dbKit.messages.confirmMediaSent(localMsg.clientId, serverEventId, serverFileInfo, roomId);
-
-            invalidateDownloadCache(localMsg.clientId);
-            setTimeout(() => URL.revokeObjectURL(localBlobUrl), 5000);
-          } catch (e) {
-            if (e instanceof DOMException && e.name === "AbortError") {
-              await handleUploadCancelled(dbKit, localMsg.clientId, localBlobUrl);
-            } else {
-              console.error("Failed to send image (Dexie path):", e);
-              const current = await dbKit.messages.getByClientId(localMsg.clientId);
-              if (current && current.status !== "synced") {
-                await dbKit.db.messages.where("clientId").equals(localMsg.clientId).modify({
-                  status: "failed" as LocalMessageStatus,
-                  uploadProgress: undefined,
-                  uploadPhase: undefined,
-                });
-              }
-            }
-          } finally {
-            unregisterUploadAbort(localMsg.clientId);
-          }
-        })();
-
-        return;
-      } catch (e) {
-        console.warn("[use-messages] Dexie sendImage failed, falling back to legacy:", e);
-      }
+    if (!isChatDbReady()) {
+      console.error("[use-messages] sendImage: chat DB not ready");
+      URL.revokeObjectURL(localBlobUrl);
+      return;
     }
 
-    // Legacy path
-    sendImageLegacy(file, roomId, dimensions, localBlobUrl, options, matrixService);
-  };
-
-  /** Legacy sendImage — fallback when Dexie is not ready */
-  const sendImageLegacy = async (
-    file: File,
-    roomId: string,
-    dimensions: { w: number; h: number },
-    localBlobUrl: string,
-    options: { caption?: string; captionAbove?: boolean },
-    matrixService: ReturnType<typeof getMatrixClientService>,
-  ) => {
-    const tempId = `msg_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
-    const message: Message = {
-      id: tempId,
+    const dbKit = getChatDb();
+    const localMsg = await dbKit.messages.createLocal({
       roomId,
       senderId: authStore.address ?? "",
       content: options.caption || file.name,
-      timestamp: Date.now(),
-      status: MessageStatus.sending,
       type: MessageType.image,
       fileInfo: {
         name: file.name,
-        type: file.type,
+        type: imageMime,
         size: file.size,
         url: localBlobUrl,
         w: dimensions.w,
@@ -704,48 +417,39 @@ export function useMessages() {
         caption: options.caption,
         captionAbove: options.captionAbove,
       },
-    };
-    chatStore.addMessage(roomId, message);
+      localBlobUrl,
+      uploadProgress: 0,
+    });
 
-    try {
-      const roomCrypto = authStore.pcrypto?.rooms[roomId] as PcryptoRoomInstance | undefined;
+    const attachmentId = await dbKit.db.attachments.add({
+      messageLocalId: localMsg.localId!,
+      fileName: file.name,
+      mimeType: imageMime,
+      size: file.size,
+      localBlob: file,
+      status: "local",
+    });
 
-      let fileToUpload: Blob = file;
-      let secrets: Record<string, unknown> | undefined;
-
-      if (roomCrypto?.canBeEncrypt()) {
-        const encrypted = await roomCrypto.encryptFile(file);
-        secrets = encrypted.secrets;
-        fileToUpload = encrypted.file;
-      }
-
-      const url = await matrixService.uploadContent(fileToUpload);
-
-      const content: Record<string, unknown> = {
-        body: options.caption || "Image",
+    await dbKit.syncEngine.enqueue(
+      "send_file",
+      roomId,
+      {
+        fileName: file.name,
+        mimeType: imageMime,
         msgtype: "m.image",
-        url,
-        info: {
+        attachmentId,
+        body: options.caption || "Image",
+        eventInfo: {
           w: dimensions.w,
           h: dimensions.h,
-          mimetype: file.type,
+          mimetype: imageMime,
           size: file.size,
-          ...(secrets ? { secrets } : {}),
           ...(options.caption ? { caption: options.caption } : {}),
           ...(options.captionAbove != null ? { captionAbove: options.captionAbove } : {}),
         },
-      };
-
-      const serverEventId = await matrixService.sendEncryptedText(roomId, content);
-      if (serverEventId) {
-        chatStore.updateMessageIdAndStatus(roomId, tempId, serverEventId, MessageStatus.sent);
-      } else {
-        chatStore.updateMessageStatus(roomId, tempId, MessageStatus.sent);
-      }
-    } catch (e) {
-      console.error("Failed to send image:", e);
-      chatStore.updateMessageStatus(roomId, tempId, MessageStatus.failed);
-    }
+      },
+      localMsg.clientId,
+    );
   };
 
   /** Send an audio/voice message (m.audio event — compatible with bastyon-chat) */
@@ -756,210 +460,62 @@ export function useMessages() {
     const matrixService = getMatrixClientService();
     if (!matrixService.isReady()) return;
 
+    const audioMime = resolveMime(file);
     const localBlobUrl = URL.createObjectURL(file);
 
-    // Dexie-first path
-    if (isChatDbReady()) {
-      try {
-        const dbKit = getChatDb();
-        const localMsg = await dbKit.messages.createLocal({
-          roomId,
-          senderId: authStore.address ?? "",
-          content: "Audio",
-          type: MessageType.audio,
-          fileInfo: {
-            name: file.name,
-            type: file.type,
-            size: file.size,
-            url: localBlobUrl,
-            duration: options.duration,
-            waveform: options.waveform,
-          },
-          localBlobUrl,
-          uploadProgress: 0,
-        });
-
-        // Async upload pipeline (with abort support)
-        (async () => {
-          const controller = registerUploadAbort(localMsg.clientId);
-          const { signal } = controller;
-
-          try {
-            const checkAbort = () => {
-              if (signal.aborted) throw new DOMException("Upload cancelled", "AbortError");
-            };
-
-            const audioMime = resolveMime(file);
-
-            // Phase 1: Encrypt
-            checkAbort();
-            await dbKit.db.messages.where("clientId").equals(localMsg.clientId)
-              .modify({ uploadPhase: "encrypting" });
-
-            const roomCrypto = authStore.pcrypto?.rooms[roomId] as PcryptoRoomInstance | undefined;
-
-            let fileToUpload: Blob = file;
-            let secrets: Record<string, unknown> | undefined;
-
-            if (roomCrypto?.canBeEncrypt()) {
-              const encrypted = await withTimeout(
-                roomCrypto.encryptFile(file),
-                ENCRYPT_TIMEOUT_MS,
-                "Audio encrypt",
-              );
-              secrets = encrypted.secrets;
-              fileToUpload = encrypted.file;
-            }
-
-            // Phase 2: Upload
-            checkAbort();
-            await dbKit.db.messages.where("clientId").equals(localMsg.clientId)
-              .modify({ uploadPhase: "uploading" });
-
-            const onProgress = makeThrottledProgress((percent) => {
-              dbKit.messages.updateUploadProgress(localMsg.clientId, percent);
-            });
-            const url = await withTimeout(
-              matrixService.uploadContent(fileToUpload, onProgress, signal),
-              UPLOAD_TIMEOUT_MS,
-              "Audio upload",
-            );
-
-            // Phase 3: Send event
-            checkAbort();
-            await dbKit.db.messages.where("clientId").equals(localMsg.clientId)
-              .modify({ uploadPhase: "sending_event", uploadProgress: 100 });
-
-            const intWaveform = options.waveform?.map((v: number) => Math.round(v * 1024));
-
-            const content: Record<string, unknown> = {
-              body: "Audio",
-              msgtype: "m.audio",
-              url,
-              info: {
-                mimetype: audioMime,
-                size: Math.round(file.size),
-                duration: options.duration ? Math.round(options.duration * 1000) : undefined,
-                waveform: intWaveform,
-                ...(secrets ? { secrets } : {}),
-              },
-            };
-
-            const serverEventId = await withTimeout(
-              matrixService.sendEncryptedText(roomId, content, localMsg.clientId),
-              SEND_EVENT_TIMEOUT_MS,
-              "Audio send event",
-            );
-
-            const serverFileInfo: FileInfo = {
-              name: file.name,
-              type: audioMime,
-              size: file.size,
-              url,
-              duration: options.duration,
-              waveform: options.waveform,
-              ...(secrets ? { secrets: secrets as FileInfo["secrets"] } : {}),
-            };
-            await dbKit.messages.confirmMediaSent(localMsg.clientId, serverEventId, serverFileInfo, roomId);
-
-            invalidateDownloadCache(localMsg.clientId);
-            setTimeout(() => URL.revokeObjectURL(localBlobUrl), 5000);
-          } catch (e) {
-            if (e instanceof DOMException && e.name === "AbortError") {
-              await handleUploadCancelled(dbKit, localMsg.clientId, localBlobUrl);
-            } else {
-              console.error("Failed to send audio (Dexie path):", e);
-              const current = await dbKit.messages.getByClientId(localMsg.clientId);
-              if (current && current.status !== "synced") {
-                await dbKit.db.messages.where("clientId").equals(localMsg.clientId).modify({
-                  status: "failed" as LocalMessageStatus,
-                  uploadProgress: undefined,
-                  uploadPhase: undefined,
-                });
-              }
-            }
-          } finally {
-            unregisterUploadAbort(localMsg.clientId);
-          }
-        })();
-
-        return;
-      } catch (e) {
-        console.warn("[use-messages] Dexie sendAudio failed, falling back to legacy:", e);
-      }
+    if (!isChatDbReady()) {
+      console.error("[use-messages] sendAudio: chat DB not ready");
+      URL.revokeObjectURL(localBlobUrl);
+      return;
     }
 
-    // Legacy path
-    sendAudioLegacy(file, roomId, localBlobUrl, options, matrixService);
-  };
-
-  /** Legacy sendAudio — fallback when Dexie is not ready */
-  const sendAudioLegacy = async (
-    file: File,
-    roomId: string,
-    localBlobUrl: string,
-    options: { duration?: number; waveform?: number[] },
-    matrixService: ReturnType<typeof getMatrixClientService>,
-  ) => {
-    const tempId = `msg_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
-    const message: Message = {
-      id: tempId,
+    const dbKit = getChatDb();
+    const localMsg = await dbKit.messages.createLocal({
       roomId,
       senderId: authStore.address ?? "",
       content: "Audio",
-      timestamp: Date.now(),
-      status: MessageStatus.sending,
       type: MessageType.audio,
       fileInfo: {
         name: file.name,
-        type: file.type,
+        type: audioMime,
         size: file.size,
         url: localBlobUrl,
         duration: options.duration,
         waveform: options.waveform,
       },
-    };
-    chatStore.addMessage(roomId, message);
+      localBlobUrl,
+      uploadProgress: 0,
+    });
 
-    try {
-      const roomCrypto = authStore.pcrypto?.rooms[roomId] as PcryptoRoomInstance | undefined;
+    const attachmentId = await dbKit.db.attachments.add({
+      messageLocalId: localMsg.localId!,
+      fileName: file.name,
+      mimeType: audioMime,
+      size: file.size,
+      localBlob: file,
+      status: "local",
+    });
 
-      let fileToUpload: Blob = file;
-      let secrets: Record<string, unknown> | undefined;
+    const intWaveform = options.waveform?.map((v: number) => Math.round(v * 1024));
 
-      if (roomCrypto?.canBeEncrypt()) {
-        const encrypted = await roomCrypto.encryptFile(file);
-        secrets = encrypted.secrets;
-        fileToUpload = encrypted.file;
-      }
-
-      const url = await matrixService.uploadContent(fileToUpload);
-
-      const intWaveform = options.waveform?.map((v: number) => Math.round(v * 1024));
-
-      const content: Record<string, unknown> = {
-        body: "Audio",
+    await dbKit.syncEngine.enqueue(
+      "send_file",
+      roomId,
+      {
+        fileName: file.name,
+        mimeType: audioMime,
         msgtype: "m.audio",
-        url,
-        info: {
-          mimetype: file.type,
+        attachmentId,
+        body: "Audio",
+        eventInfo: {
+          mimetype: audioMime,
           size: Math.round(file.size),
           duration: options.duration ? Math.round(options.duration * 1000) : undefined,
           waveform: intWaveform,
-          ...(secrets ? { secrets } : {}),
         },
-      };
-
-      const serverEventId = await matrixService.sendEncryptedText(roomId, content);
-      if (serverEventId) {
-        chatStore.updateMessageIdAndStatus(roomId, tempId, serverEventId, MessageStatus.sent);
-      } else {
-        chatStore.updateMessageStatus(roomId, tempId, MessageStatus.sent);
-      }
-    } catch (e) {
-      console.error("Failed to send audio:", e);
-      chatStore.updateMessageStatus(roomId, tempId, MessageStatus.failed);
-    }
+      },
+      localMsg.clientId,
+    );
   };
 
   /** Send a video circle (video note) message — circular video like Telegram */
@@ -2418,8 +1974,19 @@ export function useMessages() {
     // Can only cancel pending or failed uploads
     if (localMsg.status !== "pending" && localMsg.status !== "failed") return;
 
-    // Abort HTTP request if in-flight
+    // Two abort paths coexist while sendVideoCircle / sendGif still use
+    // the in-component IIFE + upload-abort-registry. sendFile/Image/Audio
+    // route through SyncEngine — abort signal lives there.
     abortUpload(mKey);
+    await dbKit.syncEngine.cancelMediaUpload(mKey);
+
+    // Race guard: if Phase 3 (sendEncryptedText) resolved between the
+    // abort signal firing and our control returning here, the server
+    // already accepted the event and confirmSent flipped the row to
+    // synced. Flipping an already-synced message to "cancelled" would
+    // make a real sent message vanish from the UI three seconds later.
+    const fresh = await dbKit.messages.getByClientId(mKey);
+    if (fresh && (fresh.status === "synced" || fresh.eventId)) return;
 
     // Force cleanup (in case abort didn't trigger catch — e.g. between phases)
     await handleUploadCancelled(dbKit, mKey, localMsg.localBlobUrl);

--- a/src/shared/lib/local-db/__tests__/sync-engine-media.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-media.test.ts
@@ -1,0 +1,407 @@
+/**
+ * SyncEngine media routing regression:
+ *   - syncSendFile must stream upload progress into the Dexie message so
+ *     the UI progress bar updates mid-upload (previously done inline in the
+ *     IIFE pipeline; must not regress when the pipeline moves into the
+ *     queue for crash-recovery).
+ *   - syncSendFile must wire the upload through `uploadContent(…, progress,
+ *     signal)` (HTTP URL path) — NOT `uploadContentMxc` — so the Abort
+ *     plumbing and progress callback reach the Matrix SDK.
+ *   - SyncEngine.cancelMediaUpload(clientId) must abort the in-flight
+ *     upload AND delete the pending op so recoverStrandedOps does not
+ *     resurrect a user-cancelled file after restart.
+ *   - recoverStrandedOps(): a send_file op left in status="syncing" after
+ *     a WebView crash must be reset to "pending" so the next processTick
+ *     picks it up. Message status is reset too so the UI does not stick
+ *     on "sending".
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Dexie from "dexie";
+import "fake-indexeddb/auto";
+import { SyncEngine } from "../sync-engine";
+import type { PendingOperation, LocalMessage, LocalRoom, LocalAttachment } from "../schema";
+
+// --- Mocks -------------------------------------------------------------------
+
+const mockMatrix = {
+  sendEncryptedText: vi.fn<
+    (roomId: string, content: unknown, txnId?: string) => Promise<string>
+  >(async () => "$server_event_id"),
+  sendText: vi.fn<(roomId: string, text: string, txnId?: string) => Promise<string>>(
+    async () => "$server_event_id",
+  ),
+  sendReaction: vi.fn<(roomId: string, eventId: string, emoji: string) => Promise<string>>(
+    async () => "$reaction_id",
+  ),
+  redactEvent: vi.fn<(roomId: string, eventId: string) => Promise<void>>(async () => undefined),
+  sendPollStart: vi.fn<(roomId: string, content: unknown) => Promise<string>>(
+    async () => "$poll_id",
+  ),
+  sendPollResponse: vi.fn<(roomId: string, content: unknown) => Promise<void>>(
+    async () => undefined,
+  ),
+  /** Upload that reports progress and honours AbortSignal. The production
+   *  path uses this — not `uploadContentMxc` — so the SyncEngine handler
+   *  must go through the same function. */
+  uploadContent: vi.fn<
+    (
+      blob: Blob,
+      progress?: (p: { loaded: number; total: number }) => void,
+      signal?: AbortSignal,
+    ) => Promise<string>
+  >(async (_blob, progress) => {
+    // Simulate three progress beats with hard-coded totals so happy-dom's
+    // Blob.size quirks don't flake the test. The SyncEngine throttle drops
+    // mid-cycle beats within 500ms — only the last (isFinal) must land.
+    progress?.({ loaded: 300, total: 900 });
+    progress?.({ loaded: 600, total: 900 });
+    progress?.({ loaded: 900, total: 900 });
+    return "https://server/_matrix/media/r0/download/server/abc123";
+  }),
+  uploadContentMxc: vi.fn<(blob: Blob) => Promise<string>>(async () => "mxc://server/file"),
+};
+
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: () => mockMatrix,
+}));
+
+// --- Test DB -----------------------------------------------------------------
+
+class TestDb extends Dexie {
+  messages!: Dexie.Table<LocalMessage, number>;
+  rooms!: Dexie.Table<LocalRoom, string>;
+  pendingOps!: Dexie.Table<PendingOperation, number>;
+  attachments!: Dexie.Table<LocalAttachment, number>;
+  users!: Dexie.Table<{ address: string }, string>;
+  syncState!: Dexie.Table<{ key: string; value: string | number }, string>;
+  decryptionQueue!: Dexie.Table<{ id?: number; status: string }, number>;
+  listenedMessages!: Dexie.Table<{ messageId: string }, string>;
+
+  constructor(name: string) {
+    super(name, { indexedDB, IDBKeyRange });
+    this.version(1).stores({
+      messages:
+        "++localId, eventId, clientId, [roomId+timestamp], [roomId+status], senderId",
+      rooms: "id, updatedAt, membership, isDeleted",
+      pendingOps:
+        "++id, [roomId+createdAt], status, clientId, [status+nextAttemptAt]",
+      attachments: "++id, messageLocalId, status",
+      users: "address, updatedAt",
+      syncState: "key",
+      decryptionQueue: "++id, status, [status+nextAttemptAt]",
+      listenedMessages: "messageId",
+    });
+  }
+}
+
+interface Harness {
+  db: TestDb;
+  engine: SyncEngine;
+  messageRepo: {
+    confirmSent: ReturnType<typeof vi.fn>;
+    updateStatus: ReturnType<typeof vi.fn>;
+    getByEventId: ReturnType<typeof vi.fn>;
+    updateReactions: ReturnType<typeof vi.fn>;
+    getByClientId: ReturnType<typeof vi.fn>;
+    updateUploadProgress: ReturnType<typeof vi.fn>;
+  };
+  roomRepo: { updateRoom: ReturnType<typeof vi.fn> };
+  getRoomCrypto: ReturnType<typeof vi.fn>;
+}
+
+function makeHarness(name: string, encrypted: boolean): Harness {
+  const db = new TestDb(name);
+  const messageRepo = {
+    confirmSent: vi.fn(async () => undefined),
+    updateStatus: vi.fn(async () => undefined),
+    getByEventId: vi.fn(async () => undefined),
+    updateReactions: vi.fn(async () => undefined),
+    getByClientId: vi.fn(async () => undefined),
+    updateUploadProgress: vi.fn(async () => undefined),
+  };
+  const roomRepo = { updateRoom: vi.fn(async () => undefined) };
+  const roomCrypto = encrypted
+    ? {
+        canBeEncrypt: () => true,
+        requiresEncryption: () => true,
+        encryptFile: async (blob: Blob) => ({
+          file: new File([blob], "enc", { type: "application/octet-stream" }),
+          secrets: { keys: "k", block: 10, v: 2 },
+        }),
+      }
+    : undefined;
+  const getRoomCrypto = vi.fn(async () => roomCrypto);
+  const engine = new SyncEngine(
+    db as never,
+    messageRepo as never,
+    roomRepo as never,
+    getRoomCrypto as never,
+  );
+  return { db, engine, messageRepo, roomRepo, getRoomCrypto };
+}
+
+async function seedFileOp(
+  db: TestDb,
+  opts: { clientId: string; encrypted: boolean; attachmentId: number },
+): Promise<number> {
+  return db.pendingOps.add({
+    type: "send_file",
+    roomId: "!room:server",
+    payload: {
+      fileName: "photo.jpg",
+      mimeType: "image/jpeg",
+      msgtype: "m.image",
+      attachmentId: opts.attachmentId,
+    },
+    status: "pending",
+    retries: 0,
+    maxRetries: 5,
+    createdAt: Date.now(),
+    clientId: opts.clientId,
+    nextAttemptAt: 0,
+  } as PendingOperation);
+}
+
+async function seedAttachment(db: TestDb, bytes = 300): Promise<number> {
+  // Use a string body so happy-dom's Blob constructor reports the expected
+  // byte length reliably (new Blob([Uint8Array]) has inconsistent .size
+  // support across happy-dom versions).
+  const blob = new Blob(["x".repeat(bytes)], { type: "image/jpeg" });
+  return db.attachments.add({
+    messageLocalId: 1,
+    fileName: "photo.jpg",
+    mimeType: "image/jpeg",
+    size: bytes,
+    localBlob: blob,
+    status: "local",
+  } as LocalAttachment);
+}
+
+async function waitForProcessed(db: TestDb, timeoutMs = 1500): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const remaining = await db.pendingOps.count();
+    if (remaining === 0) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error("pendingOps queue did not drain in time");
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SyncEngine.syncSendFile — full media pipeline", () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    h?.engine.dispose();
+    await h?.db.delete();
+  });
+
+  it("uploads via uploadContent (progress+signal path), not uploadContentMxc", async () => {
+    h = makeHarness(`media-upload-${Date.now()}-${Math.random()}`, true);
+    await h.db.open();
+
+    const attachmentId = await seedAttachment(h.db);
+    await seedFileOp(h.db, { clientId: "cli_file_up", encrypted: true, attachmentId });
+
+    await h.engine.processQueue();
+    await waitForProcessed(h.db);
+
+    // Must use the progress-aware upload path — not the state-event upload.
+    expect(mockMatrix.uploadContent).toHaveBeenCalledTimes(1);
+    expect(mockMatrix.uploadContentMxc).not.toHaveBeenCalled();
+  });
+
+  it("streams upload progress into messages.uploadProgress via repo", async () => {
+    h = makeHarness(`media-progress-${Date.now()}-${Math.random()}`, false);
+    await h.db.open();
+
+    const attachmentId = await seedAttachment(h.db, 900);
+    await seedFileOp(h.db, {
+      clientId: "cli_progress",
+      encrypted: false,
+      attachmentId,
+    });
+
+    await h.engine.processQueue();
+    await waitForProcessed(h.db);
+
+    // Three progress beats seeded by the mock; each must land on updateUploadProgress.
+    const progressPercents = h.messageRepo.updateUploadProgress.mock.calls.map(
+      (c) => c[1],
+    );
+    expect(progressPercents.length).toBeGreaterThanOrEqual(1);
+    // Last value must be 100.
+    expect(progressPercents[progressPercents.length - 1]).toBe(100);
+    // Callback must be keyed by clientId.
+    expect(h.messageRepo.updateUploadProgress.mock.calls[0][0]).toBe("cli_progress");
+  });
+
+  it("passes AbortSignal to uploadContent so the upload is cancellable", async () => {
+    h = makeHarness(`media-abort-${Date.now()}-${Math.random()}`, false);
+    await h.db.open();
+
+    const attachmentId = await seedAttachment(h.db);
+    await seedFileOp(h.db, {
+      clientId: "cli_abort",
+      encrypted: false,
+      attachmentId,
+    });
+
+    await h.engine.processQueue();
+    await waitForProcessed(h.db);
+
+    expect(mockMatrix.uploadContent).toHaveBeenCalledTimes(1);
+    const callArgs = mockMatrix.uploadContent.mock.calls[0];
+    // Third arg is the AbortSignal
+    expect(callArgs[2]).toBeInstanceOf(AbortSignal);
+  });
+
+  it("marks attachment uploaded + confirms message on success", async () => {
+    h = makeHarness(`media-uploaded-${Date.now()}-${Math.random()}`, false);
+    await h.db.open();
+
+    const attachmentId = await seedAttachment(h.db);
+    await seedFileOp(h.db, {
+      clientId: "cli_ok",
+      encrypted: false,
+      attachmentId,
+    });
+
+    await h.engine.processQueue();
+    await waitForProcessed(h.db);
+
+    const att = await h.db.attachments.get(attachmentId);
+    expect(att?.status).toBe("uploaded");
+    expect(att?.remoteUrl).toMatch(/^https?:\/\//);
+
+    expect(h.messageRepo.confirmSent).toHaveBeenCalledWith(
+      "cli_ok",
+      "$server_event_id",
+    );
+  });
+});
+
+describe("SyncEngine.recoverStrandedOps — send_file crash recovery", () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    h?.engine.dispose();
+    await h?.db.delete();
+  });
+
+  it("resets a 'syncing' send_file op to 'pending' and completes on next tick", async () => {
+    h = makeHarness(`media-recover-${Date.now()}-${Math.random()}`, false);
+    await h.db.open();
+
+    const attachmentId = await seedAttachment(h.db);
+    // Simulate a crash: op was mid-flight when WebView was killed.
+    await h.db.pendingOps.add({
+      type: "send_file",
+      roomId: "!room:server",
+      payload: {
+        fileName: "crashed.jpg",
+        mimeType: "image/jpeg",
+        msgtype: "m.image",
+        attachmentId,
+      },
+      status: "syncing",
+      retries: 1,
+      maxRetries: 5,
+      createdAt: Date.now() - 10_000,
+      clientId: "cli_crashed",
+      nextAttemptAt: 0,
+    } as PendingOperation);
+
+    await h.engine.recoverStrandedOps();
+
+    // Op must now be pending — ready for the scheduler to pick up.
+    const recovered = await h.db.pendingOps
+      .where("clientId")
+      .equals("cli_crashed")
+      .first();
+    expect(recovered?.status).toBe("pending");
+
+    // Next tick drains it — upload happens, op is deleted.
+    await h.engine.processQueue();
+    await waitForProcessed(h.db);
+
+    expect(mockMatrix.uploadContent).toHaveBeenCalledTimes(1);
+    expect(h.messageRepo.confirmSent).toHaveBeenCalledWith(
+      "cli_crashed",
+      "$server_event_id",
+    );
+  });
+});
+
+describe("SyncEngine.cancelMediaUpload — user cancel mid-flight", () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    h?.engine.dispose();
+    await h?.db.delete();
+  });
+
+  it("aborts the in-flight upload AND removes the pending op (no auto-resume)", async () => {
+    h = makeHarness(`media-cancel-${Date.now()}-${Math.random()}`, false);
+    await h.db.open();
+
+    // Upload that blocks until its AbortSignal fires.
+    const uploadStarted = new Promise<{ signal: AbortSignal; resolveFail: () => void }>(
+      (resolve) => {
+        mockMatrix.uploadContent.mockImplementationOnce(
+          (_blob, _progress, signal) =>
+            new Promise((_, reject) => {
+              resolve({ signal: signal!, resolveFail: () => {} });
+              signal?.addEventListener("abort", () => {
+                reject(new DOMException("Upload cancelled", "AbortError"));
+              });
+            }),
+        );
+      },
+    );
+
+    const attachmentId = await seedAttachment(h.db);
+    await seedFileOp(h.db, {
+      clientId: "cli_cancel",
+      encrypted: false,
+      attachmentId,
+    });
+
+    h.engine.processQueue();
+
+    // Wait until uploadContent is in flight.
+    const { signal } = await uploadStarted;
+    expect(signal.aborted).toBe(false);
+
+    // User hits cancel.
+    await h.engine.cancelMediaUpload("cli_cancel");
+
+    // SyncEngine must abort the signal and delete the op so the scheduler
+    // does not pick it back up.
+    expect(signal.aborted).toBe(true);
+
+    // Give the executeOperation catch block a moment to unwind.
+    await new Promise((r) => setTimeout(r, 20));
+
+    const remaining = await h.db.pendingOps
+      .where("clientId")
+      .equals("cli_cancel")
+      .first();
+    expect(remaining).toBeUndefined();
+  });
+});

--- a/src/shared/lib/local-db/__tests__/sync-engine-txnid.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-txnid.test.ts
@@ -32,6 +32,14 @@ const mockMatrix = {
     async () => undefined,
   ),
   uploadContentMxc: vi.fn<(blob: Blob) => Promise<string>>(async () => "mxc://server/file"),
+  // syncSendFile goes through the progress-aware upload path (not uploadContentMxc).
+  uploadContent: vi.fn<
+    (
+      blob: Blob,
+      progress?: (p: { loaded: number; total: number }) => void,
+      signal?: AbortSignal,
+    ) => Promise<string>
+  >(async () => "https://server/_matrix/media/r0/download/server/abc123"),
 };
 
 vi.mock("@/entities/matrix", () => ({
@@ -65,11 +73,12 @@ class TestDb extends Dexie {
       messages:
         "++localId, eventId, clientId, [roomId+timestamp], [roomId+status], senderId",
       rooms: "id, updatedAt, membership, isDeleted",
-      pendingOps: "++id, [roomId+createdAt], status",
+      pendingOps:
+        "++id, [roomId+createdAt], status, clientId, [status+nextAttemptAt]",
       attachments: "++id, messageLocalId, status",
       users: "address, updatedAt",
       syncState: "key",
-      decryptionQueue: "++id, status",
+      decryptionQueue: "++id, status, [status+nextAttemptAt]",
       listenedMessages: "messageId",
     });
   }
@@ -139,6 +148,9 @@ async function seedOp(
     maxRetries: 5,
     createdAt: Date.now(),
     clientId: "cli_fixed_for_test",
+    // Required for the [status+nextAttemptAt] compound index —
+    // Dexie skips rows with undefined indexed keys.
+    nextAttemptAt: 0,
     ...overrides,
   } as PendingOperation);
 }

--- a/src/shared/lib/local-db/sync-engine.ts
+++ b/src/shared/lib/local-db/sync-engine.ts
@@ -3,12 +3,46 @@ import type { MessageRepository } from "./message-repository";
 import type { RoomRepository } from "./room-repository";
 import { getMatrixClientService } from "@/entities/matrix";
 import { ENCRYPTION_REQUIRED_NO_KEYS, type PcryptoRoomInstance } from "@/entities/matrix/model/matrix-crypto";
+import { withTimeout } from "@/shared/lib/with-timeout";
 
 type GetRoomCryptoFn = (roomId: string) => Promise<PcryptoRoomInstance | undefined>;
 type OnChangeCallback = (roomId: string) => void;
 
 const MAX_BACKOFF_MS = 30_000;
 const MIN_BACKOFF_MS = 1_000;
+
+/** Per-phase media pipeline timeouts. Splitting one 5-minute cap into
+ *  per-phase caps lets retries surface phase-specific failures (e.g. crypto
+ *  hang vs. upload stall) instead of a generic "timed out" after 5 min. */
+const MEDIA_ENCRYPT_TIMEOUT_MS = 30_000;
+const MEDIA_UPLOAD_TIMEOUT_MS = 4 * 60_000;
+const MEDIA_SEND_EVENT_TIMEOUT_MS = 20_000;
+
+/** Throttle for upload-progress Dexie writes. A 20MB upload over a slow
+ *  link produces hundreds of progress callbacks per second; unthrottled
+ *  writes saturate the IDB lock on older Android WebViews. Always flush
+ *  the terminal "100%" so the UI never sticks at 97%. */
+const UPLOAD_PROGRESS_WRITE_INTERVAL_MS = 500;
+
+function makeThrottledProgress(
+  write: (percent: number) => void,
+): (p: { loaded: number; total: number }) => void {
+  let lastWriteAt = 0;
+  let lastPercent = -1;
+  return (progress) => {
+    const percent =
+      progress.total > 0
+        ? Math.round((progress.loaded / progress.total) * 100)
+        : 0;
+    const now = Date.now();
+    const isFinal = percent === 100 && lastPercent !== 100;
+    if (!isFinal && now - lastWriteAt < UPLOAD_PROGRESS_WRITE_INTERVAL_MS) return;
+    if (percent === lastPercent) return;
+    lastWriteAt = now;
+    lastPercent = percent;
+    write(percent);
+  };
+}
 
 function computeBackoff(retries: number): number {
   const base = Math.min(MIN_BACKOFF_MS * 2 ** retries, MAX_BACKOFF_MS);
@@ -33,6 +67,11 @@ export class SyncEngine {
   private scheduled = false;
   private disposed = false;
   private scheduledTimer: ReturnType<typeof setTimeout> | null = null;
+  /** AbortControllers for in-flight media uploads, keyed by clientId.
+   *  Populated by syncSendFile at the start of each execution, drained in
+   *  its finally block. cancelMediaUpload() signals through this map to
+   *  abort a running upload mid-flight. */
+  private activeUploads = new Map<string, AbortController>();
   /** Becomes true the first time setOnline() is called with `true`.
    *  Guards against the "app started offline from a previous session and
    *  wakes up online without ever seeing setOnline(false)" case, where
@@ -382,62 +421,128 @@ export class SyncEngine {
       mimeType: string;
       msgtype: string;
       attachmentId: number;
+      /** Optional human-readable body. When omitted, syncSendFile writes
+       *  the legacy JSON-encoded `{name,type,size}` body used by m.file
+       *  messages. m.image / m.audio senders override this with the
+       *  caption or a short tag string ("Image" / "Audio"). */
+      body?: string;
+      /** Optional pre-computed info object (image dimensions, audio duration,
+       *  etc.). Merged into `content.info` with secrets appended. Keeps the
+       *  per-type metadata intact without forcing syncSendFile to re-inspect
+       *  the blob. */
+      eventInfo?: Record<string, unknown>;
+      /** Optional top-level event fields merged after msgtype — e.g.
+       *  caption / captionAbove / bastyon-specific flags. */
+      eventExtras?: Record<string, unknown>;
     };
     const matrixService = getMatrixClientService();
 
-    // Get the attachment blob from DB
+    // --- Acquire blob -------------------------------------------------------
     const attachment = await this.db.attachments.get(payload.attachmentId);
     if (!attachment?.localBlob) {
       throw new Error("Attachment blob not found");
     }
 
-    // Upload file
-    const roomCrypto = await this.getRoomCrypto(op.roomId);
-    let mxcUrl: string;
-    let secrets: Record<string, unknown> | undefined;
+    // Register an AbortController for this upload so cancelMediaUpload(clientId)
+    // can interrupt the in-flight fetch.
+    const controller = new AbortController();
+    this.activeUploads.set(op.clientId, controller);
 
-    if (roomCrypto?.canBeEncrypt()) {
-      const encrypted = await roomCrypto.encryptFile(attachment.localBlob);
-      mxcUrl = await matrixService.uploadContentMxc(encrypted.file);
-      secrets = encrypted.secrets;
-    } else {
-      // Defense in depth: refuse to upload a plaintext attachment into a
-      // private room. Same rationale as syncSendMessage.
-      if (roomCrypto?.requiresEncryption()) {
+    try {
+      if (controller.signal.aborted) {
+        throw new DOMException("Upload cancelled", "AbortError");
+      }
+
+      // --- Phase 1: encrypt (fast, fails loudly) ----------------------------
+      const roomCrypto = await this.getRoomCrypto(op.roomId);
+      let fileToUpload: Blob = attachment.localBlob;
+      let secrets: Record<string, unknown> | undefined;
+
+      if (roomCrypto?.canBeEncrypt()) {
+        const encrypted = await withTimeout(
+          roomCrypto.encryptFile(attachment.localBlob),
+          MEDIA_ENCRYPT_TIMEOUT_MS,
+          "Media encrypt",
+        );
+        fileToUpload = encrypted.file;
+        secrets = encrypted.secrets;
+      } else if (roomCrypto?.requiresEncryption()) {
+        // Defense in depth: refuse to upload a plaintext attachment into a
+        // private room. Same rationale as syncSendMessage.
         throw new Error(`${ENCRYPTION_REQUIRED_NO_KEYS} — syncSendFile upload`);
       }
-      mxcUrl = await matrixService.uploadContentMxc(attachment.localBlob);
+
+      await this.db.attachments.update(attachment.id!, {
+        status: "uploading",
+        encryptionSecrets: secrets,
+      });
+
+      // --- Phase 2: upload (longest — big files on slow links) --------------
+      if (controller.signal.aborted) {
+        throw new DOMException("Upload cancelled", "AbortError");
+      }
+      const onProgress = makeThrottledProgress((percent) => {
+        // fire-and-forget; progress is advisory and must not stall upload
+        void this.messageRepo.updateUploadProgress(op.clientId, percent);
+      });
+      const url = await withTimeout(
+        matrixService.uploadContent(fileToUpload, onProgress, controller.signal),
+        MEDIA_UPLOAD_TIMEOUT_MS,
+        "Media upload",
+      );
+
+      await this.db.attachments.update(attachment.id!, {
+        status: "uploaded",
+        remoteUrl: url,
+      });
+
+      // --- Phase 3: send event (short, just a Matrix PUT) --------------------
+      if (controller.signal.aborted) {
+        throw new DOMException("Upload cancelled", "AbortError");
+      }
+
+      // Prefer structured fileInfo body (matches sendFile's JSON shape) so
+      // existing viewers keep rendering. Callers that need richer metadata
+      // (m.image with dimensions, m.audio with duration) pass eventInfo /
+      // eventExtras which merge on top.
+      const content: Record<string, unknown> = {
+        msgtype: payload.msgtype,
+        body:
+          payload.body ??
+          JSON.stringify({
+            name: payload.fileName,
+            type: payload.mimeType,
+            size: attachment.size,
+          }),
+        url,
+        ...(payload.eventExtras ?? {}),
+      };
+      if (payload.eventInfo) {
+        content.info = {
+          ...payload.eventInfo,
+          ...(secrets ? { secrets } : {}),
+        };
+      } else if (secrets) {
+        content.secrets = secrets;
+      }
+
+      const serverEventId = await withTimeout(
+        matrixService.sendEncryptedText(op.roomId, content, op.clientId),
+        MEDIA_SEND_EVENT_TIMEOUT_MS,
+        "Media send event",
+      );
+
+      await this.messageRepo.confirmSent(op.clientId, serverEventId);
+      await this.roomRepo.updateRoom(op.roomId, {
+        lastMessageLocalStatus: "synced" as import("./schema").LocalMessageStatus,
+        lastMessageEventId: serverEventId,
+      });
+    } finally {
+      // Release the controller slot regardless of outcome so a retry can
+      // register a fresh one.
+      const current = this.activeUploads.get(op.clientId);
+      if (current === controller) this.activeUploads.delete(op.clientId);
     }
-
-    // Update attachment status
-    await this.db.attachments.update(attachment.id!, {
-      status: "uploaded",
-      remoteUrl: mxcUrl,
-      encryptionSecrets: secrets,
-    });
-
-    // Send message event with file metadata
-    const content: Record<string, unknown> = {
-      msgtype: payload.msgtype,
-      body: JSON.stringify({
-        name: payload.fileName,
-        type: payload.mimeType,
-        size: attachment.size,
-      }),
-      url: mxcUrl,
-    };
-    if (secrets) {
-      content.secrets = secrets;
-    }
-
-    // Pass op.clientId as the Matrix txnId so the homeserver dedupes
-    // multi-tab/retry sends into a single event (matches syncSendMessage).
-    const serverEventId = await matrixService.sendEncryptedText(op.roomId, content, op.clientId);
-    await this.messageRepo.confirmSent(op.clientId, serverEventId);
-    await this.roomRepo.updateRoom(op.roomId, {
-      lastMessageLocalStatus: "synced" as import("./schema").LocalMessageStatus,
-      lastMessageEventId: serverEventId,
-    });
   }
 
   private async syncEditMessage(op: PendingOperation): Promise<void> {
@@ -664,6 +769,26 @@ export class SyncEngine {
     const pending = await this.db.pendingOps.where("status").equals("pending").count();
     const failed = await this.db.pendingOps.where("status").equals("failed").count();
     return { pending, failed };
+  }
+
+  /**
+   * Cancel an in-flight media upload by clientId. Aborts the signal so the
+   * Matrix SDK tears down the XHR, then removes the pending op so the
+   * scheduler does not resume it after restart. The message row itself
+   * stays untouched — the caller (use-messages cancelMediaUpload) owns
+   * flipping status to "cancelled" / revoking the preview blob URL.
+   */
+  async cancelMediaUpload(clientId: string): Promise<void> {
+    this.activeUploads.get(clientId)?.abort();
+    this.activeUploads.delete(clientId);
+    // Narrow the delete to send_file ops. clientId is not unique across
+    // op types (a send_message op could share it), so a broad delete
+    // could clobber unrelated queued sends.
+    await this.db.pendingOps
+      .where("clientId")
+      .equals(clientId)
+      .filter((op) => op.type === "send_file")
+      .delete();
   }
 
   /** Cancel a pending/failed operation and clean up */


### PR DESCRIPTION
## Summary

Moves media uploads (sendFile / sendImage / sendAudio) onto the SyncEngine's `send_file` op so they inherit the queue's crash-recovery, retry, backoff, and setOnline(true) behavior. Previously the uploads ran as in-component IIFEs talking to Matrix directly — a WebView crash mid-upload left the file in `sending` forever, there was no retry budget, and a hung upload could not be kicked by reconnect.

Also hardens the download pipeline (sequential decrypt, abortable fetch) and fixes a latent MIME restoration bug for new ciphertexts.

Unblocks (or takes meaningful chunks out of) ~17 bug reports: #38, #65, #120, #145, #146, #202, #209, #250, #277, #304, #317, #328, #336, #372, #414, #422, #452.

## What changed

- **SyncEngine.syncSendFile** — per-phase timeouts (encrypt 30s / upload 4 min / send 20s), throttled upload progress through `messageRepo.updateUploadProgress`, `AbortController` registered per `clientId` in a new `activeUploads` map, and switched from `uploadContentMxc` to `uploadContent` (HTTP URL + progress + signal path).
- **SyncEngine.cancelMediaUpload(clientId)** — new. Aborts the active upload and deletes the pending op, scoped to `type === "send_file"` so it can never collaterally delete a `send_message` op that happens to share a clientId.
- **sendFile / sendImage / sendAudio** — each one now writes the blob into `attachments`, creates the optimistic Dexie message, and enqueues a `send_file` op. `body` / `eventInfo` / `eventExtras` carry per-type metadata (caption, dimensions, duration, waveform) through the queue. All three legacy fallbacks deleted (~220 lines).
- **cancelMediaUpload (composable)** — race guard: after abort, re-read the message status. If it was already synced (Phase 3 resolved between the abort signal and our return), skip `handleUploadCancelled` so a real sent message does not get flipped to `cancelled`.
- **decrypt-queue.ts (new)** — sequential queue mirroring bastyon-chat's `decryptFileQueue`. Parallel `decryptFile` calls saturated CPU on Xiaomi Android 7/8; serialising avoids the freeze.
- **download(message, signal?)** — optional `AbortSignal` plumbed end-to-end (fetch → decrypt). AbortError is terminal (no retry, no bug-report open).
- **matrix-crypto.decryptFile(blob, secret, originalMime?)** — accepts plaintext MIME explicitly. Required because `encryptFile` now stamps ciphertexts with `application/octet-stream` and the old `file.type.replace(\"encrypted/\", \"\")` fallback would otherwise yield a generic binary for new messages. Legacy prefix path retained for old ciphertexts.

## Tests

All 44 tests in the changed scope pass. New:

- \`sync-engine-media.test.ts\` — 6 tests: uploadContent is used (not uploadContentMxc); progress streams to updateUploadProgress; AbortSignal passed to uploadContent; attachment.remoteUrl + confirmSent on success; \`recoverStrandedOps\` resets a syncing \`send_file\` op; \`cancelMediaUpload\` aborts + removes op.
- \`decrypt-queue.test.ts\` — 3 tests: sequential execution, FIFO ordering, failure does not poison the tail.
- \`matrix-crypto-mime.test.ts\` — +2 tests: \`decryptFile\` honours \`originalMime\`; legacy \`encrypted/*\` prefix still handled when omitted.
- \`sync-engine-txnid.test.ts\` — test schema fixed (added \`[status+nextAttemptAt]\` compound index, \`nextAttemptAt\` seed), \`uploadContent\` added to mock.

## Test plan

- [x] \`npm run test\` — 44/44 in the changed scope pass (remaining failures are pre-existing baseline flakes in unrelated files: open-profile-url, video-embed, chat-helpers, display-result, call-service).
- [x] \`vite build\` passes.
- [x] \`vue-tsc --noEmit\` has no new errors in touched files (the pre-existing TS errors in stores.ts / user-store.ts / MessageInput.vue are unchanged).
- [ ] Manual: upload a 10 MB photo, kill the tab mid-upload, reopen — the send should resume via \`recoverStrandedOps\`.
- [ ] Manual: go offline mid-upload, wait for failure, go online — op should flip to pending and retry.
- [ ] Manual: cancel an in-flight upload — UI should flip to cancelled immediately, no ghost retry.
- [ ] Manual: open a chat with ~10 encrypted images — main thread should stay responsive (sequential decrypt).

## Reviewer notes

- Legacy \`sendFileLegacy\` / \`sendImageLegacy\` / \`sendAudioLegacy\` paths are **deleted**, not shimmed. Without Dexie we have no crash-safe queue, so silently dropping the send (with a console error) is safer than shipping the old never-recoverable path.
- \`sendVideoCircle\` and \`sendGif\` still use the old in-component IIFE + \`upload-abort-registry\` — they are out of scope for this session and remain untouched. \`cancelMediaUpload\` in use-messages calls both abort paths, which is intentional while the two worlds coexist.
- The race-guard in \`cancelMediaUpload\` (re-read status after abort, skip if synced) is the fix for a HIGH finding from code review.
- The \`pendingOps.delete\` in \`syncEngine.cancelMediaUpload\` is filtered by \`type === "send_file"\` to avoid clobbering a \`send_message\` op sharing the same clientId (also from review).