### PR TITLE
fix(crypto): unblock sends in private groups ≥50 members

### DIFF
--- a/src/entities/matrix/model/__tests__/matrix-crypto-requires-encryption.test.ts
+++ b/src/entities/matrix/model/__tests__/matrix-crypto-requires-encryption.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression tests for requiresEncryption() vs canBeEncrypt() divergence.
+ *
+ * Bug (introduced by PR #64 — c921707):
+ *   requiresEncryption() checks only `publicChat`. canBeEncrypt() also
+ *   returns false for rooms with ≥50 members (Bastyon disables E2E for
+ *   large rooms by design — plaintext is the convention). After PR #64
+ *   the SyncEngine evaluates `canBeEncrypt() === false` on every send
+ *   into a large private group, then falls through to the
+ *   requiresEncryption() guard which, having only the publicChat gate,
+ *   returns true and throws ENCRYPTION_REQUIRED_NO_KEYS. Result: every
+ *   message to a large private group is permanently stranded in the
+ *   outbound queue.
+ *
+ *   chat-store.ts already classifies memberCount≥50 as "not-encrypted"
+ *   so the UI gate (peerKeysOk) happily enqueues the send — SyncEngine
+ *   then blocks it, leaving the compose UI looking functional while
+ *   nothing actually leaves the device.
+ *
+ * Fix: requiresEncryption() must mirror canBeEncrypt()'s member-count
+ * gate so the two signals agree on which rooms mandate encryption.
+ */
+const getSource = () =>
+  readFileSync(resolve(__dirname, "../matrix-crypto.ts"), "utf-8");
+
+describe("requiresEncryption — large-room gate", () => {
+  it("exempts rooms with ≥50 members from the encryption requirement", () => {
+    const source = getSource();
+    const start = source.indexOf("requiresEncryption(): boolean {");
+    expect(start).toBeGreaterThan(-1);
+    const end = source.indexOf("\n      },", start);
+    const section = source.slice(start, end);
+
+    // Must recognise the ≥50 threshold — plaintext is expected there by
+    // Bastyon convention (same gate as canBeEncrypt() uses).
+    expect(section).toContain("50");
+    expect(section).toMatch(/memberCount|getJoinedMemberCount/);
+  });
+
+  it("still returns false for public chats first (short-circuit)", () => {
+    const source = getSource();
+    const start = source.indexOf("requiresEncryption(): boolean {");
+    const end = source.indexOf("\n      },", start);
+    const section = source.slice(start, end);
+
+    // publicChat check must appear before the member-count check so
+    // public rooms never hit the (slightly more expensive) count lookup.
+    const publicIdx = section.indexOf("getIsChatPublic");
+    const memberIdx = section.search(/getJoinedMemberCount|memberCount/);
+    expect(publicIdx).toBeGreaterThan(-1);
+    expect(memberIdx).toBeGreaterThan(-1);
+    expect(publicIdx).toBeLessThan(memberIdx);
+  });
+});

--- a/src/entities/matrix/model/matrix-crypto.ts
+++ b/src/entities/matrix/model/matrix-crypto.ts
@@ -663,10 +663,22 @@ export class Pcrypto {
       requiresEncryption(): boolean {
         // Private (non-public) rooms mandate encryption. Public rooms are
         // allowed to send plaintext by design — Bastyon convention for
-        // open channels. Keep this in lockstep with canBeEncrypt()'s own
-        // publicChat gate so the two signals can never diverge.
+        // open channels.
         const publicChat = pcrypto.getIsChatPublic?.(chat) ?? false;
-        return !publicChat;
+        if (publicChat) return false;
+
+        // Large rooms (≥50 members) also fall back to plaintext by design —
+        // E2E group-key exchange is not workable at that scale, and
+        // canBeEncrypt() explicitly returns false for them. requiresEncryption()
+        // must mirror that same gate or the two signals diverge and every
+        // send in a large private group throws ENCRYPTION_REQUIRED_NO_KEYS,
+        // permanently stranding messages in the outbound queue.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const serverCount = (chat as any).getJoinedMemberCount?.() ?? 0;
+        const memberCount = Math.max(serverCount, Object.keys(usersinfo).length);
+        if (memberCount >= 50) return false;
+
+        return true;
       },
 
       canBeEncrypt(): boolean {


### PR DESCRIPTION
## Summary

- Restores message sending in private groups that grew to ≥50 members. Messages sat in the outbound queue forever with no visible error in the compose UI.
- Syncs `requiresEncryption()` with `canBeEncrypt()`'s member-count gate so the two crypto signals cannot diverge.
- Adds regression tests that pin both the ≥50 threshold and the publicChat-first short-circuit.

## Root cause

PR #64 (`c921707`) added `requiresEncryption()` as a defense-in-depth check to stop `SyncEngine` from silently downgrading to plaintext when peer keys were temporarily missing. The new guard checked **only** `publicChat`, but `canBeEncrypt()` (used earlier in the same branch) **also** returns `false` for rooms with ≥50 members — Bastyon disables E2E group-key exchange at that scale and ships plaintext by design.

Resulting contradiction in `SyncEngine.syncSendMessage`:

```
canBeEncrypt()        → false   (≥50 members)
requiresEncryption()  → true    (not public)
→ throw ENCRYPTION_REQUIRED_NO_KEYS → op stuck in queue
```

`chat-store.checkPeerKeys` already classifies `memberCount ≥ 50` as `"not-encrypted"` → `peerKeysOk=true`, so the composer happily enqueues the send. `SyncEngine` then refuses it silently, making the UI look functional while nothing actually leaves the device.

## Fix

`requiresEncryption()` now mirrors `canBeEncrypt()`'s member-count gate — large private groups fall through to plaintext, the same as public "open channel" rooms. All other guarded paths (1:1 and small private groups) keep the PR #64 behaviour of refusing to leak plaintext when peer keys are missing.

## Test plan

- [x] New unit tests: `matrix-crypto-requires-encryption.test.ts` (2 tests, both fail on the old code, pass on the fix)
- [x] All existing encryption regression tests pass (`sync-engine-encryption-guard.test.ts`, `encryption-guard.test.ts`, `matrix-crypto-can-be-encrypt.test.ts`)
- [x] 319 tests in affected layers (`src/entities/matrix`, `src/shared/lib/local-db`, `src/entities/chat/model`) pass
- [ ] Manual QA on device: send a message into a private group with ≥50 members — should arrive instead of hanging in the queue
- [ ] Manual QA on device: send a message into a 1:1 private chat where peer keys are missing — should still be blocked (PR #64 behaviour preserved)
- [ ] Manual QA on device: send a message into a public channel — should arrive as plaintext (unchanged)