### PR TITLE
fix(forward): show send button during bulk-forward preview

### DIFF
--- a/src/features/messaging/model/send-button-state.test.ts
+++ b/src/features/messaging/model/send-button-state.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { isSendButtonVisible, isSendButtonDisabled, type SendButtonState } from "./send-button-state";
+
+const base: SendButtonState = {
+  text: "",
+  sending: false,
+  showForwardPreview: false,
+  showBulkForwardPreview: false,
+  peerKeysOk: true,
+};
+
+describe("send-button-state", () => {
+  describe("isSendButtonVisible", () => {
+    it("hidden when idle and no content", () => {
+      expect(isSendButtonVisible(base)).toBe(false);
+    });
+
+    it("visible when user typed text", () => {
+      expect(isSendButtonVisible({ ...base, text: "hi" })).toBe(true);
+    });
+
+    it("visible while sending (spinner)", () => {
+      expect(isSendButtonVisible({ ...base, sending: true })).toBe(true);
+    });
+
+    it("visible during singular forward without caption", () => {
+      expect(isSendButtonVisible({ ...base, showForwardPreview: true })).toBe(true);
+    });
+
+    // Regression: bulk forward preview was added without updating the
+    // send button's v-if — on mobile (Enter = newline) this made it
+    // impossible to complete a multi-select forward without a caption.
+    it("visible during bulk forward without caption", () => {
+      expect(isSendButtonVisible({ ...base, showBulkForwardPreview: true })).toBe(true);
+    });
+
+    it("whitespace-only text alone is not enough to show", () => {
+      expect(isSendButtonVisible({ ...base, text: "   " })).toBe(false);
+    });
+  });
+
+  describe("isSendButtonDisabled", () => {
+    it("disabled when nothing to send", () => {
+      expect(isSendButtonDisabled(base)).toBe(true);
+    });
+
+    it("enabled with text and ready peers", () => {
+      expect(isSendButtonDisabled({ ...base, text: "hi" })).toBe(false);
+    });
+
+    it("enabled for singular forward without caption", () => {
+      expect(isSendButtonDisabled({ ...base, showForwardPreview: true })).toBe(false);
+    });
+
+    // Regression: the same omission in :disabled would leave the button
+    // grayed out even if it were somehow made visible.
+    it("enabled for bulk forward without caption", () => {
+      expect(isSendButtonDisabled({ ...base, showBulkForwardPreview: true })).toBe(false);
+    });
+
+    it("disabled while sending, even with content", () => {
+      expect(isSendButtonDisabled({ ...base, text: "hi", sending: true })).toBe(true);
+    });
+
+    it("disabled when peer keys are missing, even with content", () => {
+      expect(isSendButtonDisabled({ ...base, text: "hi", peerKeysOk: false })).toBe(true);
+    });
+
+    it("disabled for bulk forward when peer keys are missing", () => {
+      expect(isSendButtonDisabled({ ...base, showBulkForwardPreview: true, peerKeysOk: false })).toBe(true);
+    });
+
+    // Real runtime state on mobile: user taps Send during a bulk forward.
+    // Button must stay visible (so the spinner renders) AND stay disabled
+    // so a second tap doesn't re-enqueue the same batch.
+    it("visible and disabled while a bulk forward is in flight", () => {
+      const state = { ...base, showBulkForwardPreview: true, sending: true };
+      expect(isSendButtonVisible(state)).toBe(true);
+      expect(isSendButtonDisabled(state)).toBe(true);
+    });
+  });
+});

--- a/src/features/messaging/model/send-button-state.ts
+++ b/src/features/messaging/model/send-button-state.ts
@@ -1,0 +1,18 @@
+export interface SendButtonState {
+  text: string;
+  sending: boolean;
+  showForwardPreview: boolean;
+  showBulkForwardPreview: boolean;
+  peerKeysOk: boolean;
+}
+
+const hasSendableContent = (s: Pick<SendButtonState, "text" | "showForwardPreview" | "showBulkForwardPreview">): boolean =>
+  s.text.trim().length > 0 || s.showForwardPreview || s.showBulkForwardPreview;
+
+export function isSendButtonVisible(s: SendButtonState): boolean {
+  return hasSendableContent(s) || s.sending;
+}
+
+export function isSendButtonDisabled(s: SendButtonState): boolean {
+  return !hasSendableContent(s) || s.sending || !s.peerKeysOk;
+}

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -20,6 +20,7 @@ import MentionAutocomplete from "./MentionAutocomplete.vue";
 import { useMobile } from "@/shared/lib/composables/use-media-query";
 import { useResolvedRoomName } from "@/entities/chat/lib/use-resolved-room-name";
 import { shouldSendOnEnter } from "../model/enter-key-behavior";
+import { isSendButtonVisible, isSendButtonDisabled } from "../model/send-button-state";
 import { isNative } from "@/shared/lib/platform";
 
 const isMobile = useMobile();
@@ -369,6 +370,21 @@ const showBulkForwardPreview = computed(() => {
   const srcId = msgs[0].roomId;
   return chatStore.activeRoomId !== srcId;
 });
+
+const sendButtonVisible = computed(() => isSendButtonVisible({
+  text: text.value,
+  sending: sending.value,
+  showForwardPreview: showForwardPreview.value,
+  showBulkForwardPreview: showBulkForwardPreview.value,
+  peerKeysOk: peerKeysOk.value,
+}));
+const sendButtonDisabled = computed(() => isSendButtonDisabled({
+  text: text.value,
+  sending: sending.value,
+  showForwardPreview: showForwardPreview.value,
+  showBulkForwardPreview: showBulkForwardPreview.value,
+  peerKeysOk: peerKeysOk.value,
+}));
 
 const bulkForwardCount = computed(() => chatStore.forwardingMessages.length);
 
@@ -974,9 +990,9 @@ const handleKitchenSelect = async (imageUrl: string) => {
 
         <!-- Send OR record button -->
         <transition name="btn-morph" mode="out-in">
-          <button v-if="text.trim() || sending || showForwardPreview" key="send"
+          <button v-if="sendButtonVisible" key="send"
             class="send-btn flex h-10 w-10 min-h-tap min-w-tap shrink-0 items-center justify-center rounded-full bg-color-bg-ac text-white transition-all hover:bg-color-bg-ac-1 disabled:opacity-50"
-            :disabled="(!text.trim() && !showForwardPreview) || sending || !peerKeysOk" @click="handleSend">
+            :disabled="sendButtonDisabled" @click="handleSend">
             <svg v-if="sending" class="contain-strict h-5 w-5 animate-spin rounded-full border-2 border-white border-t-transparent" viewBox="0 0 24 24" />
             <svg v-else-if="isEditing" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12" /></svg>
             <svg v-else width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" /></svg>


### PR DESCRIPTION
## Summary

- On mobile, bulk-forwarding multi-selected messages was impossible to complete: after picking a target chat the **voice-record button** appeared instead of **send**, and Enter inserts newline on mobile so there was no workaround.
- Root cause: the send button's `v-if` and `:disabled` checked `showForwardPreview` (singular) but missed `showBulkForwardPreview` (bulk), even though every other branch — `handleSend` guard, the bulk preview bar, the forward options popup — was updated when bulk-forward landed in af6a440.
- Also blocked sending a forward with preview when the textarea was empty.

## Changes

- **New** `src/features/messaging/model/send-button-state.ts` — pure helper with `isSendButtonVisible` and `isSendButtonDisabled`, consuming `{ text, sending, showForwardPreview, showBulkForwardPreview, peerKeysOk }`. Extracting keeps the rule unit-testable instead of living inside a Vue template.
- **Modified** `src/features/messaging/ui/MessageInput.vue` — replaced inline `v-if` / `:disabled` expressions on the send button with two computed refs that delegate to the helper. No behavior change outside the bulk-forward fix.
- **New** `src/features/messaging/model/send-button-state.test.ts` — 14 cases including regression coverage for bulk-forward without caption and `sending + bulk` (visible + disabled).

## Test plan

- [x] Unit: \`npm run test -- src/features/messaging/model/send-button-state.test.ts\` → 14/14
- [x] Regression suite: \`npm run test -- src/features/messaging\` → 160/160
- [x] Vite production build (\`vite build\`) passes
- [ ] Manual on mobile: select ≥2 messages → Forward → pick chat → confirm send button is visible without typing a caption → send completes
- [ ] Manual on desktop: same flow, plus verify Enter-to-send still works with a typed caption

## Reviewer notes

- Pre-existing \`vue-tsc\` errors in unrelated files (user-store.ts, MessageBubble.vue, DownloadPage.vue, rtc-peer-connection-proxy.ts, etc.) and 9 pre-existing failing tests in src/shared/lib/* and src/entities/chat/lib/* are out of scope — verified they existed before this branch.
- Small intentional abstraction: helper module is pulled out solely to give the visibility rule a testable home.