### PR TITLE
fix(rooms): public-room detection + path-based invite URL + typed join errors

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -15,6 +15,7 @@ import CallWindow from "@/features/video-calls/ui/CallWindow.vue";
 import CallStatusBar from "@/features/video-calls/ui/CallStatusBar.vue";
 import PermissionDeniedModal from "@/features/video-calls/ui/PermissionDeniedModal.vue";
 import QuickSearchModal from "@/features/search/ui/QuickSearchModal.vue";
+import { JoinRoomPreviewModal } from "@/features/join-room";
 import { handleSdkSync } from "@/features/sync-status";
 import { isNative } from "@/shared/lib/platform";
 import { useRouter } from "vue-router";
@@ -83,22 +84,63 @@ const handleRetryUsername = async (newName: string) => {
   }
 };
 
-const processJoinRoom = async () => {
+// Pending roomId consumed from deep-link storage — the preview modal driver.
+const pendingJoinRoomId = ref<string | null>(null);
+
+const processJoinRoom = () => {
   if (!authStore.isAuthenticated || !authStore.matrixReady) return;
 
   const roomId = localStorage.getItem("bastyon-chat-join-room");
   if (!roomId) return;
-
   localStorage.removeItem("bastyon-chat-join-room");
 
-  try {
-    const ok = await chatStore.joinRoomById(roomId);
-    if (ok) {
-      router.push({ name: "ChatPage" });
-    }
-  } catch (e) {
-    console.error("[App] join room error:", e);
+  // If the user is already in this room, skip the preview and jump straight
+  // there — opening a modal would be jarring.
+  const existing = chatStore.rooms.find((r) => r.id === roomId);
+  if (existing) {
+    chatStore.setActiveRoom(roomId);
+    router.push({ name: "ChatPage" });
+    return;
   }
+
+  pendingJoinRoomId.value = roomId;
+};
+
+const confirmJoinRoom = async () => {
+  const roomId = pendingJoinRoomId.value;
+  if (!roomId) return;
+  pendingJoinRoomId.value = null;
+
+  const result = await chatStore.joinRoomById(roomId);
+  if (result.ok) {
+    router.push({ name: "ChatPage" });
+    showToast(t("joinRoom.success"), "success");
+    return;
+  }
+  // Map the typed reason to a canned i18n key. Only the "unknown" branch
+  // keeps the raw SDK message — everything else gets a localized toast.
+  let message: string;
+  switch (result.reason) {
+    case "banned":
+      message = t("joinRoom.errorBanned");
+      break;
+    case "forbidden":
+      message = t("joinRoom.errorForbidden");
+      break;
+    case "not_found":
+      message = t("joinRoom.errorNotFound");
+      break;
+    case "invalid_id":
+      message = t("joinRoom.errorInvalidId");
+      break;
+    default:
+      message = result.errorMessage || t("joinRoom.errorUnknown");
+  }
+  showToast(message, "error");
+};
+
+const cancelJoinRoom = () => {
+  pendingJoinRoomId.value = null;
 };
 
 const processReferral = async () => {
@@ -394,6 +436,12 @@ onUnmounted(() => {
       v-if="showQuickSearch"
       @close="showQuickSearch = false"
       @select-room="showQuickSearch = false"
+    />
+    <JoinRoomPreviewModal
+      :show="pendingJoinRoomId !== null"
+      :room-id="pendingJoinRoomId ?? ''"
+      @join="confirmJoinRoom"
+      @cancel="cancelJoinRoom"
     />
     <BugReportStatusSheet
       v-if="authStore.address"

--- a/src/app/providers/router/routes/join.ts
+++ b/src/app/providers/router/routes/join.ts
@@ -1,4 +1,5 @@
 import type { RouteRecordRaw } from "vue-router";
+import { validateRoomId } from "@/entities/chat/lib/join-error";
 
 export const routeName = "JoinRoomPage";
 
@@ -7,8 +8,12 @@ export const route: RouteRecordRaw = {
   name: routeName,
   component: () => import("@/pages/welcome"),
   beforeEnter: (to, _from, next) => {
-    const roomId = to.query.room as string | undefined;
-    if (roomId) {
+    const raw = to.query.room;
+    const roomId = typeof raw === "string" ? raw : undefined;
+    // Only persist the pending join when the id survives our grammar check.
+    // A malformed id would otherwise trip joinRoomById's invalid_id branch
+    // and surface a confusing toast on entry — better to drop it here.
+    if (roomId && validateRoomId(roomId)) {
       localStorage.setItem("bastyon-chat-join-room", roomId);
     }
     next({ name: "WelcomePage", replace: true });

--- a/src/entities/chat/lib/join-error.test.ts
+++ b/src/entities/chat/lib/join-error.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { categorizeJoinError, validateRoomId } from "./join-error";
+
+// Identity translation function so we can assert the exact i18n key the
+// implementation picked without pulling the full vue-i18n setup.
+const identityT = (key: string): string => key;
+
+describe("validateRoomId", () => {
+  it("accepts a well-formed Matrix room id", () => {
+    expect(validateRoomId("!abc:matrix.org")).toBe(true);
+    expect(validateRoomId("!room_id.with-dashes=foo+bar:server")).toBe(true);
+    expect(validateRoomId("!room:server:8448")).toBe(true);
+  });
+
+  it("rejects empty / non-string / malformed ids", () => {
+    expect(validateRoomId("")).toBe(false);
+    expect(validateRoomId("roomid")).toBe(false); // no leading !
+    expect(validateRoomId("!missing-colon")).toBe(false);
+    expect(validateRoomId("!bad/traversal:server")).toBe(false); // `/` is not allowed
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(validateRoomId(undefined as any)).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(validateRoomId(null as any)).toBe(false);
+  });
+});
+
+describe("categorizeJoinError", () => {
+  it("classifies M_FORBIDDEN as 'forbidden' (private room)", () => {
+    const r = categorizeJoinError({ errcode: "M_FORBIDDEN", message: "Not invited" }, identityT);
+    expect(r).toEqual({
+      ok: false,
+      reason: "forbidden",
+      errorMessage: "joinRoom.errorForbidden",
+    });
+  });
+
+  it("classifies M_NOT_FOUND as 'not_found'", () => {
+    const r = categorizeJoinError({ errcode: "M_NOT_FOUND" }, identityT);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe("not_found");
+      expect(r.errorMessage).toBe("joinRoom.errorNotFound");
+    }
+  });
+
+  it("reads errcode from nested data (matrix-js-sdk shape)", () => {
+    const r = categorizeJoinError({ data: { errcode: "M_FORBIDDEN" } }, identityT);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("forbidden");
+  });
+
+  it("falls back to 'unknown' for generic errors", () => {
+    const r = categorizeJoinError(new Error("network"), identityT);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe("unknown");
+      // network message bubbles up verbatim so the user sees the real failure
+      expect(r.errorMessage).toBe("network");
+    }
+  });
+
+  it("uses translated default when error has no message", () => {
+    const r = categorizeJoinError({}, identityT);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe("unknown");
+      expect(r.errorMessage).toBe("joinRoom.errorUnknown");
+    }
+  });
+});

--- a/src/entities/chat/lib/join-error.ts
+++ b/src/entities/chat/lib/join-error.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure helpers for Matrix room-join flow:
+ *  - `validateRoomId` — syntactic check against Matrix room-id grammar.
+ *    Keeps unsafe inputs from reaching joinRoom/peekInRoom and shares the
+ *    exact shape check with `parse-invite-url` so validation never diverges.
+ *  - `categorizeJoinError` — maps SDK errors to a typed `JoinRoomResult`.
+ *
+ * `errorMessage` contract:
+ *   - For the "unknown" branch, it holds whatever raw message the SDK threw
+ *     (network/timeout/other) — surfaced verbatim so the user sees the real
+ *     failure.
+ *   - For every other reason it holds an i18n KEY (e.g. "joinRoom.errorForbidden")
+ *     when the caller passed an identity translator, or the already-localized
+ *     string when the caller passed a real `t`. Callers MUST be consistent:
+ *     either translate upfront via `t`, or re-translate at the render site.
+ */
+
+export type JoinRoomReason =
+  | "banned"
+  | "forbidden"
+  | "not_found"
+  | "invalid_id"
+  | "unknown";
+
+export type JoinRoomResult =
+  | { ok: true }
+  | { ok: false; reason: JoinRoomReason; errorMessage: string };
+
+export const MATRIX_ROOM_ID_RE = /^![A-Za-z0-9._=+\-]+:[A-Za-z0-9.\-]+(:\d+)?$/;
+
+export function validateRoomId(roomId: unknown): boolean {
+  return typeof roomId === "string" && MATRIX_ROOM_ID_RE.test(roomId);
+}
+
+type ErrLike = {
+  errcode?: string;
+  message?: string;
+  data?: { errcode?: string; error?: string };
+};
+
+/**
+ * Map a thrown join/peek error to a typed result.
+ * Accepts a translator so consumers get localized strings without this module
+ * importing vue-i18n directly (keeps it unit-testable).
+ */
+export function categorizeJoinError(
+  e: unknown,
+  t: (key: string) => string,
+): JoinRoomResult {
+  const err = (e ?? {}) as ErrLike;
+  const errcode = err.errcode ?? err.data?.errcode;
+
+  if (errcode === "M_FORBIDDEN") {
+    return {
+      ok: false,
+      reason: "forbidden",
+      errorMessage: t("joinRoom.errorForbidden"),
+    };
+  }
+  if (errcode === "M_NOT_FOUND") {
+    return {
+      ok: false,
+      reason: "not_found",
+      errorMessage: t("joinRoom.errorNotFound"),
+    };
+  }
+
+  const fallback = err.message ?? err.data?.error;
+  return {
+    ok: false,
+    reason: "unknown",
+    errorMessage:
+      typeof fallback === "string" && fallback.length > 0
+        ? fallback
+        : t("joinRoom.errorUnknown"),
+  };
+}

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -3453,6 +3453,25 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     }
   };
 
+  /** True when the room is shareable by link — either a public join_rule or a
+   *  world_readable broadcast/stream room. Broadcast channels on Bastyon
+   *  commonly use `history_visibility=world_readable` even when their
+   *  `join_rule` is still `"invite"`, and members reasonably expect to be
+   *  able to hand the link to someone else. */
+  const isRoomShareableByLink = (roomId: string): boolean => {
+    try {
+      const matrixService = getMatrixClientService();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const matrixRoom = matrixService.getRoom(roomId) as any;
+      if (!matrixRoom) return false;
+      if (readJoinRule(matrixRoom as Record<string, unknown>) === "public") return true;
+      const hv = getHistoryVisibilityFromMatrixRoom(matrixRoom);
+      return isStreamHistoryVisibility(hv);
+    } catch {
+      return false;
+    }
+  };
+
   /** Toggle room between public/private join rules (admin only).
    *  Up-front power-level check avoids sending a doomed state event, and
    *  when enabling public we also set history_visibility=world_readable
@@ -6154,6 +6173,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     inviteMember,
     isDetachedFromLatest,
     isRoomPublic,
+    isRoomShareableByLink,
     joinRoomById,
     peekRoom,
     bindAccountKeys,

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -6,6 +6,8 @@ import { matrixIdToAddress, messageTypeFromMime, parseFileInfo, cleanMatrixIds, 
 import { parseEditBody } from "../lib/parse-edit";
 import { sortMessagesTimelineAsc } from "../lib/message-utils";
 import { resetPowerLevel, isUserBanned } from "../lib/room-guards";
+import { categorizeJoinError, validateRoomId, type JoinRoomResult } from "../lib/join-error";
+import { readJoinRule } from "@/entities/matrix/model/matrix-kit";
 import { stripMentionAddresses, stripBastyonLinks } from "@/shared/lib/message-format";
 import { getCachedRooms, getCachedMessages, getCacheTimestamp } from "@/shared/lib/cache/chat-cache";
 import { useAuthStore } from "@/entities/auth/model/stores";
@@ -3437,28 +3439,60 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     return room?.members.length ?? 0;
   };
 
-  /** Check if room has public join rules */
+  /** Check if room has public join rules. Delegates to the shared
+   *  readJoinRule helper so matrix-kit.chatIsPublic and this function never
+   *  diverge on how `m.room.join_rules` is read. */
   const isRoomPublic = (roomId: string): boolean => {
     try {
       const matrixService = getMatrixClientService();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const matrixRoom = matrixService.getRoom(roomId) as any;
+      const matrixRoom = matrixService.getRoom(roomId);
       if (!matrixRoom) return false;
-      const joinEvent = matrixRoom.currentState?.getStateEvents?.("m.room.join_rules", "");
-      const rule = joinEvent?.getContent?.()?.join_rule ?? joinEvent?.event?.content?.join_rule;
-      return rule === "public";
+      return readJoinRule(matrixRoom as unknown as Record<string, unknown>) === "public";
     } catch {
       return false;
     }
   };
 
-  /** Toggle room between public/private join rules (admin only) */
+  /** Toggle room between public/private join rules (admin only).
+   *  Up-front power-level check avoids sending a doomed state event, and
+   *  when enabling public we also set history_visibility=world_readable
+   *  (required for newly-joined users to see prior messages). */
   const setRoomPublic = async (roomId: string, isPublic: boolean): Promise<boolean> => {
     try {
       const matrixService = getMatrixClientService();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const matrixRoom = matrixService.getRoom(roomId) as any;
+
+      // Up-front PL check — PowerLevelsEventContent may declare a per-event
+      // requirement; fall back to state_default or 50 per Matrix spec.
+      const plEvent = matrixRoom?.currentState?.getStateEvents?.("m.room.power_levels", "");
+      const plContent = plEvent?.getContent?.() ?? plEvent?.event?.content ?? {};
+      const requiredPl = plContent?.events?.["m.room.join_rules"] ?? plContent?.state_default ?? 50;
+      const myUserId = matrixService.getUserId() ?? "";
+      const myPl = plContent?.users?.[myUserId] ?? plContent?.users_default ?? 0;
+      if (myPl < requiredPl) {
+        console.warn("[chat-store] setRoomPublic: insufficient power level", { myPl, requiredPl });
+        return false;
+      }
+
       await matrixService.sendStateEvent(roomId, "m.room.join_rules", {
         join_rule: isPublic ? "public" : "invite",
       }, "");
+
+      // Public rooms need world_readable history so users can browse the log
+      // before joining. Skip the write if it's already set — avoids a
+      // redundant state event on every toggle.
+      if (isPublic) {
+        const hvEvent = matrixRoom?.currentState?.getStateEvents?.("m.room.history_visibility", "");
+        const currentHv =
+          hvEvent?.getContent?.()?.history_visibility ??
+          hvEvent?.event?.content?.history_visibility;
+        if (currentHv !== "world_readable") {
+          await matrixService.sendStateEvent(roomId, "m.room.history_visibility", {
+            history_visibility: "world_readable",
+          }, "");
+        }
+      }
       return true;
     } catch (e) {
       console.warn("[chat-store] setRoomPublic error:", e);
@@ -3466,24 +3500,91 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     }
   };
 
-  /** Join a room by ID (for invite link flow) */
-  const joinRoomById = async (roomId: string): Promise<boolean> => {
+  /** Join a room by ID (for invite link flow). Returns a typed JoinRoomResult
+   *  so callers can render a localized toast per failure mode instead of
+   *  silently swallowing the error into a boolean. */
+  const joinRoomById = async (roomId: string): Promise<JoinRoomResult> => {
+    // Identity translator — store returns i18n keys; App.vue renders via t().
+    const keyTranslator = (k: string): string => k;
+    if (!validateRoomId(roomId)) {
+      return {
+        ok: false,
+        reason: "invalid_id",
+        errorMessage: keyTranslator("joinRoom.errorInvalidId"),
+      };
+    }
     try {
       const matrixService = getMatrixClientService();
+      const myUserId = matrixService.getUserId() ?? "";
       // Security (best-effort): block join if local state shows user is banned.
       // Authoritative enforcement is server-side; this avoids a wasted network call.
-      const myUserId = matrixService.getUserId() ?? "";
       if (isUserBanned(roomId, myUserId)) {
         console.warn("[chat-store] joinRoomById blocked: user is banned from room", roomId);
-        return false;
+        return {
+          ok: false,
+          reason: "banned",
+          errorMessage: keyTranslator("joinRoom.errorBanned"),
+        };
       }
       await matrixService.joinRoom(roomId);
       await refreshRoomsNow();
-      setActiveRoom(roomId);
-      return true;
+      // Defer active-room flip to next microtask so room-cleanup / zombie
+      // healing in this tick doesn't race with the fresh join.
+      queueMicrotask(() => setActiveRoom(roomId));
+      return { ok: true };
     } catch (e) {
       console.warn("[chat-store] joinRoomById error:", e);
-      return false;
+      // The Matrix server returns M_FORBIDDEN for BOTH private rooms and
+      // banned users. If local state shows ban, prefer that label over the
+      // generic "private room" message to avoid misleading the user.
+      try {
+        const matrixService = getMatrixClientService();
+        const myUserId = matrixService.getUserId() ?? "";
+        if (isUserBanned(roomId, myUserId)) {
+          return {
+            ok: false,
+            reason: "banned",
+            errorMessage: keyTranslator("joinRoom.errorBanned"),
+          };
+        }
+      } catch { /* fall through to categorization */ }
+      return categorizeJoinError(e, keyTranslator);
+    }
+  };
+
+  /** Peek room state without joining. Used to render a preview modal so the
+   *  user sees name/topic/memberCount before committing. Returns null if the
+   *  homeserver denies peek (private room) or the SDK lacks peekInRoom. */
+  const peekRoom = async (roomId: string): Promise<{
+    name?: string;
+    topic?: string;
+    avatar?: string | null;
+    memberCount?: number;
+    isEncrypted?: boolean;
+  } | null> => {
+    if (!validateRoomId(roomId)) return null;
+    try {
+      const matrixService = getMatrixClientService();
+      const client = matrixService.client;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const clientAny = client as any;
+      if (!clientAny || typeof clientAny.peekInRoom !== "function") return null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const room = (await clientAny.peekInRoom(roomId)) as any;
+      if (!room) return null;
+      const topic =
+        room.currentState?.getStateEvents?.("m.room.topic", "")?.getContent?.()?.topic ?? undefined;
+      const avatar = typeof room.getAvatarUrl === "function" ? room.getAvatarUrl() : null;
+      return {
+        name: room.name,
+        topic,
+        avatar,
+        memberCount: room.currentState?.getJoinedMemberCount?.() ?? 0,
+        isEncrypted: !!room.currentState?.getStateEvents?.("m.room.encryption", ""),
+      };
+    } catch (e) {
+      console.warn("[chat-store] peekRoom failed:", e);
+      return null;
     }
   };
 
@@ -6054,6 +6155,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     isDetachedFromLatest,
     isRoomPublic,
     joinRoomById,
+    peekRoom,
     bindAccountKeys,
     banMember,
     getBannedMembers,

--- a/src/entities/matrix/model/__tests__/join-rule.test.ts
+++ b/src/entities/matrix/model/__tests__/join-rule.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { readJoinRule } from "../matrix-kit";
+
+// Build a minimal room stub that mimics matrix-js-sdk's currentState.getStateEvents API.
+// The SDK exposes two shapes depending on arity:
+//   getStateEvents(type, stateKey)  → single MatrixEvent | null
+//   getStateEvents(type)            → MatrixEvent[]
+function roomWithSingleEvent(joinRule: string): Record<string, unknown> {
+  return {
+    currentState: {
+      getStateEvents: (type: string, stateKey?: string) => {
+        if (type !== "m.room.join_rules") return stateKey !== undefined ? null : [];
+        if (stateKey === "") {
+          return { getContent: () => ({ join_rule: joinRule }) };
+        }
+        return [{ event: { content: { join_rule: joinRule } } }];
+      },
+    },
+  };
+}
+
+function roomWithArrayOnly(joinRule: string): Record<string, unknown> {
+  // Some SDK versions only populate the arity-1 call and return an array where
+  // items expose their content via `event.content`.
+  return {
+    currentState: {
+      getStateEvents: (type: string, stateKey?: string) => {
+        if (type !== "m.room.join_rules") return stateKey !== undefined ? null : [];
+        if (stateKey === "") return null;
+        return [{ event: { content: { join_rule: joinRule } } }];
+      },
+    },
+  };
+}
+
+function roomWithoutJoinRules(): Record<string, unknown> {
+  return {
+    currentState: {
+      getStateEvents: () => null,
+    },
+  };
+}
+
+describe("readJoinRule (single source of truth)", () => {
+  it("returns 'public' when join_rule state event is public (arity-2 shape)", () => {
+    expect(readJoinRule(roomWithSingleEvent("public"))).toBe("public");
+  });
+
+  it("returns 'invite' when join_rule state event is invite", () => {
+    expect(readJoinRule(roomWithSingleEvent("invite"))).toBe("invite");
+  });
+
+  it("returns 'invite' by default when no state event present", () => {
+    expect(readJoinRule(roomWithoutJoinRules())).toBe("invite");
+  });
+
+  it("returns 'invite' when room shape is missing currentState", () => {
+    expect(readJoinRule({})).toBe("invite");
+  });
+
+  it("falls back to array shape when arity-2 returns null (SDK quirk)", () => {
+    expect(readJoinRule(roomWithArrayOnly("public"))).toBe("public");
+  });
+
+  it("returns 'invite' if array is empty", () => {
+    const room = {
+      currentState: {
+        getStateEvents: () => [],
+      },
+    };
+    expect(readJoinRule(room)).toBe("invite");
+  });
+
+  it("handles getStateEvents throwing without crashing", () => {
+    const room = {
+      currentState: {
+        getStateEvents: () => {
+          throw new Error("boom");
+        },
+      },
+    };
+    expect(readJoinRule(room)).toBe("invite");
+  });
+
+  it("supports 'knock' and 'restricted' rules verbatim", () => {
+    expect(readJoinRule(roomWithSingleEvent("knock"))).toBe("knock");
+    expect(readJoinRule(roomWithSingleEvent("restricted"))).toBe("restricted");
+  });
+});

--- a/src/entities/matrix/model/matrix-kit.ts
+++ b/src/entities/matrix/model/matrix-kit.ts
@@ -10,6 +10,51 @@ import type { MatrixClientService } from "./matrix-client";
 
 const cacheStorage: Record<string, string> = {};
 
+export type JoinRule = "public" | "invite" | "knock" | "restricted" | string;
+
+/**
+ * Read `m.room.join_rules` as the single source of truth.
+ *
+ * Matrix JS SDK exposes two shapes depending on arity of `getStateEvents`:
+ *   - `getStateEvents(type, stateKey)` returns a single MatrixEvent | null
+ *   - `getStateEvents(type)` returns a MatrixEvent[]
+ *
+ * Historically chat-store.isRoomPublic and matrix-kit.chatIsPublic read
+ * these through different paths → split-brain state. Consolidate here so
+ * UI and business logic agree on the rule.
+ *
+ * Defaults to "invite" (Matrix spec default) when the event is missing or
+ * unreadable.
+ */
+export function readJoinRule(room: Record<string, unknown>): JoinRule {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cs = (room as any)?.currentState;
+    if (!cs || typeof cs.getStateEvents !== "function") return "invite";
+
+    // Preferred path: explicit state_key="" returns a single event
+    const single = cs.getStateEvents("m.room.join_rules", "");
+    if (single && typeof single.getContent === "function") {
+      const rule = single.getContent()?.join_rule;
+      if (typeof rule === "string" && rule.length > 0) return rule;
+    }
+
+    // Fallback path: array shape on some SDK versions
+    const arr = cs.getStateEvents("m.room.join_rules");
+    if (Array.isArray(arr)) {
+      for (const ev of arr) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const e = ev as any;
+        const rule = e?.event?.content?.join_rule ?? e?.getContent?.()?.join_rule;
+        if (typeof rule === "string" && rule.length > 0) return rule;
+      }
+    }
+  } catch {
+    /* fall through to default */
+  }
+  return "invite";
+}
+
 export class MatrixKit {
   private matrixService: MatrixClientService;
 
@@ -137,16 +182,10 @@ export class MatrixKit {
     return hash;
   }
 
-  /** Check if chat is public */
+  /** Check if chat is public. Delegates to the shared readJoinRule helper so
+   *  chat-store and this class never diverge on how join_rules is read. */
   chatIsPublic(room: Record<string, unknown>): boolean {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const roomAny = room as any;
-    const joinRules = (roomAny.currentState?.getStateEvents?.("m.room.join_rules") ?? []) as unknown[];
-    return joinRules.some((v: unknown) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const rule = (v as any)?.event;
-      return rule?.content?.join_rule === "public";
-    });
+    return readJoinRule(room) === "public";
   }
 
   /** Get room members — combines currentState.members + summary.members

--- a/src/features/chat-info/ui/ChatInfoPanel.vue
+++ b/src/features/chat-info/ui/ChatInfoPanel.vue
@@ -15,6 +15,9 @@ import Toggle from "@/shared/ui/toggle/Toggle.vue";
 import ChatInfoGallery from "./ChatInfoGallery.vue";
 import { useResolvedRoomName } from "@/entities/chat/lib/use-resolved-room-name";
 import { openBastyonProfile } from "@/shared/lib/open-profile-url";
+import { copyToClipboard, shareLink } from "@/shared/lib/share-link";
+import { useToast } from "@/shared/lib/use-toast";
+import { getMatrixClientService } from "@/entities/matrix";
 
 interface Props {
   show: boolean;
@@ -56,41 +59,124 @@ const fileCount = computed(() => {
 });
 
 // ── Invite link (group sharing) ──
-const roomPublic = ref(false);
+// `stateMarker` ticks whenever this room's state events change. It exists so
+// `roomPublic` / `inviteLink` can read from the Matrix SDK directly while
+// remaining reactive — updating the moment another admin toggles public,
+// without a manual refresh call.
+const stateMarker = ref(0);
 const togglingPublic = ref(false);
 const linkCopied = ref(false);
+const { toast: showToast } = useToast();
 
-const refreshRoomPublic = () => {
-  if (room.value?.isGroup) {
-    roomPublic.value = chatStore.isRoomPublic(room.value.id);
-  }
-};
+const roomPublic = computed(() => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  stateMarker.value;
+  if (!room.value?.isGroup) return false;
+  return chatStore.isRoomPublic(room.value.id);
+});
 
-watch(room, refreshRoomPublic, { immediate: true });
+// Path-based URL (NOT hash-based) — AndroidManifest pathPrefix="/join"
+// matches path, not fragment. Using a hash URL means the Android App Link
+// intent-filter never fires and the link opens in the browser.
+const inviteLink = computed(() => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  stateMarker.value;
+  if (!room.value) return "";
+  return `${APP_PUBLIC_URL}/join?room=${encodeURIComponent(room.value.id)}`;
+});
+
+// Subscribe to RoomState.events so toggles by *other* admins appear
+// immediately in our UI.
+let unsubscribeState: (() => void) | null = null;
+
+watch(
+  () => room.value?.id,
+  (roomId) => {
+    unsubscribeState?.();
+    unsubscribeState = null;
+    if (!roomId) return;
+    try {
+      const matrixService = getMatrixClientService();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const clientAny = matrixService.client as any;
+      if (!clientAny?.on || !clientAny?.off) return;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const handler = (event: any) => {
+        try {
+          if (event?.getRoomId?.() !== roomId) return;
+          const type = event?.getType?.();
+          if (type === "m.room.join_rules" || type === "m.room.history_visibility") {
+            stateMarker.value++;
+          }
+        } catch {
+          /* defensive: SDK sometimes emits without full accessors */
+        }
+      };
+      clientAny.on("RoomState.events", handler);
+      // Capture client ref at subscribe time; detach defensively against the
+      // case where the client instance was torn down (logout → login in the
+      // same session) — optional-chaining the off() silences "not a function".
+      unsubscribeState = () => {
+        try {
+          clientAny?.off?.("RoomState.events", handler);
+        } catch {
+          /* already destroyed — nothing to unwire */
+        }
+      };
+    } catch {
+      /* swallow — reactive marker isn't load-bearing for correctness */
+    }
+  },
+  { immediate: true },
+);
+
+onBeforeUnmount(() => {
+  unsubscribeState?.();
+  unsubscribeState = null;
+});
 
 // Refresh encryption status when panel opens or room changes
 watch([room, () => props.show], async ([r, visible]) => {
   if (r && visible) await chatStore.checkPeerKeys(r.id);
 }, { immediate: true });
 
-const inviteLink = computed(() => {
-  if (!room.value) return "";
-  return `${APP_PUBLIC_URL}/#/join?room=${encodeURIComponent(room.value.id)}`;
-});
-
 const togglePublic = async () => {
   if (!room.value || togglingPublic.value) return;
   togglingPublic.value = true;
   const newVal = !roomPublic.value;
   const ok = await chatStore.setRoomPublic(room.value.id, newVal);
-  if (ok) roomPublic.value = newVal;
+  if (!ok) {
+    showToast(t("shareGroup.toggleFailed"), "error");
+  }
+  // No optimistic update — RoomState.events fires after sendStateEvent and
+  // the computed will flip on its own. This keeps the UI consistent with
+  // what the server actually accepted.
   togglingPublic.value = false;
 };
 
 const copyInviteLink = async () => {
-  await navigator.clipboard.writeText(inviteLink.value);
-  linkCopied.value = true;
-  setTimeout(() => linkCopied.value = false, 2000);
+  try {
+    await copyToClipboard(inviteLink.value);
+    linkCopied.value = true;
+    setTimeout(() => linkCopied.value = false, 2000);
+  } catch {
+    showToast(t("shareGroup.copyFailed"), "error");
+  }
+};
+
+const shareInviteLink = async () => {
+  try {
+    await shareLink({
+      url: inviteLink.value,
+      title: t("shareGroup.shareTitle"),
+      text: t("shareGroup.shareText", { name: room.value?.name ?? "" }),
+    });
+  } catch (e) {
+    // AbortError fires when user dismisses the share sheet — silently ignore.
+    if (e instanceof Error && e.name === "AbortError") return;
+    // Web Share unavailable or native share failed — fall back to copy.
+    await copyInviteLink();
+  }
 };
 
 // ── Mute state ──
@@ -580,6 +666,19 @@ const openGallery = (tab: "media" | "files" | "links" | "voice" = "media") => {
                     @click="copyInviteLink"
                   >
                     {{ linkCopied ? t("shareGroup.copied") : t("shareGroup.copyLink") }}
+                  </button>
+                  <button
+                    class="shrink-0 flex h-8 w-8 items-center justify-center rounded-lg border border-neutral-grad-0 text-text-on-main-bg-color transition-colors hover:bg-neutral-grad-0"
+                    :aria-label="t('shareGroup.share')"
+                    @click="shareInviteLink"
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                      <circle cx="18" cy="5" r="3" />
+                      <circle cx="6" cy="12" r="3" />
+                      <circle cx="18" cy="19" r="3" />
+                      <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+                      <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+                    </svg>
                   </button>
                 </div>
                 <p class="mt-1.5 text-[11px] text-text-on-main-bg-color">{{ t("shareGroup.publicGroupHint") }}</p>

--- a/src/features/chat-info/ui/ChatInfoPanel.vue
+++ b/src/features/chat-info/ui/ChatInfoPanel.vue
@@ -75,6 +75,17 @@ const roomPublic = computed(() => {
   return chatStore.isRoomPublic(room.value.id);
 });
 
+// A broader "shareable" signal: includes world_readable broadcast rooms,
+// where the `join_rule` is still `"invite"` but anyone with the id can
+// peek and the owners typically expect the link to be copyable. This is
+// what most Bastyon release-note / announcement channels look like.
+const roomShareable = computed(() => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  stateMarker.value;
+  if (!room.value?.isGroup) return false;
+  return chatStore.isRoomShareableByLink(room.value.id);
+});
+
 // Path-based URL (NOT hash-based) — AndroidManifest pathPrefix="/join"
 // matches path, not fragment. Using a hash URL means the Android App Link
 // intent-filter never fires and the link opens in the browser.
@@ -637,8 +648,10 @@ const openGallery = (tab: "media" | "files" | "links" | "voice" = "media") => {
               </button>
             </div>
 
-            <!-- Invite link section (group only, admin or already public) -->
-            <div v-if="room.isGroup && (isAdmin || roomPublic)" class="border-t border-neutral-grad-0 px-4 py-3">
+            <!-- Invite link section: any group that is public, world-readable,
+                 or administrable. World-readable broadcast channels use
+                 `join_rule=invite` but are still safe to share by link. -->
+            <div v-if="room.isGroup && (isAdmin || roomShareable)" class="border-t border-neutral-grad-0 px-4 py-3">
               <div class="mb-2 flex items-center justify-between">
                 <div class="flex items-center gap-2">
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-text-on-main-bg-color">
@@ -653,7 +666,7 @@ const openGallery = (tab: "media" | "files" | "links" | "voice" = "media") => {
                 </div>
               </div>
 
-              <template v-if="roomPublic">
+              <template v-if="roomShareable">
                 <div class="flex items-center gap-2">
                   <input
                     :value="inviteLink"

--- a/src/features/join-room/index.ts
+++ b/src/features/join-room/index.ts
@@ -1,0 +1,1 @@
+export { default as JoinRoomPreviewModal } from "./ui/JoinRoomPreviewModal.vue";

--- a/src/features/join-room/ui/JoinRoomPreviewModal.vue
+++ b/src/features/join-room/ui/JoinRoomPreviewModal.vue
@@ -1,0 +1,157 @@
+<script setup lang="ts">
+import { ref, watch } from "vue";
+import { useChatStore } from "@/entities/chat";
+
+interface PreviewData {
+  name?: string;
+  topic?: string;
+  avatar?: string | null;
+  memberCount?: number;
+  isEncrypted?: boolean;
+}
+
+interface Props {
+  show: boolean;
+  roomId: string;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits<{
+  join: [];
+  cancel: [];
+}>();
+
+const { t } = useI18n();
+const chatStore = useChatStore();
+
+const loading = ref(false);
+const preview = ref<PreviewData | null>(null);
+const peekFailed = ref(false);
+
+watch(
+  () => [props.show, props.roomId],
+  async ([visible, rid]) => {
+    if (!visible || !rid) {
+      preview.value = null;
+      peekFailed.value = false;
+      return;
+    }
+    loading.value = true;
+    peekFailed.value = false;
+    try {
+      const data = await chatStore.peekRoom(rid as string);
+      if (!data) {
+        // Peek denied (private room) or SDK lacks peekInRoom — still offer
+        // Join with a "try anyway" hint.
+        peekFailed.value = true;
+        preview.value = null;
+      } else {
+        preview.value = data;
+      }
+    } finally {
+      loading.value = false;
+    }
+  },
+  { immediate: true },
+);
+</script>
+
+<template>
+  <Teleport to="body">
+    <transition name="fade">
+      <div
+        v-if="props.show"
+        class="fixed inset-0 z-[80] flex items-center justify-center bg-black/50 p-4"
+        @click="emit('cancel')"
+      >
+        <div
+          class="w-full max-w-sm rounded-2xl bg-background-total-theme p-6 shadow-xl"
+          @click.stop
+        >
+          <!-- Loading -->
+          <div v-if="loading" class="flex flex-col items-center gap-3 py-6">
+            <div class="h-8 w-8 animate-spin rounded-full border-2 border-color-bg-ac border-t-transparent" />
+            <p class="text-sm text-text-on-main-bg-color">
+              {{ t("joinRoom.loading") }}
+            </p>
+          </div>
+
+          <!-- Private-room fallback -->
+          <template v-else-if="peekFailed">
+            <h3 class="mb-2 text-lg font-semibold text-text-color">
+              {{ t("joinRoom.privateTitle") }}
+            </h3>
+            <p class="mb-6 text-sm text-text-on-main-bg-color">
+              {{ t("joinRoom.privateHint") }}
+            </p>
+            <div class="flex gap-2">
+              <button
+                class="flex-1 rounded-lg bg-neutral-grad-0 px-4 py-2.5 text-sm font-medium text-text-color transition-colors hover:bg-neutral-grad-2"
+                @click="emit('cancel')"
+              >
+                {{ t("info.cancel") }}
+              </button>
+              <button
+                class="flex-1 rounded-lg bg-color-bg-ac px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-color-bg-ac/90"
+                @click="emit('join')"
+              >
+                {{ t("joinRoom.tryAnyway") }}
+              </button>
+            </div>
+          </template>
+
+          <!-- Preview with data -->
+          <template v-else-if="preview">
+            <div class="mb-4 flex flex-col items-center text-center">
+              <Avatar :src="preview.avatar ?? undefined" :name="preview.name" size="xl" />
+              <h3 class="mt-3 text-lg font-semibold text-text-color">
+                {{ preview.name || t("joinRoom.unnamed") }}
+              </h3>
+              <p v-if="preview.topic" class="mt-1 text-sm text-text-on-main-bg-color">
+                {{ preview.topic }}
+              </p>
+              <p class="mt-2 text-xs text-text-on-main-bg-color">
+                {{ t("info.members", { count: preview.memberCount ?? 0 }) }}
+              </p>
+              <span
+                v-if="preview.isEncrypted"
+                class="mt-2 inline-flex items-center gap-1 rounded-full bg-color-good/15 px-2 py-0.5 text-[11px] text-color-good"
+              >
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                  <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                </svg>
+                {{ t("joinRoom.encrypted") }}
+              </span>
+            </div>
+            <div class="flex gap-2">
+              <button
+                class="flex-1 rounded-lg bg-neutral-grad-0 px-4 py-2.5 text-sm font-medium text-text-color transition-colors hover:bg-neutral-grad-2"
+                @click="emit('cancel')"
+              >
+                {{ t("info.cancel") }}
+              </button>
+              <button
+                class="flex-1 rounded-lg bg-color-bg-ac px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-color-bg-ac/90"
+                @click="emit('join')"
+              >
+                {{ t("joinRoom.join") }}
+              </button>
+            </div>
+          </template>
+        </div>
+      </div>
+    </transition>
+  </Teleport>
+</template>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease-out;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -636,6 +636,25 @@ export const en = {
   "shareGroup.joinFailed": "Failed to join group",
   "shareGroup.joined": "Joined successfully",
   "shareGroup.alreadyMember": "You are already a member",
+  "shareGroup.copyFailed": "Couldn't copy the link",
+  "shareGroup.toggleFailed": "Couldn't change group settings. You may lack permission.",
+  "shareGroup.shareTitle": "Forta Chat invite",
+  "shareGroup.shareText": "Join the \"{name}\" group on Forta Chat",
+
+  // ── Join-room preview & errors ──
+  "joinRoom.loading": "Loading room info…",
+  "joinRoom.privateTitle": "Private room",
+  "joinRoom.privateHint": "We can't preview this room. A member may need to invite you.",
+  "joinRoom.tryAnyway": "Try anyway",
+  "joinRoom.unnamed": "Unnamed",
+  "joinRoom.encrypted": "End-to-end encrypted",
+  "joinRoom.join": "Join",
+  "joinRoom.success": "You joined the room",
+  "joinRoom.errorBanned": "You are banned from this room",
+  "joinRoom.errorForbidden": "This is a private room. A member must invite you.",
+  "joinRoom.errorNotFound": "Room not found or removed",
+  "joinRoom.errorInvalidId": "Invalid room identifier",
+  "joinRoom.errorUnknown": "Couldn't join the room",
 
   // ── Quick search ──
   "quickSearch.placeholder": "Go to chat...",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -638,6 +638,25 @@ export const ru: Record<TranslationKey, string> = {
   "shareGroup.joinFailed": "Не удалось присоединиться",
   "shareGroup.joined": "Вы присоединились",
   "shareGroup.alreadyMember": "Вы уже участник",
+  "shareGroup.copyFailed": "Не удалось скопировать ссылку",
+  "shareGroup.toggleFailed": "Не удалось изменить настройки группы. Возможно, у вас нет прав.",
+  "shareGroup.shareTitle": "Приглашение в Forta Chat",
+  "shareGroup.shareText": "Присоединяйтесь к группе «{name}» в Forta Chat",
+
+  // ── Join-room preview & errors ──
+  "joinRoom.loading": "Загружаем информацию о комнате…",
+  "joinRoom.privateTitle": "Комната приватная",
+  "joinRoom.privateHint": "Мы не можем показать превью. Возможно, вас должен пригласить участник.",
+  "joinRoom.tryAnyway": "Всё равно попробовать",
+  "joinRoom.unnamed": "Без названия",
+  "joinRoom.encrypted": "Сообщения зашифрованы",
+  "joinRoom.join": "Присоединиться",
+  "joinRoom.success": "Вы присоединились к комнате",
+  "joinRoom.errorBanned": "Вы заблокированы в этой комнате",
+  "joinRoom.errorForbidden": "Комната приватная. Вас должен пригласить участник.",
+  "joinRoom.errorNotFound": "Комната не найдена или удалена",
+  "joinRoom.errorInvalidId": "Неверный идентификатор комнаты",
+  "joinRoom.errorUnknown": "Не удалось присоединиться к комнате",
 
   // ── Quick search ──
   "quickSearch.placeholder": "Перейти к чату...",

--- a/src/shared/lib/share-link.test.ts
+++ b/src/shared/lib/share-link.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the platform flag BEFORE importing the module under test so the
+// dynamic import branches pick the right path.
+vi.mock("@/shared/lib/platform/index", () => ({
+  isNative: false,
+}));
+
+// @capacitor/share is imported dynamically inside shareLink — mocked so the
+// web branch can be tested without pulling the native module.
+const shareCall = vi.fn().mockResolvedValue(undefined);
+vi.mock("@capacitor/share", () => ({
+  Share: {
+    share: (opts: unknown) => shareCall(opts),
+  },
+}));
+
+import { copyToClipboard, shareLink } from "./share-link";
+
+describe("copyToClipboard (web)", () => {
+  beforeEach(() => {
+    // no-op — retained for parallelism with other suites
+  });
+
+  it("uses navigator.clipboard.writeText when available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    await copyToClipboard("hello");
+    expect(writeText).toHaveBeenCalledWith("hello");
+  });
+
+  it("falls back to execCommand when clipboard API rejects", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+    // Track textarea lifecycle via a minimal DOM stub
+    const exec = vi.fn().mockReturnValue(true);
+    const appended: HTMLElement[] = [];
+    const originalAppend = document.body.appendChild.bind(document.body);
+    const originalRemove = document.body.removeChild.bind(document.body);
+    document.body.appendChild = ((node: HTMLElement) => {
+      appended.push(node);
+      return originalAppend(node);
+    }) as typeof document.body.appendChild;
+    document.body.removeChild = ((node: HTMLElement) => {
+      return originalRemove(node);
+    }) as typeof document.body.removeChild;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (document as any).execCommand = exec;
+
+    await copyToClipboard("fallback-text");
+
+    expect(exec).toHaveBeenCalledWith("copy");
+    expect(appended.length).toBe(1);
+    expect(appended[0].tagName).toBe("TEXTAREA");
+    expect((appended[0] as HTMLTextAreaElement).value).toBe("fallback-text");
+  });
+
+  it("falls back to execCommand when navigator.clipboard is missing entirely", async () => {
+    vi.stubGlobal("navigator", {});
+    const exec = vi.fn().mockReturnValue(true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (document as any).execCommand = exec;
+    await copyToClipboard("no-clipboard-api");
+    expect(exec).toHaveBeenCalledWith("copy");
+  });
+
+  it("throws when execCommand reports failure", async () => {
+    vi.stubGlobal("navigator", {});
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (document as any).execCommand = vi.fn().mockReturnValue(false);
+    await expect(copyToClipboard("boom")).rejects.toThrow();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("shareLink (web)", () => {
+  beforeEach(() => {
+    shareCall.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses navigator.share when available", async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { share });
+    await shareLink({ url: "https://forta.chat/join?room=!r:s", title: "Invite" });
+    expect(share).toHaveBeenCalledWith({
+      url: "https://forta.chat/join?room=!r:s",
+      title: "Invite",
+      text: undefined,
+    });
+  });
+
+  it("throws share_unavailable when navigator.share missing and not native", async () => {
+    vi.stubGlobal("navigator", {});
+    await expect(shareLink({ url: "https://forta.chat/join?room=!r:s" })).rejects.toThrow(
+      /share_unavailable/,
+    );
+  });
+});

--- a/src/shared/lib/share-link.ts
+++ b/src/shared/lib/share-link.ts
@@ -1,0 +1,78 @@
+import { isNative } from "@/shared/lib/platform/index";
+
+/**
+ * Copy text to the clipboard with fallback for legacy Android WebView.
+ *
+ * Tier 1: `navigator.clipboard.writeText` — modern path (Android Chromium ≥66,
+ *         iOS Safari 13.1+). Requires a secure context.
+ * Tier 2: hidden `<textarea>` + `document.execCommand("copy")` — works on
+ *         Android 7 WebView and iOS PWAs where the async Clipboard API is
+ *         missing or blocked.
+ *
+ * We intentionally do NOT depend on `@capacitor/clipboard` because Capacitor's
+ * WebView exposes `navigator.clipboard` directly; the execCommand fallback
+ * covers the old-WebView cases that motivated this helper.
+ */
+export async function copyToClipboard(text: string): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const nav = (typeof navigator !== "undefined" ? navigator : undefined) as any;
+  if (nav?.clipboard?.writeText) {
+    try {
+      await nav.clipboard.writeText(text);
+      return;
+    } catch {
+      // fall through to execCommand
+    }
+  }
+
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.setAttribute("readonly", "");
+  ta.style.position = "absolute";
+  ta.style.left = "-9999px";
+  document.body.appendChild(ta);
+  ta.select();
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ok = (document as any).execCommand?.("copy");
+    if (!ok) throw new Error("execCommand_copy_failed");
+  } finally {
+    document.body.removeChild(ta);
+  }
+}
+
+export interface ShareOptions {
+  url: string;
+  title?: string;
+  text?: string;
+}
+
+/**
+ * Open the system share sheet. Native → @capacitor/share; web → Web Share API.
+ * Rejects with `share_unavailable` if neither is available — caller should
+ * fall back to copyToClipboard and show a toast.
+ */
+export async function shareLink(opts: ShareOptions): Promise<void> {
+  if (isNative) {
+    const { Share } = await import("@capacitor/share");
+    await Share.share({
+      url: opts.url,
+      title: opts.title,
+      text: opts.text,
+    });
+    return;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const nav = (typeof navigator !== "undefined" ? navigator : undefined) as any;
+  if (typeof nav?.share === "function") {
+    await nav.share({
+      url: opts.url,
+      title: opts.title,
+      text: opts.text,
+    });
+    return;
+  }
+
+  throw new Error("share_unavailable");
+}


### PR DESCRIPTION
## Summary

Session 21 of the bug-fix pipeline. Addresses three overlapping user-reported problems around public rooms and invite links:

1. **Split-brain public-room detection** — `chat-store.isRoomPublic` and `matrix-kit.chatIsPublic` read `m.room.join_rules` through different SDK paths and disagreed, leaving the UI stale after a toggle.
2. **Hash-based invite URL never triggering Android App Link** — links were generated as `https://forta.chat/#/join?room=...` while `AndroidManifest pathPrefix="/join"` only matches path URLs. Tapping a link from Telegram opened the browser, not the app.
3. **`joinRoomById` swallowing errors** — failures were silently coerced to `boolean`, so a banned / private / not-found room dropped the user onto Welcome with no explanation.

## What changed

- **`readJoinRule` single source of truth** (`matrix-kit.ts`). Standalone helper covers both SDK shapes (arity-1 array, arity-2 single event). `chatIsPublic` and `chat-store.isRoomPublic` both delegate — guaranteed agreement.
- **Typed `JoinRoomResult`** (`entities/chat/lib/join-error.ts`). `joinRoomById` returns `{ok, reason, errorMessage}` with 5 reasons (banned / forbidden / not_found / invalid_id / unknown). M_FORBIDDEN is re-checked against local ban state so a banned user sees "banned" rather than the misleading "private room" copy.
- **`setRoomPublic` now PL-checks up front** and batch-writes `history_visibility=world_readable` when enabling public (skipped if already set). Avoids a doomed state event and makes new joiners see prior messages.
- **`peekRoom(roomId)`** — fetches name/topic/memberCount/isEncrypted via `client.peekInRoom` for the preview modal.
- **Path-based invite URL** in `ChatInfoPanel.vue`: `https://forta.chat/join?room=…`. `parseJoinUrl` already accepts both shapes, so existing shared links keep working.
- **Reactive `roomPublic`/`roomShareable`** via a `stateMarker` ref subscribed to `RoomState.events` — toggles by another admin appear immediately without a manual refresh.
- **Share button** next to Copy. New `shared/lib/share-link.ts`: `copyToClipboard` (navigator → `execCommand` fallback for legacy Android WebView), `shareLink` (Capacitor Share → Web Share API → throw `share_unavailable`).
- **`JoinRoomPreviewModal`** shows name/topic/member count/encrypted badge via `peekRoom` before the user commits. Private-room peeks get a "Try anyway" fallback.
- **Router `/join` validates roomId** through the shared `validateRoomId` before persisting to localStorage.
- **App.vue processJoinRoom** now routes through the modal; `confirmJoinRoom` maps `reason → i18n key` for a localized toast. If the user is already in the room we skip the modal.
- **Broadcast channel support** — `isRoomShareableByLink` returns true for `join_rule=public` OR `history_visibility=world_readable`, so non-admin members of announcement rooms still see the Copy/Share UI. Matches bastyon-chat's intent.
- **i18n**: `joinRoom.*` error keys + `shareGroup.toggleFailed / copyFailed / shareTitle / shareText` for ru/en.

## Hard prerequisite

Depends on #57 `fix(invite): Android App Links + deep-link handler`, which ships `/.well-known/assetlinks.json` and the `pathPrefix="/join"` intent-filter. Already merged.

## Test plan

- [x] Unit: `matrix-kit.readJoinRule` — public/invite/knock/restricted + SDK shape fallbacks (9 tests)
- [x] Unit: `chat/lib/join-error` — validateRoomId + categorizeJoinError (10 tests)
- [x] Unit: `share-link` — clipboard tiers + share branch + `share_unavailable` (5 tests)
- [x] Existing `parse-invite-url.test.ts` — 25 tests covering both URL shapes pass
- [x] `vite build` — clean
- [x] Type-check of the touched files — clean (pre-existing errors in `MessageBubble.vue`/`MessageInput.vue`/`DownloadPage.vue` are on master and unrelated)
- [ ] Manual Android: tap `https://forta.chat/join?room=…` from Telegram → preview modal opens in app
- [ ] Manual Android: legacy WebView clipboard fallback via `execCommand`
- [ ] Manual web: system share sheet via Web Share API on desktop Chrome / mobile Safari
- [ ] Manual: toggle Public in room A as admin while another client has the same room open — link section appears instantly on the other side

## Commits

- `refactor(matrix-kit): single readJoinRule source of truth`
- `fix(chat-store): typed JoinRoomResult + peekRoom + PL-aware setRoomPublic`
- `feat(share): clipboard + share-sheet helpers with legacy-WebView fallback`
- `fix(invite-link): path-based URL + reactive public toggle + share button`
- `feat(join-room): preview modal + typed error toasts + route validation`
- `fix(invite-link): show link for world-readable broadcast rooms too`