### PR TITLE
fix(typing): use standard Matrix /typing API and stop on chat leave

### DIFF
--- a/src/entities/matrix/model/__tests__/matrix-client-typing.test.ts
+++ b/src/entities/matrix/model/__tests__/matrix-client-typing.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { MatrixClientService } from "../matrix-client";
+
+/**
+ * Tests for the typing indicator implementation in matrix-client.ts.
+ *
+ * Regression guard: typing must use the standard Matrix API
+ * (PUT /_matrix/client/v3/rooms/{roomId}/typing/{userId}) via
+ * `client.sendTyping`, NOT the previous `sendToDevice` workaround
+ * with the custom `com.bastyon.typing` event type.
+ */
+
+const getSource = () =>
+  readFileSync(resolve(__dirname, "../matrix-client.ts"), "utf-8");
+
+describe("matrix-client setTyping (source-level regression)", () => {
+  it("calls the standard client.sendTyping API", () => {
+    const source = getSource();
+    expect(source).toMatch(/this\.client\.sendTyping\s*\(\s*roomId\s*,\s*isTyping\s*,/);
+  });
+
+  it("does not use the custom sendToDevice typing workaround", () => {
+    const source = getSource();
+    expect(source).not.toContain("com.bastyon.typing");
+    expect(source).not.toContain("TYPING_EVENT_TYPE");
+  });
+
+  it("does not maintain client-side typing auto-clear timers", () => {
+    const source = getSource();
+    expect(source).not.toContain("typingTimers");
+  });
+
+  it("does not subscribe to toDeviceEvent for typing", () => {
+    const source = getSource();
+    // The custom typing listener used `toDeviceEvent` to catch
+    // `com.bastyon.typing` events. The standard Matrix SDK delivers typing
+    // via `RoomMember.typing`, which must remain. We scope the negative
+    // assertion to the exact removed pattern so unrelated future
+    // `toDeviceEvent` listeners (e.g. for E2E keys) don't false-trip it.
+    expect(source).toContain('"RoomMember.typing"');
+    expect(source).not.toMatch(/toDeviceEvent[\s\S]*?com\.bastyon\.typing/);
+  });
+});
+
+describe("matrix-client setTyping (behavior)", () => {
+  let service: MatrixClientService;
+  let sendTyping: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    service = new MatrixClientService("test.invalid");
+    sendTyping = vi.fn().mockResolvedValue(undefined);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).client = { sendTyping };
+  });
+
+  it("forwards roomId, isTyping=true and a positive timeout to client.sendTyping", async () => {
+    await service.setTyping("!room:test.invalid", true);
+
+    expect(sendTyping).toHaveBeenCalledTimes(1);
+    const [roomId, isTyping, timeout] = sendTyping.mock.calls[0];
+    expect(roomId).toBe("!room:test.invalid");
+    expect(isTyping).toBe(true);
+    expect(timeout).toBeGreaterThan(0);
+  });
+
+  it("uses timeout=0 when stopping typing", async () => {
+    await service.setTyping("!room:test.invalid", false);
+
+    expect(sendTyping).toHaveBeenCalledTimes(1);
+    const [, isTyping, timeout] = sendTyping.mock.calls[0];
+    expect(isTyping).toBe(false);
+    expect(timeout).toBe(0);
+  });
+
+  it("does not throw when client is not initialized", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).client = null;
+    await expect(service.setTyping("!room:test.invalid", true)).resolves.toBeUndefined();
+    expect(sendTyping).not.toHaveBeenCalled();
+  });
+
+  it("swallows errors from sendTyping and logs a warning", async () => {
+    sendTyping.mockRejectedValueOnce(new Error("network down"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(service.setTyping("!room:test.invalid", true)).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+
+    warn.mockRestore();
+  });
+});

--- a/src/entities/matrix/model/matrix-client.ts
+++ b/src/entities/matrix/model/matrix-client.ts
@@ -40,7 +40,6 @@ export class MatrixClientService {
   private db: ChatStorageInstance | null = null;
   private sdk = sdk;
   store: Record<string, unknown> | null = null;
-  private typingTimers = new Map<string, number>();
   private torProxyUrl: string = '';
 
   setTorProxyUrl(url: string) {
@@ -430,41 +429,6 @@ export class MatrixClientService {
       this.onTyping?.(event, member);
     });
 
-    // Listen for sendToDevice typing events (workaround for broken /typing endpoint)
-    this.client.on("toDeviceEvent", (event: unknown) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const ev = event as any;
-      if (ev?.getType?.() !== MatrixClientService.TYPING_EVENT_TYPE) return;
-      const content = ev.getContent?.() ?? {};
-      const roomId = content.room_id as string;
-      const isTyping = content.typing as boolean;
-      const senderId = ev.getSender?.() as string;
-      if (!roomId || !senderId || senderId === userId) return;
-
-      // Build a member-like object matching what onTyping expects
-      const member = { roomId, userId: senderId, typing: isTyping };
-      this.onTyping?.(event, member);
-
-      // Auto-clear typing after 5s if no "stop typing" received
-      if (isTyping) {
-        const key = `${roomId}:${senderId}`;
-        if (this.typingTimers.has(key)) {
-          clearTimeout(this.typingTimers.get(key)!);
-        }
-        this.typingTimers.set(key, window.setTimeout(() => {
-          this.typingTimers.delete(key);
-          const fakeMember = { roomId, userId: senderId, typing: false };
-          this.onTyping?.(null, fakeMember);
-        }, 5000));
-      } else {
-        const key = `${roomId}:${senderId}`;
-        if (this.typingTimers.has(key)) {
-          clearTimeout(this.typingTimers.get(key)!);
-          this.typingTimers.delete(key);
-        }
-      }
-    });
-
     this.client.on("Room.receipt", (event: unknown, room: unknown) => {
       if (!this.chatsReady) return;
       this.onReceipt?.(event, room);
@@ -809,39 +773,15 @@ export class MatrixClientService {
     return client.http.authedRequest("PUT", path, undefined, body);
   }
 
-  /** Custom typing event type for sendToDevice fallback */
-  private static TYPING_EVENT_TYPE = "com.bastyon.typing";
-
-  /** Set typing indicator via sendToDevice (bypasses broken /typing endpoint).
-   *  Sends typing state directly to other room members' devices. */
+  /** Set typing indicator via standard Matrix API
+   *  (PUT /_matrix/client/v3/rooms/{roomId}/typing/{userId}). */
   async setTyping(roomId: string, isTyping: boolean): Promise<void> {
     if (!this.client) return;
     try {
-      const myUserId = this.getUserId();
-      if (!myUserId) return;
-
-      const room = this.client.getRoom(roomId);
-      if (!room) return;
-
-      // Get joined members, exclude self
-      const members: unknown[] = room.getJoinedMembers?.() ?? [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const otherMembers = members.filter((m: any) => m.userId !== myUserId);
-      if (otherMembers.length === 0) return;
-
-      // Build contentMap: Map<userId, Map<deviceId, content>>
-      const contentMap = new Map<string, Map<string, Record<string, unknown>>>();
-      for (const member of otherMembers) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const userId = (member as any).userId as string;
-        const deviceMap = new Map<string, Record<string, unknown>>();
-        deviceMap.set("*", { room_id: roomId, typing: isTyping });
-        contentMap.set(userId, deviceMap);
-      }
-
-      await this.client.sendToDevice(MatrixClientService.TYPING_EVENT_TYPE, contentMap);
+      const TYPING_TIMEOUT_MS = 20_000;
+      await this.client.sendTyping(roomId, isTyping, isTyping ? TYPING_TIMEOUT_MS : 0);
     } catch (e) {
-      console.warn("[matrix-client] setTyping (toDevice) error:", e);
+      console.warn("[matrix-client] setTyping error:", e);
     }
   }
 
@@ -963,11 +903,6 @@ export class MatrixClientService {
       this.client.removeAllListeners();
       this.client.stopClient();
     }
-    // Clear typing timers
-    for (const timer of this.typingTimers.values()) {
-      clearTimeout(timer);
-    }
-    this.typingTimers.clear();
     this.chatsReady = false;
     this.ready = false;
     this.error = false;

--- a/src/features/messaging/model/use-messages.test.ts
+++ b/src/features/messaging/model/use-messages.test.ts
@@ -40,6 +40,7 @@ const mockSendPollStart = vi.fn(() => "$poll_event_1");
 const mockSendPollResponse = vi.fn();
 const mockSendPollEnd = vi.fn();
 const mockIsReady = vi.fn(() => true);
+const mockSetTyping = vi.fn();
 
 vi.mock("@/entities/matrix", () => ({
   getMatrixClientService: vi.fn(() => ({
@@ -49,7 +50,7 @@ vi.mock("@/entities/matrix", () => ({
     sendEncryptedText: mockSendEncryptedText,
     redactEvent: mockRedactEvent,
     sendReaction: mockSendReaction,
-    setTyping: vi.fn(),
+    setTyping: mockSetTyping,
     uploadContent: vi.fn(() => "mxc://server/uploaded"),
     sendPollStart: mockSendPollStart,
     sendPollResponse: mockSendPollResponse,
@@ -501,6 +502,30 @@ describe("useMessages", () => {
       const call = (mockSendEncryptedText.mock.calls as unknown[][])[0];
       const content = call[1] as Record<string, unknown>;
       expect(content.forwarded_from).toBeUndefined();
+    });
+  });
+
+  // ─── setTyping ──────────────────────────────────────────────────
+
+  describe("setTyping", () => {
+    it("uses chatStore.activeRoomId when no override is given", () => {
+      chatStore.activeRoomId = "!room:server";
+      messaging.setTyping(true);
+      expect(mockSetTyping).toHaveBeenCalledWith("!room:server", true);
+    });
+
+    it("uses the explicit roomId override even when activeRoomId differs", () => {
+      // The user has switched to a new chat; we still need to stop typing
+      // in the OLD one whose id activeRoomId no longer holds.
+      chatStore.activeRoomId = "!new:server";
+      messaging.setTyping(false, "!old:server");
+      expect(mockSetTyping).toHaveBeenCalledWith("!old:server", false);
+    });
+
+    it("noops when neither override nor activeRoomId are set", () => {
+      chatStore.activeRoomId = null;
+      messaging.setTyping(true);
+      expect(mockSetTyping).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -742,9 +742,11 @@ export function useMessages() {
     await chatStore.loadRoomMessages(roomId, { waitForSdk: true });
   };
 
-  /** Set typing indicator */
-  const setTyping = (isTyping: boolean) => {
-    const roomId = chatStore.activeRoomId;
+  /** Set typing indicator. Pass `roomIdOverride` to target a specific room
+   *  (e.g. when leaving a chat and we need to stop typing in the OLD room
+   *  while activeRoomId already points to the new one). */
+  const setTyping = (isTyping: boolean, roomIdOverride?: string) => {
+    const roomId = roomIdOverride ?? chatStore.activeRoomId;
     if (!roomId) return;
     const matrixService = getMatrixClientService();
     matrixService.setTyping(roomId, isTyping);

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -57,6 +57,17 @@ const sending = ref(false);
 let typingTimeout: ReturnType<typeof setTimeout> | null = null;
 let lastTypingSent = 0;
 const TYPING_THROTTLE_MS = 3000;
+const TYPING_IDLE_STOP_MS = 3000;
+
+/** Cancel the pending idle stop and clear throttle so the next input
+ *  immediately re-arms a fresh typing window. */
+const resetTypingTimers = () => {
+  if (typingTimeout) {
+    clearTimeout(typingTimeout);
+    typingTimeout = null;
+  }
+  lastTypingSent = 0;
+};
 
 // --- Drafts ---
 let draftTimer: ReturnType<typeof setTimeout> | undefined;
@@ -73,6 +84,13 @@ watch(
   (newId, oldId) => {
     if (oldId) {
       saveDraft(oldId, text.value);
+      // Stop typing in the room we're leaving — otherwise the indicator
+      // hangs on peers' screens until the server-side timeout (~20–30s).
+      // Pass oldId explicitly: chatStore.activeRoomId already points to newId here.
+      if (typingTimeout || lastTypingSent > 0) {
+        setTyping(false, oldId);
+        resetTypingTimers();
+      }
       // Don't save forward back to the source room — forward travels to target only
       const fwd = chatStore.forwardingMessage;
       if (fwd && fwd.roomId !== oldId) {
@@ -109,6 +127,11 @@ const saveDraftOnBlur = () => {
 onBeforeUnmount(() => {
   const roomId = chatStore.activeRoomId;
   if (roomId) saveDraft(roomId, text.value);
+  // Stop typing on unmount — same reason as in the activeRoomId watcher.
+  if (roomId && (typingTimeout || lastTypingSent > 0)) {
+    setTyping(false, roomId);
+  }
+  resetTypingTimers();
   // Clean up any lingering recording mouse/move listeners
   document.removeEventListener("mouseup", handleGlobalMouseUp);
   document.removeEventListener("mousemove", handleGlobalMouseMove);
@@ -192,6 +215,7 @@ const handleSend = async () => {
   const roomId = chatStore.activeRoomId;
   if (roomId) clearDraft(roomId);
   setTyping(false);
+  resetTypingTimers();
   nextTick(() => { if (textareaRef.value) textareaRef.value.style.height = "auto"; });
 
   let inserted: boolean | undefined;
@@ -286,7 +310,11 @@ const handleInput = () => {
     setTyping(true);
   }
   if (typingTimeout) clearTimeout(typingTimeout);
-  typingTimeout = setTimeout(() => { setTyping(false); lastTypingSent = 0; }, 5000);
+  typingTimeout = setTimeout(() => {
+    setTyping(false);
+    lastTypingSent = 0;
+    typingTimeout = null;
+  }, TYPING_IDLE_STOP_MS);
 };
 
 // --- Attachment/polls ---

--- a/src/features/messaging/ui/__tests__/message-input-typing-cleanup.test.ts
+++ b/src/features/messaging/ui/__tests__/message-input-typing-cleanup.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Source-level regression tests for typing-indicator cleanup in MessageInput.vue.
+ *
+ * Bug history: when the user navigated to another chat (or unmounted the
+ * component) we never sent `setTyping(false)` for the old room, so peers saw
+ * the indicator hanging until the server-side timeout (~20–30s).
+ * Additionally, we used `chatStore.activeRoomId` for the stop call, which
+ * already pointed at the NEW room by the time the watcher fired.
+ *
+ * These tests guard the structural shape of the fix so it cannot silently
+ * regress during refactors. The actual `setTyping(roomIdOverride)` plumbing
+ * is covered by behavioral tests in `use-messages.test.ts`.
+ */
+
+const getSource = () =>
+  readFileSync(resolve(__dirname, "../MessageInput.vue"), "utf-8");
+
+describe("MessageInput typing cleanup", () => {
+  it("stops typing in the OLD room when activeRoomId changes", () => {
+    const source = getSource();
+    const watchStart = source.indexOf("() => chatStore.activeRoomId");
+    expect(watchStart).toBeGreaterThan(-1);
+    // Slice the watcher body — be generous, the watcher is ~40 lines.
+    const watchBody = source.slice(watchStart, watchStart + 2000);
+
+    // Must call setTyping(false, oldId) — passing oldId explicitly is the
+    // whole point: activeRoomId already points at newId here.
+    expect(watchBody).toMatch(/setTyping\(\s*false\s*,\s*oldId\s*\)/);
+  });
+
+  it("stops typing in the active room on component unmount", () => {
+    const source = getSource();
+    const unmountStart = source.indexOf("onBeforeUnmount(()");
+    expect(unmountStart).toBeGreaterThan(-1);
+    const unmountBody = source.slice(unmountStart, unmountStart + 800);
+
+    expect(unmountBody).toMatch(/setTyping\(\s*false\s*,\s*roomId\s*\)/);
+  });
+
+  it("uses a 3-second idle-stop debounce (not the legacy 5s)", () => {
+    const source = getSource();
+    expect(source).toMatch(/TYPING_IDLE_STOP_MS\s*=\s*3000/);
+    // The literal `5000` for typing must be gone — the only debounce we
+    // care about here is the typing one. We assert via the named constant
+    // to avoid catching unrelated 5000ms timers elsewhere in the file.
+    expect(source).not.toMatch(/setTyping\(false\)[^;]*\}\s*,\s*5000/);
+  });
+
+  it("clears throttle and pending stop at each setTyping(false) site", () => {
+    const source = getSource();
+    expect(source).toMatch(/const resetTypingTimers\s*=\s*\(\)/);
+
+    // Each of the three sites that explicitly stop typing — handleSend,
+    // onBeforeUnmount, and the activeRoomId watcher — must also call
+    // resetTypingTimers(), or a stale debounce/throttle will fire a
+    // duplicate stop afterwards.
+
+    // handleSend: slice from `const handleSend` to its end.
+    const handleSendStart = source.indexOf("const handleSend");
+    expect(handleSendStart).toBeGreaterThan(-1);
+    const handleSendBody = source.slice(handleSendStart, handleSendStart + 3000);
+    expect(handleSendBody).toContain("setTyping(false);");
+    expect(handleSendBody).toContain("resetTypingTimers()");
+
+    // activeRoomId watcher body.
+    const watchStart = source.indexOf("() => chatStore.activeRoomId");
+    expect(watchStart).toBeGreaterThan(-1);
+    const watchBody = source.slice(watchStart, watchStart + 2000);
+    expect(watchBody).toMatch(/setTyping\(\s*false\s*,\s*oldId\s*\)/);
+    expect(watchBody).toContain("resetTypingTimers()");
+
+    // onBeforeUnmount body.
+    const unmountStart = source.indexOf("onBeforeUnmount(()");
+    expect(unmountStart).toBeGreaterThan(-1);
+    const unmountBody = source.slice(unmountStart, unmountStart + 800);
+    expect(unmountBody).toMatch(/setTyping\(\s*false\s*,\s*roomId\s*\)/);
+    expect(unmountBody).toContain("resetTypingTimers()");
+  });
+});


### PR DESCRIPTION
## Summary

- Switches `MatrixClientService.setTyping` from a custom `sendToDevice` workaround (custom event type `com.bastyon.typing`, 5s client-side auto-clear) to the standard Matrix API `PUT /_matrix/client/v3/rooms/{roomId}/typing/{userId}` via `client.sendTyping`. The custom `toDeviceEvent` listener and timer state are removed; inbound typing events are already delivered through the existing `RoomMember.typing` listener and the `m.typing` ephemeral filter on `/sync`.
- Fixes a UX bug where peers saw the typing indicator hanging for ~20–30s after the user left a chat — we now send `setTyping(false)` for the leaving room in both the `activeRoomId` watcher and `onBeforeUnmount`. `setTyping` accepts an optional `roomIdOverride` so the watcher can target the OLD room (`chatStore.activeRoomId` already points at the new one when it fires).
- Lowers the idle-stop debounce from 5000ms to 3000ms (`TYPING_IDLE_STOP_MS`), matching Element/Telegram behavior. A `resetTypingTimers()` helper is called at every `setTyping(false)` site so a stale debounce never fires a duplicate stop after a manual stop.

## Motivation

Original code shipped a `sendToDevice` workaround with a comment claiming the standard `/typing` endpoint was broken on the homeserver. That endpoint now works, so we drop the workaround and the maintenance burden it carried (custom event type, per-peer device-map fan-out, 5s client-side auto-clear timer).

User-reported follow-up bugs after the API switch:
1. Indicator hangs ~30s after navigating away from a chat (no stop sent → server timeout governs).
2. Indicator lingers ~5s after the user stops typing (debounce too long).

## Test plan

- [x] New `matrix-client-typing.test.ts` (8 tests): source-level regression guards (no `com.bastyon.typing` / `TYPING_EVENT_TYPE` / `typingTimers` / `toDeviceEvent`-typing) + behavioral tests with a mocked `client.sendTyping` (forwarded args, 20s timeout for start, 0 for stop, no-throw when client is null, swallowed error path).
- [x] New `message-input-typing-cleanup.test.ts` (4 tests): per-site regression checks that the `activeRoomId` watcher, `onBeforeUnmount`, and `handleSend` each call both `setTyping(false, ...)` and `resetTypingTimers()`. Also pins `TYPING_IDLE_STOP_MS = 3000`.
- [x] Extended `use-messages.test.ts` (3 tests): `setTyping` uses `activeRoomId` by default, uses the explicit override when provided, no-ops when neither is set.
- [x] Full repo test suite: 1299 passing, 9 pre-existing failures unchanged from `master` (open-profile-url / video-embed / chat-helpers / display-result — none touch typing).
- [ ] Manual verification: please confirm in DevTools Network that typing fires `PUT /_matrix/client/v3/rooms/.../typing/...` and that the indicator clears on the peer side within ~3s of stopping and immediately when leaving the chat.

## Notes for the reviewer

- The 20s server timeout in `sendTyping` matches Element Web; Synapse's max is 30s.
- The `if (typingTimeout || lastTypingSent > 0)` guard in the watcher and unmount handler avoids redundant stops when no typing window is open. See the inline comment for the reasoning.
- Two code reviews ran during development; both approved. The MEDIUM finding from the second review (regression test only checked existence, not per-site pairing) was addressed before commit.