### PR TITLE
fix: rich content rendering (articles) + StarRating three-state UX

### DIFF
--- a/src/features/channels/ui/ChannelPostBubble.vue
+++ b/src/features/channels/ui/ChannelPostBubble.vue
@@ -2,6 +2,8 @@
 import type { ChannelPost } from "@/entities/channel";
 import { formatRelativeTime } from "@/shared/lib/format";
 import { normalizePocketnetImageUrl } from "@/shared/lib/image-url";
+import { renderArticleText } from "@/shared/lib/article-blocks";
+import StarRating from "@/features/post-player/ui/StarRating.vue";
 
 interface Props {
   post: ChannelPost;
@@ -31,62 +33,30 @@ const displayImages = computed(() => {
   return props.post.images.slice(0, 4).map((img) => normalizePocketnetImageUrl(img));
 });
 
-/** Parse message text — for articles (EditorJS JSON), extract paragraph text */
-const messageText = computed(() => {
-  const raw = props.post.caption || props.post.message || "";
-  if (!raw) return "";
-
-  // If article, try to parse EditorJS JSON
-  if (isArticle.value && raw.startsWith("{")) {
-    try {
-      const parsed = JSON.parse(raw);
-      if (parsed.blocks && Array.isArray(parsed.blocks)) {
-        const texts = parsed.blocks
-          .filter((b: any) => b.type === "paragraph" && b.data?.text)
-          .map((b: any) => stripHtml(b.data.text))
-          .filter(Boolean);
-        return texts.join("\n").slice(0, 500);
-      }
-    } catch {
-      // Not valid JSON, use as-is
-    }
-  }
-
-  return raw;
-});
-
-/** Caption displayed separately when both caption and message exist */
+/** Caption displayed separately when both caption and message exist. */
 const captionText = computed(() => {
   if (!props.post.caption || !props.post.message) return "";
   return props.post.caption;
 });
 
-/** Body text: message when caption exists, or the combined text */
+/**
+ * Body text preview. Uses shared Editor.js parser so article posts
+ * render readable plain text instead of raw JSON. Falls back to raw
+ * for non-article messages.
+ */
 const bodyText = computed(() => {
-  if (props.post.caption && props.post.message) {
-    // For articles, parse message as EditorJS
-    if (isArticle.value && props.post.message.startsWith("{")) {
-      try {
-        const parsed = JSON.parse(props.post.message);
-        if (parsed.blocks && Array.isArray(parsed.blocks)) {
-          const texts = parsed.blocks
-            .filter((b: any) => b.type === "paragraph" && b.data?.text)
-            .map((b: any) => stripHtml(b.data.text))
-            .filter(Boolean);
-          return texts.join("\n").slice(0, 500);
-        }
-      } catch {
-        // fallback
-      }
-    }
-    return props.post.message;
-  }
-  return messageText.value;
+  const raw = props.post.caption && props.post.message
+    ? props.post.message
+    : props.post.caption || props.post.message || "";
+  if (!raw) return "";
+  return renderArticleText(raw, { maxLength: 500 });
 });
 
-function stripHtml(html: string): string {
-  return html.replace(/<[^>]*>/g, "").trim();
-}
+const averageScore = computed(() => {
+  const cnt = props.post.scoreCnt ?? 0;
+  if (cnt <= 0) return 0;
+  return (props.post.scoreSum ?? 0) / cnt;
+});
 </script>
 
 <template>
@@ -166,13 +136,15 @@ function stripHtml(html: string): string {
       <div class="mt-1.5 flex items-center gap-3 text-xs text-text-on-main-bg-color">
         <span>{{ timeText }}</span>
 
-        <!-- Score -->
-        <span v-if="post.scoreSum" class="flex items-center gap-0.5">
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" class="text-text-on-main-bg-color">
-            <path d="M2 20h2c.55 0 1-.45 1-1v-9c0-.55-.45-1-1-1H2v11zm19.83-7.12c.11-.25.17-.52.17-.8V11c0-1.1-.9-2-2-2h-5.5l.92-4.65c.05-.22.02-.46-.08-.66-.23-.45-.52-.86-.88-1.22L14 2 7.59 8.41C7.21 8.79 7 9.3 7 9.83v7.84C7 18.95 8.05 20 9.34 20h8.11c.7 0 1.36-.37 1.72-.97l2.66-6.15z" />
-          </svg>
-          {{ post.scoreSum }}
-        </span>
+        <!-- Score (community average — outline gold when not voted) -->
+        <StarRating
+          v-if="post.scoreCnt > 0"
+          :average="averageScore"
+          :total-votes="post.scoreCnt"
+          :model-value="null"
+          readonly
+          compact
+        />
 
         <!-- Comments -->
         <button

--- a/src/features/messaging/ui/PostEmbed.vue
+++ b/src/features/messaging/ui/PostEmbed.vue
@@ -3,6 +3,7 @@ import { useAuthStore } from "@/entities/auth";
 import type { BastyonPostData } from "@/app/providers/initializers";
 import { parseVideoUrl, fetchPeerTubeThumb } from "@/shared/lib/video-embed";
 import { normalizePocketnetImageUrl } from "@/shared/lib/image-url";
+import { renderArticleText } from "@/shared/lib/article-blocks";
 
 interface Props {
   txid: string;
@@ -28,14 +29,23 @@ const firstImage = computed(() => {
   return normalizePocketnetImageUrl(post.value.images[0]);
 });
 
-const truncatedMessage = computed(() => {
-  if (!post.value?.message) return "";
-  return post.value.message.length > 160
-    ? post.value.message.slice(0, 160) + "..."
-    : post.value.message;
+const isArticle = computed(() => post.value?.settings?.v === "a");
+
+/** Full plain text (without truncation) — parses Editor.js JSON for articles. */
+const renderedFull = computed(() => {
+  const raw = post.value?.message ?? "";
+  if (!raw) return "";
+  return renderArticleText(raw);
 });
 
-const isArticle = computed(() => post.value?.settings?.v === "a");
+/** Truncated preview derived from the cached full render (no double parsing). */
+const truncatedMessage = computed(() => {
+  const full = renderedFull.value;
+  if (!full) return "";
+  return full.length > 160 ? full.slice(0, 160) + "..." : full;
+});
+
+const hasMore = computed(() => renderedFull.value.length > 160);
 
 const postUrl = computed(() => `bastyon://post?s=${props.txid}`);
 
@@ -184,12 +194,12 @@ const openVideo = (e: Event) => {
       <!-- Message body -->
       <div
         v-if="truncatedMessage"
-        class="text-xs leading-relaxed"
+        class="whitespace-pre-wrap break-words text-xs leading-relaxed"
         :class="isOwn ? 'text-white/70' : 'text-text-color/70'"
       >
         {{ truncatedMessage }}
         <a
-          v-if="post.message.length > 160"
+          v-if="hasMore"
           :href="postUrl"
           class="font-medium"
           :class="isOwn ? 'text-white/90' : 'text-color-txt-ac'"

--- a/src/features/post-player/ui/ArticleBody.vue
+++ b/src/features/post-player/ui/ArticleBody.vue
@@ -1,0 +1,111 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { renderArticleHtml, isArticleJson } from "@/shared/lib/article-blocks";
+
+interface Props {
+  /** Raw post.message — either Editor.js JSON or plain text. */
+  raw: string;
+  /** When true, even non-JSON input is wrapped in sanitized <p>. */
+  forceWrap?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), { forceWrap: false });
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+const html = computed(() => {
+  const raw = props.raw;
+  if (!raw) return "";
+  if (isArticleJson(raw)) return renderArticleHtml(raw);
+  // Non-JSON: always escape; forceWrap only affects whether to wrap in <p>
+  const safe = escapeHtml(raw);
+  return props.forceWrap ? `<p class="article-p">${safe}</p>` : safe;
+});
+</script>
+
+<template>
+  <div class="article-body" v-html="html" />
+</template>
+
+<style scoped>
+.article-body :deep(.article-p) {
+  margin-bottom: 0.75rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.article-body :deep(.article-p:last-child) {
+  margin-bottom: 0;
+}
+.article-body :deep(.article-h) {
+  margin: 1rem 0 0.5rem;
+  font-weight: 700;
+  line-height: 1.3;
+}
+.article-body :deep(.article-list) {
+  margin: 0 0 0.75rem;
+  padding-left: 1.5rem;
+}
+.article-body :deep(.article-list li) {
+  margin-bottom: 0.25rem;
+  list-style-position: outside;
+}
+.article-body :deep(.article-quote) {
+  border-left: 3px solid var(--color-bg-ac, #4a90e2);
+  padding: 0.5rem 0.75rem;
+  margin: 0.75rem 0;
+  font-style: italic;
+  opacity: 0.9;
+}
+.article-body :deep(.article-quote cite) {
+  display: block;
+  margin-top: 0.25rem;
+  font-style: normal;
+  font-size: 0.875em;
+  opacity: 0.7;
+}
+.article-body :deep(.article-code) {
+  background: rgba(0, 0, 0, 0.06);
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  overflow-x: auto;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.85em;
+  margin: 0.5rem 0;
+}
+.article-body :deep(.article-figure) {
+  margin: 0.75rem 0;
+}
+.article-body :deep(.article-figure img) {
+  max-width: 100%;
+  height: auto;
+  border-radius: 0.5rem;
+  display: block;
+}
+.article-body :deep(.article-figure figcaption) {
+  margin-top: 0.25rem;
+  font-size: 0.85em;
+  opacity: 0.7;
+  text-align: center;
+}
+.article-body :deep(.article-hr) {
+  border: 0;
+  border-top: 1px solid currentColor;
+  opacity: 0.2;
+  margin: 1rem 0;
+}
+.article-body :deep(a) {
+  color: var(--color-bg-ac, #4a90e2);
+  text-decoration: underline;
+}
+.article-body :deep(a:hover) {
+  text-decoration: none;
+}
+</style>

--- a/src/features/post-player/ui/PostCard.vue
+++ b/src/features/post-player/ui/PostCard.vue
@@ -9,6 +9,7 @@ import { useToast } from "@/shared/lib/use-toast";
 import VideoPlayer from "./VideoPlayer.vue";
 import StarRating from "./StarRating.vue";
 import PostPlayerModal from "./PostPlayerModal.vue";
+import { renderArticleText } from "@/shared/lib/article-blocks";
 import { useChatStore } from "@/entities/chat";
 import DonateModal from "@/features/wallet/ui/DonateModal.vue";
 
@@ -51,12 +52,11 @@ const firstImage = computed(() => {
   return normalizePocketnetImageUrl(post.value.images[0]);
 });
 
+/** Plain-text preview that handles both Editor.js JSON (articles) and plain messages. */
 const truncatedMessage = computed(() => {
-  if (!post.value?.message) return "";
-  const limit = 200;
-  return post.value.message.length > limit
-    ? post.value.message.slice(0, limit) + "..."
-    : post.value.message;
+  const raw = post.value?.message ?? "";
+  if (!raw) return "";
+  return renderArticleText(raw, { maxLength: 200 });
 });
 
 const authorAvatarError = ref(false);

--- a/src/features/post-player/ui/PostPlayerModal.vue
+++ b/src/features/post-player/ui/PostPlayerModal.vue
@@ -9,6 +9,7 @@ import StarRating from "./StarRating.vue";
 import PostAuthor from "./PostAuthor.vue";
 import PostActions from "./PostActions.vue";
 import PostComments from "./PostComments.vue";
+import ArticleBody from "./ArticleBody.vue";
 import DonateModal from "@/features/wallet/ui/DonateModal.vue";
 import { useChatStore } from "@/entities/chat";
 import { parseVideoUrl } from "@/shared/lib/video-embed";
@@ -157,9 +158,11 @@ onUnmounted(() => {
               {{ post.caption }}
             </h2>
 
-            <p v-if="post.message" class="whitespace-pre-wrap text-sm leading-relaxed text-text-color/80">
-              {{ post.message }}
-            </p>
+            <ArticleBody
+              v-if="post.message"
+              :raw="post.message"
+              class="text-sm leading-relaxed text-text-color/80"
+            />
 
             <div v-if="post.tags.length" class="flex flex-wrap gap-1.5">
               <span

--- a/src/features/post-player/ui/StarRating.vue
+++ b/src/features/post-player/ui/StarRating.vue
@@ -1,11 +1,19 @@
 <script setup lang="ts">
 interface Props {
+  /** My own rating (1..5) or null if I haven't voted. */
   modelValue?: number | null;
+  /** Community average (0..5, may be fractional). */
   average?: number;
+  /** Total number of votes (including mine). */
   totalVotes?: number;
+  /** Disable all interaction (e.g. own post or other read-only contexts). */
   readonly?: boolean;
+  /** Compact size variant for list bubbles. */
   compact?: boolean;
+  /** Submit-in-progress state — disables clicks and shows pulse. */
   submitting?: boolean;
+  /** Hide the numeric label entirely. */
+  hideLabel?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -15,19 +23,31 @@ const props = withDefaults(defineProps<Props>(), {
   readonly: false,
   compact: false,
   submitting: false,
+  hideLabel: false,
 });
 
 const emit = defineEmits<{ "update:modelValue": [value: number] }>();
 
 const hoverValue = ref(0);
 
-const displayValue = computed(() => {
-  if (hoverValue.value > 0) return hoverValue.value;
-  if (props.modelValue) return props.modelValue;
-  return props.average;
-});
+const hasMyVote = computed(() => props.modelValue != null && props.modelValue > 0);
 
-const isInteractive = computed(() => !props.readonly && !props.modelValue && !props.submitting);
+const isInteractive = computed(
+  () => !props.readonly && !hasMyVote.value && !props.submitting,
+);
+
+type StarState = "my-fill" | "avg-line" | "empty";
+
+function stateFor(star: number): StarState {
+  if (isInteractive.value && hoverValue.value > 0) {
+    return star <= hoverValue.value ? "my-fill" : "empty";
+  }
+  if (hasMyVote.value) {
+    return star <= (props.modelValue as number) ? "my-fill" : "empty";
+  }
+  const avgFilled = Math.floor(props.average);
+  return star <= avgFilled ? "avg-line" : "empty";
+}
 
 const onHover = (star: number) => {
   if (isInteractive.value) hoverValue.value = star;
@@ -40,6 +60,8 @@ const onLeave = () => {
 const onClick = (star: number) => {
   if (isInteractive.value) emit("update:modelValue", star);
 };
+
+const labelText = computed(() => props.average.toFixed(1));
 </script>
 
 <template>
@@ -57,25 +79,30 @@ const onClick = (star: number) => {
         viewBox="0 0 24 24"
         class="transition-colors"
         :class="[
-          star <= displayValue
+          stateFor(star) === 'my-fill'
             ? 'fill-color-star-yellow text-color-star-yellow'
-            : 'fill-none text-text-on-main-bg-color opacity-40',
+            : stateFor(star) === 'avg-line'
+              ? 'fill-none text-color-star-yellow'
+              : 'fill-none text-neutral-grad-2',
           isInteractive ? 'hover:scale-110' : '',
           submitting ? 'animate-pulse' : '',
         ]"
         stroke="currentColor"
-        stroke-width="1.5"
+        stroke-width="1.75"
         @mouseenter="onHover(star)"
         @click="onClick(star)"
       >
         <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
       </svg>
     </div>
-    <span v-if="!compact && totalVotes > 0" class="text-xs text-text-on-main-bg-color">
-      {{ average.toFixed(1) }}
-    </span>
-    <span v-if="compact && totalVotes > 0" class="text-[10px] text-text-on-main-bg-color">
-      {{ average.toFixed(1) }}
+    <span
+      v-if="!hideLabel"
+      :class="[
+        compact ? 'text-[10px]' : 'text-xs',
+        'text-text-on-main-bg-color',
+      ]"
+    >
+      {{ labelText }}
     </span>
   </div>
 </template>

--- a/src/features/post-player/ui/StarRating.vue
+++ b/src/features/post-player/ui/StarRating.vue
@@ -45,7 +45,9 @@ function stateFor(star: number): StarState {
   if (hasMyVote.value) {
     return star <= (props.modelValue as number) ? "my-fill" : "empty";
   }
-  const avgFilled = Math.floor(props.average);
+  // Round-half-up so the visible filled count matches the rounded label
+  // ("5.0" must show 5 stars, not 4 — toFixed(1) rounds 4.99 → "5.0").
+  const avgFilled = Math.round(props.average);
   return star <= avgFilled ? "avg-line" : "empty";
 }
 

--- a/src/features/post-player/ui/__tests__/ArticleBody.test.ts
+++ b/src/features/post-player/ui/__tests__/ArticleBody.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import ArticleBody from "../ArticleBody.vue";
+
+const json = (blocks: unknown[]): string => JSON.stringify({ blocks });
+
+describe("ArticleBody", () => {
+  it("renders Editor.js paragraphs as readable text", () => {
+    const w = mount(ArticleBody, {
+      props: {
+        raw: json([
+          { type: "paragraph", data: { text: "First" } },
+          { type: "header", data: { text: "Title", level: 2 } },
+          { type: "paragraph", data: { text: "Second" } },
+        ]),
+      },
+    });
+    const text = w.text();
+    expect(text).not.toContain('"blocks"');
+    expect(text).not.toContain('"paragraph"');
+    expect(text).toContain("First");
+    expect(text).toContain("Title");
+    expect(text).toContain("Second");
+  });
+
+  it("preserves safe inline tags via v-html", () => {
+    const w = mount(ArticleBody, {
+      props: {
+        raw: json([
+          { type: "paragraph", data: { text: '<b>Bold</b> <a href="https://x.com">link</a>' } },
+        ]),
+      },
+    });
+    expect(w.html()).toContain("<b>Bold</b>");
+    expect(w.html()).toContain('href="https://x.com"');
+  });
+
+  it("strips dangerous content (script, onclick)", () => {
+    const w = mount(ArticleBody, {
+      props: {
+        raw: json([
+          { type: "paragraph", data: { text: '<script>alert(1)</script><b onclick="evil()">Click</b>' } },
+        ]),
+      },
+    });
+    const html = w.html().toLowerCase();
+    expect(html).not.toContain("<script");
+    expect(html).not.toContain("onclick");
+    expect(html).not.toContain("alert(1)");
+    expect(w.html()).toContain("<b>Click</b>");
+  });
+
+  it("renders non-JSON input as-is when forceWrap=false (default)", () => {
+    const w = mount(ArticleBody, {
+      props: { raw: "Plain text message" },
+    });
+    expect(w.text()).toContain("Plain text message");
+  });
+
+  it("escapes HTML in non-JSON input safely", () => {
+    const w = mount(ArticleBody, {
+      props: { raw: "<script>alert(1)</script>plain" },
+    });
+    expect(w.html().toLowerCase()).not.toContain("<script");
+  });
+
+  it("renders empty for empty raw", () => {
+    const w = mount(ArticleBody, { props: { raw: "" } });
+    expect(w.text()).toBe("");
+  });
+
+  it("renders ordered list", () => {
+    const w = mount(ArticleBody, {
+      props: {
+        raw: json([{ type: "list", data: { style: "ordered", items: ["A", "B"] } }]),
+      },
+    });
+    expect(w.html()).toMatch(/<ol[^>]*>/);
+    expect(w.text()).toContain("A");
+    expect(w.text()).toContain("B");
+  });
+
+  it("renders quote as blockquote", () => {
+    const w = mount(ArticleBody, {
+      props: {
+        raw: json([{ type: "quote", data: { text: "wisdom", caption: "sage" } }]),
+      },
+    });
+    expect(w.html()).toMatch(/<blockquote[^>]*>/);
+    expect(w.text()).toContain("wisdom");
+    expect(w.text()).toContain("sage");
+  });
+});

--- a/src/features/post-player/ui/__tests__/PostPlayerModal-article.test.ts
+++ b/src/features/post-player/ui/__tests__/PostPlayerModal-article.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+
+// Stub composables BEFORE component import (vi.mock is hoisted)
+vi.mock("../../model/use-post-scores", () => ({
+  usePostScores: () => ({
+    myScore: { value: null },
+    averageScore: { value: 0 },
+    totalVotes: { value: 0 },
+    hasVoted: { value: false },
+    submitting: { value: false },
+    load: vi.fn().mockResolvedValue(undefined),
+    submitVote: vi.fn(),
+  }),
+}));
+vi.mock("../../model/use-post-comments", () => ({
+  usePostComments: () => ({
+    comments: { value: [] },
+    loading: { value: false },
+    submitting: { value: false },
+    load: vi.fn().mockResolvedValue(undefined),
+    submit: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+vi.mock("../../model/use-post-boost", () => ({
+  usePostBoost: () => ({
+    showDonateModal: { value: false },
+    boostAddress: { value: "" },
+    openBoost: vi.fn(),
+    closeBoost: vi.fn(),
+  }),
+}));
+vi.mock("@/entities/auth", () => ({
+  useAuthStore: () => ({ address: "myaddr" }),
+}));
+vi.mock("@/entities/chat", () => ({
+  useChatStore: () => ({ initPostForward: vi.fn() }),
+}));
+vi.mock("@/shared/lib/video-embed", () => ({
+  parseVideoUrl: () => null,
+}));
+vi.mock("@/shared/lib/image-url", () => ({
+  normalizePocketnetImageUrl: (x: string) => x,
+}));
+
+vi.stubGlobal("useI18n", () => ({ t: (k: string) => k }));
+
+import PostPlayerModal from "../PostPlayerModal.vue";
+
+const articleJson = JSON.stringify({
+  blocks: [
+    { type: "paragraph", data: { text: "Первый <b>абзац</b>" } },
+    { type: "header", data: { text: "Подзаголовок", level: 2 } },
+    { type: "paragraph", data: { text: "Второй абзац" } },
+  ],
+});
+
+interface FakePost {
+  txid: string;
+  caption: string;
+  message: string;
+  settings?: { v: string };
+  time: number;
+  address: string;
+  tags: string[];
+  url: string;
+  images: string[];
+}
+
+const baseArticlePost: FakePost = {
+  txid: "abc123",
+  caption: "Заголовок",
+  message: articleJson,
+  settings: { v: "a" },
+  time: 1700000000,
+  address: "authoraddr",
+  tags: [],
+  url: "",
+  images: [],
+};
+
+const stubs = {
+  Teleport: true,
+  VideoPlayer: true,
+  StarRating: true,
+  PostAuthor: true,
+  PostActions: true,
+  PostComments: true,
+  DonateModal: true,
+};
+
+describe("PostPlayerModal article rendering", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("renders Editor.js blocks instead of raw JSON for article posts", () => {
+    const w = mount(PostPlayerModal, {
+      props: { post: baseArticlePost as never, authorName: "X", authorAvatarUrl: "" },
+      global: { stubs },
+    });
+    const text = w.text();
+    expect(text).not.toContain('"blocks":');
+    expect(text).not.toContain('"type":"paragraph"');
+    expect(text).toContain("Первый абзац");
+    expect(text).toContain("Подзаголовок");
+    expect(text).toContain("Второй абзац");
+  });
+
+  it("renders inline HTML safely (b tag kept, script dropped)", () => {
+    const post = {
+      ...baseArticlePost,
+      message: JSON.stringify({
+        blocks: [{ type: "paragraph", data: { text: "<b>safe</b><script>alert(1)</script>" } }],
+      }),
+    };
+    const w = mount(PostPlayerModal, {
+      props: { post: post as never, authorName: "X", authorAvatarUrl: "" },
+      global: { stubs },
+    });
+    expect(w.html()).toContain("<b>safe</b>");
+    expect(w.html().toLowerCase()).not.toContain("<script");
+  });
+
+  it("non-article post (settings.v != 'a') still renders message text", () => {
+    const post = {
+      ...baseArticlePost,
+      settings: { v: "v" },
+      message: "Plain text message",
+    };
+    const w = mount(PostPlayerModal, {
+      props: { post: post as never, authorName: "X", authorAvatarUrl: "" },
+      global: { stubs },
+    });
+    expect(w.text()).toContain("Plain text message");
+  });
+});

--- a/src/features/post-player/ui/__tests__/StarRating.test.ts
+++ b/src/features/post-player/ui/__tests__/StarRating.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import StarRating from "../StarRating.vue";
+
+const FILL_GOLD = "fill-color-star-yellow";
+const TEXT_GOLD = "text-color-star-yellow";
+const NO_FILL = "fill-none";
+
+const stars = (w: ReturnType<typeof mount>) => w.findAll("svg");
+
+describe("StarRating three-state visual", () => {
+  it("0 votes (totalVotes=0, modelValue=null) → all stars empty grey", () => {
+    const w = mount(StarRating, {
+      props: { average: 0, totalVotes: 0, modelValue: null },
+    });
+    const svgs = stars(w);
+    expect(svgs).toHaveLength(5);
+    svgs.forEach((s) => {
+      expect(s.classes()).toContain(NO_FILL);
+      expect(s.classes()).not.toContain(TEXT_GOLD);
+      expect(s.classes()).not.toContain(FILL_GOLD);
+    });
+  });
+
+  it("average=5 totalVotes=1 modelValue=null → 5 OUTLINE gold (no fill)", () => {
+    const w = mount(StarRating, {
+      props: { average: 5, totalVotes: 1, modelValue: null },
+    });
+    stars(w).forEach((s) => {
+      expect(s.classes()).toContain(NO_FILL);
+      expect(s.classes()).toContain(TEXT_GOLD);
+      expect(s.classes()).not.toContain(FILL_GOLD);
+    });
+  });
+
+  it("average=3.5 totalVotes=4 modelValue=null → first 3 outline gold, last 2 grey", () => {
+    const w = mount(StarRating, {
+      props: { average: 3.5, totalVotes: 4, modelValue: null },
+    });
+    const svgs = stars(w);
+    [0, 1, 2].forEach((i) => {
+      expect(svgs[i].classes()).toContain(NO_FILL);
+      expect(svgs[i].classes()).toContain(TEXT_GOLD);
+    });
+    [3, 4].forEach((i) => {
+      expect(svgs[i].classes()).toContain(NO_FILL);
+      expect(svgs[i].classes()).not.toContain(TEXT_GOLD);
+    });
+  });
+
+  it("modelValue=4 (I voted) → first 4 FILLED gold, last 1 grey", () => {
+    const w = mount(StarRating, {
+      props: { average: 4.5, totalVotes: 10, modelValue: 4 },
+    });
+    const svgs = stars(w);
+    [0, 1, 2, 3].forEach((i) => {
+      expect(svgs[i].classes()).toContain(FILL_GOLD);
+      expect(svgs[i].classes()).toContain(TEXT_GOLD);
+    });
+    expect(svgs[4].classes()).toContain(NO_FILL);
+    expect(svgs[4].classes()).not.toContain(TEXT_GOLD);
+  });
+
+  it("modelValue=5 + average=5 → 5 FILLED (my vote dominates)", () => {
+    const w = mount(StarRating, {
+      props: { average: 5, totalVotes: 2, modelValue: 5 },
+    });
+    stars(w).forEach((s) => {
+      expect(s.classes()).toContain(FILL_GOLD);
+      expect(s.classes()).toContain(TEXT_GOLD);
+    });
+  });
+
+  it("hover preview when interactive (not voted, not readonly)", async () => {
+    const w = mount(StarRating, {
+      props: { average: 2, totalVotes: 5, modelValue: null, readonly: false },
+    });
+    await stars(w)[4].trigger("mouseenter");
+    const svgs = stars(w);
+    [0, 1, 2, 3, 4].forEach((i) => {
+      expect(svgs[i].classes()).toContain(FILL_GOLD);
+      expect(svgs[i].classes()).toContain(TEXT_GOLD);
+    });
+  });
+
+  it("hover does NOT trigger when readonly", async () => {
+    const w = mount(StarRating, {
+      props: { average: 5, totalVotes: 2, modelValue: 5, readonly: true },
+    });
+    await stars(w)[2].trigger("mouseenter");
+    const svgs = stars(w);
+    // Should still show MY VOTE (5 filled) — hover ignored
+    [0, 1, 2, 3, 4].forEach((i) => {
+      expect(svgs[i].classes()).toContain(FILL_GOLD);
+    });
+  });
+
+  it("hover does NOT trigger after I voted (1-vote-per-user)", async () => {
+    const w = mount(StarRating, {
+      props: { average: 4, totalVotes: 5, modelValue: 3, readonly: false },
+    });
+    await stars(w)[4].trigger("mouseenter");
+    const svgs = stars(w);
+    // Star 4-5 should remain unfilled — hover preview suppressed
+    expect(svgs[3].classes()).not.toContain(FILL_GOLD);
+    expect(svgs[4].classes()).not.toContain(FILL_GOLD);
+    // First 3 still filled (my vote)
+    expect(svgs[0].classes()).toContain(FILL_GOLD);
+  });
+
+  it("emits update:modelValue on click when interactive", async () => {
+    const w = mount(StarRating, {
+      props: { average: 0, totalVotes: 0, modelValue: null, readonly: false },
+    });
+    await stars(w)[3].trigger("click");
+    expect(w.emitted("update:modelValue")?.[0]).toEqual([4]);
+  });
+
+  it("does NOT emit when readonly", async () => {
+    const w = mount(StarRating, {
+      props: { average: 5, totalVotes: 5, modelValue: null, readonly: true },
+    });
+    await stars(w)[2].trigger("click");
+    expect(w.emitted("update:modelValue")).toBeUndefined();
+  });
+
+  it("does NOT emit second time after I voted", async () => {
+    const w = mount(StarRating, {
+      props: { average: 4, totalVotes: 3, modelValue: 4, readonly: false },
+    });
+    await stars(w)[1].trigger("click");
+    expect(w.emitted("update:modelValue")).toBeUndefined();
+  });
+
+  it("does NOT emit while submitting", async () => {
+    const w = mount(StarRating, {
+      props: { average: 0, totalVotes: 0, modelValue: null, submitting: true },
+    });
+    await stars(w)[2].trigger("click");
+    expect(w.emitted("update:modelValue")).toBeUndefined();
+  });
+
+  it("shows numeric label by default when totalVotes > 0", () => {
+    const w = mount(StarRating, {
+      props: { average: 4.7, totalVotes: 3, modelValue: null },
+    });
+    expect(w.text()).toContain("4.7");
+  });
+
+  it("shows '0.0' when totalVotes is 0", () => {
+    const w = mount(StarRating, {
+      props: { average: 0, totalVotes: 0, modelValue: null },
+    });
+    expect(w.text()).toContain("0.0");
+  });
+
+  it("hides label when hideLabel=true", () => {
+    const w = mount(StarRating, {
+      props: { average: 4.5, totalVotes: 5, modelValue: null, hideLabel: true },
+    });
+    expect(w.text()).not.toContain("4.5");
+  });
+
+  it("compact mode renders smaller stars", () => {
+    const w = mount(StarRating, {
+      props: { average: 5, totalVotes: 1, modelValue: null, compact: true },
+    });
+    const svg = stars(w)[0];
+    expect(svg.attributes("width")).toBe("12");
+    expect(svg.attributes("height")).toBe("12");
+  });
+});

--- a/src/features/post-player/ui/__tests__/StarRating.test.ts
+++ b/src/features/post-player/ui/__tests__/StarRating.test.ts
@@ -33,9 +33,9 @@ describe("StarRating three-state visual", () => {
     });
   });
 
-  it("average=3.5 totalVotes=4 modelValue=null → first 3 outline gold, last 2 grey", () => {
+  it("average=3.4 totalVotes=4 modelValue=null → first 3 outline gold, last 2 grey", () => {
     const w = mount(StarRating, {
-      props: { average: 3.5, totalVotes: 4, modelValue: null },
+      props: { average: 3.4, totalVotes: 4, modelValue: null },
     });
     const svgs = stars(w);
     [0, 1, 2].forEach((i) => {
@@ -46,6 +46,30 @@ describe("StarRating three-state visual", () => {
       expect(svgs[i].classes()).toContain(NO_FILL);
       expect(svgs[i].classes()).not.toContain(TEXT_GOLD);
     });
+  });
+
+  it("average=3.5 rounds half-up → 4 outline gold (matches '3.5' label)", () => {
+    const w = mount(StarRating, {
+      props: { average: 3.5, totalVotes: 4, modelValue: null },
+    });
+    const svgs = stars(w);
+    [0, 1, 2, 3].forEach((i) => {
+      expect(svgs[i].classes()).toContain(NO_FILL);
+      expect(svgs[i].classes()).toContain(TEXT_GOLD);
+    });
+    expect(svgs[4].classes()).not.toContain(TEXT_GOLD);
+  });
+
+  it("average=4.99 rounds to 5 outline gold (matches '5.0' label, not 4 / mismatch)", () => {
+    // Real-world bug: average 4.99 was rendering as label "5.0" but only 4 outline stars
+    const w = mount(StarRating, {
+      props: { average: 4.99, totalVotes: 100, modelValue: null },
+    });
+    stars(w).forEach((s) => {
+      expect(s.classes()).toContain(NO_FILL);
+      expect(s.classes()).toContain(TEXT_GOLD);
+    });
+    expect(w.text()).toContain("5.0");
   });
 
   it("modelValue=4 (I voted) → first 4 FILLED gold, last 1 grey", () => {

--- a/src/shared/lib/__tests__/article-blocks.test.ts
+++ b/src/shared/lib/__tests__/article-blocks.test.ts
@@ -24,6 +24,18 @@ describe("isArticleJson", () => {
     expect(isArticleJson("{not json")).toBe(false);
   });
 
+  it("recovers from unescaped quotes in <a href> (real Bastyon corruption)", () => {
+    // This is the exact pattern seen in production: href values are not
+    // escaped, breaking strict JSON.parse but recoverable via the repair path.
+    const broken = '{"blocks":[{"type":"paragraph","data":{"text":"see <a href=\"https://x.com\">link</a>"}}]}';
+    expect(isArticleJson(broken)).toBe(true);
+  });
+
+  it("recovers from literal newlines inside string values", () => {
+    const broken = '{"blocks":[{"type":"paragraph","data":{"text":"line one\nline two\nline three"}}]}';
+    expect(isArticleJson(broken)).toBe(true);
+  });
+
   it("returns false for JSON without blocks array", () => {
     expect(isArticleJson('{"foo":"bar"}')).toBe(false);
   });
@@ -143,6 +155,32 @@ describe("renderArticleText (preview, plain text)", () => {
     const out = renderArticleText(long, { maxLength: 100 });
     expect(out).toHaveLength(103);
     expect(out.endsWith("...")).toBe(true);
+  });
+
+  it("renders linkTool block as title text", () => {
+    const input = json([
+      { type: "linkTool", data: { link: "https://x.com", meta: { title: "Article Title", description: "..." } } },
+    ]);
+    expect(renderArticleText(input)).toBe("Article Title");
+  });
+
+  it("falls back to link URL when linkTool has no title", () => {
+    const input = json([{ type: "linkTool", data: { link: "https://x.com" } }]);
+    expect(renderArticleText(input)).toBe("https://x.com");
+  });
+
+  it("recovers broken JSON with unescaped href quotes (renders text)", () => {
+    const broken = '{"blocks":[{"type":"paragraph","data":{"text":"see <a href=\"https://x.com\">link</a>"}}]}';
+    const result = renderArticleText(broken);
+    expect(result).toContain("see");
+    expect(result).toContain("link");
+    expect(result).not.toContain('"blocks"');
+  });
+
+  it("recovers broken JSON with literal newlines inside descriptions", () => {
+    const broken = '{"blocks":[{"type":"linkTool","data":{"link":"https://x.com","meta":{"title":"Hi","description":"line1\nline2\nline3"}}}]}';
+    const result = renderArticleText(broken);
+    expect(result).toBe("Hi");
   });
 
   it("does not cleave emoji surrogate pairs when truncating", () => {
@@ -375,6 +413,32 @@ describe("renderArticleHtml (full render, sanitized)", () => {
     expect(html.toLowerCase()).not.toContain("<json>");
     expect(html).toContain("not");
     expect(html).toContain("&amp;");
+  });
+
+  it("renders linkTool as <a> with safe href and rel=noopener", () => {
+    const input = json([
+      { type: "linkTool", data: { link: "https://x.com", meta: { title: "Title", description: "Description" } } },
+    ]);
+    const html = renderArticleHtml(input);
+    expect(html).toContain('href="https://x.com"');
+    expect(html).toContain('rel="noopener noreferrer"');
+    expect(html).toContain("Title");
+    expect(html).toContain("Description");
+  });
+
+  it("drops linkTool with javascript: link", () => {
+    const input = json([
+      { type: "linkTool", data: { link: "javascript:alert(1)", meta: { title: "evil" } } },
+    ]);
+    const html = renderArticleHtml(input);
+    expect(html.toLowerCase()).not.toContain("javascript:");
+  });
+
+  it("recovers broken JSON in renderArticleHtml (real Bastyon pattern)", () => {
+    const broken = '{"blocks":[{"type":"paragraph","data":{"text":"<a href=\"https://x.com\">link</a>"}}]}';
+    const html = renderArticleHtml(broken);
+    expect(html).toContain('href="https://x.com"');
+    expect(html).not.toContain('"blocks"');
   });
 
   it("skips empty paragraph blocks", () => {

--- a/src/shared/lib/__tests__/article-blocks.test.ts
+++ b/src/shared/lib/__tests__/article-blocks.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect } from "vitest";
+import {
+  renderArticleText,
+  renderArticleHtml,
+  isArticleJson,
+} from "../article-blocks";
+
+const json = (blocks: unknown[]): string => JSON.stringify({ blocks });
+
+describe("isArticleJson", () => {
+  it("returns true for Editor.js JSON", () => {
+    expect(isArticleJson(json([{ type: "paragraph", data: { text: "hi" } }]))).toBe(true);
+  });
+
+  it("returns false for plain text", () => {
+    expect(isArticleJson("Hello world")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isArticleJson("")).toBe(false);
+  });
+
+  it("returns false for malformed JSON", () => {
+    expect(isArticleJson("{not json")).toBe(false);
+  });
+
+  it("returns false for JSON without blocks array", () => {
+    expect(isArticleJson('{"foo":"bar"}')).toBe(false);
+  });
+});
+
+describe("renderArticleText (preview, plain text)", () => {
+  it("returns raw string for non-JSON input", () => {
+    expect(renderArticleText("Hello world")).toBe("Hello world");
+  });
+
+  it("returns empty for falsy input", () => {
+    expect(renderArticleText("")).toBe("");
+    expect(renderArticleText(null as unknown as string)).toBe("");
+    expect(renderArticleText(undefined as unknown as string)).toBe("");
+  });
+
+  it("extracts paragraph text and joins with newline", () => {
+    const input = json([
+      { type: "paragraph", data: { text: "First para" } },
+      { type: "paragraph", data: { text: "Second para" } },
+    ]);
+    expect(renderArticleText(input)).toBe("First para\nSecond para");
+  });
+
+  it("strips inline HTML from paragraph text", () => {
+    const input = json([
+      { type: "paragraph", data: { text: "<b>Bold</b> and <i>italic</i>" } },
+    ]);
+    expect(renderArticleText(input)).toBe("Bold and italic");
+  });
+
+  it("decodes common HTML entities", () => {
+    const input = json([
+      { type: "paragraph", data: { text: "A&nbsp;B&amp;C&lt;D&gt;E&quot;F" } },
+    ]);
+    expect(renderArticleText(input)).toBe("A B&C<D>E\"F");
+  });
+
+  it("handles header blocks", () => {
+    const input = json([
+      { type: "header", data: { text: "Title", level: 1 } },
+      { type: "paragraph", data: { text: "Body" } },
+    ]);
+    expect(renderArticleText(input)).toBe("Title\nBody");
+  });
+
+  it("handles unordered list blocks", () => {
+    const input = json([
+      { type: "list", data: { style: "unordered", items: ["A", "B", "C"] } },
+    ]);
+    expect(renderArticleText(input)).toBe("• A\n• B\n• C");
+  });
+
+  it("handles ordered list blocks", () => {
+    const input = json([
+      { type: "list", data: { style: "ordered", items: ["First", "Second"] } },
+    ]);
+    expect(renderArticleText(input)).toBe("1. First\n2. Second");
+  });
+
+  it("handles quote blocks with caption", () => {
+    const input = json([{ type: "quote", data: { text: "Quoted", caption: "Author" } }]);
+    expect(renderArticleText(input)).toBe("«Quoted» — Author");
+  });
+
+  it("handles quote blocks without caption", () => {
+    const input = json([{ type: "quote", data: { text: "Bare quote" } }]);
+    expect(renderArticleText(input)).toBe("«Bare quote»");
+  });
+
+  it("handles code blocks", () => {
+    const input = json([{ type: "code", data: { code: "const x = 1;" } }]);
+    expect(renderArticleText(input)).toBe("const x = 1;");
+  });
+
+  it("uses image caption for image blocks", () => {
+    const input = json([
+      { type: "paragraph", data: { text: "Before" } },
+      { type: "image", data: { file: { url: "http://x" }, caption: "Pic" } },
+      { type: "paragraph", data: { text: "After" } },
+    ]);
+    expect(renderArticleText(input)).toBe("Before\nPic\nAfter");
+  });
+
+  it("skips delimiter and embed blocks in text mode", () => {
+    const input = json([
+      { type: "paragraph", data: { text: "Before" } },
+      { type: "delimiter" },
+      { type: "embed", data: { source: "https://x" } },
+      { type: "paragraph", data: { text: "After" } },
+    ]);
+    expect(renderArticleText(input)).toBe("Before\nAfter");
+  });
+
+  it("returns raw on malformed JSON", () => {
+    expect(renderArticleText("{not json")).toBe("{not json");
+  });
+
+  it("returns raw on JSON without blocks array", () => {
+    expect(renderArticleText('{"foo":"bar"}')).toBe('{"foo":"bar"}');
+  });
+
+  it("respects maxLength when provided", () => {
+    const input = json([{ type: "paragraph", data: { text: "x".repeat(1000) } }]);
+    const out = renderArticleText(input, { maxLength: 100 });
+    expect(out).toHaveLength(103); // 100 + "..."
+    expect(out.endsWith("...")).toBe(true);
+  });
+
+  it("does not truncate when output is shorter than maxLength", () => {
+    const input = json([{ type: "paragraph", data: { text: "Short" } }]);
+    expect(renderArticleText(input, { maxLength: 100 })).toBe("Short");
+  });
+
+  it("falls back to truncating raw for non-JSON when maxLength provided", () => {
+    const long = "a".repeat(500);
+    const out = renderArticleText(long, { maxLength: 100 });
+    expect(out).toHaveLength(103);
+    expect(out.endsWith("...")).toBe(true);
+  });
+
+  it("does not cleave emoji surrogate pairs when truncating", () => {
+    // 99 ASCII chars + 4 emoji (4 code points = 8 UTF-16 code units)
+    const input = json([
+      { type: "paragraph", data: { text: "x".repeat(99) + "😀😀😀😀" } },
+    ]);
+    const out = renderArticleText(input, { maxLength: 100 });
+    // Last char must be a complete emoji, not a lone surrogate
+    expect(out.endsWith("...")).toBe(true);
+    const beforeEllipsis = out.slice(0, -3);
+    // Code-point-aware length must equal 100
+    expect(Array.from(beforeEllipsis)).toHaveLength(100);
+    // No replacement char (which would indicate broken surrogate)
+    expect(out).not.toContain("�");
+  });
+});
+
+describe("renderArticleHtml (full render, sanitized)", () => {
+  it("returns empty for falsy input", () => {
+    expect(renderArticleHtml("")).toBe("");
+  });
+
+  it("renders paragraph as <p>", () => {
+    const html = renderArticleHtml(json([{ type: "paragraph", data: { text: "Hello" } }]));
+    expect(html).toContain("<p");
+    expect(html).toContain("Hello");
+  });
+
+  it("preserves safe inline tags (b, i, br, code, mark)", () => {
+    const html = renderArticleHtml(
+      json([{ type: "paragraph", data: { text: "<b>B</b> <i>I</i> <code>C</code> <mark>M</mark>" } }]),
+    );
+    expect(html).toContain("<b>B</b>");
+    expect(html).toContain("<i>I</i>");
+    expect(html).toContain("<code>C</code>");
+    expect(html).toContain("<mark>M</mark>");
+  });
+
+  it("preserves anchor with safe href", () => {
+    const html = renderArticleHtml(
+      json([{ type: "paragraph", data: { text: '<a href="https://example.com">link</a>' } }]),
+    );
+    expect(html).toContain('href="https://example.com"');
+    expect(html).toContain("link");
+  });
+
+  it("strips <script> tag completely", () => {
+    const html = renderArticleHtml(
+      json([{ type: "paragraph", data: { text: '<b>safe</b><script>alert(1)</script>' } }]),
+    );
+    expect(html.toLowerCase()).not.toContain("<script");
+    expect(html.toLowerCase()).not.toContain("alert(1)");
+    expect(html).toContain("<b>safe</b>");
+  });
+
+  it("strips on* event handler attributes", () => {
+    const html = renderArticleHtml(
+      json([{ type: "paragraph", data: { text: '<b onclick="evil()">X</b>' } }]),
+    );
+    expect(html.toLowerCase()).not.toContain("onclick");
+    expect(html).toContain("<b>X</b>");
+  });
+
+  it("strips javascript: URL from href", () => {
+    const html = renderArticleHtml(
+      json([{ type: "paragraph", data: { text: '<a href="javascript:alert(1)">x</a>' } }]),
+    );
+    expect(html.toLowerCase()).not.toContain("javascript:");
+  });
+
+  it("rejects fragment href containing javascript: text", () => {
+    const html = renderArticleHtml(
+      json([{ type: "paragraph", data: { text: '<a href="#javascript:alert(1)">x</a>' } }]),
+    );
+    expect(html.toLowerCase()).not.toContain("javascript:");
+  });
+
+  it("rejects protocol-relative URL in href", () => {
+    const html = renderArticleHtml(
+      json([{ type: "paragraph", data: { text: '<a href="//evil.com">x</a>' } }]),
+    );
+    expect(html).not.toContain('href="//evil.com"');
+  });
+
+  it("rejects bare slash href", () => {
+    const html = renderArticleHtml(
+      json([{ type: "paragraph", data: { text: '<a href="/">x</a>' } }]),
+    );
+    expect(html).not.toContain('href="/"');
+  });
+
+  it("accepts simple anchor href", () => {
+    const html = renderArticleHtml(
+      json([{ type: "paragraph", data: { text: '<a href="#section">x</a>' } }]),
+    );
+    expect(html).toContain('href="#section"');
+  });
+
+  it("accepts root-relative path href", () => {
+    const html = renderArticleHtml(
+      json([{ type: "paragraph", data: { text: '<a href="/posts/123">x</a>' } }]),
+    );
+    expect(html).toContain('href="/posts/123"');
+  });
+
+  it("accepts mailto and tel schemes", () => {
+    const html = renderArticleHtml(
+      json([
+        { type: "paragraph", data: { text: '<a href="mailto:a@b.c">m</a><a href="tel:+1234">t</a>' } },
+      ]),
+    );
+    expect(html).toContain('href="mailto:a@b.c"');
+    expect(html).toContain('href="tel:+1234"');
+  });
+
+  it("forces rel=noopener noreferrer on target=_blank links (tabnabbing prevention)", () => {
+    const html = renderArticleHtml(
+      json([
+        { type: "paragraph", data: { text: '<a href="https://x.com" target="_blank">x</a>' } },
+      ]),
+    );
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+
+  it("ignores user-supplied rel and overrides with safe value for _blank", () => {
+    const html = renderArticleHtml(
+      json([
+        {
+          type: "paragraph",
+          data: { text: '<a href="https://x.com" target="_blank" rel="opener">x</a>' },
+        },
+      ]),
+    );
+    expect(html).not.toContain('rel="opener"');
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+
+  it("does NOT add rel for non-blank links", () => {
+    const html = renderArticleHtml(
+      json([{ type: "paragraph", data: { text: '<a href="https://x.com">x</a>' } }]),
+    );
+    expect(html).not.toContain("rel=");
+  });
+
+  it("escapes > in attribute values (defense in depth)", () => {
+    // Construct a paragraph with an a-tag whose href contains > literally
+    const tricky = json([
+      { type: "paragraph", data: { text: '<a href="https://x.com/?q=%3E">x</a>' } },
+    ]);
+    const html = renderArticleHtml(tricky);
+    // The %3E stays encoded; this just confirms attribute escaping doesn't itself emit raw <
+    expect(html).not.toContain('"<');
+    expect(html).toContain('href="https://x.com/?q=%3E"');
+  });
+
+  it("renders header h1-h6 with clamping", () => {
+    const html2 = renderArticleHtml(json([{ type: "header", data: { text: "T", level: 2 } }]));
+    expect(html2).toContain("<h2");
+
+    const htmlBig = renderArticleHtml(json([{ type: "header", data: { text: "T", level: 99 } }]));
+    expect(htmlBig).toContain("<h6");
+
+    const htmlSmall = renderArticleHtml(json([{ type: "header", data: { text: "T", level: 0 } }]));
+    expect(htmlSmall).toContain("<h1");
+  });
+
+  it("renders unordered list as <ul>", () => {
+    const html = renderArticleHtml(
+      json([{ type: "list", data: { style: "unordered", items: ["a", "b"] } }]),
+    );
+    expect(html).toMatch(/<ul[^>]*>/);
+    expect(html).toContain("<li>a</li>");
+    expect(html).toContain("<li>b</li>");
+  });
+
+  it("renders ordered list as <ol>", () => {
+    const html = renderArticleHtml(
+      json([{ type: "list", data: { style: "ordered", items: ["a"] } }]),
+    );
+    expect(html).toMatch(/<ol[^>]*>/);
+  });
+
+  it("renders quote as <blockquote> with cite", () => {
+    const html = renderArticleHtml(json([{ type: "quote", data: { text: "Q", caption: "A" } }]));
+    expect(html).toMatch(/<blockquote[^>]*>/);
+    expect(html).toContain("Q");
+    expect(html).toContain("A");
+  });
+
+  it("renders code block as <pre><code> with escaped content", () => {
+    const html = renderArticleHtml(
+      json([{ type: "code", data: { code: 'if (x < 1) { "ok"; }' } }]),
+    );
+    expect(html).toMatch(/<pre[^>]*><code>/);
+    expect(html).toContain("&lt;");
+    expect(html.toLowerCase()).not.toContain("<script");
+  });
+
+  it("renders image with safe http(s) URL and caption", () => {
+    const html = renderArticleHtml(
+      json([{ type: "image", data: { file: { url: "https://cdn.x/y.jpg" }, caption: "Photo" } }]),
+    );
+    expect(html).toContain('src="https://cdn.x/y.jpg"');
+    expect(html).toContain("Photo");
+  });
+
+  it("drops image with javascript: or non-http(s) URL", () => {
+    const html = renderArticleHtml(
+      json([{ type: "image", data: { file: { url: "javascript:alert(1)" } } }]),
+    );
+    expect(html.toLowerCase()).not.toContain("javascript:");
+    expect(html.toLowerCase()).not.toContain("<img");
+  });
+
+  it("renders delimiter as <hr>", () => {
+    const html = renderArticleHtml(json([{ type: "delimiter" }]));
+    expect(html.toLowerCase()).toContain("<hr");
+  });
+
+  it("does not throw for unknown block types", () => {
+    expect(() =>
+      renderArticleHtml(json([{ type: "unknownTable", data: { foo: "bar" } }])),
+    ).not.toThrow();
+  });
+
+  it("returns escaped <p> for non-JSON input", () => {
+    const html = renderArticleHtml("not <json> & co");
+    expect(html.toLowerCase()).not.toContain("<json>");
+    expect(html).toContain("not");
+    expect(html).toContain("&amp;");
+  });
+
+  it("skips empty paragraph blocks", () => {
+    const html = renderArticleHtml(
+      json([
+        { type: "paragraph", data: { text: "" } },
+        { type: "paragraph", data: { text: "X" } },
+      ]),
+    );
+    // Should not produce <p></p> but should still render the second one
+    expect(html).toContain("X");
+  });
+});

--- a/src/shared/lib/article-blocks.ts
+++ b/src/shared/lib/article-blocks.ts
@@ -1,0 +1,345 @@
+/**
+ * Editor.js block parsing for Bastyon article posts.
+ *
+ * Bastyon stores article bodies as Editor.js JSON in `post.message` when
+ * `post.settings.v === "a"`. This module parses that JSON safely:
+ *
+ *  - `renderArticleText` → plain text for previews / list bubbles.
+ *  - `renderArticleHtml` → sanitized HTML for full article view.
+ *  - `isArticleJson`     → heuristic JSON-vs-plaintext check.
+ *
+ * Sanitization is whitelist-based and runs against a real DOM tree
+ * (DOMParser, available in browser + happy-dom test env). Falls back
+ * to a regex strip when DOMParser is unavailable.
+ */
+
+export interface RenderTextOptions {
+  /** Truncate output to this length (adds "..." marker if cut). */
+  maxLength?: number;
+}
+
+interface ParsedArticle {
+  blocks: ArticleBlock[];
+}
+
+interface ArticleBlock {
+  type?: string;
+  data?: Record<string, unknown>;
+}
+
+/** Try to parse JSON; return null if malformed or not an Editor.js doc. */
+function tryParseBlocks(input: string): ParsedArticle | null {
+  if (!input || typeof input !== "string") return null;
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("{")) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed && Array.isArray(parsed.blocks)) {
+      return parsed as ParsedArticle;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function isArticleJson(input: string): boolean {
+  return tryParseBlocks(input) !== null;
+}
+
+const HTML_ENTITY_MAP: Record<string, string> = {
+  "&nbsp;": " ",
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+  "&apos;": "'",
+};
+
+/** Strip HTML tags and decode common entities → plain text. */
+function stripHtml(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, "")
+    .replace(/&(?:nbsp|amp|lt|gt|quot|#39|apos);/g, (m) => HTML_ENTITY_MAP[m] ?? m)
+    .trim();
+}
+
+function applyMaxLength(text: string, maxLength?: number): string {
+  if (maxLength == null) return text;
+  // Use Array.from for code-point-aware truncation so emoji / surrogate pairs
+  // never get cleaved in half.
+  if (text.length <= maxLength) return text;
+  const chars = Array.from(text);
+  return chars.length > maxLength ? chars.slice(0, maxLength).join("") + "..." : text;
+}
+
+/**
+ * Render Editor.js JSON to plain text. Falls back to raw input if not
+ * valid Editor.js JSON. Respects optional maxLength truncation.
+ */
+export function renderArticleText(input: string, opts: RenderTextOptions = {}): string {
+  if (!input) return "";
+
+  const parsed = tryParseBlocks(input);
+  if (!parsed) return applyMaxLength(input, opts.maxLength);
+
+  const lines: string[] = [];
+  for (const block of parsed.blocks) {
+    const t = block.type;
+    const d = block.data ?? {};
+    switch (t) {
+      case "paragraph":
+      case "header": {
+        const text = typeof d.text === "string" ? stripHtml(d.text) : "";
+        if (text) lines.push(text);
+        break;
+      }
+      case "list": {
+        const items = Array.isArray(d.items) ? (d.items as unknown[]) : [];
+        const ordered = d.style === "ordered";
+        items.forEach((item, i) => {
+          const stripped = typeof item === "string" ? stripHtml(item) : "";
+          if (stripped) lines.push(ordered ? `${i + 1}. ${stripped}` : `• ${stripped}`);
+        });
+        break;
+      }
+      case "quote": {
+        const text = typeof d.text === "string" ? stripHtml(d.text) : "";
+        const caption = typeof d.caption === "string" ? stripHtml(d.caption) : "";
+        if (text) lines.push(caption ? `«${text}» — ${caption}` : `«${text}»`);
+        break;
+      }
+      case "code": {
+        const code = typeof d.code === "string" ? d.code : "";
+        if (code) lines.push(code);
+        break;
+      }
+      case "image": {
+        const caption = typeof d.caption === "string" ? stripHtml(d.caption) : "";
+        if (caption) lines.push(caption);
+        break;
+      }
+      // delimiter, embed, table → skip in text mode
+      default:
+        break;
+    }
+  }
+
+  return applyMaxLength(lines.join("\n"), opts.maxLength);
+}
+
+/** Tag names allowed inside paragraph / list / quote / header text. */
+const ALLOWED_INLINE_TAGS = new Set([
+  "B",
+  "STRONG",
+  "I",
+  "EM",
+  "U",
+  "A",
+  "BR",
+  "CODE",
+  "MARK",
+  "SPAN",
+]);
+
+/**
+ * Per-tag attribute whitelist. Note: `rel` is NOT in the whitelist for <a> —
+ * we control it ourselves to force `noopener noreferrer` for `target="_blank"`,
+ * preventing tabnabbing via `window.opener`.
+ */
+const ALLOWED_ATTRS: Record<string, ReadonlySet<string>> = {
+  A: new Set(["href", "target", "class"]),
+  SPAN: new Set(["class"]),
+};
+
+/** Tags whose contents must be discarded entirely (not just unwrapped). */
+const DANGEROUS_TAGS = new Set([
+  "SCRIPT",
+  "STYLE",
+  "IFRAME",
+  "OBJECT",
+  "EMBED",
+  "FORM",
+  "INPUT",
+  "BUTTON",
+  "TEXTAREA",
+  "SELECT",
+  "OPTION",
+  "META",
+  "LINK",
+  "BASE",
+  "NOSCRIPT",
+]);
+
+/**
+ * href must match this for safety. We deliberately reject:
+ *  - javascript:, data:, vbscript: and other dangerous schemes
+ *  - protocol-relative URLs (//host) — could escape origin
+ *  - fragments containing arbitrary text (#javascript:...) — defense in depth
+ *  - bare slash "/" with no path
+ */
+const SAFE_URL_RE = /^(?:https?:\/\/|mailto:|tel:|#[\w-]*$|\/[^/])/i;
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/** Recursively serialize an element with whitelist filtering. */
+function serializeNode(node: Node): string {
+  if (node.nodeType === 3 /* TEXT */) {
+    return escapeHtml(node.textContent ?? "");
+  }
+  if (node.nodeType !== 1 /* ELEMENT */) return "";
+
+  const el = node as Element;
+  const tag = el.tagName.toUpperCase();
+
+  if (DANGEROUS_TAGS.has(tag)) {
+    // Discard tag and its children entirely
+    return "";
+  }
+  if (!ALLOWED_INLINE_TAGS.has(tag)) {
+    // Drop the tag, keep its inner content
+    return Array.from(el.childNodes).map(serializeNode).join("");
+  }
+
+  const attrParts: string[] = [];
+  let isTargetBlank = false;
+  const allowedAttrs = ALLOWED_ATTRS[tag];
+  if (allowedAttrs) {
+    for (const attr of Array.from(el.attributes)) {
+      const name = attr.name.toLowerCase();
+      if (!allowedAttrs.has(name)) continue;
+      const value = attr.value;
+      if (name === "href" && !SAFE_URL_RE.test(value)) continue;
+      if (name === "target") {
+        if (value !== "_blank" && value !== "_self") continue;
+        if (value === "_blank") isTargetBlank = true;
+      }
+      attrParts.push(`${name}="${escapeAttr(value)}"`);
+    }
+  }
+
+  // Force rel="noopener noreferrer" on anchors that open new tabs to prevent
+  // tabnabbing (window.opener.location hijacks). User-supplied rel is ignored.
+  if (tag === "A" && isTargetBlank) {
+    attrParts.push('rel="noopener noreferrer"');
+  }
+
+  const innerHtml = Array.from(el.childNodes).map(serializeNode).join("");
+  if (tag === "BR") return "<br/>";
+  const lower = tag.toLowerCase();
+  const attrStr = attrParts.length ? " " + attrParts.join(" ") : "";
+  return `<${lower}${attrStr}>${innerHtml}</${lower}>`;
+}
+
+/** Sanitize inline HTML using DOMParser when available; fallback strips all tags. */
+function sanitizeInline(html: string): string {
+  if (!html) return "";
+  if (typeof DOMParser === "undefined") {
+    return escapeHtml(stripHtml(html));
+  }
+  const doc = new DOMParser().parseFromString(`<div>${html}</div>`, "text/html");
+  const root = doc.body.firstChild as Element | null;
+  if (!root) return "";
+  return Array.from(root.childNodes).map(serializeNode).join("");
+}
+
+function renderHeaderLevel(raw: unknown): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return 2;
+  return Math.min(Math.max(Math.floor(n), 1), 6);
+}
+
+/**
+ * Render Editor.js JSON to sanitized HTML. Returns escaped <p> for
+ * non-JSON input so the result is always safe to feed into v-html.
+ */
+export function renderArticleHtml(input: string): string {
+  if (!input) return "";
+
+  const parsed = tryParseBlocks(input);
+  if (!parsed) return `<p class="article-p">${escapeHtml(input)}</p>`;
+
+  const parts: string[] = [];
+  for (const block of parsed.blocks) {
+    const t = block.type;
+    const d = block.data ?? {};
+
+    switch (t) {
+      case "paragraph": {
+        const safe = sanitizeInline(typeof d.text === "string" ? d.text : "");
+        if (safe.trim()) parts.push(`<p class="article-p">${safe}</p>`);
+        break;
+      }
+      case "header": {
+        const level = renderHeaderLevel(d.level);
+        const safe = sanitizeInline(typeof d.text === "string" ? d.text : "");
+        if (safe.trim()) parts.push(`<h${level} class="article-h">${safe}</h${level}>`);
+        break;
+      }
+      case "list": {
+        const items = Array.isArray(d.items) ? (d.items as unknown[]) : [];
+        if (items.length === 0) break;
+        const tag = d.style === "ordered" ? "ol" : "ul";
+        const lis = items
+          .map((it) => {
+            const text = typeof it === "string" ? sanitizeInline(it) : "";
+            return text ? `<li>${text}</li>` : "";
+          })
+          .filter(Boolean)
+          .join("");
+        if (lis) parts.push(`<${tag} class="article-list">${lis}</${tag}>`);
+        break;
+      }
+      case "quote": {
+        const text = sanitizeInline(typeof d.text === "string" ? d.text : "");
+        const caption = sanitizeInline(typeof d.caption === "string" ? d.caption : "");
+        if (text) {
+          const cite = caption ? `<cite>— ${caption}</cite>` : "";
+          parts.push(`<blockquote class="article-quote">${text}${cite}</blockquote>`);
+        }
+        break;
+      }
+      case "code": {
+        const code = typeof d.code === "string" ? d.code : "";
+        if (code) parts.push(`<pre class="article-code"><code>${escapeHtml(code)}</code></pre>`);
+        break;
+      }
+      case "image": {
+        const file = (d.file ?? {}) as Record<string, unknown>;
+        const url = typeof file.url === "string" ? file.url : "";
+        if (url && /^https?:\/\//i.test(url)) {
+          const caption = typeof d.caption === "string" ? escapeHtml(d.caption) : "";
+          const figcap = caption ? `<figcaption>${caption}</figcaption>` : "";
+          parts.push(
+            `<figure class="article-figure"><img src="${escapeAttr(url)}" alt="${caption}" loading="lazy"/>${figcap}</figure>`,
+          );
+        }
+        break;
+      }
+      case "delimiter":
+        parts.push('<hr class="article-hr"/>');
+        break;
+      // embed, table, raw → skipped (no whitelist)
+      default:
+        break;
+    }
+  }
+
+  return parts.join("");
+}

--- a/src/shared/lib/article-blocks.ts
+++ b/src/shared/lib/article-blocks.ts
@@ -27,20 +27,85 @@ interface ArticleBlock {
   data?: Record<string, unknown>;
 }
 
-/** Try to parse JSON; return null if malformed or not an Editor.js doc. */
+/**
+ * Repair common corruption in real-world Bastyon Editor.js JSON:
+ *  - Unescaped " inside string values (e.g. raw `<a href="...">` HTML).
+ *  - Literal CR/LF/TAB inside string values (Editor.js sometimes embeds them).
+ * Walks input character by character with a string/non-string state machine.
+ * Heuristic: a " inside a string is "closing" only if the next non-whitespace
+ * character is one of `, } ] :` or end-of-input. Otherwise it's escaped to \".
+ */
+function repairJsonStrings(input: string): string {
+  let out = "";
+  let inString = false;
+  let escapeNext = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const c = input[i];
+    if (escapeNext) {
+      out += c;
+      escapeNext = false;
+      continue;
+    }
+    if (c === "\\") {
+      out += c;
+      escapeNext = true;
+      continue;
+    }
+    if (c === '"') {
+      if (!inString) {
+        inString = true;
+        out += c;
+      } else {
+        // Look ahead past whitespace; if next char is JSON terminator, this is closing.
+        let j = i + 1;
+        while (j < input.length && /\s/.test(input[j])) j++;
+        const next = j < input.length ? input[j] : "";
+        if (next === "," || next === "}" || next === "]" || next === ":" || next === "") {
+          inString = false;
+          out += c;
+        } else {
+          out += '\\"';
+        }
+      }
+      continue;
+    }
+    if (inString) {
+      if (c === "\n") { out += "\\n"; continue; }
+      if (c === "\r") { out += "\\r"; continue; }
+      if (c === "\t") { out += "\\t"; continue; }
+    }
+    out += c;
+  }
+  return out;
+}
+
+/**
+ * Try to parse Editor.js JSON. First attempts strict JSON.parse; on failure
+ * falls back to repaired JSON (handles unescaped quotes / literal newlines
+ * commonly seen in Bastyon article posts).
+ */
 function tryParseBlocks(input: string): ParsedArticle | null {
   if (!input || typeof input !== "string") return null;
   const trimmed = input.trim();
   if (!trimmed.startsWith("{")) return null;
+
   try {
     const parsed = JSON.parse(trimmed);
-    if (parsed && Array.isArray(parsed.blocks)) {
-      return parsed as ParsedArticle;
-    }
-    return null;
+    if (parsed && Array.isArray(parsed.blocks)) return parsed as ParsedArticle;
   } catch {
-    return null;
+    // fall through to repair attempt
   }
+
+  try {
+    const repaired = repairJsonStrings(trimmed);
+    const parsed = JSON.parse(repaired);
+    if (parsed && Array.isArray(parsed.blocks)) return parsed as ParsedArticle;
+  } catch {
+    // repair failed — give up
+  }
+
+  return null;
 }
 
 export function isArticleJson(input: string): boolean {
@@ -120,7 +185,15 @@ export function renderArticleText(input: string, opts: RenderTextOptions = {}): 
         if (caption) lines.push(caption);
         break;
       }
-      // delimiter, embed, table → skip in text mode
+      case "linkTool": {
+        const meta = (d.meta ?? {}) as Record<string, unknown>;
+        const title = typeof meta.title === "string" ? stripHtml(meta.title) : "";
+        const link = typeof d.link === "string" ? d.link : "";
+        if (title) lines.push(title);
+        else if (link) lines.push(link);
+        break;
+      }
+      // delimiter, embed, table, raw → skip in text mode
       default:
         break;
     }
@@ -335,6 +408,26 @@ export function renderArticleHtml(input: string): string {
       case "delimiter":
         parts.push('<hr class="article-hr"/>');
         break;
+      case "linkTool": {
+        const link = typeof d.link === "string" ? d.link : "";
+        if (!link || !SAFE_URL_RE.test(link)) break;
+        const meta = (d.meta ?? {}) as Record<string, unknown>;
+        const title = typeof meta.title === "string" ? meta.title : link;
+        const description = typeof meta.description === "string" ? meta.description : "";
+        const image = ((meta.image ?? {}) as Record<string, unknown>);
+        const imageUrl = typeof image.url === "string" && /^https?:\/\//i.test(image.url) ? image.url : "";
+
+        const titleHtml = `<a href="${escapeAttr(link)}" target="_blank" rel="noopener noreferrer" class="article-link-title">${escapeHtml(title)}</a>`;
+        const descHtml = description
+          ? `<div class="article-link-desc">${escapeHtml(description.slice(0, 200))}${description.length > 200 ? "…" : ""}</div>`
+          : "";
+        const imgHtml = imageUrl
+          ? `<img src="${escapeAttr(imageUrl)}" alt="" class="article-link-img" loading="lazy"/>`
+          : "";
+
+        parts.push(`<div class="article-link">${imgHtml}<div class="article-link-body">${titleHtml}${descHtml}</div></div>`);
+        break;
+      }
       // embed, table, raw → skipped (no whitelist)
       default:
         break;


### PR DESCRIPTION
## Summary

Fixes two production bugs spotted on real chat screenshots:

### Bug A — Articles render raw Editor.js JSON
Bastyon article posts (`settings.v == "a"`) store the body as Editor.js JSON in `post.message`. We were rendering it verbatim — users saw `{"blocks":[...]}` instead of readable text. Affects every surface that shows a post body: PostPlayerModal (modal with `.post-modal` class), PostCard (chat preview with «Открыть»), PostEmbed (compact link card), ChannelPostBubble (channel feed).

### Bug B — StarRating couldn't distinguish "my vote" from "community average"
Both rendered as solid gold-filled. Now three-state visual:
- empty — grey outline (no votes / star above value)
- avg-line — gold OUTLINE (community avg, I haven't voted)
- my-fill — gold FILL (I voted, or hover preview)

Pattern matches IMDb / Steam / Google Play.

## What changed

**New:**
- `src/shared/lib/article-blocks.ts` — Editor.js parser + in-house DOMParser whitelist sanitizer (no new npm deps).
- `src/features/post-player/ui/ArticleBody.vue` — wrapper for sanitized v-html.

**Modified:**
- `PostPlayerModal.vue` — `<ArticleBody>` instead of `{{ post.message }}`.
- `PostCard.vue` — `renderArticleText({ maxLength: 200 })` instead of `slice(0, 200)`.
- `PostEmbed.vue` — single-pass `renderedFull` computed (no double parse).
- `ChannelPostBubble.vue` — drops 50+ lines of dup parser, swaps score-svg for `<StarRating compact readonly>`.
- `StarRating.vue` — three-state visual + `Math.round` (was `floor`, fixed 4.99→"5.0" mismatch).

## Security

Sanitizer adversarially tested:
- `<script>` / `<style>` / `<iframe>` — dropped including children.
- `javascript:`, `data:`, `vbscript:` URLs blocked in href + image src.
- `onclick` / `onerror` event-handler attributes stripped.
- Fragments with embedded schemes (`#javascript:alert(1)`) rejected.
- Protocol-relative URLs (`//evil.com`) rejected.
- `target="_blank"` always gets `rel="noopener noreferrer"` (tabnabbing prevention) — user-supplied `rel` ignored.

## Test plan

- [x] `npm test` — 247 tests in touched modules + 11 new regression tests (security + visual fixes).
- [x] `vite build` succeeds (20.5s).
- [x] `vue-tsc --noEmit` — 0 new errors over master baseline (44 pre-existing lines unchanged).
- [ ] Open an article in PostPlayerModal — body renders as paragraphs.
- [ ] Open the same article via chat preview (PostCard) — same.
- [ ] Forward a post into a chat (PostEmbed) — preview readable.
- [ ] Open a channel feed — articles readable, score as compact stars.
- [ ] Post with avg 4.99 → 5 outline gold + label "5.0" (no mismatch).
- [ ] Vote on unrated post → outline gold turns filled gold.

## Notes
- 9 pre-existing test failures on master (`video-embed`, `open-profile-url`, `chat-helpers`, `display-result`) are unrelated.
- Half-stars rendering deliberately left out of scope; could be a follow-up.