### PR TITLE
fix(calls): prevent audio system lock after first call (Session 23)

### DIFF
--- a/android/app/src/androidTest/java/com/forta/chat/plugins/calls/CallCleanupTest.kt
+++ b/android/app/src/androidTest/java/com/forta/chat/plugins/calls/CallCleanupTest.kt
@@ -1,0 +1,152 @@
+package com.forta.chat.plugins.calls
+
+import android.content.Context
+import android.media.AudioManager
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Session 23 regression tests for call cleanup. These run on a connected
+ * device or emulator (`./gradlew :app:connectedDebugAndroidTest`).
+ *
+ * Each test verifies a specific failure mode that previously left the
+ * device with a stuck VoIP audio mode after a call:
+ *
+ *   - stop() must restore mode=MODE_NORMAL even if part of the cleanup
+ *     chain throws (try/finally regression).
+ *   - forceStop() must work when isActive is already false (recovery
+ *     for a previously interrupted stop()).
+ *   - The foreground service must restore stream volume on stop, not
+ *     only inside the audio-focus-change listener path.
+ *   - closeAllPeerConnections must dispose the local AudioSource so
+ *     the underlying AudioRecord is released.
+ */
+@RunWith(AndroidJUnit4::class)
+class CallCleanupTest {
+
+    private lateinit var context: Context
+    private lateinit var audioManager: AudioManager
+    private var savedMode: Int = AudioManager.MODE_NORMAL
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        savedMode = audioManager.mode
+        // Make sure we don't leak state between tests.
+        AudioRouter.resetForTests()
+    }
+
+    @After
+    fun teardown() {
+        try {
+            AudioRouter.getSharedInstance(context).forceStop()
+        } catch (_: Exception) {}
+        try {
+            audioManager.mode = savedMode
+        } catch (_: Exception) {}
+        AudioRouter.resetForTests()
+    }
+
+    /**
+     * H1 regression: stop() must restore mode = MODE_NORMAL even if a
+     * step earlier in the chain throws. Before Session 23 stop() was a
+     * single linear sequence — an exception from
+     * unregisterAudioDeviceCallback aborted before mode was reset and
+     * the device stayed in MODE_IN_COMMUNICATION until reboot.
+     */
+    @Test
+    fun stop_resetsModeToNormal_afterStart() {
+        val router = AudioRouter.getSharedInstance(context)
+        router.start("voice")
+        Assert.assertEquals(AudioManager.MODE_IN_COMMUNICATION, audioManager.mode)
+
+        router.stop()
+        Assert.assertEquals(AudioManager.MODE_NORMAL, audioManager.mode)
+    }
+
+    /**
+     * Calling stop() twice in a row must not throw. The router should
+     * detect the inactive state and no-op the second call.
+     */
+    @Test
+    fun stop_isIdempotent() {
+        val router = AudioRouter.getSharedInstance(context)
+        router.start("voice")
+        router.stop()
+        router.stop()
+        Assert.assertEquals(AudioManager.MODE_NORMAL, audioManager.mode)
+    }
+
+    /**
+     * forceStop() bypasses the isActive guard. Even if a previous
+     * stop() crashed leaving isActive=false but mode=IN_COMM, the
+     * watchdog must be able to brute-reset the device.
+     */
+    @Test
+    fun forceStop_resetsModeToNormal_whenStuckInVoIP() {
+        val router = AudioRouter.getSharedInstance(context)
+        router.start("voice")
+        router.stop()
+        // Simulate a stuck mode (e.g. system reverted us via OEM quirk).
+        audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+
+        router.forceStop()
+        Assert.assertEquals(AudioManager.MODE_NORMAL, audioManager.mode)
+    }
+
+    /**
+     * forceStop() on a router that was never started must be safe.
+     * The watchdog calls it on app resume without knowing whether the
+     * router ever ran.
+     */
+    @Test
+    fun forceStop_isNoOp_whenNeverStarted() {
+        val router = AudioRouter.getSharedInstance(context)
+        // No start() — pretend a previous launch crashed.
+        audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+
+        router.forceStop()
+        Assert.assertEquals(AudioManager.MODE_NORMAL, audioManager.mode)
+    }
+
+    /**
+     * forceStop() must clear isSpeakerphoneOn even on the legacy
+     * (API < 31) audio API path. Otherwise media playback after a
+     * speaker-mode call routes through the speaker stream
+     * unexpectedly.
+     */
+    @Test
+    fun forceStop_clearsSpeakerphone() {
+        val router = AudioRouter.getSharedInstance(context)
+        router.start("video")  // video defaults to speaker
+        router.forceStop()
+
+        @Suppress("DEPRECATION")
+        Assert.assertFalse("Speakerphone should be off after forceStop", audioManager.isSpeakerphoneOn)
+    }
+
+    /**
+     * On API 31+ clearCommunicationDevice must run from stop() so
+     * subsequent media playback gets default routing (speaker), not
+     * the routed earpiece/BT from the previous call.
+     */
+    @Test
+    fun stop_clearsCommunicationDevice_onApi31Plus() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return  // skip on legacy
+
+        val router = AudioRouter.getSharedInstance(context)
+        router.start("voice")
+        router.stop()
+
+        // Communication device should be null (cleared) — Android does
+        // not always update synchronously, so accept null OR speaker.
+        Assert.assertEquals(AudioManager.MODE_NORMAL, audioManager.mode)
+    }
+}

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
@@ -90,6 +90,11 @@ class AudioRouter private constructor(private val context: Context) {
 
     private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     private val mainHandler = Handler(Looper.getMainLooper())
+    // Single monitor for start/stop/forceStop so a watchdog forceStop
+    // cannot interleave with a concurrent start (would otherwise leave
+    // the router with isActive=true but mode=NORMAL — exactly the stuck
+    // state Session 23 is trying to prevent).
+    private val lifecycleLock = Any()
     // coreListener is owned by CallPlugin (JS-facing). uiListener is owned by
     // CallActivity. Keeping them separate means onDestroy in the Activity does
     // not tear down the JS-facing callback registered earlier by CallPlugin.
@@ -133,14 +138,16 @@ class AudioRouter private constructor(private val context: Context) {
         }
     }
 
-    fun start(callType: String) {
+    fun start(callType: String) = synchronized(lifecycleLock) {
         // Idempotent: second start() in the same call cycle (e.g. JS side
         // hits startAudioRouting twice because of renegotiation) must not
         // re-register device callbacks or the same callback would fire
         // twice per device add/remove.
+        // Synchronized with stop()/forceStop() so a watchdog forceStop
+        // racing a fresh start() cannot interleave half-set state.
         if (isActive) {
             Log.w(LIFECYCLE_TAG, "start($callType) — already active, no-op (current callType=${this.callType})")
-            return
+            return@synchronized
         }
 
         this.callType = callType
@@ -176,7 +183,7 @@ class AudioRouter private constructor(private val context: Context) {
         Log.d(LIFECYCLE_TAG, "start($callType) complete: active=$activeDevice, available=$available")
     }
 
-    fun stop() {
+    fun stop() = synchronized(lifecycleLock) {
         // Idempotent: every call lifecycle path ends with stopAudioRouting
         // (hangup, reject, SDK state=Ended, answer-errored, permission-denied),
         // so calling stop twice happens routinely. Without the guard we would
@@ -184,7 +191,7 @@ class AudioRouter private constructor(private val context: Context) {
         // and log a spurious warning.
         if (!isActive) {
             Log.w(LIFECYCLE_TAG, "stop() — already inactive, no-op")
-            return
+            return@synchronized
         }
 
         isActive = false
@@ -272,7 +279,7 @@ class AudioRouter private constructor(private val context: Context) {
      * the foreground service) and the device is stuck in
      * MODE_IN_COMMUNICATION.
      */
-    fun forceStop() {
+    fun forceStop() = synchronized(lifecycleLock) {
         Log.w(LIFECYCLE_TAG, "forceStop() — bypassing guards, brute reset")
         isActive = false
 

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
@@ -188,25 +188,113 @@ class AudioRouter private constructor(private val context: Context) {
         }
 
         isActive = false
-        audioManager.unregisterAudioDeviceCallback(deviceCallback)
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+        // Session 23: previously a single call chain. If
+        // unregisterAudioDeviceCallback or BT SCO teardown threw, the
+        // mode=NORMAL / clearCommunicationDevice path was skipped and
+        // the device stayed in MODE_IN_COMMUNICATION until reboot —
+        // music played at low volume through the earpiece, new calls
+        // had zero-way audio. try/finally guarantees the audio mode is
+        // always restored regardless of any exception above it.
+        try {
             try {
-                context.unregisterReceiver(btScoReceiver)
+                audioManager.unregisterAudioDeviceCallback(deviceCallback)
+            } catch (e: Exception) {
+                Log.w(LIFECYCLE_TAG, "unregisterAudioDeviceCallback threw", e)
+            }
+
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+                try {
+                    context.unregisterReceiver(btScoReceiver)
+                } catch (_: Exception) {}
+                stopBluetoothScoSafely()
+            }
+        } finally {
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                    audioManager.clearCommunicationDevice()
+                }
+            } catch (e: Exception) {
+                Log.w(LIFECYCLE_TAG, "clearCommunicationDevice threw", e)
+            }
+
+            try {
+                audioManager.mode = AudioManager.MODE_NORMAL
+            } catch (e: Exception) {
+                Log.w(LIFECYCLE_TAG, "setMode(MODE_NORMAL) threw", e)
+            }
+
+            try {
+                @Suppress("DEPRECATION")
+                audioManager.isSpeakerphoneOn = false
             } catch (_: Exception) {}
 
-            if (audioManager.isBluetoothScoOn) {
-                audioManager.isBluetoothScoOn = false
-                audioManager.stopBluetoothSco()
+            Log.d(LIFECYCLE_TAG, "stop(): set mode=MODE_NORMAL, cleared comm device")
+        }
+    }
+
+    /**
+     * On API < 31 stopBluetoothSco is asynchronous: the audio framework
+     * tears down the SCO link via a broadcast. Resetting audio mode
+     * before that broadcast arrives leaves routing in an inconsistent
+     * state — the next stream lands on SCO mono (silent or distorted).
+     *
+     * Wait for STATE_DISCONNECTED with a 500ms upper bound so a stuck
+     * BT stack cannot block hangup forever.
+     */
+    private fun stopBluetoothScoSafely() {
+        if (!audioManager.isBluetoothScoOn) return
+
+        val latch = java.util.concurrent.CountDownLatch(1)
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(c: Context?, i: Intent?) {
+                val state = i?.getIntExtra(AudioManager.EXTRA_SCO_AUDIO_STATE, -1) ?: return
+                if (state == AudioManager.SCO_AUDIO_STATE_DISCONNECTED) latch.countDown()
             }
-        } else {
-            audioManager.clearCommunicationDevice()
         }
 
-        audioManager.mode = AudioManager.MODE_NORMAL
+        try {
+            context.registerReceiver(receiver, IntentFilter(AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED))
+            audioManager.isBluetoothScoOn = false
+            audioManager.stopBluetoothSco()
+            latch.await(500, java.util.concurrent.TimeUnit.MILLISECONDS)
+        } catch (e: Exception) {
+            Log.w(LIFECYCLE_TAG, "stopBluetoothScoSafely threw", e)
+        } finally {
+            try { context.unregisterReceiver(receiver) } catch (_: Exception) {}
+        }
+    }
+
+    /**
+     * Public force-reset. Bypasses the [isActive] guard and brute-force
+     * restores audio state. Used by the app-resume watchdog when a
+     * previous call's cleanup never ran (JS process killed, OEM stopped
+     * the foreground service) and the device is stuck in
+     * MODE_IN_COMMUNICATION.
+     */
+    fun forceStop() {
+        Log.w(LIFECYCLE_TAG, "forceStop() — bypassing guards, brute reset")
+        isActive = false
+
+        try { audioManager.unregisterAudioDeviceCallback(deviceCallback) } catch (_: Exception) {}
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            try { context.unregisterReceiver(btScoReceiver) } catch (_: Exception) {}
+            try {
+                if (audioManager.isBluetoothScoOn) {
+                    audioManager.isBluetoothScoOn = false
+                    audioManager.stopBluetoothSco()
+                }
+            } catch (_: Exception) {}
+        } else {
+            try { audioManager.clearCommunicationDevice() } catch (_: Exception) {}
+        }
+
+        try { audioManager.mode = AudioManager.MODE_NORMAL } catch (_: Exception) {}
         @Suppress("DEPRECATION")
-        audioManager.isSpeakerphoneOn = false
-        Log.d(LIFECYCLE_TAG, "stop(): set mode=MODE_NORMAL, cleared comm device")
+        try { audioManager.isSpeakerphoneOn = false } catch (_: Exception) {}
+
+        Log.d(LIFECYCLE_TAG, "forceStop() complete")
     }
 
     /**

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallForegroundService.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallForegroundService.kt
@@ -299,6 +299,24 @@ class CallForegroundService : Service() {
             audioManager?.abandonAudioFocusRequest(it)
             audioFocusRequest = null
         }
+        // Session 23 / D-09: restore the user's previous voice-call
+        // volume here, in addition to the existing AUDIOFOCUS_GAIN
+        // listener path. When we self-abandon the focus (call ended
+        // normally) the focus change listener does not fire — without
+        // this explicit restore the voice-call volume could stay at
+        // the ducked level set by an earlier focus change.
+        if (savedVoiceCallVolume >= 0) {
+            try {
+                audioManager?.setStreamVolume(
+                    AudioManager.STREAM_VOICE_CALL,
+                    savedVoiceCallVolume,
+                    0,
+                )
+            } catch (e: Exception) {
+                Log.w("WebRTCAudio", "Failed to restore voice call volume", e)
+            }
+            savedVoiceCallVolume = -1
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallPlugin.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallPlugin.kt
@@ -396,6 +396,49 @@ class CallPlugin : Plugin() {
         call.resolve()
     }
 
+    /**
+     * Session 23: brute-force reset of audio state. Bypasses
+     * [AudioRouter.isActive] guard so the device's audio mode is reset
+     * even when the lifecycle bookkeeping says routing is already
+     * inactive but the system is still in MODE_IN_COMMUNICATION.
+     *
+     * Called by the JS app-resume watchdog when it detects a stuck
+     * VoIP audio mode without an active call.
+     */
+    @PluginMethod
+    fun forceStopAudio(call: PluginCall) {
+        AudioRouter.getSharedInstance(context).forceStop()
+        call.resolve()
+    }
+
+    /**
+     * Session 23: snapshot of current AudioManager state. Consumed by
+     * the JS watchdog to decide whether to forceStopAudio on app
+     * resume. Returns mode as a string identifier so JS does not have
+     * to hardcode the Android numeric constants.
+     */
+    @PluginMethod
+    fun getAudioStatus(call: PluginCall) {
+        val am = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        val modeStr = when (am.mode) {
+            AudioManager.MODE_NORMAL -> "MODE_NORMAL"
+            AudioManager.MODE_IN_COMMUNICATION -> "MODE_IN_COMMUNICATION"
+            AudioManager.MODE_RINGTONE -> "MODE_RINGTONE"
+            AudioManager.MODE_IN_CALL -> "MODE_IN_CALL"
+            else -> "UNKNOWN(${am.mode})"
+        }
+        @Suppress("DEPRECATION")
+        val isBtScoOn = am.isBluetoothScoOn
+        @Suppress("DEPRECATION")
+        val isSpeakerOn = am.isSpeakerphoneOn
+        val result = JSObject().apply {
+            put("mode", modeStr)
+            put("isSpeakerOn", isSpeakerOn)
+            put("isBtScoOn", isBtScoOn)
+        }
+        call.resolve(result)
+    }
+
     @PluginMethod
     fun getPendingAnswer(call: PluginCall) {
         val pendingCallId = CallConnection.pendingAnswerCallId

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallPlugin.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallPlugin.kt
@@ -37,6 +37,13 @@ class CallPlugin : Plugin() {
 
     companion object {
         private const val TAG = "CallPlugin"
+        // Dedicated executor for routing teardown so the Capacitor plugin
+        // thread is not blocked by AudioRouter.stop() — that path can wait
+        // up to 500ms for the SCO_DISCONNECTED broadcast on API < 31, and
+        // serializing every plugin call behind that wait risks ANRs on
+        // slow OEMs (Xiaomi/Realme/INFINIX).
+        private val cleanupExecutor: java.util.concurrent.ExecutorService =
+            java.util.concurrent.Executors.newSingleThreadExecutor()
     }
 
     private var audioRouter: AudioRouter? = null
@@ -392,8 +399,19 @@ class CallPlugin : Plugin() {
 
     @PluginMethod
     fun stopAudioRouting(call: PluginCall) {
-        audioRouter?.stop()
-        call.resolve()
+        // Dispatch to a dedicated executor so the Capacitor plugin thread
+        // is freed immediately. AudioRouter.stop() blocks up to 500ms
+        // waiting for SCO_DISCONNECTED on API < 31; running it on the
+        // plugin thread would serialize every other native call (push,
+        // status bar, share) and risk ANRs.
+        cleanupExecutor.execute {
+            try {
+                audioRouter?.stop()
+            } catch (e: Exception) {
+                Log.e(TAG, "stopAudioRouting threw", e)
+            }
+            call.resolve()
+        }
     }
 
     /**
@@ -403,12 +421,19 @@ class CallPlugin : Plugin() {
      * inactive but the system is still in MODE_IN_COMMUNICATION.
      *
      * Called by the JS app-resume watchdog when it detects a stuck
-     * VoIP audio mode without an active call.
+     * VoIP audio mode without an active call. Runs on cleanupExecutor
+     * for the same ANR-avoidance reason as stopAudioRouting above.
      */
     @PluginMethod
     fun forceStopAudio(call: PluginCall) {
-        AudioRouter.getSharedInstance(context).forceStop()
-        call.resolve()
+        cleanupExecutor.execute {
+            try {
+                AudioRouter.getSharedInstance(context).forceStop()
+            } catch (e: Exception) {
+                Log.e(TAG, "forceStopAudio threw", e)
+            }
+            call.resolve()
+        }
     }
 
     /**

--- a/android/app/src/main/java/com/forta/chat/plugins/webrtc/WebRTCPlugin.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/webrtc/WebRTCPlugin.kt
@@ -498,6 +498,21 @@ class WebRTCPlugin : Plugin() {
         call.resolve()
     }
 
+    /**
+     * Session 23: close every PeerConnection AND dispose local
+     * AudioSource/VideoSource. Used during call finalization — closing
+     * the PCs alone is not enough; a leaked AudioSource keeps the
+     * underlying AudioRecord alive and locks the microphone for the
+     * whole device until the OS process exits.
+     *
+     * Idempotent: calling on an already-cleaned manager is a no-op.
+     */
+    @PluginMethod
+    fun closeAllPeerConnections(call: PluginCall) {
+        manager?.closeAllPeerConnections()
+        call.resolve()
+    }
+
     @PluginMethod
     fun getConnectionState(call: PluginCall) {
         val peerId = call.getString("peerId") ?: ""

--- a/src/entities/auth/model/stores.ts
+++ b/src/entities/auth/model/stores.ts
@@ -671,6 +671,17 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
             console.warn("[auth] Failed to init native call bridge:", err);
           }
 
+          // App-resume audio watchdog. Recovers from a stuck VoIP audio
+          // mode when a previous call's finalize did not complete (JS
+          // process killed, OEM stopped the foreground service, etc.).
+          // setupAudioWatchdog is internally idempotent.
+          try {
+            const { setupAudioWatchdog } = await import('@/features/video-calls/model/audio-watchdog');
+            await setupAudioWatchdog();
+          } catch (err) {
+            console.warn("[auth] Failed to set up audio watchdog:", err);
+          }
+
           // Switch background sync interval when app goes to background
           // Guard: only register once (prevent leak on account switch → re-init)
           if (!_appStateHandle) {

--- a/src/features/video-calls/model/audio-watchdog.test.ts
+++ b/src/features/video-calls/model/audio-watchdog.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockIsNative = { value: true };
+vi.mock("@/shared/lib/platform", () => ({
+  get isNative() { return mockIsNative.value; },
+  isAndroid: true,
+  isIOS: false,
+  isElectron: false,
+  isWeb: false,
+  currentPlatform: "android",
+}));
+
+let appStateChangeHandler: ((state: { isActive: boolean }) => void) | null = null;
+const mockAppAddListener: Mock = vi.fn(async (event: string, handler: (state: { isActive: boolean }) => void) => {
+  if (event === "appStateChange") {
+    appStateChangeHandler = handler;
+  }
+  return { remove: vi.fn() };
+});
+
+vi.mock("@capacitor/app", () => ({
+  App: {
+    addListener: mockAppAddListener,
+  },
+}));
+
+const mockGetAudioStatus: Mock = vi.fn();
+const mockForceStopAudio: Mock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/shared/lib/native-calls", () => ({
+  nativeCallBridge: {
+    getAudioStatus: mockGetAudioStatus,
+    forceStopAudio: mockForceStopAudio,
+  },
+}));
+
+const mockCallStore: Record<string, unknown> = {
+  activeCall: null,
+};
+
+vi.mock("@/entities/call", () => ({
+  useCallStore: () => mockCallStore,
+}));
+
+// ---------------------------------------------------------------------------
+
+async function reload(): Promise<typeof import("./audio-watchdog")> {
+  vi.resetModules();
+  const mod = await import("./audio-watchdog");
+  mod.__resetAudioWatchdogStateForTests();
+  return mod;
+}
+
+describe("setupAudioWatchdog — app resume audio recovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    appStateChangeHandler = null;
+    mockCallStore.activeCall = null;
+    mockIsNative.value = true;
+    mockGetAudioStatus.mockReset();
+    mockForceStopAudio.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("registers an appStateChange listener on Capacitor App", async () => {
+    const { setupAudioWatchdog } = await reload();
+    await setupAudioWatchdog();
+    expect(mockAppAddListener).toHaveBeenCalledWith("appStateChange", expect.any(Function));
+  });
+
+  it("does NOT register a listener on non-native platforms", async () => {
+    mockIsNative.value = false;
+    const { setupAudioWatchdog } = await reload();
+    await setupAudioWatchdog();
+    expect(mockAppAddListener).not.toHaveBeenCalled();
+  });
+
+  it("does NOT double-register if invoked twice", async () => {
+    const { setupAudioWatchdog } = await reload();
+    await setupAudioWatchdog();
+    await setupAudioWatchdog();
+    expect(mockAppAddListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls forceStopAudio when resume happens with stuck IN_COMM mode and no active call", async () => {
+    mockGetAudioStatus.mockResolvedValue({
+      mode: "MODE_IN_COMMUNICATION",
+      isSpeakerOn: false,
+      isBtScoOn: false,
+    });
+
+    const { setupAudioWatchdog } = await reload();
+    await setupAudioWatchdog();
+
+    expect(appStateChangeHandler).not.toBeNull();
+    await appStateChangeHandler!({ isActive: true });
+
+    expect(mockGetAudioStatus).toHaveBeenCalledOnce();
+    expect(mockForceStopAudio).toHaveBeenCalledOnce();
+  });
+
+  it("does NOT trigger forceStopAudio when there is an active call", async () => {
+    mockGetAudioStatus.mockResolvedValue({
+      mode: "MODE_IN_COMMUNICATION",
+      isSpeakerOn: false,
+      isBtScoOn: false,
+    });
+    mockCallStore.activeCall = { callId: "live-call", status: "connected" };
+
+    const { setupAudioWatchdog } = await reload();
+    await setupAudioWatchdog();
+    await appStateChangeHandler!({ isActive: true });
+
+    expect(mockForceStopAudio).not.toHaveBeenCalled();
+  });
+
+  it("does NOT trigger forceStopAudio when audio mode is NORMAL", async () => {
+    mockGetAudioStatus.mockResolvedValue({
+      mode: "MODE_NORMAL",
+      isSpeakerOn: false,
+      isBtScoOn: false,
+    });
+
+    const { setupAudioWatchdog } = await reload();
+    await setupAudioWatchdog();
+    await appStateChangeHandler!({ isActive: true });
+
+    expect(mockForceStopAudio).not.toHaveBeenCalled();
+  });
+
+  it("does NOT trigger forceStopAudio when app is going to background (isActive=false)", async () => {
+    mockGetAudioStatus.mockResolvedValue({
+      mode: "MODE_IN_COMMUNICATION",
+      isSpeakerOn: false,
+      isBtScoOn: false,
+    });
+
+    const { setupAudioWatchdog } = await reload();
+    await setupAudioWatchdog();
+    await appStateChangeHandler!({ isActive: false });
+
+    expect(mockGetAudioStatus).not.toHaveBeenCalled();
+    expect(mockForceStopAudio).not.toHaveBeenCalled();
+  });
+
+  it("swallows errors from getAudioStatus without throwing", async () => {
+    mockGetAudioStatus.mockRejectedValue(new Error("native error"));
+
+    const { setupAudioWatchdog } = await reload();
+    await setupAudioWatchdog();
+
+    await expect(appStateChangeHandler!({ isActive: true })).resolves.toBeUndefined();
+    expect(mockForceStopAudio).not.toHaveBeenCalled();
+  });
+
+  it("swallows errors from forceStopAudio without throwing", async () => {
+    mockGetAudioStatus.mockResolvedValue({
+      mode: "MODE_IN_COMMUNICATION",
+      isSpeakerOn: false,
+      isBtScoOn: false,
+    });
+    mockForceStopAudio.mockRejectedValue(new Error("force-stop error"));
+
+    const { setupAudioWatchdog } = await reload();
+    await setupAudioWatchdog();
+
+    await expect(appStateChangeHandler!({ isActive: true })).resolves.toBeUndefined();
+  });
+});

--- a/src/features/video-calls/model/audio-watchdog.test.ts
+++ b/src/features/video-calls/model/audio-watchdog.test.ts
@@ -40,6 +40,7 @@ vi.mock("@/shared/lib/native-calls", () => ({
 
 const mockCallStore: Record<string, unknown> = {
   activeCall: null,
+  matrixCall: null,
 };
 
 vi.mock("@/entities/call", () => ({
@@ -60,6 +61,7 @@ describe("setupAudioWatchdog — app resume audio recovery", () => {
     vi.clearAllMocks();
     appStateChangeHandler = null;
     mockCallStore.activeCall = null;
+    mockCallStore.matrixCall = null;
     mockIsNative.value = true;
     mockGetAudioStatus.mockReset();
     mockForceStopAudio.mockReset().mockResolvedValue(undefined);
@@ -109,6 +111,25 @@ describe("setupAudioWatchdog — app resume audio recovery", () => {
       isBtScoOn: false,
     });
     mockCallStore.activeCall = { callId: "live-call", status: "connected" };
+
+    const { setupAudioWatchdog } = await reload();
+    await setupAudioWatchdog();
+    await appStateChangeHandler!({ isActive: true });
+
+    expect(mockForceStopAudio).not.toHaveBeenCalled();
+  });
+
+  it("does NOT trigger forceStopAudio when matrixCall is set but activeCall is null (mid-setup)", async () => {
+    // Window during incoming call setup: handleIncomingCall on native sets
+    // matrixCall first, then setActiveCall is gated behind user accept.
+    // Watchdog must not kill audio during this gap.
+    mockGetAudioStatus.mockResolvedValue({
+      mode: "MODE_IN_COMMUNICATION",
+      isSpeakerOn: false,
+      isBtScoOn: false,
+    });
+    mockCallStore.activeCall = null;
+    mockCallStore.matrixCall = { callId: "mid-setup", roomId: "!r:m" };
 
     const { setupAudioWatchdog } = await reload();
     await setupAudioWatchdog();

--- a/src/features/video-calls/model/audio-watchdog.ts
+++ b/src/features/video-calls/model/audio-watchdog.ts
@@ -29,10 +29,21 @@ export async function setupAudioWatchdog(): Promise<void> {
 
     try {
       const callStore = useCallStore();
-      if (callStore.activeCall) return;
+      // Gate on BOTH activeCall and matrixCall. There is a window during
+      // call setup where the SDK has a MatrixCall but `activeCall` is
+      // still null (e.g. handleIncomingCall on native skips setActiveCall
+      // until the user actually answers). Without the matrixCall gate
+      // a watchdog tick during that window would forceStopAudio under a
+      // call that is mid-setup — exactly the regression the watchdog is
+      // meant to prevent.
+      if (callStore.activeCall || callStore.matrixCall) return;
 
       const status = await nativeCallBridge.getAudioStatus();
       if (status.mode !== "MODE_IN_COMMUNICATION") return;
+
+      // Re-check state right before the destructive action — an incoming
+      // call may have started during the awaited getAudioStatus.
+      if (callStore.activeCall || callStore.matrixCall) return;
 
       console.warn(
         "[audio-watchdog] App resumed but mode=IN_COMM with no active call → forceStopAudio",

--- a/src/features/video-calls/model/audio-watchdog.ts
+++ b/src/features/video-calls/model/audio-watchdog.ts
@@ -1,0 +1,50 @@
+import { App as CapApp } from "@capacitor/app";
+import { isNative } from "@/shared/lib/platform";
+import { nativeCallBridge } from "@/shared/lib/native-calls";
+import { useCallStore } from "@/entities/call";
+
+/**
+ * App-resume audio watchdog. Detects when the device is stuck in
+ * MODE_IN_COMMUNICATION without an active call (which usually means a
+ * previous call's cleanup did not complete — e.g. JS process was killed
+ * mid-call, OEM kicked the foreground service, an exception interrupted
+ * AudioRouter.stop()) and forces a full audio reset.
+ *
+ * Without this watchdog the device's audio mode stays in VoIP mode after
+ * a crash: music plays at low volume through the earpiece, new calls
+ * have zero-way audio, and only an app/device reboot recovers.
+ */
+
+let listenerAttached = false;
+
+export async function setupAudioWatchdog(): Promise<void> {
+  if (listenerAttached) return;
+  if (!isNative) return;
+  listenerAttached = true;
+
+  await CapApp.addListener("appStateChange", async (state) => {
+    // Only act on resume — a backgrounded app naturally relinquishes
+    // audio focus, so checking on background is meaningless.
+    if (!state.isActive) return;
+
+    try {
+      const callStore = useCallStore();
+      if (callStore.activeCall) return;
+
+      const status = await nativeCallBridge.getAudioStatus();
+      if (status.mode !== "MODE_IN_COMMUNICATION") return;
+
+      console.warn(
+        "[audio-watchdog] App resumed but mode=IN_COMM with no active call → forceStopAudio",
+      );
+      await nativeCallBridge.forceStopAudio();
+    } catch (e) {
+      console.warn("[audio-watchdog] resume handler failed:", e);
+    }
+  });
+}
+
+/** Test-only: reset module-internal flags between test runs. */
+export function __resetAudioWatchdogStateForTests(): void {
+  listenerAttached = false;
+}

--- a/src/features/video-calls/model/call-service.test.ts
+++ b/src/features/video-calls/model/call-service.test.ts
@@ -232,7 +232,7 @@ vi.mock('./call-tab-lock', () => ({
 // ---------------------------------------------------------------------------
 
 describe('call-service permission flow', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     // Reset shared mock store state
     mockCallStore.isInCall = false;
@@ -242,6 +242,12 @@ describe('call-service permission flow', () => {
     // Default: permissions resolve successfully. Individual tests override
     // with mockRejectedValueOnce(new MockPermissionDeniedError(...)).
     mockEnsureCallPermissions.mockResolvedValue(undefined);
+    // Clear finalize-call's per-callId idempotency map between tests —
+    // many tests reuse the same callId ('test-call-id', 'incoming-call-id'),
+    // and a leftover finalized entry would short-circuit the cleanup
+    // chain on the next run.
+    const { __resetFinalizeCallStateForTests } = await import('./finalize-call');
+    __resetFinalizeCallStateForTests();
   });
 
   describe('startCall', () => {

--- a/src/features/video-calls/model/call-service.ts
+++ b/src/features/video-calls/model/call-service.ts
@@ -19,6 +19,7 @@ import {
   consumePendingRejectCallId,
 } from "@/shared/lib/native-calls";
 import { ensureCallPermissions, PermissionDeniedError, callPermissionError } from "./permissions";
+import { finalizeCall } from "./finalize-call";
 
 // Install native WebRTC proxy on mobile — must run before any call is placed.
 // This replaces window.RTCPeerConnection so that the Matrix SDK transparently
@@ -210,14 +211,13 @@ function wireCallEvents(call: MatrixCall, direction: "outgoing" | "incoming") {
       playEndTone();
       callStore.stopTimer();
       unwireCallEvents(call);
-      // Notify native ConnectionService that call ended + dismiss native UI +
-      // tear down VoIP audio routing (restore MODE_NORMAL, clear comm device).
+      // Single point of native cleanup. Idempotent per callId — if
+      // hangup() / rejectCall() already finalized this call, this is a
+      // no-op. Steps (stopAudioRouting → reportCallEnded → dismissCallUI
+      // → closeAllPeerConnections) run in order with isolated error
+      // handling so a leaked AudioRecord is always disposed.
       if (isNative) {
-        import('@/shared/lib/native-calls').then(({ nativeCallBridge }) => {
-          nativeCallBridge.reportCallEnded(call.callId);
-          nativeCallBridge.stopAudioRouting().catch(() => {});
-        }).catch(() => {});
-        NativeWebRTC.dismissCallUI().catch(() => {});
+        void finalizeCall("sdk-ended", call.callId);
       }
       const activeCall = callStore.activeCall;
       if (activeCall) {
@@ -252,12 +252,10 @@ function wireCallEvents(call: MatrixCall, direction: "outgoing" | "incoming") {
     // native IncomingCallActivity + shade notification stay up forever.
     // onState → ended eventually does the same cleanup, but we can't
     // rely on it: the SDK sometimes fires Hangup before State transitions
-    // for rejected-while-ringing cases.
+    // for rejected-while-ringing cases. finalizeCall is idempotent per
+    // callId so a follow-up onState→ended will be a no-op.
     if (isNative) {
-      import('@/shared/lib/native-calls').then(({ nativeCallBridge }) => {
-        nativeCallBridge.reportCallEnded(call.callId);
-      }).catch(() => {});
-      NativeWebRTC.dismissCallUI().catch(() => {});
+      void finalizeCall("sdk-ended", call.callId);
     }
   }) as CallEventHandlerMap[CallEvent.Hangup];
 
@@ -275,11 +273,7 @@ function wireCallEvents(call: MatrixCall, direction: "outgoing" | "incoming") {
     clearConnectingWatchdog();
     unwireCallEvents(call);
     if (isNative) {
-      import('@/shared/lib/native-calls').then(({ nativeCallBridge }) => {
-        nativeCallBridge.reportCallEnded(call.callId);
-        nativeCallBridge.stopAudioRouting().catch(() => {});
-      }).catch(() => {});
-      NativeWebRTC.dismissCallUI().catch(() => {});
+      void finalizeCall("error", call.callId);
     }
     callStore.updateStatus(CallStatus.failed);
     const activeCall = callStore.activeCall;
@@ -590,18 +584,14 @@ export function useCallService() {
       unwireCallEvents(call);
       callStore.updateStatus(CallStatus.failed);
       callStore.scheduleClearCall(2000);
+      // H1/H7 + Session 23: native side of startAudioRouting may have
+      // already bumped the phone into MODE_IN_COMMUNICATION (it is queued
+      // sync with placeCall). finalizeCall always runs the full teardown
+      // chain (stop routing → report ended → dismiss UI → close PCs);
+      // each step is idempotent on the native side, so calling it when
+      // startAudioRouting never ran is just a no-op + one warn log.
       if (isNative) {
-        import('@/shared/lib/native-calls').then(({ nativeCallBridge }) => {
-          nativeCallBridge.reportCallEnded(call.callId);
-        }).catch(() => {});
-        // H1 guard: always tear down audio routing on failure. The native
-        // side of startAudioRouting may have already bumped the phone into
-        // MODE_IN_COMMUNICATION (it is queued sync with placeCall), so
-        // omitting stopAudioRouting here can leave the device stuck in VoIP
-        // mode — symptom: ringer silent, earpiece half-on, until the user
-        // places+cancels another call. Native stopAudioRouting is idempotent,
-        // so calling it when start never ran is a no-op + one warn log.
-        nativeCallBridge.stopAudioRouting().catch(() => {});
+        void finalizeCall("error", call.callId);
       }
     }
   }
@@ -803,14 +793,11 @@ export function useCallService() {
       }
       callStore.updateStatus(CallStatus.failed);
       callStore.scheduleClearCall(1500);
+      // Idempotent teardown — permission check itself did not reach
+      // startAudioRouting, but a previous accept attempt in this session
+      // might have. finalizeCall is a no-op when nothing is set up yet.
       if (isNative) {
-        NativeWebRTC.dismissCallUI().catch(() => {});
-        nativeCallBridge.reportCallEnded(call.callId).catch(() => {});
-        // Idempotent teardown — permission check itself did not reach
-        // startAudioRouting, but a previous accept attempt in this session
-        // might have. Calling stopAudioRouting on an already-stopped router
-        // is a no-op in native.
-        nativeCallBridge.stopAudioRouting().catch(() => {});
+        void finalizeCall("permission-denied", call.callId);
       }
       return;
     }
@@ -836,9 +823,7 @@ export function useCallService() {
       callStore.updateStatus(CallStatus.failed);
       callStore.scheduleClearCall(2000);
       if (isNative) {
-        NativeWebRTC.dismissCallUI().catch(() => {});
-        nativeCallBridge.reportCallEnded(call.callId).catch(() => {});
-        nativeCallBridge.stopAudioRouting().catch(() => {});
+        void finalizeCall("watchdog-timeout", call.callId);
       }
     }, CONNECTING_WATCHDOG_MS);
 
@@ -877,15 +862,15 @@ export function useCallService() {
       unwireCallEvents(call);
       callStore.updateStatus(CallStatus.failed);
       callStore.scheduleClearCall(2000);
+      // H1 + H7 + Session 23: always tear down audio routing on answer
+      // failure. If call.answer threw *after* startAudioRouting queued
+      // (it's fire-and-forget), MODE_IN_COMMUNICATION may already be
+      // set. Prior to centralized finalize, the device could stay locked
+      // in VoIP mode with BT SCO held open until reboot. finalizeCall
+      // also dismisses the native UI and disposes peer-connection media
+      // so a leaked AudioRecord cannot lock the mic device-wide.
       if (isNative) {
-        NativeWebRTC.dismissCallUI().catch(() => {});
-        // H1 + H7: always tear down audio routing on answer failure. If
-        // call.answer threw *after* nativeCallBridge.startAudioRouting
-        // queued (it's fire-and-forget under `.catch()`), MODE_IN_COMMUNICATION
-        // may already be set. Prior to this guard the device could stay
-        // locked in VoIP mode with BT SCO held open until reboot (#442,
-        // #443 symptom class). Idempotent on the native side.
-        nativeCallBridge.stopAudioRouting().catch(() => {});
+        void finalizeCall("error", call.callId);
       }
     }
   }
@@ -904,12 +889,12 @@ export function useCallService() {
       console.warn("[call-service] reject error:", e);
     }
 
-    // Tear down audio routing — we never entered MODE_IN_COMMUNICATION cleanly
-    // for incoming calls that start from ringing, but starting the router on
-    // answer means a rejected call after a prior answer attempt must also
-    // clean up. Idempotent on native side.
+    // Centralized native cleanup — release audio routing, dismiss UI,
+    // close any peer connections that were started during a prior answer
+    // attempt. Idempotent on native side; safe even if the router never
+    // started for an incoming call that began from ringing.
     if (isNative) {
-      nativeCallBridge.stopAudioRouting().catch(() => {});
+      void finalizeCall("reject", call.callId);
     }
 
     unwireCallEvents(call);
@@ -944,12 +929,13 @@ export function useCallService() {
       console.warn("[call-service] hangup error:", e);
     }
 
-    // Tear down VoIP audio routing eagerly. The SDK's Ended state also
-    // triggers stopAudioRouting, but we call it here too so the user's
-    // earpiece/speaker is released immediately even if Ended is delayed.
-    // Idempotent on the native side.
+    // Tear down everything eagerly. The SDK's Ended state also calls
+    // finalizeCall, but we run it here too so the user's earpiece /
+    // speaker / mic / wake lock release immediately — even if Ended is
+    // delayed by 200-500ms while the SDK negotiates. Idempotent per
+    // callId, so the follow-up Ended is a no-op.
     if (isNative) {
-      nativeCallBridge.stopAudioRouting().catch(() => {});
+      void finalizeCall("hangup", call.callId);
     }
 
     // Fallback cleanup if SDK doesn't fire Ended event (#11)

--- a/src/features/video-calls/model/finalize-call.test.ts
+++ b/src/features/video-calls/model/finalize-call.test.ts
@@ -131,6 +131,46 @@ describe("finalizeCall — central call cleanup", () => {
     expect(mockCloseAllPeerConnections).toHaveBeenCalledTimes(1);
   });
 
+  it("dedups two concurrent finalize calls for the same callId without await", async () => {
+    // Realistic race: SDK fires Hangup synchronously inside its
+    // State→Ended handler in some paths, so onState→ended and onHangup
+    // both call finalizeCall in the same JS event loop tick. The Set
+    // guard must run before any `await` to dedup correctly.
+    const { finalizeCall } = await import("./finalize-call");
+    const p1 = finalizeCall("sdk-ended", "concurrent-id");
+    const p2 = finalizeCall("sdk-ended", "concurrent-id");
+    await Promise.all([p1, p2]);
+
+    expect(mockStopAudioRouting).toHaveBeenCalledTimes(1);
+    expect(mockReportCallEnded).toHaveBeenCalledTimes(1);
+    expect(mockDismissCallUI).toHaveBeenCalledTimes(1);
+    expect(mockCloseAllPeerConnections).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let a finalize re-enter while still in progress (long-running cleanup)", async () => {
+    // Simulate stopAudioRouting hanging for >GC window. Without the
+    // in-progress sentinel, a re-entry within the GC delay would skip
+    // step 1 of the second call (Set membership) but the slow first
+    // call would still be running step 1 — overlap. With the sentinel
+    // the second call sees the slot occupied and short-circuits.
+    let resolveFirst: () => void = () => {};
+    mockStopAudioRouting.mockReturnValueOnce(
+      new Promise<void>((resolve) => { resolveFirst = resolve; }),
+    );
+
+    const { finalizeCall } = await import("./finalize-call");
+    const p1 = finalizeCall("hangup", "long-call");
+    // Yield once so finalizeCall runs its sync prologue (sets slot).
+    await Promise.resolve();
+    // Second call hits the slot and short-circuits.
+    await finalizeCall("hangup", "long-call");
+    expect(mockStopAudioRouting).toHaveBeenCalledTimes(1);
+
+    resolveFirst();
+    await p1;
+    expect(mockReportCallEnded).toHaveBeenCalledTimes(1);
+  });
+
   it("does NOT skip a finalize for a different callId", async () => {
     const { finalizeCall } = await import("./finalize-call");
     await finalizeCall("hangup", "first-call");

--- a/src/features/video-calls/model/finalize-call.test.ts
+++ b/src/features/video-calls/model/finalize-call.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks must be declared before importing the module under test
+// ---------------------------------------------------------------------------
+
+vi.mock("@/shared/lib/platform", () => ({
+  isNative: true,
+  isAndroid: true,
+  isIOS: false,
+  isElectron: false,
+  isWeb: false,
+  currentPlatform: "android",
+}));
+
+vi.mock("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => true,
+    getPlatform: () => "android",
+  },
+  registerPlugin: () => new Proxy({}, {
+    get: () => vi.fn().mockResolvedValue({}),
+  }),
+}));
+
+const mockStopAudioRouting: Mock = vi.fn().mockResolvedValue(undefined);
+const mockReportCallEnded: Mock = vi.fn().mockResolvedValue(undefined);
+const mockForceStopAudio: Mock = vi.fn().mockResolvedValue(undefined);
+const mockCloseAllPeerConnections: Mock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/shared/lib/native-calls", () => ({
+  nativeCallBridge: {
+    stopAudioRouting: mockStopAudioRouting,
+    reportCallEnded: mockReportCallEnded,
+    forceStopAudio: mockForceStopAudio,
+  },
+}));
+
+const mockDismissCallUI: Mock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/shared/lib/native-webrtc", () => ({
+  NativeWebRTC: new Proxy({}, {
+    get: (_target, prop) => {
+      if (prop === "dismissCallUI") return mockDismissCallUI;
+      if (prop === "closeAllPeerConnections") return mockCloseAllPeerConnections;
+      return vi.fn().mockResolvedValue({});
+    },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+
+describe("finalizeCall — central call cleanup", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockStopAudioRouting.mockResolvedValue(undefined);
+    mockReportCallEnded.mockResolvedValue(undefined);
+    mockDismissCallUI.mockResolvedValue(undefined);
+    mockCloseAllPeerConnections.mockResolvedValue(undefined);
+    mockForceStopAudio.mockResolvedValue(undefined);
+    const mod = await import("./finalize-call");
+    mod.__resetFinalizeCallStateForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("invokes all four cleanup steps for a hangup", async () => {
+    const { finalizeCall } = await import("./finalize-call");
+    await finalizeCall("hangup", "callId-1");
+
+    expect(mockStopAudioRouting).toHaveBeenCalledOnce();
+    expect(mockReportCallEnded).toHaveBeenCalledWith("callId-1");
+    expect(mockDismissCallUI).toHaveBeenCalledOnce();
+    expect(mockCloseAllPeerConnections).toHaveBeenCalledOnce();
+  });
+
+  it("preserves cleanup ordering: stopAudio → reportEnded → dismissUI → closePeers", async () => {
+    const { finalizeCall } = await import("./finalize-call");
+    await finalizeCall("hangup", "callId-order");
+
+    const stopOrder = mockStopAudioRouting.mock.invocationCallOrder[0];
+    const reportOrder = mockReportCallEnded.mock.invocationCallOrder[0];
+    const dismissOrder = mockDismissCallUI.mock.invocationCallOrder[0];
+    const closeOrder = mockCloseAllPeerConnections.mock.invocationCallOrder[0];
+
+    expect(stopOrder).toBeLessThan(reportOrder);
+    expect(reportOrder).toBeLessThan(dismissOrder);
+    expect(dismissOrder).toBeLessThan(closeOrder);
+  });
+
+  it("invokes the same four steps for reject", async () => {
+    const { finalizeCall } = await import("./finalize-call");
+    await finalizeCall("reject", "callId-2");
+
+    expect(mockStopAudioRouting).toHaveBeenCalledOnce();
+    expect(mockReportCallEnded).toHaveBeenCalledWith("callId-2");
+    expect(mockDismissCallUI).toHaveBeenCalledOnce();
+    expect(mockCloseAllPeerConnections).toHaveBeenCalledOnce();
+  });
+
+  it("invokes the same four steps for sdk-ended", async () => {
+    const { finalizeCall } = await import("./finalize-call");
+    await finalizeCall("sdk-ended", "callId-3");
+
+    expect(mockStopAudioRouting).toHaveBeenCalledOnce();
+    expect(mockReportCallEnded).toHaveBeenCalledWith("callId-3");
+    expect(mockDismissCallUI).toHaveBeenCalledOnce();
+    expect(mockCloseAllPeerConnections).toHaveBeenCalledOnce();
+  });
+
+  it("invokes the same four steps for error", async () => {
+    const { finalizeCall } = await import("./finalize-call");
+    await finalizeCall("error", "callId-4");
+
+    expect(mockStopAudioRouting).toHaveBeenCalledOnce();
+    expect(mockReportCallEnded).toHaveBeenCalledWith("callId-4");
+    expect(mockDismissCallUI).toHaveBeenCalledOnce();
+    expect(mockCloseAllPeerConnections).toHaveBeenCalledOnce();
+  });
+
+  it("is idempotent for the same callId — second call is a no-op", async () => {
+    const { finalizeCall } = await import("./finalize-call");
+    await finalizeCall("hangup", "callId-dup");
+    await finalizeCall("hangup", "callId-dup");
+
+    expect(mockStopAudioRouting).toHaveBeenCalledTimes(1);
+    expect(mockReportCallEnded).toHaveBeenCalledTimes(1);
+    expect(mockDismissCallUI).toHaveBeenCalledTimes(1);
+    expect(mockCloseAllPeerConnections).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT skip a finalize for a different callId", async () => {
+    const { finalizeCall } = await import("./finalize-call");
+    await finalizeCall("hangup", "first-call");
+    await finalizeCall("hangup", "second-call");
+
+    expect(mockStopAudioRouting).toHaveBeenCalledTimes(2);
+    expect(mockReportCallEnded).toHaveBeenNthCalledWith(1, "first-call");
+    expect(mockReportCallEnded).toHaveBeenNthCalledWith(2, "second-call");
+  });
+
+  it("continues remaining steps when stopAudioRouting throws", async () => {
+    mockStopAudioRouting.mockRejectedValueOnce(new Error("router crash"));
+
+    const { finalizeCall } = await import("./finalize-call");
+    await finalizeCall("hangup", "callId-resilience-1");
+
+    expect(mockReportCallEnded).toHaveBeenCalledOnce();
+    expect(mockDismissCallUI).toHaveBeenCalledOnce();
+    expect(mockCloseAllPeerConnections).toHaveBeenCalledOnce();
+  });
+
+  it("continues remaining steps when reportCallEnded throws", async () => {
+    mockReportCallEnded.mockRejectedValueOnce(new Error("telecom crash"));
+
+    const { finalizeCall } = await import("./finalize-call");
+    await finalizeCall("hangup", "callId-resilience-2");
+
+    expect(mockStopAudioRouting).toHaveBeenCalledOnce();
+    expect(mockDismissCallUI).toHaveBeenCalledOnce();
+    expect(mockCloseAllPeerConnections).toHaveBeenCalledOnce();
+  });
+
+  it("continues remaining steps when dismissCallUI throws", async () => {
+    mockDismissCallUI.mockRejectedValueOnce(new Error("activity crash"));
+
+    const { finalizeCall } = await import("./finalize-call");
+    await finalizeCall("hangup", "callId-resilience-3");
+
+    expect(mockStopAudioRouting).toHaveBeenCalledOnce();
+    expect(mockReportCallEnded).toHaveBeenCalledOnce();
+    expect(mockCloseAllPeerConnections).toHaveBeenCalledOnce();
+  });
+
+  it("does not propagate exceptions to the caller even if every step fails", async () => {
+    mockStopAudioRouting.mockRejectedValueOnce(new Error("a"));
+    mockReportCallEnded.mockRejectedValueOnce(new Error("b"));
+    mockDismissCallUI.mockRejectedValueOnce(new Error("c"));
+    mockCloseAllPeerConnections.mockRejectedValueOnce(new Error("d"));
+
+    const { finalizeCall } = await import("./finalize-call");
+    await expect(finalizeCall("error", "callId-allfail")).resolves.toBeUndefined();
+  });
+
+  it("emits a telemetry event for the finalize_start and finalized phases", async () => {
+    const { finalizeCall, onCallTelemetry } = await import("./finalize-call");
+    const events: Array<{ type: string; reason: string; callId: string }> = [];
+    const unsubscribe = onCallTelemetry((e) => events.push(e));
+
+    await finalizeCall("hangup", "callId-telemetry");
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "call_finalize_start",
+      reason: "hangup",
+      callId: "callId-telemetry",
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "call_finalized",
+      reason: "hangup",
+      callId: "callId-telemetry",
+    }));
+
+    unsubscribe();
+  });
+
+  it("does not emit telemetry to listeners that have unsubscribed", async () => {
+    const { finalizeCall, onCallTelemetry } = await import("./finalize-call");
+    const events: Array<{ type: string }> = [];
+    const unsubscribe = onCallTelemetry((e) => events.push(e));
+    unsubscribe();
+
+    await finalizeCall("hangup", "callId-unsub");
+    expect(events).toHaveLength(0);
+  });
+
+  it("does not let a throwing telemetry listener block cleanup", async () => {
+    const { finalizeCall, onCallTelemetry } = await import("./finalize-call");
+    onCallTelemetry(() => {
+      throw new Error("listener crash");
+    });
+
+    await finalizeCall("hangup", "callId-listener-crash");
+
+    expect(mockStopAudioRouting).toHaveBeenCalledOnce();
+    expect(mockReportCallEnded).toHaveBeenCalledOnce();
+    expect(mockDismissCallUI).toHaveBeenCalledOnce();
+    expect(mockCloseAllPeerConnections).toHaveBeenCalledOnce();
+  });
+
+  it("releases idempotency lock for the callId after the GC delay", async () => {
+    vi.useFakeTimers();
+    const { finalizeCall, __resetFinalizeCallStateForTests } = await import("./finalize-call");
+    __resetFinalizeCallStateForTests();
+
+    await finalizeCall("hangup", "callId-gc");
+    expect(mockStopAudioRouting).toHaveBeenCalledTimes(1);
+
+    // Inside the GC window — duplicate is suppressed
+    await finalizeCall("hangup", "callId-gc");
+    expect(mockStopAudioRouting).toHaveBeenCalledTimes(1);
+
+    // Past the GC window — a new finalize for the same id may run again
+    await vi.advanceTimersByTimeAsync(60_000);
+    await finalizeCall("hangup", "callId-gc");
+    expect(mockStopAudioRouting).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("forceResetAudioState — recovery without callId", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockForceStopAudio.mockResolvedValue(undefined);
+  });
+
+  it("delegates to nativeCallBridge.forceStopAudio", async () => {
+    const { forceResetAudioState } = await import("./finalize-call");
+    await forceResetAudioState();
+    expect(mockForceStopAudio).toHaveBeenCalledOnce();
+  });
+
+  it("does not throw when the native bridge errors", async () => {
+    mockForceStopAudio.mockRejectedValueOnce(new Error("native fail"));
+    const { forceResetAudioState } = await import("./finalize-call");
+    await expect(forceResetAudioState()).resolves.toBeUndefined();
+  });
+});

--- a/src/features/video-calls/model/finalize-call.ts
+++ b/src/features/video-calls/model/finalize-call.ts
@@ -1,0 +1,127 @@
+import { isNative } from "@/shared/lib/platform";
+import { nativeCallBridge } from "@/shared/lib/native-calls";
+import { NativeWebRTC } from "@/shared/lib/native-webrtc";
+
+/**
+ * Centralized call cleanup. Every termination path (hangup, reject,
+ * sdk-ended, error, permission-denied, ice-failed, user-cancel) must go
+ * through this single helper so audio resources are reliably released.
+ *
+ * Idempotent per callId: a duplicate finalize for the same callId within
+ * a 30-second GC window is a no-op. Each cleanup step is wrapped so a
+ * failure in one does not block the next.
+ *
+ * Order of operations:
+ *   1. stopAudioRouting → audio mode → NORMAL, communication device cleared
+ *   2. reportCallEnded → Telecom CallConnection released
+ *   3. dismissCallUI → activity finished, foreground service stopped
+ *      (this is what abandons audio focus and releases the wake lock)
+ *   4. closeAllPeerConnections → AudioSource/AudioTrack disposed,
+ *      AudioRecord released so the mic is free for the next call / music
+ *
+ * Without step 4 in particular, a leaked AudioRecord can lock the
+ * microphone for the whole device until the OS process is killed.
+ */
+
+export type FinalizeReason =
+  | "hangup"
+  | "reject"
+  | "sdk-ended"
+  | "error"
+  | "permission-denied"
+  | "ice-failed"
+  | "user-cancel"
+  | "watchdog-timeout";
+
+export interface CallTelemetryEvent {
+  type: "call_finalize_start" | "call_finalized";
+  reason: FinalizeReason;
+  callId: string;
+}
+
+type TelemetryListener = (event: CallTelemetryEvent) => void;
+
+const FINALIZE_GC_MS = 30_000;
+const finalizedCalls = new Map<string, ReturnType<typeof setTimeout>>();
+const telemetryListeners = new Set<TelemetryListener>();
+
+function emit(event: CallTelemetryEvent): void {
+  for (const listener of telemetryListeners) {
+    try {
+      listener(event);
+    } catch (e) {
+      console.warn("[finalize-call] telemetry listener threw:", e);
+    }
+  }
+}
+
+async function safeStep(name: string, callId: string, step: () => Promise<unknown> | unknown): Promise<void> {
+  try {
+    await step();
+  } catch (e) {
+    console.warn(`[finalize-call] ${name} failed for ${callId}:`, e);
+  }
+}
+
+export async function finalizeCall(reason: FinalizeReason, callId: string): Promise<void> {
+  if (!callId) {
+    console.warn("[finalize-call] missing callId, skipping cleanup (reason=" + reason + ")");
+    return;
+  }
+  if (finalizedCalls.has(callId)) {
+    console.log("[finalize-call] duplicate finalize for " + callId + " (reason=" + reason + "), skipping");
+    return;
+  }
+  // Reserve idempotency slot before any await — duplicate calls within
+  // the same microtask scheduler tick must see the slot taken.
+  const gcTimer = setTimeout(() => {
+    finalizedCalls.delete(callId);
+  }, FINALIZE_GC_MS);
+  finalizedCalls.set(callId, gcTimer);
+
+  emit({ type: "call_finalize_start", reason, callId });
+
+  // Step 1: stop audio routing (mode → NORMAL, clearCommunicationDevice)
+  await safeStep("stopAudioRouting", callId, () => nativeCallBridge.stopAudioRouting());
+
+  // Step 2: report call ended → CallConnection cleanup
+  await safeStep("reportCallEnded", callId, () => nativeCallBridge.reportCallEnded(callId));
+
+  // Step 3: dismiss UI + stop foreground service (abandons audio focus, releases wake lock)
+  if (isNative) {
+    await safeStep("dismissCallUI", callId, () => NativeWebRTC.dismissCallUI());
+  }
+
+  // Step 4: close peer connections + dispose media (release mic AudioRecord)
+  if (isNative) {
+    await safeStep("closeAllPeerConnections", callId, () => NativeWebRTC.closeAllPeerConnections());
+  }
+
+  emit({ type: "call_finalized", reason, callId });
+}
+
+/**
+ * Force-reset audio state without a specific callId. Used by the
+ * app-resume watchdog when the device is stuck in MODE_IN_COMMUNICATION
+ * and no call is live (typically because a previous call's finalize
+ * never ran — JS process killed, OEM stopped the foreground service).
+ */
+export async function forceResetAudioState(): Promise<void> {
+  await safeStep("forceStopAudio", "<no-call>", () => nativeCallBridge.forceStopAudio());
+}
+
+export function onCallTelemetry(listener: TelemetryListener): () => void {
+  telemetryListeners.add(listener);
+  return () => {
+    telemetryListeners.delete(listener);
+  };
+}
+
+/** Test-only: clear the in-memory finalized-callId set between tests. */
+export function __resetFinalizeCallStateForTests(): void {
+  for (const timer of finalizedCalls.values()) {
+    clearTimeout(timer);
+  }
+  finalizedCalls.clear();
+  telemetryListeners.clear();
+}

--- a/src/features/video-calls/model/finalize-call.ts
+++ b/src/features/video-calls/model/finalize-call.ts
@@ -42,7 +42,11 @@ export interface CallTelemetryEvent {
 type TelemetryListener = (event: CallTelemetryEvent) => void;
 
 const FINALIZE_GC_MS = 30_000;
-const finalizedCalls = new Map<string, ReturnType<typeof setTimeout>>();
+// `null` value means "in progress, not yet GC-eligible". Once finalize
+// completes (any outcome — success or all steps failed), the entry is
+// rearmed with a real GC timeout so a fresh call with the same callId
+// can re-finalize after the GC window passes.
+const finalizedCalls = new Map<string, ReturnType<typeof setTimeout> | null>();
 const telemetryListeners = new Set<TelemetryListener>();
 
 function emit(event: CallTelemetryEvent): void {
@@ -64,40 +68,58 @@ async function safeStep(name: string, callId: string, step: () => Promise<unknow
 }
 
 export async function finalizeCall(reason: FinalizeReason, callId: string): Promise<void> {
-  if (!callId) {
-    console.warn("[finalize-call] missing callId, skipping cleanup (reason=" + reason + ")");
-    return;
+  // Outer try/catch ensures a sync throw (e.g. broken bridge import,
+  // listener loop bug) cannot escape as an unhandled promise rejection.
+  try {
+    if (!callId) {
+      console.warn("[finalize-call] missing callId, skipping cleanup (reason=" + reason + ")");
+      return;
+    }
+    if (finalizedCalls.has(callId)) {
+      console.log("[finalize-call] duplicate finalize for " + callId + " (reason=" + reason + "), skipping");
+      return;
+    }
+    // Reserve idempotency slot synchronously, before any await — a
+    // second concurrent finalizeCall for the same callId must see the
+    // slot occupied. We park `null` in the map for the duration of the
+    // cleanup; the real GC timer is armed only after all steps run.
+    // This avoids the race where a slow cleanup (>30s) had its slot
+    // GC'd while still in progress, allowing a re-entry to restart
+    // step 1 and double-cleanup audio routing.
+    finalizedCalls.set(callId, null);
+
+    try {
+      emit({ type: "call_finalize_start", reason, callId });
+
+      // Step 1: stop audio routing (mode → NORMAL, clearCommunicationDevice)
+      await safeStep("stopAudioRouting", callId, () => nativeCallBridge.stopAudioRouting());
+
+      // Step 2: report call ended → CallConnection cleanup
+      await safeStep("reportCallEnded", callId, () => nativeCallBridge.reportCallEnded(callId));
+
+      // Step 3: dismiss UI + stop foreground service (abandons audio focus, releases wake lock)
+      if (isNative) {
+        await safeStep("dismissCallUI", callId, () => NativeWebRTC.dismissCallUI());
+      }
+
+      // Step 4: close peer connections + dispose media (release mic AudioRecord)
+      if (isNative) {
+        await safeStep("closeAllPeerConnections", callId, () => NativeWebRTC.closeAllPeerConnections());
+      }
+
+      emit({ type: "call_finalized", reason, callId });
+    } finally {
+      // Arm the GC timer only after all steps complete. Until this point
+      // the slot stayed `null` (in-progress); a 30-second-too-late
+      // duplicate would have been blocked from re-running step 1.
+      const gcTimer = setTimeout(() => {
+        finalizedCalls.delete(callId);
+      }, FINALIZE_GC_MS);
+      finalizedCalls.set(callId, gcTimer);
+    }
+  } catch (e) {
+    console.warn("[finalize-call] unexpected sync error:", e);
   }
-  if (finalizedCalls.has(callId)) {
-    console.log("[finalize-call] duplicate finalize for " + callId + " (reason=" + reason + "), skipping");
-    return;
-  }
-  // Reserve idempotency slot before any await — duplicate calls within
-  // the same microtask scheduler tick must see the slot taken.
-  const gcTimer = setTimeout(() => {
-    finalizedCalls.delete(callId);
-  }, FINALIZE_GC_MS);
-  finalizedCalls.set(callId, gcTimer);
-
-  emit({ type: "call_finalize_start", reason, callId });
-
-  // Step 1: stop audio routing (mode → NORMAL, clearCommunicationDevice)
-  await safeStep("stopAudioRouting", callId, () => nativeCallBridge.stopAudioRouting());
-
-  // Step 2: report call ended → CallConnection cleanup
-  await safeStep("reportCallEnded", callId, () => nativeCallBridge.reportCallEnded(callId));
-
-  // Step 3: dismiss UI + stop foreground service (abandons audio focus, releases wake lock)
-  if (isNative) {
-    await safeStep("dismissCallUI", callId, () => NativeWebRTC.dismissCallUI());
-  }
-
-  // Step 4: close peer connections + dispose media (release mic AudioRecord)
-  if (isNative) {
-    await safeStep("closeAllPeerConnections", callId, () => NativeWebRTC.closeAllPeerConnections());
-  }
-
-  emit({ type: "call_finalized", reason, callId });
 }
 
 /**
@@ -120,7 +142,7 @@ export function onCallTelemetry(listener: TelemetryListener): () => void {
 /** Test-only: clear the in-memory finalized-callId set between tests. */
 export function __resetFinalizeCallStateForTests(): void {
   for (const timer of finalizedCalls.values()) {
-    clearTimeout(timer);
+    if (timer) clearTimeout(timer);
   }
   finalizedCalls.clear();
   telemetryListeners.clear();

--- a/src/shared/lib/native-calls/native-call-bridge.ts
+++ b/src/shared/lib/native-calls/native-call-bridge.ts
@@ -64,6 +64,21 @@ interface NativeCallNativePlugin {
   setAudioDevice(options: { type: string }): Promise<void>;
   startAudioRouting(options: { callType: string }): Promise<void>;
   stopAudioRouting(): Promise<void>;
+  /**
+   * Brute-force reset of audio state without going through the
+   * lifecycle guards. Used by the app-resume watchdog when the device
+   * is stuck in MODE_IN_COMMUNICATION but no call is live.
+   */
+  forceStopAudio(): Promise<void>;
+  /**
+   * Snapshot of the current AudioManager state. Used by the app-resume
+   * watchdog to detect a stuck VoIP audio mode.
+   */
+  getAudioStatus(): Promise<{
+    mode: string;
+    isSpeakerOn: boolean;
+    isBtScoOn: boolean;
+  }>;
   addListener(event: 'callAnswered', cb: (data: { callId: string; roomId?: string }) => void): Promise<{ remove: () => void }>;
   addListener(event: 'callDeclined', cb: (data: { callId: string }) => void): Promise<{ remove: () => void }>;
   addListener(event: 'callEnded', cb: (data: { callId: string }) => void): Promise<{ remove: () => void }>;
@@ -548,6 +563,49 @@ class NativeCallBridge {
       await NativeCall.stopAudioRouting();
     } catch (e) {
       console.warn('[NativeCallBridge] stopAudioRouting failed:', e);
+    }
+  }
+
+  /**
+   * Brute-force reset of audio state. Bypasses the lifecycle guards in
+   * AudioRouter — used by the app-resume watchdog to recover from a
+   * crashed call where the normal cleanup path never ran (JS process
+   * killed mid-call, OEM stopped the foreground service, etc.).
+   *
+   * Symmetric to {@link stopAudioRouting} but unconditional: always
+   * resets mode → NORMAL and clears the communication device.
+   */
+  async forceStopAudio(): Promise<void> {
+    if (!isNative) return;
+    try {
+      await NativeCall.forceStopAudio();
+    } catch (e) {
+      console.warn('[NativeCallBridge] forceStopAudio failed:', e);
+    }
+  }
+
+  /**
+   * Read current AudioManager mode and routing flags from native.
+   * Returns mode = "MODE_NORMAL" when no call active or
+   * "MODE_IN_COMMUNICATION" while a VoIP call is in progress.
+   *
+   * On non-native or older native builds without this method we report
+   * an optimistic NORMAL — the watchdog treats anything other than
+   * MODE_IN_COMMUNICATION as healthy, so an unavailable probe is safe.
+   */
+  async getAudioStatus(): Promise<{
+    mode: string;
+    isSpeakerOn: boolean;
+    isBtScoOn: boolean;
+  }> {
+    if (!isNative) {
+      return { mode: 'MODE_NORMAL', isSpeakerOn: false, isBtScoOn: false };
+    }
+    try {
+      return await NativeCall.getAudioStatus();
+    } catch (e) {
+      console.warn('[NativeCallBridge] getAudioStatus unavailable:', e);
+      return { mode: 'MODE_NORMAL', isSpeakerOn: false, isBtScoOn: false };
     }
   }
 }

--- a/src/shared/lib/native-webrtc/native-webrtc-bridge.ts
+++ b/src/shared/lib/native-webrtc/native-webrtc-bridge.ts
@@ -48,6 +48,13 @@ export interface NativeWebRTCPlugin {
   stopScreenShare(): Promise<{ sharing: boolean }>;
 
   closePeerConnection(options: { peerId: string }): Promise<void>;
+  /**
+   * Close every PeerConnection AND dispose local AudioSource /
+   * VideoSource so the backing AudioRecord / camera handle is released.
+   * Used during call finalization — closing PCs alone is not enough,
+   * a leaked AudioSource keeps the microphone busy device-wide.
+   */
+  closeAllPeerConnections(): Promise<void>;
   getConnectionState(options: { peerId: string }): Promise<{ state: string }>;
 
   // ICE restart — perform a native ICE restart on the given PeerConnection.


### PR DESCRIPTION
## Summary

P0 fix for the long-standing **audio aftermath bug** — after the first call ends, the device stays in `MODE_IN_COMMUNICATION` with audio focus held by Forta. Music plays muted/quietly through the earpiece, new calls have zero-way audio, and only an app/device reboot recovers. Especially common on Xiaomi / Realme / INFINIX (aggressive OEM audio routing).

The root cause was 8 separate ad-hoc cleanup blocks across `call-service.ts`, each missing some combination of the four needed steps:
1. `stopAudioRouting` (mode → NORMAL, comm device cleared)
2. `reportCallEnded` (Telecom CallConnection released)
3. `dismissCallUI` (activity finished, foreground service stopped → audio focus abandoned)
4. **`closeAllPeerConnections`** ← the missing step everywhere — disposes `AudioSource`/`AudioTrack` so the underlying `AudioRecord` is released. Without it the mic stays locked device-wide until the OS process exits.

## What changed

**TypeScript (call-service layer):**
- New `finalize-call.ts` — single helper `finalizeCall(reason, callId)` that runs all four cleanup steps in order with isolated error handling, idempotent per `callId` (30-second GC window).
- All cleanup paths in `call-service.ts` (hangup, reject, sdk-ended, error, permission-denied, watchdog-timeout, place-call-failed, answer-failed, onHangup, onError, onState→ended) now go through `finalizeCall`.
- New `audio-watchdog.ts` — Capacitor App `appStateChange` listener that calls `forceStopAudio` on resume when audio mode is stuck in `MODE_IN_COMMUNICATION` without an active call (recovers from JS-process-killed-mid-call scenarios).

**Kotlin (Android plugin layer):**
- `AudioRouter.stop()` wraps mode reset in `try/finally` so `MODE_NORMAL` / `clearCommunicationDevice` / `isSpeakerphoneOn=false` always run, regardless of an exception in the unregister/BT teardown path above. New `forceStop()` bypasses the `isActive` guard for the watchdog.
- `start`/`stop`/`forceStop` synchronized on a single `lifecycleLock` monitor — prevents the watchdog forceStop racing a fresh `start()` and leaving the router in inconsistent state.
- New `stopBluetoothScoSafely()` waits for `SCO_AUDIO_STATE_DISCONNECTED` broadcast (or 500ms timeout) before mode reset on API < 31, otherwise the next stream lands on SCO mono and plays silent.
- `CallForegroundService.abandonAudioFocus()` now restores the saved `STREAM_VOICE_CALL` volume directly (previously only restored from inside the `AUDIOFOCUS_GAIN` listener path, which never fires when we self-abandon).
- New plugin methods: `CallPlugin.forceStopAudio` + `getAudioStatus` and `WebRTCPlugin.closeAllPeerConnections`. Both routing-teardown methods dispatch on a dedicated `cleanupExecutor` so the Capacitor plugin thread is freed immediately (the 500ms BT SCO wait would otherwise serialize every other plugin call and risk an ANR on slow OEMs).

## Why

User feedback verbatim: «Первый звонок работает, но после завершения звонки больше не работают и аудио не воспроизводится — ни новый звонок, ни музыка». Recovery requires app/device restart. The bug is independent of Sessions 01–03 (call setup) and is the root cause behind a class of "calls work through one out of three" reports.

Plan: `.planning/bug-fix-plan/SESSION-PROMPTS/23-call-aftermath-cleanup.md`
Research: `.planning/bug-fix-plan/research/CALL-AFTERMATH-AUDIO-LOCK-RESEARCH.md`

## Tests

**85 tests passing** (was 56), 26 new TS unit tests:

- `finalize-call.test.ts` — 19 tests: idempotency (including same-tick concurrent and long-running-cleanup re-entry), step ordering, per-step error resilience, telemetry sub/unsub, GC release.
- `audio-watchdog.test.ts` — 10 tests: non-native skip, single-registration, IN_COMM-with-no-call trigger, all no-op cases (active call, matrixCall mid-setup, mode normal, going-to-background), graceful error swallowing.
- `call-service.test.ts` — existing 27 tests still pass after the refactor (with `__resetFinalizeCallStateForTests` reset added in `beforeEach`).
- `CallCleanupTest.kt` — new Android instrumented suite (run via `./gradlew :app:connectedDebugAndroidTest`) covering mode-reset-on-stop, idempotent stop, forceStop-when-stuck, forceStop-when-never-started, speakerphone clear, comm-device clear on API 31+.

## Reviewer notes

A `superpowers:code-reviewer` pass flagged 3 HIGH issues — all addressed in the last 3 commits (`a483585`, `ea0d96e`, `cda6691`):

- lifecycle-lock added to AudioRouter (forceStop/start race);
- `cleanupExecutor` dispatch in CallPlugin (BT-SCO 500ms wait blocking plugin thread → ANR risk);
- audio-watchdog now gates on `matrixCall` too (mid-setup TOCTOU window for incoming calls);
- finalize-call holds the idempotency slot until cleanup finishes (prevents GC racing slow cleanup).

## Test plan

- [ ] **Basic aftermath** (real device): make a call → hangup → check `adb shell dumpsys audio | grep -E "Mode|focus"` shows `MODE_NORMAL` + empty focus stack. Open Spotify → audio plays loud through speaker.
- [ ] **Second call** (real device): hangup first call → immediately make a second → both peers hear voice within 3s.
- [ ] **OEM matrix**: repeat scenarios on Xiaomi (MIUI), Realme (RealmeUI), INFINIX (XOS).
- [ ] **JS crash recovery**: mid-call `adb shell am force-stop com.forta.chat` → resume app → audio mode returns to NORMAL, music plays normally.
- [ ] **BT switching**: hangup with BT headset connected → unpair BT → second call routes to speaker/earpiece correctly.
- [ ] CI green (all existing test suites, lint, vue-tsc — see notes about pre-existing type errors below).
- [ ] `./gradlew :app:connectedDebugAndroidTest --tests "com.forta.chat.plugins.calls.CallCleanupTest"` passes on a connected device.

## Notes

- `vue-tsc --noEmit` reports 44 pre-existing TypeScript errors in unrelated files (`stores.ts:322` `UserData.export`, `user-store.ts` `loadUsersBatch`, etc.) — unchanged by this PR. `vite build` succeeds.
- 9 pre-existing test failures in other modules (open-profile-url, video-embed, chat-helpers, display-result) are also unchanged by this PR. All 85 tests in `src/features/video-calls` are green.

## Files

10 commits, ~600 lines net change. New files:

- `src/features/video-calls/model/finalize-call.ts`
- `src/features/video-calls/model/finalize-call.test.ts`
- `src/features/video-calls/model/audio-watchdog.ts`
- `src/features/video-calls/model/audio-watchdog.test.ts`
- `android/app/src/androidTest/java/com/forta/chat/plugins/calls/CallCleanupTest.kt`