### PR TITLE
fix(video): proactive orientation save + WebView reset guard

### DIFF
--- a/src/shared/lib/composables/use-video-state-preservation.test.ts
+++ b/src/shared/lib/composables/use-video-state-preservation.test.ts
@@ -74,6 +74,16 @@ describe("useVideoStatePreservation", () => {
   });
 
   afterEach(() => {
+    // Drain any pending dispose callbacks so window event listeners (e.g.
+    // orientationchange) do not leak across tests and inflate the cache for
+    // the next case.
+    const pending = [...disposeCallbacks];
+    disposeCallbacks.length = 0;
+    mountedCallbacks.length = 0;
+    for (const cb of pending) {
+      try { cb(); } catch { /* ignore */ }
+    }
+    _resetVideoStateCache();
     if (vi.isFakeTimers()) {
       vi.runOnlyPendingTimers();
     }
@@ -258,6 +268,7 @@ describe("useVideoStatePreservation", () => {
     useVideoStatePreservation(freshRef, "msg-0");
     simulateMount();
     expect(freshEl.currentTime).toBe(0); // evicted → not restored
+    simulateUnmount(); // dispose before clearing arrays to avoid window listener leak
 
     // A recent entry (msg-249) should still be restorable.
     mountedCallbacks.length = 0;
@@ -309,5 +320,154 @@ describe("useVideoStatePreservation", () => {
 
     expect(el2.play).not.toHaveBeenCalled();
     expect(el2.currentTime).toBe(5);
+  });
+
+  it("saves state synchronously when orientationchange fires", () => {
+    const el = createMockVideoEl({ currentTime: 30, paused: false });
+    const videoRef = ref<HTMLVideoElement | null>(el);
+    useVideoStatePreservation(videoRef, "msg-orient", { saveIntervalMs: 0 });
+    simulateMount();
+
+    // Cache is empty before rotation.
+    expect(_getCacheSize()).toBe(0);
+
+    window.dispatchEvent(new Event("orientationchange"));
+
+    // Orientation handler captures state without waiting for unmount or auto-save.
+    expect(_getCacheSize()).toBe(1);
+
+    // Verify the captured state is the playback position at rotation time.
+    simulateUnmount();
+    mountedCallbacks.length = 0;
+    disposeCallbacks.length = 0;
+    const el2 = createMockVideoEl({ readyState: 1, duration: 100 });
+    const videoRef2 = ref<HTMLVideoElement | null>(el2);
+    useVideoStatePreservation(videoRef2, "msg-orient", { saveIntervalMs: 0 });
+    simulateMount();
+
+    expect(el2.currentTime).toBe(30);
+  });
+
+  it("uses screen.orientation API when available (modern path)", () => {
+    // Stub modern screen.orientation API
+    const orientationListeners = new Map<string, Set<EventListener>>();
+    const stubOrientation = {
+      addEventListener: vi.fn((evt: string, h: EventListener) => {
+        if (!orientationListeners.has(evt)) orientationListeners.set(evt, new Set());
+        orientationListeners.get(evt)!.add(h);
+      }),
+      removeEventListener: vi.fn((evt: string, h: EventListener) => {
+        orientationListeners.get(evt)?.delete(h);
+      }),
+    };
+    const originalOrientation = (screen as unknown as { orientation?: unknown }).orientation;
+    Object.defineProperty(screen, "orientation", {
+      configurable: true,
+      value: stubOrientation,
+    });
+
+    try {
+      const el = createMockVideoEl({ currentTime: 17, paused: false });
+      const videoRef = ref<HTMLVideoElement | null>(el);
+      useVideoStatePreservation(videoRef, "msg-modern-orient", { saveIntervalMs: 0 });
+      simulateMount();
+
+      expect(stubOrientation.addEventListener).toHaveBeenCalledWith(
+        "change",
+        expect.any(Function),
+      );
+
+      // Fire the modern event and verify state was saved.
+      orientationListeners.get("change")?.forEach((h) => h(new Event("change")));
+      expect(_getCacheSize()).toBe(1);
+
+      simulateUnmount();
+      // Cleanup must remove the listener.
+      expect(stubOrientation.removeEventListener).toHaveBeenCalledWith(
+        "change",
+        expect.any(Function),
+      );
+    } finally {
+      if (originalOrientation === undefined) {
+        delete (screen as unknown as { orientation?: unknown }).orientation;
+      } else {
+        Object.defineProperty(screen, "orientation", {
+          configurable: true,
+          value: originalOrientation,
+        });
+      }
+    }
+  });
+
+  it("removes orientationchange listener on dispose to prevent leaks", () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    const el = createMockVideoEl({ currentTime: 5 });
+    const videoRef = ref<HTMLVideoElement | null>(el);
+    useVideoStatePreservation(videoRef, "msg-cleanup");
+    simulateMount();
+    simulateUnmount();
+
+    expect(removeSpy).toHaveBeenCalledWith("orientationchange", expect.any(Function));
+    removeSpy.mockRestore();
+  });
+
+  it("does not overwrite valid cached state with currentTime=0 (WebView reset guard)", () => {
+    // Establish a cached state of currentTime=42.
+    const el = createMockVideoEl({ currentTime: 42, paused: false, readyState: 4 });
+    const videoRef = ref<HTMLVideoElement | null>(el);
+    useVideoStatePreservation(videoRef, "msg-protect", { saveIntervalMs: 0 });
+    simulateMount();
+
+    window.dispatchEvent(new Event("orientationchange"));
+    expect(_getCacheSize()).toBe(1);
+
+    // Simulate WebView reflow: currentTime briefly zeroed AND readyState drops
+    // below HAVE_CURRENT_DATA — the signature of a transient reset, not a
+    // user-initiated seek.
+    el.currentTime = 0;
+    el.readyState = 0;
+    window.dispatchEvent(new Event("orientationchange"));
+
+    // Re-mount a fresh element with the same id and verify 42 (not 0) was preserved.
+    simulateUnmount();
+    mountedCallbacks.length = 0;
+    disposeCallbacks.length = 0;
+    const el2 = createMockVideoEl({ readyState: 1, duration: 100 });
+    const videoRef2 = ref<HTMLVideoElement | null>(el2);
+    useVideoStatePreservation(videoRef2, "msg-protect", { saveIntervalMs: 0 });
+    simulateMount();
+
+    expect(el2.currentTime).toBe(42);
+  });
+
+  it("preserves a deliberate user pause+seek-to-0 (readyState>=2 keeps the write)", () => {
+    // Pre-populate the cache with t=42 + playing.
+    const el = createMockVideoEl({ currentTime: 42, paused: false, readyState: 4 });
+    const videoRef = ref<HTMLVideoElement | null>(el);
+    useVideoStatePreservation(videoRef, "msg-rewind", { saveIntervalMs: 0 });
+    simulateMount();
+    window.dispatchEvent(new Event("orientationchange"));
+
+    // User scrubs to start AND pauses. Element keeps HAVE_ENOUGH_DATA so this
+    // is a real interaction, not a WebView reflow zero-out. The cache MUST
+    // update with paused=true even though currentTime is 0.
+    el.currentTime = 0;
+    el.paused = true;
+    el.readyState = 4;
+    window.dispatchEvent(new Event("orientationchange"));
+
+    // Re-mount and verify the rewound + paused state survived.
+    simulateUnmount();
+    mountedCallbacks.length = 0;
+    disposeCallbacks.length = 0;
+    const el2 = createMockVideoEl({ readyState: 1, duration: 100, paused: true });
+    const videoRef2 = ref<HTMLVideoElement | null>(el2);
+    useVideoStatePreservation(videoRef2, "msg-rewind", { saveIntervalMs: 0 });
+    simulateMount();
+
+    // If the guard had blocked the save, cache would still hold paused=false
+    // and restoreState would call play(). Verifying play() was NOT called
+    // proves the user's pause was persisted.
+    expect(el2.play).not.toHaveBeenCalled();
   });
 });

--- a/src/shared/lib/composables/use-video-state-preservation.ts
+++ b/src/shared/lib/composables/use-video-state-preservation.ts
@@ -73,8 +73,18 @@ export function useVideoStatePreservation(
   function saveStateFrom(el: HTMLVideoElement | null) {
     const key = currentId();
     if (!el || !key) return;
+    const newTime = sanitizeTime(el.currentTime);
+    // Android WebViews briefly zero currentTime AND drop readyState below
+    // HAVE_CURRENT_DATA (2) while re-laying out on rotation. That signature
+    // distinguishes a transient WebView reset from a deliberate user seek
+    // (which keeps readyState >= 2). Only suppress the 0-write in the
+    // reset case so user-initiated rewinds and pauses still persist.
+    if (newTime === 0 && el.readyState < 2) {
+      const cached = stateCache.get(key);
+      if (cached && cached.currentTime > 0) return;
+    }
     cachePut(key, {
-      currentTime: sanitizeTime(el.currentTime),
+      currentTime: newTime,
       paused: el.paused,
       volume: sanitizeVolume(el.volume),
       muted: !!el.muted,
@@ -134,10 +144,36 @@ export function useVideoStatePreservation(
     }
   }
 
+  // Capture state proactively when the device rotates. Vue's mount/unmount
+  // cycle and the auto-save interval can both lose up to ~1s of progress in
+  // the window between an orientation event and the next sample. Hooking the
+  // event directly closes that gap before the WebView starts re-laying out.
+  let orientationCleanup: (() => void) | null = null;
+
+  function setupOrientationListener() {
+    if (typeof window === "undefined") return;
+    const handler = () => saveState();
+    window.addEventListener("orientationchange", handler);
+
+    const screenOrientation =
+      typeof screen !== "undefined" && screen.orientation ? screen.orientation : null;
+    if (screenOrientation && typeof screenOrientation.addEventListener === "function") {
+      screenOrientation.addEventListener("change", handler);
+    }
+
+    orientationCleanup = () => {
+      window.removeEventListener("orientationchange", handler);
+      if (screenOrientation && typeof screenOrientation.removeEventListener === "function") {
+        screenOrientation.removeEventListener("change", handler);
+      }
+    };
+  }
+
   onMounted(() => {
     const el = videoRef.value;
     if (el) attachRestoreHandler(el);
     startAutoSave();
+    setupOrientationListener();
   });
 
   watch(videoRef, (el, prev) => {
@@ -150,6 +186,8 @@ export function useVideoStatePreservation(
   onScopeDispose(() => {
     saveState();
     stopAutoSave();
+    orientationCleanup?.();
+    orientationCleanup = null;
   });
 
   return { saveState, restoreState };


### PR DESCRIPTION
## Summary

Closes the last gap from the Session 18 (orientation + video) bug-fix plan that wasn't already addressed by [c1c6f7c (#62)](https://github.com/pocketnetteam/forta.chat/pull/62) `fix(video): preserve playback state on remount + call peer aspect`.

The existing `useVideoStatePreservation` composable saves video state on mount/unmount and via a 1s auto-save interval. Between an `orientationchange` event and the next interval tick, up to a second of playback could be lost on Android WebViews that re-layout aggressively on rotation. This PR closes that window.

## What changed

- **Proactive orientation listener** in [use-video-state-preservation.ts](src/shared/lib/composables/use-video-state-preservation.ts): hook both `window.orientationchange` (legacy) and `screen.orientation.change` (modern) events in `onMounted`, tear down in `onScopeDispose`. The handler calls `saveState()` synchronously so the playback position is captured before the WebView begins re-laying out.
- **WebView reset guard** in `saveStateFrom`: when a save attempt has `currentTime === 0` AND `el.readyState < 2` (below `HAVE_CURRENT_DATA`), keep the existing non-zero cached entry. That signature distinguishes a transient WebView reflow from a legitimate user pause+seek-to-0 (which keeps `readyState >= 2`), so deliberate rewinds still persist. The `readyState < 2` part was added after a code review caught that an unconditional guard would regress the user-rewind case — there is an explicit regression test for it.
- **Test isolation fix**: existing test suite leaked window listeners across cases via the `caps cache size` test, which cleared callback arrays without disposing one of its scopes. Added an `afterEach` drain that runs any pending dispose callbacks, plus a `simulateUnmount()` in that one test.

## Test plan

- [x] `vitest run src/shared/lib/composables/use-video-state-preservation.test.ts` — 16/16 green
- [x] `vitest run src/shared/lib/composables src/features/video-calls src/features/messaging/ui/__tests__` — 135/135 green (all consumers of the composable)
- [x] `vue-tsc --noEmit` — 44 lines of pre-existing errors, no new errors from these files
- [x] Code review via `superpowers:code-reviewer` — approved on second pass after narrowing the WebView guard
- [ ] Manual: open a video in a channel post or chat, start playback, rotate device, verify playback continues from the same position (±0.5s)
- [ ] Manual: pause + scrub to t=0 in a video, rotate device, verify the rewound + paused state is preserved on remount (regression check for the user-seek case)

## Why no CDN-refresh / channel-video logic from the plan

The Session 18 plan also asked for a CDN token refresh on 403 in a `ChannelPostVideo.vue`. That component does not exist — `ChannelPostBubble.vue` only renders a "Video" indicator and emits `openPost`; there is no full-screen channel video player to attach the refresh handler to. Worth a separate issue if/when one is added.