### PR TITLE
fix(calls): ICE watchdog + network-aware restart + connection diagnostics

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -133,6 +133,7 @@
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@capacitor/filesystem": "^8.1.2",
         "@capacitor/haptics": "^8.0.1",
         "@capacitor/local-notifications": "^8.0.2",
+        "@capacitor/network": "^8.0.1",
         "@capacitor/push-notifications": "^8.0.2",
         "@capacitor/share": "^8.0.1",
         "@capacitor/status-bar": "^8.0.1",
@@ -280,6 +281,15 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@capacitor/local-notifications/-/local-notifications-8.0.2.tgz",
       "integrity": "sha512-X7KE/I4ZutMTGVHNUyTjIugYcQEcHJRLks+TsPnOriuS+lo0geSTuaRln6zAZlJSSXSoVMSSzHexdSbIjR/8iw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/network": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/network/-/network-8.0.1.tgz",
+      "integrity": "sha512-9xK/FHFmzKGanB6BdoSZOzXk8vF0OFVQSQ4PAsIrzAzLuXHryO317qy8dcHVpgxYeuZq2noI0My9z1DvVDi/9w==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
@@ -1024,6 +1034,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -1041,6 +1069,24 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -1056,6 +1102,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -10323,6 +10387,420 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
@@ -10348,6 +10826,50 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/vitest/node_modules/estree-walker": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@capacitor/filesystem": "^8.1.2",
     "@capacitor/haptics": "^8.0.1",
     "@capacitor/local-notifications": "^8.0.2",
+    "@capacitor/network": "^8.0.1",
     "@capacitor/push-notifications": "^8.0.2",
     "@capacitor/share": "^8.0.1",
     "@capacitor/status-bar": "^8.0.1",

--- a/src/features/video-calls/model/call-service.ts
+++ b/src/features/video-calls/model/call-service.ts
@@ -9,10 +9,13 @@ import type { CallFeed } from "matrix-js-sdk-bastyon/lib/webrtc/callFeed";
 import { playRingtone, playDialtone, playEndTone, stopAllSounds } from "./call-sounds";
 import { checkOtherTabHasCall } from "./call-tab-lock";
 import { webrtcDiagnostics } from "./webrtc-diagnostics";
+import type { DiagnosticsWarningDetail } from "./webrtc-diagnostics";
 import { isNative } from "@/shared/lib/platform";
 import { useBugReport } from "@/features/bug-report";
 import { tRaw } from "@/shared/lib/i18n";
 import { installNativeWebRTCProxy, NativeWebRTC } from "@/shared/lib/native-webrtc";
+import { onConnectivityChange } from "@/shared/lib/connectivity";
+import { useToast } from "@/shared/lib/use-toast";
 import {
   nativeCallBridge,
   consumePendingAnswerCallId,
@@ -20,6 +23,11 @@ import {
 } from "@/shared/lib/native-calls";
 import { ensureCallPermissions, PermissionDeniedError, callPermissionError } from "./permissions";
 import { finalizeCall } from "./finalize-call";
+
+// Module-scope handle for the connectivity subscription so we don't stack
+// listeners on HMR / repeated module evaluation. Declared above the
+// `if (isNative)` block so the function can read it without hitting TDZ.
+let _networkChangeUnsubscribe: (() => void) | null = null;
 
 // Install native WebRTC proxy on mobile — must run before any call is placed.
 // This replaces window.RTCPeerConnection so that the Matrix SDK transparently
@@ -33,6 +41,67 @@ if (isNative) {
     if (data.type === "permission_denied") {
       callStore.updateStatus(CallStatus.failed);
       callStore.scheduleClearCall(1500);
+    }
+  });
+
+  // Session 03: WiFi↔cellular handover does not reliably fire
+  // window.online/offline on Android WebView. We subscribe to
+  // @capacitor/network instead so transport flips during a live call
+  // trigger an explicit ICE restart instead of waiting for the SDK's
+  // sentinel timeout (by which time the call has already dropped).
+  //
+  // Idempotent registration: HMR / repeated module evaluation must not
+  // stack listeners. We hold the unsubscribe handle so a future teardown
+  // path (e.g. a hot reload helper) can call it; right now we only need
+  // the once-per-process guarantee.
+  registerNetworkChangeRestart();
+}
+
+function registerNetworkChangeRestart(): void {
+  if (_networkChangeUnsubscribe) return;
+  _networkChangeUnsubscribe = onConnectivityChange((change) => {
+    if (!change.connected) return;
+    if (change.previousType === change.type) return;
+
+    const callStore = useCallStore();
+    const matrixCall = callStore.matrixCall as MatrixCall | null;
+    if (!matrixCall) return;
+    const pc = (matrixCall as unknown as { peerConn?: RTCPeerConnection })
+      .peerConn;
+    if (!pc) return;
+
+    // Don't restart while the SDK is mid-glare (have-local-offer /
+    // have-remote-offer / have-local-pranswer / have-remote-pranswer):
+    // a second restartIce in that window leaves libwebrtc with mismatched
+    // SDP state and we end up wedged in "checking" forever — exactly the
+    // failure mode this code is meant to prevent. The proxy's
+    // restartIce() also debounces concurrent calls, but the cheaper
+    // check here is to skip the call entirely if signaling is unstable.
+    if (pc.signalingState !== "stable") {
+      console.log(
+        `[call-service] skip restartIce on network change (${change.previousType}→${change.type}); signalingState=${pc.signalingState}`,
+      );
+      return;
+    }
+
+    const state = pc.iceConnectionState;
+    if (
+      state === "connected" ||
+      state === "completed" ||
+      state === "disconnected" ||
+      state === "checking"
+    ) {
+      console.warn(
+        `[call-service] network ${change.previousType}→${change.type}, restartIce`,
+      );
+      try {
+        pc.restartIce();
+      } catch (e) {
+        console.error(
+          "[call-service] restartIce on network change failed:",
+          e,
+        );
+      }
     }
   });
 }
@@ -154,8 +223,20 @@ let boundHandlers: {
   onError: CallEventHandlerMap[CallEvent.Error];
 } | null = null;
 
+// Listener bound on the diagnostics singleton when a PC is wrapped — kept
+// at module scope so unwireCallEvents can detach it without holding a
+// reference inside boundHandlers (we only get a PC from the SDK).
+let diagnosticsWarningListener: EventListener | null = null;
+
 function unwireCallEvents(call: MatrixCall) {
   webrtcDiagnostics.detach();
+  if (diagnosticsWarningListener) {
+    webrtcDiagnostics.removeEventListener(
+      "warning",
+      diagnosticsWarningListener,
+    );
+    diagnosticsWarningListener = null;
+  }
   cleanupRemoteFeedListener();
   if (!boundHandlers) return;
   try {
@@ -309,6 +390,50 @@ function wireCallEvents(call: MatrixCall, direction: "outgoing" | "incoming") {
     if ((pc as unknown as Record<string, unknown>).__callServiceDiagAttached) return;
     (pc as unknown as Record<string, unknown>).__callServiceDiagAttached = true;
     webrtcDiagnostics.attach(pc);
+
+    // Session 03: the proxy fires "connectiondead" when ICE has been
+    // failed for 20s after a restart attempt. At that point the call is
+    // unrecoverable, so hang up cleanly with a user-visible toast
+    // instead of leaving the user staring at a frozen UI.
+    pc.addEventListener("connectiondead", () => {
+      console.error("[call-service] PC connectiondead → hangup");
+      try {
+        useToast().toast(tRaw("call.error.connectionLost"), "error", 4000);
+      } catch (e) {
+        console.warn("[call-service] toast failed:", e);
+      }
+      try {
+        call.hangup(CallErrorCode.IceFailed, false);
+      } catch (e) {
+        console.error(
+          "[call-service] hangup after connectiondead failed:",
+          e,
+        );
+      }
+    });
+
+    // Session 03: surface diagnostics warnings (no inbound/outbound
+    // audio) as toasts. The diagnostics singleton emits each warning
+    // type at most once per attach so the user sees one toast, not a
+    // flood. Stored on a module ref so unwireCallEvents removes it.
+    diagnosticsWarningListener = ((ev: Event) => {
+      const detail = (ev as CustomEvent<DiagnosticsWarningDetail>).detail;
+      if (!detail) return;
+      const key =
+        detail.type === "no_inbound_audio"
+          ? "call.warning.noInboundAudio"
+          : "call.warning.noOutboundAudio";
+      try {
+        useToast().toast(tRaw(key), "info", 5000);
+      } catch (e) {
+        console.warn(
+          "[call-service] toast failed for",
+          detail.type,
+          e,
+        );
+      }
+    }) as EventListener;
+    webrtcDiagnostics.addEventListener("warning", diagnosticsWarningListener);
   };
   if (typeof (call as any).on === "function" && (CallEvent as any).PeerConnectionCreated) {
     call.on((CallEvent as any).PeerConnectionCreated, onPeerConnectionCreated);

--- a/src/features/video-calls/model/webrtc-diagnostics.test.ts
+++ b/src/features/video-calls/model/webrtc-diagnostics.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for webrtcDiagnostics — Session 03 event-emitter API.
+ *
+ * The diagnostics module already polls getStats every 3s and detects sustained
+ * zero-audio. Session 03 adds an event-emitter so the UI can show a toast
+ * ("Нет входящего аудио") instead of silently logging to console.error.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { webrtcDiagnostics } from "./webrtc-diagnostics";
+
+interface FakeStat {
+  type: string;
+  kind?: string;
+  bytesSent?: number;
+  bytesReceived?: number;
+  packetsSent?: number;
+  packetsReceived?: number;
+}
+
+function buildStatsReport(
+  inboundBytes: number,
+  outboundBytes: number,
+): Map<string, FakeStat> {
+  const map = new Map<string, FakeStat>();
+  map.set("outbound-audio-0", {
+    type: "outbound-rtp",
+    kind: "audio",
+    bytesSent: outboundBytes,
+    packetsSent: outboundBytes > 0 ? Math.floor(outboundBytes / 100) : 0,
+  });
+  map.set("inbound-audio-0", {
+    type: "inbound-rtp",
+    kind: "audio",
+    bytesReceived: inboundBytes,
+    packetsReceived: inboundBytes > 0 ? Math.floor(inboundBytes / 100) : 0,
+  });
+  return map;
+}
+
+function makeMockPc(reports: Array<Map<string, FakeStat>>): RTCPeerConnection {
+  const queue = [...reports];
+  return {
+    iceConnectionState: "connected",
+    iceGatheringState: "complete",
+    signalingState: "stable",
+    connectionState: "connected",
+    oniceconnectionstatechange: null,
+    onsignalingstatechange: null,
+    onconnectionstatechange: null,
+    onicecandidate: null,
+    getStats: vi.fn(async () => {
+      const next =
+        queue.shift() ??
+        reports[reports.length - 1] ??
+        buildStatsReport(0, 0);
+      return next as unknown as RTCStatsReport;
+    }),
+  } as unknown as RTCPeerConnection;
+}
+
+describe("webrtcDiagnostics — event emitter (Session 03)", () => {
+  let warningHandler: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    warningHandler = vi.fn();
+    webrtcDiagnostics.addEventListener(
+      "warning",
+      warningHandler as unknown as EventListener,
+    );
+  });
+
+  afterEach(() => {
+    webrtcDiagnostics.detach();
+    webrtcDiagnostics.removeEventListener(
+      "warning",
+      warningHandler as unknown as EventListener,
+    );
+    vi.useRealTimers();
+  });
+
+  it("emits 'warning' with type=no_inbound_audio after sustained zero bytesReceived", async () => {
+    // 4 reports: outbound increments (mic works), inbound stays at 0.
+    const reports = [
+      buildStatsReport(0, 1_000),
+      buildStatsReport(0, 2_000),
+      buildStatsReport(0, 3_000),
+      buildStatsReport(0, 4_000),
+    ];
+    webrtcDiagnostics.attach(makeMockPc(reports));
+
+    // Each poll = 3s; need at least 3 polls to trigger ZERO_AUDIO_ALERT_THRESHOLD.
+    await vi.advanceTimersByTimeAsync(12_000);
+
+    const noInboundCalls = warningHandler.mock.calls.filter((c) => {
+      const ev = c[0] as CustomEvent;
+      return ev?.detail?.type === "no_inbound_audio";
+    });
+    expect(noInboundCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("emits 'warning' with type=no_outbound_audio after sustained zero bytesSent", async () => {
+    const reports = [
+      buildStatsReport(1_000, 0),
+      buildStatsReport(2_000, 0),
+      buildStatsReport(3_000, 0),
+      buildStatsReport(4_000, 0),
+    ];
+    webrtcDiagnostics.attach(makeMockPc(reports));
+
+    await vi.advanceTimersByTimeAsync(12_000);
+
+    const noOutboundCalls = warningHandler.mock.calls.filter((c) => {
+      const ev = c[0] as CustomEvent;
+      return ev?.detail?.type === "no_outbound_audio";
+    });
+    expect(noOutboundCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("emits each warning type at most once per session (no spam)", async () => {
+    // Sustained zero-inbound for many polls — should only emit once.
+    const reports = Array.from({ length: 10 }, (_, i) =>
+      buildStatsReport(0, (i + 1) * 1_000),
+    );
+    webrtcDiagnostics.attach(makeMockPc(reports));
+
+    await vi.advanceTimersByTimeAsync(35_000);
+
+    const noInboundCalls = warningHandler.mock.calls.filter((c) => {
+      const ev = c[0] as CustomEvent;
+      return ev?.detail?.type === "no_inbound_audio";
+    });
+    expect(noInboundCalls.length).toBe(1);
+  });
+
+  it("does NOT emit warning when audio is flowing", async () => {
+    const reports = [
+      buildStatsReport(1_000, 1_000),
+      buildStatsReport(2_000, 2_000),
+      buildStatsReport(3_000, 3_000),
+      buildStatsReport(4_000, 4_000),
+    ];
+    webrtcDiagnostics.attach(makeMockPc(reports));
+
+    await vi.advanceTimersByTimeAsync(15_000);
+
+    expect(warningHandler).not.toHaveBeenCalled();
+  });
+
+  it("resets warning state on detach so a new attach can re-emit", async () => {
+    const firstReports = [
+      buildStatsReport(0, 1_000),
+      buildStatsReport(0, 2_000),
+      buildStatsReport(0, 3_000),
+      buildStatsReport(0, 4_000),
+    ];
+    webrtcDiagnostics.attach(makeMockPc(firstReports));
+    await vi.advanceTimersByTimeAsync(13_000);
+
+    const firstCount = warningHandler.mock.calls.length;
+    expect(firstCount).toBeGreaterThanOrEqual(1);
+
+    webrtcDiagnostics.detach();
+    warningHandler.mockClear();
+
+    const secondReports = [
+      buildStatsReport(0, 1_000),
+      buildStatsReport(0, 2_000),
+      buildStatsReport(0, 3_000),
+      buildStatsReport(0, 4_000),
+    ];
+    webrtcDiagnostics.attach(makeMockPc(secondReports));
+    await vi.advanceTimersByTimeAsync(13_000);
+
+    // After detach + re-attach we expect the warning to be fresh.
+    expect(warningHandler).toHaveBeenCalled();
+  });
+});

--- a/src/features/video-calls/model/webrtc-diagnostics.ts
+++ b/src/features/video-calls/model/webrtc-diagnostics.ts
@@ -29,7 +29,21 @@ const POLL_INTERVAL_MS = 3_000;
 const MAX_ENTRIES = 200;
 const ZERO_AUDIO_ALERT_THRESHOLD = 3; // 3 consecutive polls = 9s
 
-class WebRTCDiagnostics {
+/**
+ * Session 03: typed warning payloads emitted on the "warning" event so
+ * call-service / UI can surface a user-visible toast instead of relying
+ * on console.error. Each type fires at most once per attach() — we don't
+ * spam the user every poll.
+ */
+export type DiagnosticsWarningType =
+  | "no_inbound_audio"
+  | "no_outbound_audio";
+
+export interface DiagnosticsWarningDetail {
+  type: DiagnosticsWarningType;
+}
+
+class WebRTCDiagnostics extends EventTarget {
   private entries: DiagnosticEntry[] = [];
   private pollTimer: ReturnType<typeof setInterval> | null = null;
   private pc: RTCPeerConnection | null = null;
@@ -38,6 +52,7 @@ class WebRTCDiagnostics {
   private zeroSentStreak = 0;
   private zeroRecvStreak = 0;
   private iceCandidatesLog: string[] = [];
+  private emittedWarnings: Set<DiagnosticsWarningType> = new Set();
 
   // Marker placed on a PC we've already wrapped, so a second attach on
   // the same pc is a no-op. Without this, and with our handlers stored
@@ -63,6 +78,8 @@ class WebRTCDiagnostics {
     this.zeroSentStreak = 0;
     this.zeroRecvStreak = 0;
     this.iceCandidatesLog = [];
+    // New attach == new call; allow each warning type to fire again.
+    this.emittedWarnings.clear();
 
     // Capture each original handler in a LOCAL CLOSURE variable rather
     // than `this.origXxx`. Closure-binding the original means wrapper
@@ -259,12 +276,14 @@ class WebRTCDiagnostics {
         dtlsState,
       };
 
-      // Real-time zero-audio detection
+      // Real-time zero-audio detection. We log to console (kept for bug
+      // reports) AND emit a typed "warning" event for the UI layer.
       if (pc.iceConnectionState === "connected" || pc.iceConnectionState === "completed") {
         if (audioBytesSent === this.prevAudioBytesSent) {
           this.zeroSentStreak++;
           if (this.zeroSentStreak === ZERO_AUDIO_ALERT_THRESHOLD) {
             console.error("[WebRTC-Diag] OUTBOUND AUDIO DEAD for 9s — mic may be muted or track not flowing");
+            this.emitWarning("no_outbound_audio");
           }
         } else {
           this.zeroSentStreak = 0;
@@ -274,6 +293,7 @@ class WebRTCDiagnostics {
           this.zeroRecvStreak++;
           if (this.zeroRecvStreak === ZERO_AUDIO_ALERT_THRESHOLD) {
             console.error("[WebRTC-Diag] INBOUND AUDIO DEAD for 9s — remote not sending or TURN relay broken");
+            this.emitWarning("no_inbound_audio");
           }
         } else {
           this.zeroRecvStreak = 0;
@@ -300,6 +320,17 @@ class WebRTCDiagnostics {
     } catch (e) {
       console.warn("[WebRTC-Diag] getStats error:", e);
     }
+  }
+
+  /**
+   * Fire the "warning" event at most once per type per attach() so the UI
+   * shows a single toast instead of repeating every poll.
+   */
+  private emitWarning(type: DiagnosticsWarningType): void {
+    if (this.emittedWarnings.has(type)) return;
+    this.emittedWarnings.add(type);
+    const detail: DiagnosticsWarningDetail = { type };
+    this.dispatchEvent(new CustomEvent("warning", { detail }));
   }
 }
 

--- a/src/shared/lib/connectivity.ts
+++ b/src/shared/lib/connectivity.ts
@@ -1,35 +1,160 @@
-import { ref, onMounted, onUnmounted } from "vue";
+import { ref } from "vue";
+import { isNative } from "./platform";
+
+/**
+ * Connectivity layer.
+ *
+ * Two reactive surfaces:
+ *   - `useConnectivity()` for Vue components — observes online + bandwidth tier.
+ *   - `onConnectivityChange()` for low-level subscribers (call-service) — fires
+ *     on every transport flip, including WiFi↔cellular handover. The browser's
+ *     `online/offline` events are not enough on Android WebView: they only
+ *     fire on full network loss, never on smooth WiFi↔cellular swap, so a
+ *     call running on WiFi when the phone roams to mobile data drops without
+ *     anyone notifying ICE. We subscribe to Capacitor's `@capacitor/network`
+ *     plugin alongside the browser events to catch transport changes.
+ */
+
+export type ConnectionType =
+  | "wifi"
+  | "cellular"
+  | "ethernet"
+  | "unknown"
+  | "none";
+
+export interface ConnectivityChange {
+  connected: boolean;
+  type: ConnectionType;
+  previousConnected: boolean;
+  previousType: ConnectionType;
+}
+
+type ConnectivityListener = (change: ConnectivityChange) => void;
 
 const isOnline = ref(typeof navigator !== "undefined" ? navigator.onLine : true);
 const isSlow = ref(false);
+const connectionType = ref<ConnectionType>("unknown");
 
-function updateOnline() {
-  isOnline.value = navigator.onLine;
-}
+const listeners: Set<ConnectivityListener> = new Set();
 
-function updateConnection() {
-  const conn = (navigator as any).connection;
-  if (conn) {
-    const type = conn.effectiveType as string;
-    isSlow.value = type === "slow-2g" || type === "2g" || type === "3g";
+function emitChange(next: { connected: boolean; type: ConnectionType }): void {
+  const prevConnected = isOnline.value;
+  const prevType = connectionType.value;
+  if (next.connected === prevConnected && next.type === prevType) return;
+
+  isOnline.value = next.connected;
+  connectionType.value = next.type;
+
+  const change: ConnectivityChange = {
+    connected: next.connected,
+    type: next.type,
+    previousConnected: prevConnected,
+    previousType: prevType,
+  };
+  for (const cb of listeners) {
+    try {
+      cb(change);
+    } catch (e) {
+      console.error("[connectivity] listener threw:", e);
+    }
   }
 }
 
-// Global listeners (only initialized once)
+function readBrowserConnectionType(): ConnectionType {
+  // navigator.connection.type isn't widely supported, but where it is
+  // we use it as a fallback when Capacitor isn't available (Electron / web).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const conn = (navigator as any).connection;
+  if (!conn) return "unknown";
+  const type = (conn.type as string) ?? (conn.effectiveType as string);
+  if (type === "wifi") return "wifi";
+  if (type === "cellular" || /^[2345]g$/i.test(type ?? "")) return "cellular";
+  if (type === "ethernet") return "ethernet";
+  if (type === "none") return "none";
+  return "unknown";
+}
+
+function updateOnline(): void {
+  emitChange({
+    connected: navigator.onLine,
+    type: navigator.onLine ? readBrowserConnectionType() : "none",
+  });
+}
+
+function updateConnectionTier(): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const conn = (navigator as any).connection;
+  if (conn) {
+    const eff = conn.effectiveType as string;
+    isSlow.value = eff === "slow-2g" || eff === "2g" || eff === "3g";
+  }
+}
+
 let initialized = false;
-function initListeners() {
+
+async function initListeners(): Promise<void> {
   if (initialized || typeof window === "undefined") return;
   initialized = true;
+
   window.addEventListener("online", updateOnline);
   window.addEventListener("offline", updateOnline);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const conn = (navigator as any).connection;
   if (conn) {
-    updateConnection();
-    conn.addEventListener("change", updateConnection);
+    updateConnectionTier();
+    conn.addEventListener("change", () => {
+      updateConnectionTier();
+      emitChange({
+        connected: navigator.onLine,
+        type: navigator.onLine ? readBrowserConnectionType() : "none",
+      });
+    });
   }
+
+  if (isNative) {
+    try {
+      // Lazy import so web/Electron builds don't bundle the native plugin.
+      const { Network } = await import("@capacitor/network");
+      const status = await Network.getStatus();
+      emitChange({
+        connected: status.connected,
+        type: (status.connectionType as ConnectionType) ?? "unknown",
+      });
+      Network.addListener("networkStatusChange", (next) => {
+        emitChange({
+          connected: next.connected,
+          type: (next.connectionType as ConnectionType) ?? "unknown",
+        });
+      });
+    } catch (e) {
+      console.warn(
+        "[connectivity] @capacitor/network unavailable; falling back to browser events:",
+        e,
+      );
+    }
+  }
+}
+
+/**
+ * Subscribe to connectivity transitions. Fires on:
+ *   - online ↔ offline
+ *   - WiFi ↔ cellular swaps (Android handover)
+ *
+ * Returns an unsubscribe function. Safe to call before init.
+ */
+export function onConnectivityChange(
+  callback: ConnectivityListener,
+): () => void {
+  // Kick off initialization on first subscription so the test harness and
+  // first caller don't have to wait for a Vue component to mount.
+  void initListeners();
+  listeners.add(callback);
+  return () => {
+    listeners.delete(callback);
+  };
 }
 
 export function useConnectivity() {
-  initListeners();
-  return { isOnline, isSlow };
+  void initListeners();
+  return { isOnline, isSlow, connectionType };
 }

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -501,6 +501,9 @@ export const en = {
   "call.permissionDenied.noInputDevice": "No microphone was found. Connect a headset or microphone and try again.",
   "call.permissionDenied.instructions": "Grant access in your system settings: Settings → Apps → Forta Chat → Permissions.",
   "call.permissionDenied.close": "Close",
+  "call.warning.noInboundAudio": "No incoming audio — the other party may have a microphone problem.",
+  "call.warning.noOutboundAudio": "No outgoing audio — check your microphone.",
+  "call.error.connectionLost": "Call connection lost.",
 
   // ── Auth / Login ──
   "auth.signIn": "Sign In",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -503,6 +503,9 @@ export const ru: Record<TranslationKey, string> = {
   "call.permissionDenied.noInputDevice": "Микрофон не найден. Подключите гарнитуру или микрофон и попробуйте снова.",
   "call.permissionDenied.instructions": "Разрешите доступ в настройках системы: «Настройки → Приложения → Forta Chat → Разрешения».",
   "call.permissionDenied.close": "Закрыть",
+  "call.warning.noInboundAudio": "Нет входящего звука — возможно, проблема с микрофоном собеседника.",
+  "call.warning.noOutboundAudio": "Нет исходящего звука — проверьте микрофон.",
+  "call.error.connectionLost": "Соединение со звонком потеряно.",
 
   // ── Auth / Login ──
   "auth.signIn": "Войти",

--- a/src/shared/lib/native-webrtc/rtc-peer-connection-proxy.test.ts
+++ b/src/shared/lib/native-webrtc/rtc-peer-connection-proxy.test.ts
@@ -25,6 +25,21 @@ function getBridgeMethod(name: string): BridgeMethod {
   return bridgeMethods[name];
 }
 
+// Capture native event handlers so tests can simulate native callbacks
+// (e.g. fire onIceConnectionStateChange to drive the proxy through state transitions).
+type NativeListener = (data: unknown) => void;
+const nativeListeners: Record<string, Set<NativeListener>> = {};
+
+function fireNativeEvent(event: string, data: unknown): void {
+  nativeListeners[event]?.forEach((handler) => handler(data));
+}
+
+function clearNativeListeners(): void {
+  for (const k of Object.keys(nativeListeners)) {
+    nativeListeners[k].clear();
+  }
+}
+
 vi.mock("@capacitor/core", () => ({
   Capacitor: {
     isNativePlatform: () => true,
@@ -35,9 +50,15 @@ vi.mock("@capacitor/core", () => ({
       get: (_t, prop: string) => {
         if (prop === "addListener") {
           return vi.fn().mockImplementation(
-            async (_event: string, _handler: unknown): Promise<PluginListenerHandle> => ({
-              remove: async () => {},
-            })
+            async (event: string, handler: NativeListener): Promise<PluginListenerHandle> => {
+              if (!nativeListeners[event]) nativeListeners[event] = new Set();
+              nativeListeners[event].add(handler);
+              return {
+                remove: async () => {
+                  nativeListeners[event]?.delete(handler);
+                },
+              };
+            }
           );
         }
         return getBridgeMethod(prop);
@@ -60,6 +81,7 @@ describe("NativeRTCPeerConnection proxy", () => {
     for (const k of Object.keys(bridgeMethods)) {
       bridgeMethods[k].mockClear();
     }
+    clearNativeListeners();
     installNativeWebRTCProxy();
   });
 
@@ -194,6 +216,219 @@ describe("NativeRTCPeerConnection proxy", () => {
       const stats = await pc.getStats();
       expect(stats).toBeInstanceOf(Map);
       expect(stats.size).toBe(0);
+
+      pc.close();
+    });
+  });
+
+  describe("ICE watchdog (Session 03)", () => {
+    // These tests use fake timers to drive disconnected/failed → restartIce
+    // and the 20s dead-connection escalation.
+    let restartIceMock: BridgeMethod;
+    let createPcMock: BridgeMethod;
+
+    async function newPcAndPeerId(): Promise<{
+      pc: RTCPeerConnection;
+      peerId: string;
+    }> {
+      const pc = new window.RTCPeerConnection();
+      // Flush microtasks so _initNative completes (createPeerConnection +
+      // addListener calls) under fake timers.
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(0);
+      const arg = createPcMock.mock.calls.at(-1)?.[0] as { peerId: string };
+      return { pc, peerId: arg.peerId };
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      restartIceMock = getBridgeMethod("restartIce");
+      createPcMock = getBridgeMethod("createPeerConnection");
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("calls restartIce after 10s of sustained disconnected state", async () => {
+      const { pc, peerId } = await newPcAndPeerId();
+
+      fireNativeEvent("onIceConnectionStateChange", {
+        peerId,
+        state: "disconnected",
+      });
+
+      // Just before 10s — no restart yet.
+      await vi.advanceTimersByTimeAsync(9_000);
+      expect(restartIceMock).not.toHaveBeenCalled();
+
+      // After 10s — restart must fire.
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(restartIceMock).toHaveBeenCalledOnce();
+
+      pc.close();
+    });
+
+    it("does NOT call restartIce when disconnected recovers to connected within 10s", async () => {
+      const { pc, peerId } = await newPcAndPeerId();
+
+      fireNativeEvent("onIceConnectionStateChange", {
+        peerId,
+        state: "disconnected",
+      });
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      // Recover before timeout.
+      fireNativeEvent("onIceConnectionStateChange", {
+        peerId,
+        state: "connected",
+      });
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(restartIceMock).not.toHaveBeenCalled();
+
+      pc.close();
+    });
+
+    it("calls restartIce immediately when ICE state transitions to failed", async () => {
+      const { pc, peerId } = await newPcAndPeerId();
+
+      fireNativeEvent("onIceConnectionStateChange", {
+        peerId,
+        state: "failed",
+      });
+      // Allow microtasks to drain so restartIce delegate fires.
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(restartIceMock).toHaveBeenCalledOnce();
+
+      pc.close();
+    });
+
+    it("dispatches 'connectiondead' event 20s after failed without recovery", async () => {
+      const { pc, peerId } = await newPcAndPeerId();
+
+      const deadHandler = vi.fn();
+      pc.addEventListener("connectiondead", deadHandler);
+
+      fireNativeEvent("onIceConnectionStateChange", {
+        peerId,
+        state: "failed",
+      });
+      // Restart fires, ICE remains failed (we never simulate recovery).
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(deadHandler).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(deadHandler).toHaveBeenCalledOnce();
+
+      pc.close();
+    });
+
+    it("does NOT dispatch 'connectiondead' if ICE recovers after failed", async () => {
+      const { pc, peerId } = await newPcAndPeerId();
+
+      const deadHandler = vi.fn();
+      pc.addEventListener("connectiondead", deadHandler);
+
+      fireNativeEvent("onIceConnectionStateChange", {
+        peerId,
+        state: "failed",
+      });
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      fireNativeEvent("onIceConnectionStateChange", {
+        peerId,
+        state: "connected",
+      });
+      await vi.advanceTimersByTimeAsync(25_000);
+
+      expect(deadHandler).not.toHaveBeenCalled();
+
+      pc.close();
+    });
+
+    it("clears watchdog timers on close so no late restart fires", async () => {
+      const { pc, peerId } = await newPcAndPeerId();
+
+      fireNativeEvent("onIceConnectionStateChange", {
+        peerId,
+        state: "disconnected",
+      });
+
+      pc.close();
+      restartIceMock.mockClear();
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(restartIceMock).not.toHaveBeenCalled();
+    });
+
+    it("debounces back-to-back restartIce calls within 3s", async () => {
+      const { pc } = await newPcAndPeerId();
+
+      pc.restartIce();
+      pc.restartIce();
+      pc.restartIce();
+      await vi.advanceTimersByTimeAsync(50);
+
+      // Three callers, one native call.
+      expect(restartIceMock).toHaveBeenCalledTimes(1);
+
+      // After the debounce window expires, a fresh request goes through.
+      await vi.advanceTimersByTimeAsync(3_500);
+      pc.restartIce();
+      await vi.advanceTimersByTimeAsync(50);
+      expect(restartIceMock).toHaveBeenCalledTimes(2);
+
+      pc.close();
+    });
+
+    it("escalates sustained disconnected to connectiondead at ~30s (10s wait + 20s dead)", async () => {
+      const { pc, peerId } = await newPcAndPeerId();
+      const deadHandler = vi.fn();
+      pc.addEventListener("connectiondead", deadHandler);
+
+      fireNativeEvent("onIceConnectionStateChange", {
+        peerId,
+        state: "disconnected",
+      });
+
+      // 10s tick → restartIce, dead timer armed, but no event yet.
+      await vi.advanceTimersByTimeAsync(10_500);
+      expect(restartIceMock).toHaveBeenCalledOnce();
+      expect(deadHandler).not.toHaveBeenCalled();
+
+      // No recovery — fire connectiondead 20s later.
+      await vi.advanceTimersByTimeAsync(21_000);
+      expect(deadHandler).toHaveBeenCalledOnce();
+
+      pc.close();
+    });
+
+    it("does NOT re-arm the dead timer when ICE flaps between failed and disconnected", async () => {
+      const { pc, peerId } = await newPcAndPeerId();
+      const deadHandler = vi.fn();
+      pc.addEventListener("connectiondead", deadHandler);
+
+      // Initial failed → dead timer armed.
+      fireNativeEvent("onIceConnectionStateChange", { peerId, state: "failed" });
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Flap to disconnected then failed every few seconds. If the dead
+      // timer were re-armed each time, the 20s deadline would never fire.
+      for (let i = 0; i < 4; i++) {
+        await vi.advanceTimersByTimeAsync(4_000);
+        fireNativeEvent("onIceConnectionStateChange", {
+          peerId,
+          state: i % 2 === 0 ? "disconnected" : "failed",
+        });
+      }
+
+      // Total elapsed: 0 + 4 + 4 + 4 + 4 = 16s; dead timer was armed at 0.
+      // Advance past 20s to ensure it fires once.
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(deadHandler).toHaveBeenCalledOnce();
 
       pc.close();
     });

--- a/src/shared/lib/native-webrtc/rtc-peer-connection-proxy.ts
+++ b/src/shared/lib/native-webrtc/rtc-peer-connection-proxy.ts
@@ -99,6 +99,27 @@ class NativeRTCPeerConnection extends EventTarget {
   private _closed = false;
   private _iceGatheringTimer: ReturnType<typeof setTimeout> | null = null;
 
+  // Session 03 — ICE watchdog timers.
+  // `_disconnectTimer` waits 10s after a "disconnected" before forcing
+  // restartIce — sometimes ICE recovers on its own (transient packet loss),
+  // so we don't want to thrash the connection.
+  // `_deadConnectionTimer` is armed when we hit "failed": we trigger an
+  // immediate restartIce and give the negotiation 20s to land us back in
+  // "connected"/"completed". If it doesn't, the call is unrecoverable and
+  // we dispatch "connectiondead" so call-service can hang up cleanly
+  // instead of leaving the user staring at a frozen UI.
+  private _disconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private _deadConnectionTimer: ReturnType<typeof setTimeout> | null = null;
+  // Timestamp of the last restartIce attempt — used to debounce. Multiple
+  // sources can trigger restartIce concurrently (the watchdog on a `failed`
+  // transition, the call-service network-change handler, and the SDK's own
+  // glare resolution). Two back-to-back native restarts while signaling is
+  // mid-offer reliably wedge libwebrtc on Android — we must collapse them.
+  private _lastRestartIceAt = 0;
+  private static readonly DISCONNECT_RESTART_DELAY_MS = 10_000;
+  private static readonly DEAD_CONNECTION_TIMEOUT_MS = 20_000;
+  private static readonly RESTART_ICE_DEBOUNCE_MS = 3_000;
+
   constructor(config?: RTCConfiguration) {
     super();
     this._peerId = `pc_${++peerIdCounter}_${Date.now()}`;
@@ -193,24 +214,7 @@ class NativeRTCPeerConnection extends EventTarget {
           "onIceConnectionStateChange",
           (data) => {
             if (this._closed || data.peerId !== this._peerId) return;
-            this._iceConnectionState =
-              ICE_STATE_MAP[data.state] ?? "new";
-            // Map to connection state too
-            if (data.state === "connected" || data.state === "completed") {
-              this._connectionState = "connected";
-            } else if (data.state === "failed") {
-              this._connectionState = "failed";
-            } else if (data.state === "disconnected") {
-              this._connectionState = "disconnected";
-            } else if (data.state === "closed") {
-              this._connectionState = "closed";
-            }
-            const event = new Event("iceconnectionstatechange");
-            this.oniceconnectionstatechange?.(event);
-            this._fireEvent(event);
-            const connEvent = new Event("connectionstatechange");
-            this.onconnectionstatechange?.(connEvent);
-            this._fireEvent(connEvent);
+            this._handleIceConnectionStateChange(data.state);
           }
         )
       );
@@ -496,6 +500,18 @@ class NativeRTCPeerConnection extends EventTarget {
     // so we can't propagate the async failure — log it and move on. Guard
     // against close() racing with init so we don't call native on a
     // torn-down peer.
+    if (this._closed) return;
+    const now = Date.now();
+    const sinceLast = now - this._lastRestartIceAt;
+    if (sinceLast < NativeRTCPeerConnection.RESTART_ICE_DEBOUNCE_MS) {
+      console.log(
+        "[NativeRTCProxy] restartIce debounced (last call",
+        sinceLast,
+        "ms ago)",
+      );
+      return;
+    }
+    this._lastRestartIceAt = now;
     this._waitReady()
       .then(() => {
         if (this._closed) return;
@@ -546,6 +562,16 @@ class NativeRTCPeerConnection extends EventTarget {
     this._connectionState = "closed";
     this._signalingState = "closed";
     if (this._iceGatheringTimer) clearTimeout(this._iceGatheringTimer);
+    // Drop watchdog timers so a disconnect/failed scheduled before close()
+    // can't trigger restartIce or fire connectiondead on a torn-down peer.
+    if (this._disconnectTimer) {
+      clearTimeout(this._disconnectTimer);
+      this._disconnectTimer = null;
+    }
+    if (this._deadConnectionTimer) {
+      clearTimeout(this._deadConnectionTimer);
+      this._deadConnectionTimer = null;
+    }
 
     console.log("[NativeRTCProxy] close, peerId:", this._peerId);
     NativeWebRTC.closePeerConnection({ peerId: this._peerId }).catch(() => {});
@@ -554,6 +580,131 @@ class NativeRTCPeerConnection extends EventTarget {
       handle.remove();
     }
     this.listeners = [];
+  }
+
+  // -----------------------------------------------------------------------
+  // ICE connection state + Session 03 watchdog
+  // -----------------------------------------------------------------------
+
+  /**
+   * Handle a native ICE state transition: update state, fire SDK events,
+   * and drive the resilience watchdog (auto-restart on disconnected/failed,
+   * dead-connection escalation).
+   */
+  private _handleIceConnectionStateChange(state: string): void {
+    this._iceConnectionState = ICE_STATE_MAP[state] ?? "new";
+    if (state === "connected" || state === "completed") {
+      this._connectionState = "connected";
+    } else if (state === "failed") {
+      this._connectionState = "failed";
+    } else if (state === "disconnected") {
+      this._connectionState = "disconnected";
+    } else if (state === "closed") {
+      this._connectionState = "closed";
+    }
+
+    const event = new Event("iceconnectionstatechange");
+    this.oniceconnectionstatechange?.(event);
+    this._fireEvent(event);
+    const connEvent = new Event("connectionstatechange");
+    this.onconnectionstatechange?.(connEvent);
+    this._fireEvent(connEvent);
+
+    this._driveWatchdog(state);
+  }
+
+  /**
+   * Session 03: ICE resilience watchdog.
+   *
+   * Why: Android WebView does not always fire `online/offline` on
+   * WiFi↔cellular handover, and even when it does the SDK's restartIce
+   * call needs a healthy ICE agent on both sides. Without these timers
+   * a momentary packet loss or network swap leaves ICE wedged in
+   * "disconnected"/"failed" forever; the user sees the call freeze, then
+   * eventually drop with no useful feedback. We:
+   *
+   *  - Wait 10s on "disconnected" before forcing restartIce — short
+   *    transients self-heal and we don't want to thrash the connection.
+   *    Once the timer is armed, repeated "disconnected" events do NOT
+   *    re-arm it: the goal is to escalate after sustained instability,
+   *    not to extend the patience window every time the state retoggles.
+   *  - On "failed" we hit restartIce immediately. Both paths arm the
+   *    same 20s dead-connection timer (idempotent — once armed, repeated
+   *    failed↔disconnected oscillation will NOT push out the deadline,
+   *    otherwise a flapping peer could postpone connectiondead forever).
+   *    If ICE has not reached connected/completed when the timer fires,
+   *    the call is unrecoverable and we dispatch "connectiondead" so
+   *    call-service can hang up cleanly with a user-visible message.
+   *  - Successful recovery (connected/completed) clears both timers.
+   */
+  private _driveWatchdog(state: string): void {
+    if (this._closed) return;
+
+    if (state === "connected" || state === "completed") {
+      if (this._disconnectTimer) {
+        clearTimeout(this._disconnectTimer);
+        this._disconnectTimer = null;
+      }
+      if (this._deadConnectionTimer) {
+        clearTimeout(this._deadConnectionTimer);
+        this._deadConnectionTimer = null;
+      }
+      return;
+    }
+
+    if (state === "disconnected") {
+      // Once-armed, do not extend the window if disconnected fires again
+      // — we want a strict 10s ceiling on instability before forcing a
+      // restart, not a sliding window that a flapping peer can exploit.
+      if (this._disconnectTimer) return;
+      this._disconnectTimer = setTimeout(() => {
+        this._disconnectTimer = null;
+        if (this._closed) return;
+        if (this._iceConnectionState !== "disconnected") return;
+        console.warn(
+          "[NativeRTCProxy] ICE stuck disconnected for",
+          NativeRTCPeerConnection.DISCONNECT_RESTART_DELAY_MS,
+          "ms → restartIce",
+        );
+        this.restartIce();
+        // After the recovery attempt, give it 20s to land on
+        // connected/completed before declaring the call dead.
+        this._armDeadConnectionTimer();
+      }, NativeRTCPeerConnection.DISCONNECT_RESTART_DELAY_MS);
+      return;
+    }
+
+    if (state === "failed") {
+      console.warn("[NativeRTCProxy] ICE failed → immediate restartIce");
+      this.restartIce();
+      this._armDeadConnectionTimer();
+      return;
+    }
+  }
+
+  /**
+   * Arm the dead-connection timer iff one isn't already running. Idempotent
+   * on purpose: failed↔disconnected oscillation must not keep pushing the
+   * deadline outwards. Once we decide "we're trying to recover", we give
+   * a single 20s budget regardless of how the broken state cycles.
+   */
+  private _armDeadConnectionTimer(): void {
+    if (this._closed) return;
+    if (this._deadConnectionTimer) return;
+    this._deadConnectionTimer = setTimeout(() => {
+      this._deadConnectionTimer = null;
+      if (this._closed) return;
+      const stuck =
+        this._iceConnectionState === "failed" ||
+        this._iceConnectionState === "disconnected";
+      if (!stuck) return;
+      console.error(
+        "[NativeRTCProxy] ICE dead",
+        NativeRTCPeerConnection.DEAD_CONNECTION_TIMEOUT_MS,
+        "ms — emitting connectiondead",
+      );
+      this._fireEvent(new Event("connectiondead"));
+    }, NativeRTCPeerConnection.DEAD_CONNECTION_TIMEOUT_MS);
   }
 
   // -----------------------------------------------------------------------

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,6 +119,11 @@
   resolved "https://registry.npmjs.org/@capacitor/local-notifications/-/local-notifications-8.0.2.tgz"
   integrity sha512-X7KE/I4ZutMTGVHNUyTjIugYcQEcHJRLks+TsPnOriuS+lo0geSTuaRln6zAZlJSSXSoVMSSzHexdSbIjR/8iw==
 
+"@capacitor/network@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.npmjs.org/@capacitor/network/-/network-8.0.1.tgz"
+  integrity sha512-9xK/FHFmzKGanB6BdoSZOzXk8vF0OFVQSQ4PAsIrzAzLuXHryO317qy8dcHVpgxYeuZq2noI0My9z1DvVDi/9w==
+
 "@capacitor/push-notifications@^8.0.2":
   version "8.0.3"
   resolved "https://registry.npmjs.org/@capacitor/push-notifications/-/push-notifications-8.0.3.tgz"
@@ -274,10 +279,15 @@
   resolved "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz"
   integrity sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==
 
-"@esbuild/win32-x64@0.21.5":
+"@esbuild/darwin-arm64@0.21.5":
   version "0.21.5"
-  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz"
-  integrity sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz"
+  integrity sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
+
+"@esbuild/darwin-arm64@0.28.0":
+  version "0.28.0"
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz"
+  integrity sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==
 
 "@hapi/address@^5.1.1":
   version "5.1.1"
@@ -543,10 +553,10 @@
   resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@rolldown/binding-win32-x64-msvc@1.0.0-rc.15":
+"@rolldown/binding-darwin-arm64@1.0.0-rc.15":
   version "1.0.0-rc.15"
-  resolved "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz"
-  integrity sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==
+  resolved "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz"
+  integrity sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==
 
 "@rolldown/pluginutils@1.0.0-rc.15":
   version "1.0.0-rc.15"
@@ -562,15 +572,10 @@
     estree-walker "^2.0.2"
     picomatch "^4.0.2"
 
-"@rollup/rollup-win32-x64-gnu@4.60.1":
+"@rollup/rollup-darwin-arm64@4.60.1":
   version "4.60.1"
-  resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz"
-  integrity sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==
-
-"@rollup/rollup-win32-x64-msvc@4.60.1":
-  version "4.60.1"
-  resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz"
-  integrity sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==
+  resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz"
+  integrity sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==
 
 "@sindresorhus/is@^4.0.0":
   version "4.6.0"
@@ -681,6 +686,14 @@
   dependencies:
     undici-types "~7.16.0"
 
+"@types/plist@^3.0.1":
+  version "3.0.5"
+  resolved "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz"
+  integrity sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==
+  dependencies:
+    "@types/node" "*"
+    xmlbuilder ">=11.0.1"
+
 "@types/responselike@^1.0.0":
   version "1.0.3"
   resolved "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz"
@@ -697,6 +710,11 @@
   version "4.0.0"
   resolved "https://registry.npmjs.org/@types/slice-ansi/-/slice-ansi-4.0.0.tgz"
   integrity sha512-+OpjSaq85gvlZAYINyzKpLeiFkSC4EsC6IIiT6v6TLSU5k5U83fHGj9Lel8oKEXM0HqgrMVCjXPDPVICtxF7EQ==
+
+"@types/verror@^1.10.3":
+  version "1.10.11"
+  resolved "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz"
+  integrity sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==
 
 "@types/whatwg-mimetype@^3.0.2":
   version "3.0.2"
@@ -988,7 +1006,7 @@ ajv-keywords@^3.4.1:
   resolved "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.12.0, ajv@^6.9.1:
+ajv@^6.10.0, ajv@^6.12.0, ajv@^6.9.1:
   version "6.14.0"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz"
   integrity sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==
@@ -1099,6 +1117,11 @@ argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+assert-plus@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+  integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
 
 assertion-error@^2.0.1:
   version "2.0.1"
@@ -1299,6 +1322,14 @@ buffer-from@^1.0.0:
   resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
+buffer@^5.1.0:
+  version "5.7.1"
+  resolved "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
+
 buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz"
@@ -1493,6 +1524,14 @@ cli-spinners@^2.5.0:
   resolved "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz"
   integrity sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==
 
+cli-truncate@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz"
+  integrity sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==
+  dependencies:
+    slice-ansi "^3.0.0"
+    string-width "^4.2.0"
+
 cliui@^8.0.1:
   version "8.0.1"
   resolved "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz"
@@ -1629,6 +1668,18 @@ core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
+
+core-util-is@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+  integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
+
+crc@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz"
+  integrity sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==
+  dependencies:
+    buffer "^5.1.0"
 
 create-hash@^1.1.0, create-hash@^1.2.0:
   version "1.2.0"
@@ -1796,6 +1847,20 @@ dmg-builder@26.8.1:
     js-yaml "^4.1.0"
   optionalDependencies:
     dmg-license "^1.0.11"
+
+dmg-license@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz"
+  integrity sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==
+  dependencies:
+    "@types/plist" "^3.0.1"
+    "@types/verror" "^1.10.3"
+    ajv "^6.10.0"
+    crc "^3.8.0"
+    iconv-corefoundation "^1.1.7"
+    plist "^3.0.4"
+    smart-buffer "^4.0.2"
+    verror "^1.10.0"
 
 dotenv-expand@^11.0.6:
   version "11.0.7"
@@ -2001,7 +2066,7 @@ es6-error@^4.1.1:
   resolved "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
-esbuild@^0.21.3, "esbuild@^0.27.0 || ^0.28.0":
+esbuild@^0.21.3:
   version "0.21.5"
   resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz"
   integrity sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==
@@ -2029,6 +2094,38 @@ esbuild@^0.21.3, "esbuild@^0.27.0 || ^0.28.0":
     "@esbuild/win32-arm64" "0.21.5"
     "@esbuild/win32-ia32" "0.21.5"
     "@esbuild/win32-x64" "0.21.5"
+
+"esbuild@^0.27.0 || ^0.28.0":
+  version "0.28.0"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz"
+  integrity sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.28.0"
+    "@esbuild/android-arm" "0.28.0"
+    "@esbuild/android-arm64" "0.28.0"
+    "@esbuild/android-x64" "0.28.0"
+    "@esbuild/darwin-arm64" "0.28.0"
+    "@esbuild/darwin-x64" "0.28.0"
+    "@esbuild/freebsd-arm64" "0.28.0"
+    "@esbuild/freebsd-x64" "0.28.0"
+    "@esbuild/linux-arm" "0.28.0"
+    "@esbuild/linux-arm64" "0.28.0"
+    "@esbuild/linux-ia32" "0.28.0"
+    "@esbuild/linux-loong64" "0.28.0"
+    "@esbuild/linux-mips64el" "0.28.0"
+    "@esbuild/linux-ppc64" "0.28.0"
+    "@esbuild/linux-riscv64" "0.28.0"
+    "@esbuild/linux-s390x" "0.28.0"
+    "@esbuild/linux-x64" "0.28.0"
+    "@esbuild/netbsd-arm64" "0.28.0"
+    "@esbuild/netbsd-x64" "0.28.0"
+    "@esbuild/openbsd-arm64" "0.28.0"
+    "@esbuild/openbsd-x64" "0.28.0"
+    "@esbuild/openharmony-arm64" "0.28.0"
+    "@esbuild/sunos-x64" "0.28.0"
+    "@esbuild/win32-arm64" "0.28.0"
+    "@esbuild/win32-ia32" "0.28.0"
+    "@esbuild/win32-x64" "0.28.0"
 
 escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
@@ -2087,6 +2184,11 @@ extract-zip@^2.0.1:
     yauzl "^2.10.0"
   optionalDependencies:
     "@types/yauzl" "^2.9.1"
+
+extsprintf@^1.2.0:
+  version "1.4.1"
+  resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz"
+  integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
 
 fake-indexeddb@^6.2.5:
   version "6.2.5"
@@ -2264,6 +2366,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fsevents@~2.3.2, fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"
@@ -2517,6 +2624,14 @@ https-proxy-agent@^7.0.0, https-proxy-agent@^7.0.1:
   dependencies:
     agent-base "^7.1.2"
     debug "4"
+
+iconv-corefoundation@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz"
+  integrity sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==
+  dependencies:
+    cli-truncate "^2.1.0"
+    node-addon-api "^1.6.3"
 
 iconv-lite@^0.6.2:
   version "0.6.3"
@@ -2800,10 +2915,10 @@ lazy-val@^1.0.5:
   resolved "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz"
   integrity sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==
 
-lightningcss-win32-x64-msvc@1.32.0:
+lightningcss-darwin-arm64@1.32.0:
   version "1.32.0"
-  resolved "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz"
-  integrity sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==
+  resolved "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz"
+  integrity sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==
 
 lightningcss@^1.21.0, lightningcss@^1.32.0:
   version "1.32.0"
@@ -3236,6 +3351,11 @@ node-abi@^4.2.0:
   dependencies:
     semver "^7.6.3"
 
+node-addon-api@^1.6.3:
+  version "1.7.2"
+  resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz"
+  integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
+
 node-api-version@^0.2.1:
   version "0.2.1"
   resolved "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz"
@@ -3519,7 +3639,7 @@ pkg-types@^2.3.0:
     exsolve "^1.0.7"
     pathe "^2.0.3"
 
-plist@^3.0.5, plist@^3.1.0, plist@3.1.0:
+plist@^3.0.4, plist@^3.0.5, plist@^3.1.0, plist@3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz"
   integrity sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==
@@ -4085,6 +4205,15 @@ sisteransi@^1.0.5:
   resolved "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
+slice-ansi@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz"
+  integrity sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
+
 slice-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz"
@@ -4094,7 +4223,7 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-smart-buffer@^4.2.0:
+smart-buffer@^4.0.2, smart-buffer@^4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
@@ -4627,6 +4756,15 @@ vee-validate@^4.13.2, vee-validate@4.15.1:
     "@vue/devtools-api" "^7.5.2"
     type-fest "^4.8.3"
 
+verror@^1.10.0:
+  version "1.10.1"
+  resolved "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz"
+  integrity sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==
+  dependencies:
+    assert-plus "^1.0.0"
+    core-util-is "1.0.2"
+    extsprintf "^1.2.0"
+
 virtua@^0.48.8:
   version "0.48.8"
   resolved "https://registry.npmjs.org/virtua/-/virtua-0.48.8.tgz"
@@ -4851,7 +4989,7 @@ xml2js@^0.6.2:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"
 
-xmlbuilder@^15.1.1:
+xmlbuilder@^15.1.1, xmlbuilder@>=11.0.1:
   version "15.1.1"
   resolved "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz"
   integrity sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==


### PR DESCRIPTION
## Summary

Закрывает подгруппу «звонок рвётся / теряется соединение» (#447 Teclast Android 16 + ~10 сопутствующих жалоб). Native-уровень `restartIce`/`getStats` уже был сделан в предыдущих сессиях — здесь добавлен JS-watchdog, обработка смены сети и user-visible диагностика.

### Что меняется

- **Proxy watchdog** (`rtc-peer-connection-proxy.ts`): 10с в `disconnected` → принудительный `restartIce`; `failed` → немедленный restart; 20с без восстановления → `connectiondead` event. Dead-timer идемпотентен — flapping peer не может оттянуть дедлайн. `restartIce` дебаунсится (3с) — последовательные native рестарты во время glare ломают libwebrtc на Android.
- **@capacitor/network listener** (`connectivity.ts`): `window.online/offline` не fires на Android WebView при WiFi↔cellular handover. Подписываемся на события Capacitor; при смене transport во время звонка явно вызываем `restartIce`. Защита `signalingState === "stable"` чтобы не пересечься с SDK-glare.
- **Diagnostics emitter** (`webrtc-diagnostics.ts`): класс расширяет `EventTarget`, эмитит типизированные `warning` (`no_inbound_audio`, `no_outbound_audio`) максимум 1 раз за attach.
- **call-service**: idempotent module-scope подписка на сетевые изменения; per-call подписки на `connectiondead` (toast + hangup `CallErrorCode.IceFailed`) и diagnostics warnings (toast). Cleanup в `unwireCallEvents`.
- **AndroidManifest**: `ACCESS_NETWORK_STATE` permission.
- **i18n**: `call.warning.noInboundAudio`, `call.warning.noOutboundAudio`, `call.error.connectionLost` (en + ru).

### Code review

Все 3 high-severity issue от `superpowers:code-reviewer` адресованы:
1. **Idempotent listener registration** на module-scope (HMR-safe).
2. **`restartIce` debounce** 3с в одной точке (proxy) — собирает источники (watchdog, network, SDK glare).
3. **Idempotent dead-timer + 10с-disconnected → arm dead timer** — flap не может оттянуть `connectiondead` индефинитно; sustained disconnected эскалируется через 30с.

### Test plan

- [ ] Unit: `npm run test src/shared/lib/native-webrtc src/features/video-calls/model` — 49/49 зелёные
- [ ] Manual WiFi→cellular swap (`adb shell svc wifi disable` через ~10с) → звонок продолжается, в logcat `[NativeRTCProxy] restartIce`
- [ ] Manual: блокировка UDP / sustained packet loss → через ~30с `connectiondead` → call ended + toast «Соединение со звонком потеряно»
- [ ] Manual: muted микрофон на той стороне → через 9с toast «Нет входящего звука...»
- [ ] `webrtcDiagnostics.getReport()` возвращает non-empty report с заполненными bytes/RTT

### Тесты

- **+9 новых** в `rtc-peer-connection-proxy.test.ts` (watchdog disconnected/failed/recover/dead, close cleanup, debounce, no-rearm on flap, sustained-disconnected → connectiondead).
- **+5 новых** в `webrtc-diagnostics.test.ts` (warning emission, once-per-attach, no-spam, no-emit когда audio есть, reset on detach).
- Полный suite: 1466 pass / 9 fail — все 9 fail пре-существуют на master (не связаны с этими изменениями).