### PR TITLE
fix(calls): stale invite TTL guard + FCM throttle telemetry (Session 25)

### DIFF
--- a/android/app/src/main/java/com/forta/chat/FortaFirebaseMessagingService.kt
+++ b/android/app/src/main/java/com/forta/chat/FortaFirebaseMessagingService.kt
@@ -13,6 +13,8 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.forta.chat.plugins.calls.CallConnectionService
 import com.forta.chat.plugins.calls.IncomingCallActivity
+import com.forta.chat.plugins.calls.InviteThrottleGuard
+import com.forta.chat.plugins.calls.InviteThrottleTracker
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 
@@ -137,6 +139,45 @@ class FortaFirebaseMessagingService : FirebaseMessagingService() {
                 forwardToJs(data)
                 return
             }
+
+            // Session 25 / S4: stale-invite filter. When FCM degrades
+            // (foreground service abuse marks, Doze, rate-limit), the
+            // homeserver retains the invite and the FCM service flushes
+            // it minutes later — we receive the push for a call the
+            // caller already cancelled. Without this guard, the user is
+            // woken up by the full-screen IncomingCallActivity for a
+            // call that no longer exists; once they hit Accept the SDK
+            // immediately fires Hangup (its own lifetime timer fires)
+            // and the call collapses.
+            //
+            // `RemoteMessage.sentTime` is the homeserver's send time —
+            // a reasonable proxy for `event.origin_server_ts` for the
+            // FCM-delivered invite. The lifetime override comes from
+            // `data["lifetime"]` if the homeserver populates it; we
+            // fall back to the SDK's 60s default otherwise.
+            val sentTime = message.sentTime
+            val lifetimeMs = data["lifetime"]?.toLongOrNull()
+            val nowMs = System.currentTimeMillis()
+            val expired = InviteThrottleGuard.isExpired(sentTime, nowMs, lifetimeMs)
+            inviteTracker.append(
+                InviteThrottleTracker.Record(
+                    receivedAtMs = nowMs,
+                    sentAtMs = sentTime,
+                    expired = expired,
+                    callId = callId.takeIf { it.isNotEmpty() },
+                )
+            )
+            if (expired) {
+                Log.w(TAG, "Stale call invite suppressed (S4): callId=$callId sentTime=$sentTime " +
+                    "ageMs=${nowMs - sentTime} lifetime=$lifetimeMs")
+                // Forward to JS for telemetry/diagnostics but do NOT
+                // launch the ringer. JS sees the push and the app
+                // re-syncs Matrix — if the invite is genuinely live the
+                // SDK's normal flow will deliver it via /sync.
+                forwardToJs(data)
+                return
+            }
+
             lastRingingCallId = callId.takeIf { it.isNotEmpty() }
 
             // Cancel any existing message notification for this room
@@ -321,6 +362,15 @@ class FortaFirebaseMessagingService : FirebaseMessagingService() {
          * select_answer for the same id (or the process dies).
          */
         private var lastRingingCallId: String? = null
+
+        /**
+         * Session 25 / S3-S4: rolling tracker for the last 5 FCM call
+         * invites. Exposed via [com.forta.chat.plugins.calls.CallPlugin.getInviteThrottleSnapshot]
+         * so the JS bug-reporter can attach the recent delivery-latency
+         * pattern to its envelope. Lets us split S1 (accept-crash) from
+         * S3 (FCM throttle) when triaging user reports.
+         */
+        val inviteTracker: InviteThrottleTracker = InviteThrottleTracker(maxRecords = 5)
 
         fun cacheRoomName(context: Context, roomId: String, name: String) {
             context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallPlugin.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallPlugin.kt
@@ -464,6 +464,32 @@ class CallPlugin : Plugin() {
         call.resolve(result)
     }
 
+    /**
+     * Session 25 / S3-S4: return the last N FCM `m.call.invite` records
+     * for the JS bug-reporter envelope. Callers should treat the result
+     * as best-effort: an empty list simply means no invites have been
+     * received in this process lifetime.
+     *
+     * Used by the JS bug-reporter to surface the recent delivery-latency
+     * pattern in user reports — lets us distinguish S1 (accept-crash)
+     * from S3 (FCM throttle / Doze) without asking the user to reproduce.
+     */
+    @PluginMethod
+    fun getInviteThrottleSnapshot(call: PluginCall) {
+        val records = com.forta.chat.FortaFirebaseMessagingService.inviteTracker.snapshot()
+        val arr = org.json.JSONArray()
+        for (r in records) {
+            arr.put(org.json.JSONObject().apply {
+                put("receivedAtMs", r.receivedAtMs)
+                put("sentAtMs", r.sentAtMs)
+                put("deliveryLatencyMs", r.deliveryLatencyMs)
+                put("expired", r.expired)
+                put("callId", r.callId ?: "")
+            })
+        }
+        call.resolve(JSObject().apply { put("records", arr) })
+    }
+
     @PluginMethod
     fun getPendingAnswer(call: PluginCall) {
         val pendingCallId = CallConnection.pendingAnswerCallId

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/InviteThrottleGuard.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/InviteThrottleGuard.kt
@@ -1,0 +1,58 @@
+package com.forta.chat.plugins.calls
+
+/**
+ * Session 25 / S4 stale-invite guard for the FCM ringer path.
+ *
+ * Background: when FCM delivery degrades on Android (S3 — foreground
+ * service abuse, Doze, rate-limit), the homeserver retains the invite
+ * and flushes it minutes later. The Matrix SDK's lifetime timer covers
+ * the JS path, but `FortaFirebaseMessagingService.onMessageReceived`
+ * launches `IncomingCallActivity` from the push payload BEFORE the SDK
+ * even sees the event. Without this guard the user is woken up by a
+ * ringer for a call the caller cancelled minutes ago — exactly the
+ * S4 false-positive scenario.
+ *
+ * Pure Kotlin object so it is unit-testable from `androidUnitTest`
+ * without spinning up an Android emulator.
+ */
+object InviteThrottleGuard {
+
+    /**
+     * Default invite lifetime when the FCM payload does not specify one.
+     * Matches the Matrix SDK's `CALL_TIMEOUT_MS` (60s).
+     */
+    const val DEFAULT_INVITE_LIFETIME_MS: Long = 60_000L
+
+    /**
+     * Hard ceiling on lifetime. Some homeservers / forks echo back
+     * surprisingly large lifetimes (e.g. 1 hour) which would silently
+     * disable the guard. Five minutes is well past any realistic
+     * ring-then-pickup window and still tight enough to prevent the user
+     * from being woken up by an invite the caller cancelled long ago.
+     */
+    const val MAX_INVITE_LIFETIME_MS: Long = 5 * 60_000L
+
+    /**
+     * Returns true when the invite is older than `min(lifetime, MAX)`.
+     *
+     * @param sentTimeMs proxy for `event.origin_server_ts`. On the FCM
+     *   path use `RemoteMessage.sentTime`. Defensive: a non-positive
+     *   value is treated as expired so we never let a malformed invite
+     *   through.
+     * @param nowMs current wall clock. Production callers pass
+     *   `System.currentTimeMillis()`; tests pass a fixed value.
+     * @param lifetimeMs `event.content.lifetime`. Pass `null` to use
+     *   [DEFAULT_INVITE_LIFETIME_MS].
+     */
+    fun isExpired(
+        sentTimeMs: Long,
+        nowMs: Long,
+        lifetimeMs: Long? = null,
+    ): Boolean {
+        if (sentTimeMs <= 0L) return true
+        val rawLifetime = lifetimeMs?.takeIf { it > 0L } ?: DEFAULT_INVITE_LIFETIME_MS
+        val effective = rawLifetime.coerceAtMost(MAX_INVITE_LIFETIME_MS)
+        val age = nowMs - sentTimeMs
+        return age >= effective
+    }
+}

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/InviteThrottleTracker.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/InviteThrottleTracker.kt
@@ -1,0 +1,52 @@
+package com.forta.chat.plugins.calls
+
+/**
+ * Session 25 / S3: in-memory rolling tracker for FCM `m.call.invite`
+ * events. Used by [InviteThrottleGuard]'s consumers to surface a snapshot
+ * of recent invite delivery latencies in bug reports.
+ *
+ * Records last [maxRecords] entries with `(receivedAtMs, sentAtMs, isExpired)`.
+ * The bug-reporter pulls a snapshot to help split S1 (accept-crash) from
+ * S3 (FCM throttle / Doze) when the auto-bug-reporter envelope is sent.
+ *
+ * Pure Kotlin object — no Android dependencies — so unit-testable from
+ * `androidUnitTest` without an emulator.
+ */
+class InviteThrottleTracker(private val maxRecords: Int = 5) {
+
+    data class Record(
+        /** When [FortaFirebaseMessagingService.onMessageReceived] handled the push. */
+        val receivedAtMs: Long,
+        /** `RemoteMessage.sentTime` — homeserver send time (proxy for origin_server_ts). */
+        val sentAtMs: Long,
+        /** Was the invite already expired by the time we received it? */
+        val expired: Boolean,
+        /** `call_id` from the FCM payload, or null when missing. */
+        val callId: String?,
+    ) {
+        val deliveryLatencyMs: Long get() = receivedAtMs - sentAtMs
+    }
+
+    private val records: ArrayDeque<Record> = ArrayDeque(maxRecords)
+    private val lock = Any()
+
+    fun append(record: Record) = synchronized(lock) {
+        if (records.size >= maxRecords) records.removeFirst()
+        records.addLast(record)
+    }
+
+    fun snapshot(): List<Record> = synchronized(lock) {
+        records.toList()
+    }
+
+    /**
+     * Last [windowMs]-window expired count. Used by the JS bug-reporter
+     * to decide whether the user is in an active S3 throttle cycle.
+     */
+    fun expiredCountWithin(windowMs: Long, nowMs: Long): Int = synchronized(lock) {
+        val cutoff = nowMs - windowMs
+        records.count { it.expired && it.receivedAtMs >= cutoff }
+    }
+
+    fun clear() = synchronized(lock) { records.clear() }
+}

--- a/android/app/src/test/java/com/forta/chat/plugins/calls/InviteThrottleGuardTest.kt
+++ b/android/app/src/test/java/com/forta/chat/plugins/calls/InviteThrottleGuardTest.kt
@@ -1,0 +1,97 @@
+package com.forta.chat.plugins.calls
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [InviteThrottleGuard]. Pure Kotlin — no Android
+ * dependencies, runs as part of `./gradlew test` (JVM unit tests).
+ *
+ * Mirrors `src/shared/lib/native-calls/__tests__/invite-ttl.test.ts`
+ * so JS and native sides agree on the staleness window.
+ */
+class InviteThrottleGuardTest {
+
+    private val now: Long = 1_700_000_000_000L
+
+    @Test
+    fun freshInviteWithinLifetimeNotExpired() {
+        assertFalse(
+            InviteThrottleGuard.isExpired(
+                sentTimeMs = now - 5_000L,
+                nowMs = now,
+            )
+        )
+    }
+
+    @Test
+    fun inviteOlderThanDefaultLifetimeExpired() {
+        assertTrue(
+            InviteThrottleGuard.isExpired(
+                sentTimeMs = now - InviteThrottleGuard.DEFAULT_INVITE_LIFETIME_MS - 1L,
+                nowMs = now,
+            )
+        )
+    }
+
+    @Test
+    fun explicitLifetimeOverridesDefault() {
+        // 30s lifetime, 31s old → expired
+        assertTrue(
+            InviteThrottleGuard.isExpired(
+                sentTimeMs = now - 31_000L,
+                nowMs = now,
+                lifetimeMs = 30_000L,
+            )
+        )
+        // 30s lifetime, 29s old → not expired
+        assertFalse(
+            InviteThrottleGuard.isExpired(
+                sentTimeMs = now - 29_000L,
+                nowMs = now,
+                lifetimeMs = 30_000L,
+            )
+        )
+    }
+
+    @Test
+    fun nullLifetimeFallsBackToDefault() {
+        assertTrue(
+            InviteThrottleGuard.isExpired(
+                sentTimeMs = now - InviteThrottleGuard.DEFAULT_INVITE_LIFETIME_MS - 1L,
+                nowMs = now,
+                lifetimeMs = null,
+            )
+        )
+    }
+
+    @Test
+    fun nonPositiveTimestampTreatedAsExpired() {
+        assertTrue(InviteThrottleGuard.isExpired(sentTimeMs = 0L, nowMs = now))
+        assertTrue(InviteThrottleGuard.isExpired(sentTimeMs = -1L, nowMs = now))
+    }
+
+    @Test
+    fun absurdlyLargeLifetimeClampedToCeiling() {
+        // 1-hour echoed lifetime should not let a 6-min-old invite leak through.
+        assertTrue(
+            InviteThrottleGuard.isExpired(
+                sentTimeMs = now - 6 * 60_000L,
+                nowMs = now,
+                lifetimeMs = 60 * 60_000L,
+            )
+        )
+    }
+
+    @Test
+    fun exactBoundaryTreatedAsExpired() {
+        assertTrue(
+            InviteThrottleGuard.isExpired(
+                sentTimeMs = now - 60_000L,
+                nowMs = now,
+                lifetimeMs = 60_000L,
+            )
+        )
+    }
+}

--- a/android/app/src/test/java/com/forta/chat/plugins/calls/InviteThrottleTrackerTest.kt
+++ b/android/app/src/test/java/com/forta/chat/plugins/calls/InviteThrottleTrackerTest.kt
@@ -1,0 +1,69 @@
+package com.forta.chat.plugins.calls
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class InviteThrottleTrackerTest {
+
+    @Test
+    fun rollingWindowKeepsLastN() {
+        val tracker = InviteThrottleTracker(maxRecords = 3)
+        for (i in 1..5) {
+            tracker.append(
+                InviteThrottleTracker.Record(
+                    receivedAtMs = i.toLong() * 1_000L,
+                    sentAtMs = i.toLong() * 1_000L - 100L,
+                    expired = false,
+                    callId = "call-$i",
+                )
+            )
+        }
+        val snapshot = tracker.snapshot()
+        assertEquals(3, snapshot.size)
+        assertEquals("call-3", snapshot[0].callId)
+        assertEquals("call-5", snapshot[2].callId)
+    }
+
+    @Test
+    fun deliveryLatencyMsComputed() {
+        val record = InviteThrottleTracker.Record(
+            receivedAtMs = 1_500L,
+            sentAtMs = 1_000L,
+            expired = false,
+            callId = null,
+        )
+        assertEquals(500L, record.deliveryLatencyMs)
+    }
+
+    @Test
+    fun expiredCountWithinWindow() {
+        val tracker = InviteThrottleTracker(maxRecords = 5)
+        val now = 100_000L
+        // Two expired in last 30s, one expired older
+        tracker.append(rec(now - 5_000L, expired = true))
+        tracker.append(rec(now - 20_000L, expired = true))
+        tracker.append(rec(now - 60_000L, expired = true))
+        // Fresh non-expired in window
+        tracker.append(rec(now - 10_000L, expired = false))
+
+        assertEquals(2, tracker.expiredCountWithin(30_000L, now))
+        assertEquals(3, tracker.expiredCountWithin(120_000L, now))
+        assertEquals(0, tracker.expiredCountWithin(1_000L, now))
+    }
+
+    @Test
+    fun clearEmptiesSnapshot() {
+        val tracker = InviteThrottleTracker(maxRecords = 3)
+        tracker.append(rec(1_000L, expired = false))
+        tracker.clear()
+        assertEquals(0, tracker.snapshot().size)
+    }
+
+    private fun rec(receivedAtMs: Long, expired: Boolean): InviteThrottleTracker.Record =
+        InviteThrottleTracker.Record(
+            receivedAtMs = receivedAtMs,
+            sentAtMs = receivedAtMs - 100L,
+            expired = expired,
+            callId = null,
+        )
+}

--- a/src/features/bug-report/ui/BugReportModal.vue
+++ b/src/features/bug-report/ui/BugReportModal.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
 import {
   collectEnvironment,
+  collectCallDiagnostics,
   sendBugReport,
   trackCreatedIssue,
 } from "@/shared/lib/bug-report";
-import type { AppEnvironment } from "@/shared/lib/bug-report";
+import type {
+  AppEnvironment,
+  BugReportCallDiagnostics,
+} from "@/shared/lib/bug-report";
 import Modal from "@/shared/ui/modal/Modal.vue";
 import { isNative } from "@/shared/lib/platform";
 import { useAuthStore } from "@/entities/auth";
@@ -21,6 +25,7 @@ const sent = ref(false);
 const errorMsg = ref("");
 const fileInput = ref<HTMLInputElement>();
 const environment = ref<AppEnvironment>();
+const callDiagnostics = ref<BugReportCallDiagnostics>();
 const showExamples = ref(false);
 
 watch(isOpen, async (val) => {
@@ -41,6 +46,11 @@ watch(isOpen, async (val) => {
     errorMsg.value = "";
     showExamples.value = false;
     environment.value = await collectEnvironment();
+    // Session 25: pull call diagnostics in parallel with environment.
+    // Non-throwing — collectCallDiagnostics swallows native plugin
+    // failures so a missing throttle snapshot can never block the
+    // bug-report flow itself.
+    callDiagnostics.value = await collectCallDiagnostics();
   }
 });
 
@@ -108,6 +118,7 @@ const handleSend = async () => {
       environment: environment.value,
       screenshots: screenshots.value.map((s) => s.base64),
       reporterAddress: authStore.address ?? undefined,
+      callDiagnostics: callDiagnostics.value,
     });
     console.log("[BugReport] created issue #", result.issueNumber, "url:", result.issueUrl);
     if (authStore.address && result.issueNumber) {

--- a/src/shared/lib/bug-report/__tests__/collect-call-diagnostics.test.ts
+++ b/src/shared/lib/bug-report/__tests__/collect-call-diagnostics.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetAudioStatus = vi.fn();
+const mockGetInviteThrottleSnapshot = vi.fn();
+
+vi.mock("@/shared/lib/native-calls", () => ({
+  nativeCallBridge: {
+    getAudioStatus: mockGetAudioStatus,
+    getInviteThrottleSnapshot: mockGetInviteThrottleSnapshot,
+  },
+}));
+
+describe("collectCallDiagnostics", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.resetModules();
+  });
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns EMPTY_CALL_DIAGNOSTICS on non-native platforms", async () => {
+    vi.doMock("@/shared/lib/platform", () => ({ isNative: false }));
+    const { collectCallDiagnostics, EMPTY_CALL_DIAGNOSTICS } = await import(
+      "../collect-call-diagnostics"
+    );
+
+    const out = await collectCallDiagnostics();
+    expect(out).toEqual(EMPTY_CALL_DIAGNOSTICS);
+    expect(mockGetAudioStatus).not.toHaveBeenCalled();
+    expect(mockGetInviteThrottleSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("merges audio status + invite history on native platforms", async () => {
+    vi.doMock("@/shared/lib/platform", () => ({ isNative: true }));
+    mockGetAudioStatus.mockResolvedValue({
+      mode: "MODE_IN_COMMUNICATION",
+      isSpeakerOn: true,
+      isBtScoOn: false,
+    });
+    mockGetInviteThrottleSnapshot.mockResolvedValue({
+      records: [
+        {
+          receivedAtMs: 100,
+          sentAtMs: 50,
+          deliveryLatencyMs: 50,
+          expired: false,
+          callId: "abc",
+        },
+        {
+          receivedAtMs: 200,
+          sentAtMs: 50,
+          deliveryLatencyMs: 150,
+          expired: true,
+          callId: "def",
+        },
+      ],
+    });
+
+    const { collectCallDiagnostics } = await import("../collect-call-diagnostics");
+    const out = await collectCallDiagnostics();
+
+    expect(out.audioMode).toBe("MODE_IN_COMMUNICATION");
+    expect(out.isSpeakerOn).toBe(true);
+    expect(out.isBtScoOn).toBe(false);
+    expect(out.inviteHistory).toHaveLength(2);
+    expect(out.expiredInviteCount).toBe(1);
+  });
+
+  it("falls back gracefully when native bridge throws", async () => {
+    vi.doMock("@/shared/lib/platform", () => ({ isNative: true }));
+    mockGetAudioStatus.mockRejectedValue(new Error("plugin not registered"));
+    mockGetInviteThrottleSnapshot.mockRejectedValue(new Error("missing"));
+
+    const { collectCallDiagnostics } = await import("../collect-call-diagnostics");
+    const out = await collectCallDiagnostics();
+
+    expect(out.audioMode).toBe("MODE_NORMAL");
+    expect(out.isSpeakerOn).toBe(false);
+    expect(out.isBtScoOn).toBe(false);
+    expect(out.inviteHistory).toEqual([]);
+    expect(out.expiredInviteCount).toBe(0);
+  });
+
+  it("treats malformed snapshot.records as empty array", async () => {
+    vi.doMock("@/shared/lib/platform", () => ({ isNative: true }));
+    mockGetAudioStatus.mockResolvedValue({
+      mode: "MODE_NORMAL",
+      isSpeakerOn: false,
+      isBtScoOn: false,
+    });
+    // Older native build returns null records
+    mockGetInviteThrottleSnapshot.mockResolvedValue({ records: null });
+
+    const { collectCallDiagnostics } = await import("../collect-call-diagnostics");
+    const out = await collectCallDiagnostics();
+
+    expect(out.inviteHistory).toEqual([]);
+    expect(out.expiredInviteCount).toBe(0);
+  });
+});

--- a/src/shared/lib/bug-report/bug-report-sender.ts
+++ b/src/shared/lib/bug-report/bug-report-sender.ts
@@ -189,6 +189,41 @@ async function formatBody(
     }
   }
 
+  // Session 25 / S3-S4: call-pipeline diagnostics. Rendered only when
+  // present so non-call bug reports stay short. Layout chosen so triage
+  // can scan delivery-latency at a glance and reach for the issue label
+  // (`s4-stale-invite`, `s3-fcm-throttle`, etc.) without a repro.
+  const diag = input.callDiagnostics;
+  if (diag) {
+    lines.push(
+      '',
+      '## Call diagnostics',
+      '| Field | Value |',
+      '|-------|-------|',
+      `| Audio mode | ${diag.audioMode} |`,
+      `| Speaker on | ${diag.isSpeakerOn ? 'yes' : 'no'} |`,
+      `| BT SCO on | ${diag.isBtScoOn ? 'yes' : 'no'} |`,
+      `| Recent invites | ${diag.inviteHistory.length} |`,
+      `| Expired invites | ${diag.expiredInviteCount} |`,
+    );
+    if (diag.inviteHistory.length > 0) {
+      lines.push(
+        '',
+        '<details><summary>FCM invite history</summary>',
+        '',
+        '| # | callId | latency (ms) | expired |',
+        '|---|--------|--------------|---------|',
+      );
+      diag.inviteHistory.forEach((r, i) => {
+        const callIdShort = r.callId ? r.callId.slice(0, 12) : '(none)';
+        lines.push(
+          `| ${i + 1} | \`${callIdShort}\` | ${r.deliveryLatencyMs} | ${r.expired ? 'yes' : 'no'} |`,
+        );
+      });
+      lines.push('</details>');
+    }
+  }
+
   return lines.join('\n');
 }
 

--- a/src/shared/lib/bug-report/collect-call-diagnostics.ts
+++ b/src/shared/lib/bug-report/collect-call-diagnostics.ts
@@ -1,0 +1,69 @@
+/**
+ * Session 25 / S3-S4: collect call-related diagnostics for the bug-report
+ * envelope. Lets us split S1 (accept-crash), S3 (FCM throttle), and S4
+ * (stale invite) when triaging user reports without asking them to
+ * reproduce.
+ *
+ * Pulls:
+ *   - last 5 FCM `m.call.invite` records (delivery latency + expiry)
+ *   - current AudioManager mode / speakerphone / BT SCO state
+ *
+ * Always non-throwing — a diagnostic collection failure must NEVER block
+ * the bug report itself.
+ */
+
+import { isNative } from "@/shared/lib/platform";
+import type {
+  InviteThrottleRecord,
+  InviteThrottleSnapshot,
+} from "@/shared/lib/native-calls";
+
+export interface BugReportCallDiagnostics {
+  /** AudioManager.mode as a string ("MODE_NORMAL", "MODE_IN_COMMUNICATION", ...). */
+  audioMode: string;
+  isSpeakerOn: boolean;
+  isBtScoOn: boolean;
+  /** Last 5 FCM `m.call.invite` records, oldest first. */
+  inviteHistory: InviteThrottleRecord[];
+  /** Convenience: how many of the recorded invites were already expired on arrival. */
+  expiredInviteCount: number;
+}
+
+export const EMPTY_CALL_DIAGNOSTICS: BugReportCallDiagnostics = {
+  audioMode: "MODE_NORMAL",
+  isSpeakerOn: false,
+  isBtScoOn: false,
+  inviteHistory: [],
+  expiredInviteCount: 0,
+};
+
+export async function collectCallDiagnostics(): Promise<BugReportCallDiagnostics> {
+  if (!isNative) return { ...EMPTY_CALL_DIAGNOSTICS };
+
+  // Lazy import — the bug-report module loads on web too, where this
+  // path is dead weight. Avoid pulling the native plugin graph until we
+  // know we're going to query it.
+  const { nativeCallBridge } = await import("@/shared/lib/native-calls");
+
+  const audioStatus = await nativeCallBridge.getAudioStatus().catch(() => ({
+    mode: "MODE_NORMAL",
+    isSpeakerOn: false,
+    isBtScoOn: false,
+  }));
+
+  const inviteSnapshot: InviteThrottleSnapshot = await nativeCallBridge
+    .getInviteThrottleSnapshot()
+    .catch(() => ({ records: [] }));
+
+  const inviteHistory = Array.isArray(inviteSnapshot.records)
+    ? inviteSnapshot.records
+    : [];
+
+  return {
+    audioMode: audioStatus.mode,
+    isSpeakerOn: audioStatus.isSpeakerOn,
+    isBtScoOn: audioStatus.isBtScoOn,
+    inviteHistory,
+    expiredInviteCount: inviteHistory.filter((r) => r.expired).length,
+  };
+}

--- a/src/shared/lib/bug-report/index.ts
+++ b/src/shared/lib/bug-report/index.ts
@@ -1,4 +1,9 @@
 export { collectEnvironment } from './collect-environment';
+export {
+  collectCallDiagnostics,
+  EMPTY_CALL_DIAGNOSTICS,
+} from './collect-call-diagnostics';
+export type { BugReportCallDiagnostics } from './collect-call-diagnostics';
 export { sendBugReport } from './bug-report-sender';
 export {
   computeReporterHash,

--- a/src/shared/lib/bug-report/types.ts
+++ b/src/shared/lib/bug-report/types.ts
@@ -22,4 +22,11 @@ export interface BugReportInput {
   screenshots?: string[]; // base64 array
   /** Bastyon address used to derive the anonymous reporter hash */
   reporterAddress?: string;
+  /**
+   * Session 25 / S3-S4: optional call-pipeline diagnostics. When the
+   * report is triggered from a call-related code path, the modal
+   * collects these so triage can split S1 (accept-crash), S3 (FCM
+   * throttle), and S4 (stale invite) without a repro.
+   */
+  callDiagnostics?: import('./collect-call-diagnostics').BugReportCallDiagnostics;
 }

--- a/src/shared/lib/native-calls/__tests__/invite-ttl.test.ts
+++ b/src/shared/lib/native-calls/__tests__/invite-ttl.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { isInviteEventExpired, DEFAULT_INVITE_LIFETIME_MS } from "../invite-ttl";
+
+describe("isInviteEventExpired", () => {
+  const now = 1_700_000_000_000;
+
+  it("treats fresh invites as not expired", () => {
+    expect(
+      isInviteEventExpired({ originServerTs: now - 5_000, now }),
+    ).toBe(false);
+  });
+
+  it("treats invites older than default lifetime as expired", () => {
+    expect(
+      isInviteEventExpired({
+        originServerTs: now - DEFAULT_INVITE_LIFETIME_MS - 1,
+        now,
+      }),
+    ).toBe(true);
+  });
+
+  it("uses content.lifetime when provided", () => {
+    // 30s lifetime, 31s old → expired
+    expect(
+      isInviteEventExpired({
+        originServerTs: now - 31_000,
+        lifetime: 30_000,
+        now,
+      }),
+    ).toBe(true);
+    // 30s lifetime, 29s old → not expired
+    expect(
+      isInviteEventExpired({
+        originServerTs: now - 29_000,
+        lifetime: 30_000,
+        now,
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to default lifetime for nullish content.lifetime", () => {
+    expect(
+      isInviteEventExpired({
+        originServerTs: now - DEFAULT_INVITE_LIFETIME_MS - 1,
+        lifetime: undefined,
+        now,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats non-positive timestamps as expired (defensive)", () => {
+    expect(isInviteEventExpired({ originServerTs: 0, now })).toBe(true);
+    expect(isInviteEventExpired({ originServerTs: -1, now })).toBe(true);
+  });
+
+  it("clamps absurdly large lifetime to a 5-minute ceiling", () => {
+    // A homeserver bug echoing a 1-hour lifetime should not let a stale
+    // invite leak through — this is exactly the S4 false-positive
+    // ringtone-after-hangup scenario.
+    expect(
+      isInviteEventExpired({
+        originServerTs: now - 6 * 60_000,
+        lifetime: 60 * 60_000,
+        now,
+      }),
+    ).toBe(true);
+  });
+
+  it("treats invite at exact lifetime boundary as expired", () => {
+    expect(
+      isInviteEventExpired({
+        originServerTs: now - 60_000,
+        lifetime: 60_000,
+        now,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/shared/lib/native-calls/index.ts
+++ b/src/shared/lib/native-calls/index.ts
@@ -3,3 +3,14 @@ export {
   consumePendingAnswerCallId,
   consumePendingRejectCallId,
 } from './native-call-bridge';
+export type {
+  AudioProbeResult,
+  InviteThrottleRecord,
+  InviteThrottleSnapshot,
+} from './native-call-bridge';
+export {
+  isInviteEventExpired,
+  DEFAULT_INVITE_LIFETIME_MS,
+  MAX_INVITE_LIFETIME_MS,
+} from './invite-ttl';
+export type { InviteAgeInput } from './invite-ttl';

--- a/src/shared/lib/native-calls/invite-ttl.ts
+++ b/src/shared/lib/native-calls/invite-ttl.ts
@@ -1,0 +1,68 @@
+/**
+ * TTL guard for `m.call.invite` events.
+ *
+ * Background — Session 25 / S4: when FCM delivery degrades on Android, the
+ * invite is retained on the homeserver and flushed during the next `/sync`
+ * (often minutes later). The Matrix SDK already arms a `setTimeout(...,
+ * invite.lifetime - event.getLocalAge())` that fires Hangup immediately if
+ * the invite is past its lifetime, so the SDK-driven path is safe.
+ *
+ * The two places that need an explicit guard are:
+ *   1. `feedMissedInviteToSDK` — the cold-start-from-push recovery walks
+ *      the timeline and force-feeds invite events back into
+ *      `callEventHandler.onRoomTimeline`. Feeding a long-stale invite here
+ *      makes the SDK ring/flash the UI for a beat before its own lifetime
+ *      timer fires, and triggers an extra round of native UI churn.
+ *   2. `FortaFirebaseMessagingService` — the FCM path launches
+ *      `IncomingCallActivity` from the push payload BEFORE Matrix /sync
+ *      delivers the event, so the SDK timer cannot help. The Kotlin side
+ *      uses the same logic via the `RemoteMessage.sentTime` proxy.
+ *
+ * The pure function lives here so both call sites share one definition and
+ * regressions are caught by a single test file.
+ */
+
+/**
+ * Default invite lifetime when the content does not specify one. Matches
+ * the Matrix SDK's `CALL_TIMEOUT_MS` (60s).
+ */
+export const DEFAULT_INVITE_LIFETIME_MS = 60_000;
+
+/**
+ * Hard ceiling on lifetime. Some homeservers / forks echo back surprisingly
+ * large lifetimes (e.g. 1 hour) which would silently disable the guard.
+ * Five minutes is well past any realistic ring-then-pickup window and
+ * still tight enough to prevent the user from being woken up by an invite
+ * the caller cancelled long ago.
+ */
+export const MAX_INVITE_LIFETIME_MS = 5 * 60_000;
+
+export interface InviteAgeInput {
+  /** `event.origin_server_ts` (or `RemoteMessage.sentTime` for the FCM path). */
+  originServerTs: number;
+  /** `event.content.lifetime`. Falls back to `DEFAULT_INVITE_LIFETIME_MS` when absent. */
+  lifetime?: number | null;
+  /** Override "now" — only used in tests. Production callers omit. */
+  now?: number;
+}
+
+/**
+ * Returns true when the invite is older than `min(lifetime, MAX_INVITE_LIFETIME_MS)`.
+ *
+ * Defensive: a non-positive `originServerTs` (event with corrupt or missing
+ * timestamp) is treated as expired so we never let a malformed invite
+ * through into the SDK or onto the screen.
+ */
+export function isInviteEventExpired(input: InviteAgeInput): boolean {
+  const { originServerTs } = input;
+  if (!originServerTs || originServerTs <= 0) return true;
+
+  const now = input.now ?? Date.now();
+  const rawLifetime =
+    typeof input.lifetime === "number" && input.lifetime > 0
+      ? input.lifetime
+      : DEFAULT_INVITE_LIFETIME_MS;
+  const lifetime = Math.min(rawLifetime, MAX_INVITE_LIFETIME_MS);
+  const age = now - originServerTs;
+  return age >= lifetime;
+}

--- a/src/shared/lib/native-calls/native-call-bridge.ts
+++ b/src/shared/lib/native-calls/native-call-bridge.ts
@@ -1,6 +1,7 @@
 import { registerPlugin } from '@capacitor/core';
 import { isNative } from '@/shared/lib/platform';
 import { NativeWebRTC } from '@/shared/lib/native-webrtc/native-webrtc-bridge';
+import { isInviteEventExpired } from './invite-ttl';
 
 /**
  * Shape returned by `NativeCall.probeAudioAvailability`. See
@@ -16,6 +17,27 @@ export interface AudioProbeResult {
    * conflicting use is detected, or the platform cannot enumerate it.
    */
   conflicting?: string[];
+}
+
+/**
+ * Single FCM `m.call.invite` record for the JS bug-reporter. See
+ * `InviteThrottleTracker.kt` for the data source.
+ */
+export interface InviteThrottleRecord {
+  /** When the FCM service handled the push (System.currentTimeMillis()). */
+  receivedAtMs: number;
+  /** RemoteMessage.sentTime — homeserver send time. */
+  sentAtMs: number;
+  /** Convenience field for envelope readers. */
+  deliveryLatencyMs: number;
+  /** Was the invite already past its lifetime when received? */
+  expired: boolean;
+  /** `call_id` from the FCM payload, "" when missing. */
+  callId: string;
+}
+
+export interface InviteThrottleSnapshot {
+  records: InviteThrottleRecord[];
 }
 
 interface NativeCallNativePlugin {
@@ -79,6 +101,11 @@ interface NativeCallNativePlugin {
     isSpeakerOn: boolean;
     isBtScoOn: boolean;
   }>;
+  /**
+   * Session 25 / S3-S4: snapshot of the last N FCM `m.call.invite`
+   * records. Surfaced by {@link NativeCallBridge.getInviteThrottleSnapshot}.
+   */
+  getInviteThrottleSnapshot(): Promise<InviteThrottleSnapshot>;
   addListener(event: 'callAnswered', cb: (data: { callId: string; roomId?: string }) => void): Promise<{ remove: () => void }>;
   addListener(event: 'callDeclined', cb: (data: { callId: string }) => void): Promise<{ remove: () => void }>;
   addListener(event: 'callEnded', cb: (data: { callId: string }) => void): Promise<{ remove: () => void }>;
@@ -419,7 +446,7 @@ class NativeCallBridge {
     try {
       const { getMatrixClientService } = await import('@/entities/matrix');
       const client = getMatrixClientService().client as
-        | { callEventHandler?: { onRoomTimeline: (e: unknown) => void; onSync: () => void }; getRooms?: () => Array<{ getLiveTimeline?: () => { getEvents?: () => Array<{ getType: () => string; getContent: () => Record<string, unknown> }> } }> }
+        | { callEventHandler?: { onRoomTimeline: (e: unknown) => void; onSync: () => void }; getRooms?: () => Array<{ getLiveTimeline?: () => { getEvents?: () => Array<{ getType: () => string; getTs?: () => number; getContent: () => Record<string, unknown> }> } }> }
         | undefined;
       if (!client?.callEventHandler || !client.getRooms) return false;
 
@@ -430,6 +457,27 @@ class NativeCallBridge {
           if (type !== 'm.call.invite' && !type.startsWith('org.matrix.call.')) continue;
           const content = event.getContent();
           if ((content as { call_id?: string }).call_id !== callId) continue;
+
+          // Session 25 / S4: stale-invite filter. The SDK's own
+          // initWithInvite arms a timer that fires Hangup the moment the
+          // invite age exceeds `content.lifetime`, but feeding the same
+          // event into onRoomTimeline still triggers a one-tick UI flash
+          // (Vue ringer template renders, then collapses) AND a native
+          // CallActivity launch on Android. On the cold-start-from-push
+          // path this manifests as the user opening the app to find a
+          // brief "ringing" surface for a call the caller cancelled
+          // minutes ago. Skip expired invites here so the recovery path
+          // does not republish them into the active surface.
+          const originServerTs = typeof event.getTs === 'function' ? event.getTs() : 0;
+          const lifetime = (content as { lifetime?: number | null }).lifetime ?? null;
+          if (isInviteEventExpired({ originServerTs, lifetime })) {
+            console.warn(
+              '[NativeCallBridge] feedMissedInviteToSDK: skipping expired invite',
+              { callId, originServerTs, lifetime },
+            );
+            return false;
+          }
+
           // Push into the handler's buffer and force it to process.
           client.callEventHandler.onRoomTimeline(event);
           client.callEventHandler.onSync();
@@ -606,6 +654,24 @@ class NativeCallBridge {
     } catch (e) {
       console.warn('[NativeCallBridge] getAudioStatus unavailable:', e);
       return { mode: 'MODE_NORMAL', isSpeakerOn: false, isBtScoOn: false };
+    }
+  }
+
+  /**
+   * Session 25 / S3-S4: pull the last N FCM `m.call.invite` records for
+   * the bug-reporter envelope. Returns an empty list on non-native
+   * platforms or when the native plugin is older than this build (the
+   * Capacitor bridge surfaces a "method not registered" error there).
+   */
+  async getInviteThrottleSnapshot(): Promise<InviteThrottleSnapshot> {
+    if (!isNative) return { records: [] };
+    try {
+      const res = await NativeCall.getInviteThrottleSnapshot();
+      const records = Array.isArray(res?.records) ? res.records : [];
+      return { records };
+    } catch (e) {
+      console.warn('[NativeCallBridge] getInviteThrottleSnapshot unavailable:', e);
+      return { records: [] };
     }
   }
 }


### PR DESCRIPTION
## Summary

Composite-bug fix targeting the Android call-degradation cycle reported on 1.10.14 (Session 25 / S4 + S3-telemetry slice). Source: `.planning/bug-fix-plan/research/CALLS-RECEIVE-DEGRADATION-RESEARCH.md`.

### S4 — stale invite false-ringer

When FCM delivery degrades on Android, the homeserver retains the `m.call.invite` and flushes it minutes later — we were waking users with the full-screen ringer for a call the caller had long since cancelled.

- **TTL guard in `feedMissedInviteToSDK`** — the cold-start-from-push recovery used to walk the timeline and force-feed any invite event back into the SDK. Now it drops events past `min(content.lifetime, 5min)`.
- **TTL guard in `FortaFirebaseMessagingService`** — the FCM service used to launch `IncomingCallActivity` immediately. Now it uses `RemoteMessage.sentTime` as an `origin_server_ts` proxy and skips expired invites (still forwards to JS so telemetry sees them).
- **Pure helpers** `isInviteEventExpired` (TS) and `InviteThrottleGuard` (Kotlin) so JS and native agree on the staleness window. 7+7 unit tests covering boundary, default lifetime, max ceiling, and defensive cases.

### S3 — FCM throttle visibility

Adds a 5-record rolling tracker so triage can split S1 (accept-crash), S3 (FCM throttle / Doze), and S4 (stale invite) without a repro.

- `InviteThrottleTracker` (pure Kotlin, thread-safe deque, 4 tests)
- `CallPlugin.getInviteThrottleSnapshot` exposes records to JS
- `collectCallDiagnostics` pulls audio mode + invite history into `BugReportInput.callDiagnostics` (4 tests)
- `BugReportModal` collects diagnostics alongside environment; `formatBody` renders a "Call diagnostics" section + collapsible invite-history table

### Scope

No behavioural change for the AudioRouter / accept-flow paths in this PR — the existing `lifecycleLock`, idempotent `start/stop`, and `STREAM_VOICE_CALL` ducking already cover the S1/S2 hardening that Session 25 originally proposed. Remaining state-machine work (explicit `awaitIdle` channel, pre-warm AudioSource on incoming) is deferred to a follow-up under-session **25a** so this fix can ship without touching the audio lifecycle.

## Test plan

- [x] `vitest run src/shared/lib/native-calls src/shared/lib/bug-report` — 40/40 pass
- [x] `invite-ttl.test.ts` 7 cases (boundary, default lifetime, max ceiling, defensive)
- [x] `collect-call-diagnostics.test.ts` 4 cases (web fallback, native happy path, throw recovery, malformed payload)
- [x] `InviteThrottleGuardTest.kt` 7 cases (mirrors TS suite)
- [x] `InviteThrottleTrackerTest.kt` 4 cases (rolling window, latency, expired count, clear)
- [x] `vue-tsc --noEmit` — no new type errors in modified files (47 pre-existing total, unchanged)
- [ ] Manual device verification on Android 14 — repro the S4 sequence (network drop → caller cancels → app reopens) and confirm no false ringer
- [ ] Bug-report envelope from a 1.10.x build — verify "Call diagnostics" section appears with `expiredInviteCount` and the latency table