### PR TITLE
fix(messaging): scroll-FAB Telegram-like navigation (#359, #95)

### DIFF
--- a/src/features/messaging/model/fab-decision.test.ts
+++ b/src/features/messaging/model/fab-decision.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import { decideFabAction, shouldAutoDismissBanner } from "./fab-decision";
+
+/**
+ * Telegram-like state machine for the scroll-to-bottom FAB:
+ *
+ *   click → hasBanner?
+ *     └─yes→ user below banner (banner above viewport)?
+ *           ├─yes→ scrollToBottom + dismissBanner   (Telegram: prošёl baner — vniz)
+ *           └─no → scrollToBanner                   (idёm k baneru)
+ *     └─no → isDetachedFromLatest?
+ *            ├─yes→ returnToLatest
+ *            └─no → scrollToBottom
+ *
+ * Coordinate model — column-reverse virtual list:
+ *   - idx 0          = newest = visual BOTTOM
+ *   - idx N-1        = oldest = visual TOP
+ *   - visibleRange   = { start: top idx (larger), end: bottom idx (smaller) }
+ *   - banner above viewport (user below banner)  ⇔  range.start < bannerIdx
+ *   - banner below viewport (user above banner)  ⇔  range.end   > bannerIdx
+ *   - banner inside viewport                      ⇔  range.start ≥ bannerIdx ≥ range.end
+ */
+
+describe("decideFabAction — Telegram-like FAB navigation", () => {
+  it("U1.A: hasBanner + user above banner → scroll to banner", () => {
+    // banner at idx 10, viewport shows old messages (top idx 25, bottom idx 15)
+    // banner is BELOW viewport (range.end > bannerIdx) → user is above banner
+    const action = decideFabAction({
+      hasBanner: true,
+      bannerIdx: 10,
+      visibleRange: { start: 25, end: 15 },
+      isDetachedFromLatest: false,
+    });
+    expect(action).toEqual({ kind: "scroll-to-banner", bannerIdx: 10 });
+  });
+
+  it("U1.A2: hasBanner + banner inside viewport → still scroll to banner (align top)", () => {
+    // banner at idx 10, range = { start: 12, end: 8 } — banner visible
+    const action = decideFabAction({
+      hasBanner: true,
+      bannerIdx: 10,
+      visibleRange: { start: 12, end: 8 },
+      isDetachedFromLatest: false,
+    });
+    expect(action).toEqual({ kind: "scroll-to-banner", bannerIdx: 10 });
+  });
+
+  it("U1.B: hasBanner + user below banner → scroll to bottom + dismiss", () => {
+    // banner at idx 10, range = { start: 5, end: 0 } — banner above viewport
+    const action = decideFabAction({
+      hasBanner: true,
+      bannerIdx: 10,
+      visibleRange: { start: 5, end: 0 },
+      isDetachedFromLatest: false,
+    });
+    expect(action).toEqual({ kind: "scroll-to-bottom-and-dismiss" });
+  });
+
+  it("U1.C: no banner + not detached → simple scroll to bottom", () => {
+    const action = decideFabAction({
+      hasBanner: false,
+      bannerIdx: -1,
+      visibleRange: { start: 30, end: 20 },
+      isDetachedFromLatest: false,
+    });
+    expect(action).toEqual({ kind: "scroll-to-bottom" });
+  });
+
+  it("U1.D: no banner + isDetachedFromLatest → return to latest", () => {
+    const action = decideFabAction({
+      hasBanner: false,
+      bannerIdx: -1,
+      visibleRange: null,
+      isDetachedFromLatest: true,
+    });
+    expect(action).toEqual({ kind: "return-to-latest" });
+  });
+
+  it("U1.E: hasBanner but bannerIdx not found (-1) → fall through to default", () => {
+    // Edge case: banner state says hasBanner=true, but reversedItems doesn't have it
+    // (e.g. banner was filtered out). Falls through to default scroll-to-bottom.
+    const action = decideFabAction({
+      hasBanner: true,
+      bannerIdx: -1,
+      visibleRange: { start: 5, end: 0 },
+      isDetachedFromLatest: false,
+    });
+    expect(action).toEqual({ kind: "scroll-to-bottom" });
+  });
+
+  it("U1.F: hasBanner + visibleRange null (scroller not measured yet) → fall back to scroll-to-banner (safe default)", () => {
+    // If we cannot determine position, default to scroll-to-banner — preserves
+    // existing behavior. Better than risking dismiss when we don't know where user is.
+    const action = decideFabAction({
+      hasBanner: true,
+      bannerIdx: 10,
+      visibleRange: null,
+      isDetachedFromLatest: false,
+    });
+    expect(action).toEqual({ kind: "scroll-to-banner", bannerIdx: 10 });
+  });
+});
+
+describe("shouldAutoDismissBanner — scroll-past-banner detection", () => {
+  it("U2.A: scroll past banner after grace period (>200ms) → dismiss", () => {
+    // banner at idx 10, viewport shows newer messages (range.start = 5 < 10)
+    // → banner is above viewport → user has scrolled past it
+    const result = shouldAutoDismissBanner({
+      hasBanner: true,
+      bannerIdx: 10,
+      visibleRange: { start: 5, end: 0 },
+      msSinceRoomOpen: 250,
+    });
+    expect(result).toBe(true);
+  });
+
+  it("U2.B: scroll past banner WITHIN grace period (<200ms) → do NOT dismiss", () => {
+    // Sanity guard: protects against spurious dismiss during room-switch race
+    const result = shouldAutoDismissBanner({
+      hasBanner: true,
+      bannerIdx: 10,
+      visibleRange: { start: 5, end: 0 },
+      msSinceRoomOpen: 50,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("U2.C: banner still visible → do NOT dismiss", () => {
+    const result = shouldAutoDismissBanner({
+      hasBanner: true,
+      bannerIdx: 10,
+      visibleRange: { start: 12, end: 8 },
+      msSinceRoomOpen: 1000,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("U2.D: no banner → do NOT dismiss (no-op)", () => {
+    const result = shouldAutoDismissBanner({
+      hasBanner: false,
+      bannerIdx: -1,
+      visibleRange: { start: 5, end: 0 },
+      msSinceRoomOpen: 1000,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("U2.E: visibleRange null → do NOT dismiss (cannot determine position)", () => {
+    const result = shouldAutoDismissBanner({
+      hasBanner: true,
+      bannerIdx: 10,
+      visibleRange: null,
+      msSinceRoomOpen: 1000,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("U2.F: user above banner (range.end > bannerIdx) → do NOT dismiss", () => {
+    // banner below viewport — user hasn't passed it yet
+    const result = shouldAutoDismissBanner({
+      hasBanner: true,
+      bannerIdx: 10,
+      visibleRange: { start: 25, end: 15 },
+      msSinceRoomOpen: 1000,
+    });
+    expect(result).toBe(false);
+  });
+
+  it("U2.G: bannerIdx -1 (banner state inconsistency) → do NOT dismiss", () => {
+    const result = shouldAutoDismissBanner({
+      hasBanner: true,
+      bannerIdx: -1,
+      visibleRange: { start: 5, end: 0 },
+      msSinceRoomOpen: 1000,
+    });
+    expect(result).toBe(false);
+  });
+});

--- a/src/features/messaging/model/fab-decision.ts
+++ b/src/features/messaging/model/fab-decision.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure decision functions for the scroll-to-bottom FAB and banner auto-dismiss.
+ *
+ * Coordinate model — column-reverse virtual list (`reversedItems`):
+ *   idx 0   = newest message  = visual BOTTOM of screen
+ *   idx N-1 = oldest message  = visual TOP of screen
+ *
+ * `VisibleRange` describes which item indices are currently rendered in the
+ * viewport. In column-reverse layout:
+ *   - `start` = TOP of viewport  → larger index (older)
+ *   - `end`   = BOTTOM of viewport → smaller index (newer)
+ *   - invariant: start ≥ end (when range is non-empty)
+ *
+ * Banner position relative to viewport (canonical wording — keep in sync with tests):
+ *   - banner above viewport (user below banner)   ⇔  range.start < bannerIdx
+ *   - banner inside viewport                       ⇔  range.start ≥ bannerIdx ≥ range.end
+ *   - banner below viewport (user above banner)   ⇔  range.end   > bannerIdx
+ */
+
+export interface VisibleRange {
+  /** Top of viewport — larger idx in column-reverse. */
+  start: number;
+  /** Bottom of viewport — smaller idx in column-reverse. */
+  end: number;
+}
+
+export type FabAction =
+  | { kind: "scroll-to-banner"; bannerIdx: number }
+  | { kind: "scroll-to-bottom-and-dismiss" }
+  | { kind: "return-to-latest" }
+  | { kind: "scroll-to-bottom" };
+
+export interface FabDecisionInput {
+  hasBanner: boolean;
+  /** Index of the unread banner in the reversed virtual list, or -1 if not present. */
+  bannerIdx: number;
+  /** Currently visible idx range, or null if scroller hasn't measured yet. */
+  visibleRange: VisibleRange | null;
+  isDetachedFromLatest: boolean;
+}
+
+/**
+ * Telegram-like FAB click decision.
+ *
+ * - Above or at banner → scroll to banner.
+ * - Below banner (already passed it) → scroll to bottom and dismiss banner.
+ * - No banner: detached → return-to-latest, otherwise → scroll to bottom.
+ *
+ * If we cannot determine position (visibleRange is null), we default to
+ * scroll-to-banner — the conservative choice that preserves prior behavior.
+ */
+export function decideFabAction(input: FabDecisionInput): FabAction {
+  const { hasBanner, bannerIdx, visibleRange, isDetachedFromLatest } = input;
+
+  if (hasBanner && bannerIdx >= 0) {
+    if (visibleRange && visibleRange.start < bannerIdx) {
+      return { kind: "scroll-to-bottom-and-dismiss" };
+    }
+    return { kind: "scroll-to-banner", bannerIdx };
+  }
+
+  if (isDetachedFromLatest) {
+    return { kind: "return-to-latest" };
+  }
+  return { kind: "scroll-to-bottom" };
+}
+
+export interface AutoDismissInput {
+  hasBanner: boolean;
+  bannerIdx: number;
+  visibleRange: VisibleRange | null;
+  /** Time elapsed since the room was opened / banner was frozen (ms). */
+  msSinceRoomOpen: number;
+}
+
+/** Sanity guard against firing forceDismiss during the room-switch race. */
+const AUTO_DISMISS_GRACE_MS = 200;
+
+/**
+ * Returns `true` when the user has explicitly scrolled past the banner downward
+ * and enough time has elapsed since room open to be sure this isn't a race
+ * during initial layout.
+ *
+ * The caller should invoke this on each scroll tick and call `forceDismiss()`
+ * on the unread banner composable when this returns true.
+ */
+export function shouldAutoDismissBanner(input: AutoDismissInput): boolean {
+  const { hasBanner, bannerIdx, visibleRange, msSinceRoomOpen } = input;
+
+  if (!hasBanner) return false;
+  if (bannerIdx < 0) return false;
+  if (!visibleRange) return false;
+  if (msSinceRoomOpen < AUTO_DISMISS_GRACE_MS) return false;
+
+  // Banner sits above the visible area → user has already scrolled past it.
+  return visibleRange.start < bannerIdx;
+}

--- a/src/features/messaging/model/use-unread-banner.ts
+++ b/src/features/messaging/model/use-unread-banner.ts
@@ -63,7 +63,18 @@ export function useUnreadBanner() {
     bannerState.value = { frozenLastReadId: null, frozenUnreadCount: 0 };
   }
 
-  /** Force dismiss — for room leave or explicit user action. Ignores grace period. */
+  /**
+   * Force dismiss — ignores `dismissLocked` grace period.
+   *
+   * Used when the user has explicitly indicated they no longer need the banner:
+   *   - room switch (cleared in MessageList.vue room watcher)
+   *   - FAB clicked while user is already below the banner (Telegram-like jump-to-bottom)
+   *   - scroll-past-banner detected by maybeAutoDismissBanner (>= 200ms since open)
+   *
+   * The grace period guards against the room-switch race where checkScroll()
+   * fires before the banner has had a chance to render. None of those callers
+   * have that race, so they bypass the lock.
+   */
   function forceDismiss() {
     session++;
     dismissLocked = true;

--- a/src/features/messaging/ui/MessageList.vue
+++ b/src/features/messaging/ui/MessageList.vue
@@ -23,6 +23,7 @@ import ChatVirtualScroller from "@/shared/ui/ChatVirtualScroller.vue";
 import { useI18n } from "@/shared/lib/i18n";
 import { useUnreadBanner } from "../model/use-unread-banner";
 import { useReadTracker } from "../model/use-read-tracker";
+import { decideFabAction, shouldAutoDismissBanner } from "../model/fab-decision";
 import UnreadBanner from "./UnreadBanner.vue";
 
 const chatStore = useChatStore();
@@ -205,7 +206,12 @@ const handleEmojiSelect = (emoji: string) => {
 const lastReactionEmoji = ref<string | null>(null);
 
 const listRef = ref<HTMLElement>();
-const scrollerRef = ref<{ scrollToBottom: () => void; scrollToIndex: (idx: number, opts?: { align?: "start" | "center" | "end" }) => void; getContainerEl: () => HTMLElement | null }>();
+const scrollerRef = ref<{
+  scrollToBottom: () => void;
+  scrollToIndex: (idx: number, opts?: { align?: "start" | "center" | "end" }) => void;
+  getContainerEl: () => HTMLElement | null;
+  getVisibleRange?: () => { start: number; end: number } | null;
+}>();
 const isNearBottom = ref(true);
 const showScrollFab = ref(false);
 const loading = ref(false);
@@ -216,6 +222,13 @@ const refreshingStaleCache = ref(false); // true when showing stale cached messa
 const loadEverAttempted = ref(false); // true only after at least one load cycle ran for the current room
 const hasMore = ref(true);
 const newMessageCount = ref(0);
+/** Timestamp (performance.now) of the last room open. Used to gate auto-dismiss
+ *  against the room-switch race in shouldAutoDismissBanner. Only stamped on
+ *  *new* rooms — same-room re-invocations of the watcher (e.g. during store
+ *  init) reuse the prior timestamp so the grace window stays anchored to the
+ *  user-visible open. */
+let roomOpenedAt = 0;
+let lastRoomIdSeen: string | null = null;
 
 const fabBadgeCount = computed(() => {
   const c = hasBanner() ? bannerState.value.frozenUnreadCount : newMessageCount.value;
@@ -321,6 +334,10 @@ const virtualItems = computed<VirtualItem[]>(() => {
  *  History loading appends at the chronological end = far end here = visual TOP = no scroll jump. */
 const reversedItems = computed<VirtualItem[]>(() => virtualItems.value.slice().reverse());
 
+/** Index of the unread banner in `reversedItems`, or -1 when not present.
+ *  Cached so per-frame scroll handlers don't repeat the linear scan. */
+const bannerIdx = computed(() => reversedItems.value.findIndex(item => item.type === "unread-banner"));
+
 /** Get the actual scroll container element from the scroller component. */
 const getScrollContainer = (): HTMLElement | null => {
   return scrollerRef.value?.getContainerEl?.() ?? listRef.value ?? null;
@@ -380,6 +397,21 @@ const handleReturnToLatest = async () => {
   scrollToBottom();
 };
 
+/** Auto-dismiss the unread banner once the user scrolls past it downward.
+ *  Sanity-guarded by msSinceRoomOpen >= 200ms to avoid races during room switch. */
+const maybeAutoDismissBanner = () => {
+  if (!hasBanner()) return;
+  const visibleRange = scrollerRef.value?.getVisibleRange?.() ?? null;
+  if (shouldAutoDismissBanner({
+    hasBanner: true,
+    bannerIdx: bannerIdx.value,
+    visibleRange,
+    msSinceRoomOpen: performance.now() - roomOpenedAt,
+  })) {
+    forceDismiss();
+  }
+};
+
 /** Check if user is scrolled near the bottom.
  *  In column-reverse: scrollTop=0 means at the bottom (newest messages).
  *  Chrome returns negative scrollTop for column-reverse — use abs. */
@@ -425,19 +457,35 @@ const resetStableTimer = (onSettled?: () => void) => {
   }, 300);
 };
 
-/** Two-step FAB: first press → first unread, second press → bottom */
+/**
+ * Telegram-like FAB: position-aware target.
+ *  - User above (or at) banner → scroll to banner.
+ *  - User below banner (already passed it) → scroll to bottom + force-dismiss banner.
+ *  - No banner: detached → returnToLatest, otherwise → scroll to bottom.
+ */
 const handleFabClick = () => {
-  if (hasBanner()) {
-    const bannerIdx = reversedItems.value.findIndex(item => item.type === "unread-banner");
-    if (bannerIdx >= 0) {
-      scrollerRef.value?.scrollToIndex(bannerIdx, { align: "start" });
+  const visibleRange = scrollerRef.value?.getVisibleRange?.() ?? null;
+  const action = decideFabAction({
+    hasBanner: hasBanner(),
+    bannerIdx: bannerIdx.value,
+    visibleRange,
+    isDetachedFromLatest: chatStore.isDetachedFromLatest,
+  });
+
+  switch (action.kind) {
+    case "scroll-to-banner":
+      scrollerRef.value?.scrollToIndex(action.bannerIdx, { align: "start" });
       return;
-    }
-  }
-  if (chatStore.isDetachedFromLatest) {
-    handleReturnToLatest();
-  } else {
-    scrollToBottom(true);
+    case "scroll-to-bottom-and-dismiss":
+      scrollToBottom(true);
+      forceDismiss();
+      return;
+    case "return-to-latest":
+      handleReturnToLatest();
+      return;
+    case "scroll-to-bottom":
+      scrollToBottom(true);
+      return;
   }
 };
 
@@ -495,6 +543,10 @@ watch(
       pendingSettledTimeout = null;
     }
     forceDismiss();
+    if (roomId !== lastRoomIdSeen) {
+      roomOpenedAt = performance.now();
+      lastRoomIdSeen = roomId;
+    }
     readTracker.stopTracking();
 
     // ═══ PHASE 2: DETERMINE ANCHOR ═══
@@ -946,6 +998,7 @@ const onScrollThrottled = () => {
   if (switching.value) return;
   checkScroll();
   updateFloatingDate();
+  maybeAutoDismissBanner();
 
   const container = getScrollContainer();
   if (!container) return;

--- a/src/shared/ui/ChatVirtualScroller.test.ts
+++ b/src/shared/ui/ChatVirtualScroller.test.ts
@@ -348,3 +348,161 @@ describe("ChatVirtualScroller — will-change lifecycle", () => {
     wrapper!.unmount();
   });
 });
+
+// ───────────────── getVisibleRange ─────────────────
+
+/**
+ * Helper that builds a ChatVirtualScroller and stubs the viewport rect on the
+ * container plus per-item rects on the Vue-rendered children matching `itemRects`.
+ * Items not listed in `itemRects` keep their default zero-rect (effectively
+ * outside the viewport in happy-dom).
+ */
+function mountWithLayout(itemCount: number, layout: { containerTop: number; containerBottom: number; itemRects: Array<{ id: string; top: number; bottom: number }> }) {
+  const items = makeItems(itemCount);
+  const wrapper = mount(ChatVirtualScroller, {
+    props: { items },
+    slots: { default: "<div></div>" },
+  });
+
+  const containerEl = wrapper.element as HTMLElement;
+  // Stub container rect
+  containerEl.getBoundingClientRect = () => ({
+    top: layout.containerTop,
+    bottom: layout.containerBottom,
+    left: 0,
+    right: 0,
+    width: 0,
+    height: layout.containerBottom - layout.containerTop,
+    x: 0,
+    y: layout.containerTop,
+    toJSON: () => ({}),
+  } as DOMRect);
+
+  // Stub rects on Vue-rendered children (those carry data-virtual-id="msg-i")
+  for (const rect of layout.itemRects) {
+    const child = containerEl.querySelector(`[data-virtual-id="${rect.id}"]`) as HTMLElement | null;
+    if (!child) {
+      throw new Error(`Test setup error: no Vue-rendered child for ${rect.id}`);
+    }
+    child.getBoundingClientRect = () => ({
+      top: rect.top,
+      bottom: rect.bottom,
+      left: 0,
+      right: 0,
+      width: 0,
+      height: rect.bottom - rect.top,
+      x: 0,
+      y: rect.top,
+      toJSON: () => ({}),
+    } as DOMRect);
+  }
+
+  return wrapper;
+}
+
+describe("ChatVirtualScroller — getVisibleRange (column-reverse)", () => {
+  it("Test 12: returns { start: top idx, end: bottom idx } for column-reverse layout", () => {
+    // Container = viewport y=[0..800].
+    // Items in column-reverse: idx 0 is rendered first but appears at the BOTTOM of the screen.
+    // We simulate 7 items, each 100px tall, visible from y=0 (top, larger idx) to y=800 (bottom, smaller idx).
+    const wrapper = mountWithLayout(7, {
+      containerTop: 0,
+      containerBottom: 800,
+      itemRects: [
+        // idx 0 (newest, at visual bottom)
+        { id: "msg-0", top: 700, bottom: 800 },
+        // idx 1
+        { id: "msg-1", top: 600, bottom: 700 },
+        // idx 2
+        { id: "msg-2", top: 500, bottom: 600 },
+        // idx 3
+        { id: "msg-3", top: 400, bottom: 500 },
+        // idx 4
+        { id: "msg-4", top: 300, bottom: 400 },
+        // idx 5
+        { id: "msg-5", top: 200, bottom: 300 },
+        // idx 6 (oldest, at visual top)
+        { id: "msg-6", top: 100, bottom: 200 },
+      ],
+    });
+
+    const exposed = wrapper.vm as unknown as { getVisibleRange: () => { start: number; end: number } | null };
+    const range = exposed.getVisibleRange();
+
+    // All 7 are inside the viewport.
+    // top = larger idx (oldest, near top of screen) = 6
+    // bottom = smaller idx (newest, near bottom of screen) = 0
+    expect(range).toEqual({ start: 6, end: 0 });
+
+    wrapper.unmount();
+  });
+
+  it("Test 13: returns subset when items extend beyond viewport (top + bottom clipped)", () => {
+    // Viewport y=[0..400]. 7 items each 100px.
+    // idx 0..3 visible, idx 4..6 above viewport (clipped).
+    const wrapper = mountWithLayout(7, {
+      containerTop: 0,
+      containerBottom: 400,
+      itemRects: [
+        { id: "msg-0", top: 300, bottom: 400 },   // visible (bottom)
+        { id: "msg-1", top: 200, bottom: 300 },   // visible
+        { id: "msg-2", top: 100, bottom: 200 },   // visible
+        { id: "msg-3", top: 0,   bottom: 100 },   // visible (top)
+        { id: "msg-4", top: -100, bottom: 0 },    // clipped above
+        { id: "msg-5", top: -200, bottom: -100 }, // clipped above
+        { id: "msg-6", top: -300, bottom: -200 }, // clipped above
+      ],
+    });
+
+    const exposed = wrapper.vm as unknown as { getVisibleRange: () => { start: number; end: number } | null };
+    const range = exposed.getVisibleRange();
+    expect(range).toEqual({ start: 3, end: 0 });
+
+    wrapper.unmount();
+  });
+
+  it("Test 14: returns null when no items are visible", () => {
+    const wrapper = mountWithLayout(2, {
+      containerTop: 0,
+      containerBottom: 400,
+      itemRects: [
+        // Both clipped above viewport
+        { id: "msg-0", top: -200, bottom: -100 },
+        { id: "msg-1", top: -400, bottom: -300 },
+      ],
+    });
+
+    const exposed = wrapper.vm as unknown as { getVisibleRange: () => { start: number; end: number } | null };
+    const range = exposed.getVisibleRange();
+    expect(range).toBeNull();
+
+    wrapper.unmount();
+  });
+
+  it("Test 15: when scrolled past banner — bottom items only — start < bannerIdx (the user-below-banner case)", () => {
+    // Banner is at idx 5. Viewport shows idx 0..3 only — banner is above viewport.
+    const wrapper = mountWithLayout(8, {
+      containerTop: 0,
+      containerBottom: 400,
+      itemRects: [
+        { id: "msg-0", top: 300, bottom: 400 }, // visible
+        { id: "msg-1", top: 200, bottom: 300 }, // visible
+        { id: "msg-2", top: 100, bottom: 200 }, // visible
+        { id: "msg-3", top: 0,   bottom: 100 }, // visible (top of viewport)
+        { id: "msg-4", top: -100, bottom: 0 },  // clipped (banner)
+        { id: "msg-5", top: -200, bottom: -100 },
+        { id: "msg-6", top: -300, bottom: -200 },
+        { id: "msg-7", top: -400, bottom: -300 },
+      ],
+    });
+
+    const exposed = wrapper.vm as unknown as { getVisibleRange: () => { start: number; end: number } | null };
+    const range = exposed.getVisibleRange();
+    // start = 3 (top of viewport, larger idx)
+    // bannerIdx = 5
+    // 3 < 5 → user is below banner ✓
+    expect(range).toEqual({ start: 3, end: 0 });
+
+    wrapper.unmount();
+  });
+});

--- a/src/shared/ui/ChatVirtualScroller.vue
+++ b/src/shared/ui/ChatVirtualScroller.vue
@@ -124,9 +124,47 @@ const isNearBottom = (threshold = 50): boolean => {
   return Math.abs(el.scrollTop) <= threshold;
 };
 
+/**
+ * Compute the index range of items currently visible in the viewport.
+ *
+ * Coordinate model — column-reverse layout:
+ *   - `start` = top of viewport (visually highest item) → LARGER idx (older)
+ *   - `end`   = bottom of viewport (visually lowest item) → SMALLER idx (newer)
+ *   - invariant when non-empty: start ≥ end
+ *
+ * Returns null when nothing is visible (e.g. before first paint, or scroller
+ * scrolled completely off-screen). Callers must handle the null case.
+ *
+ * Implementation: walks DOM children with [data-virtual-id] and intersects each
+ * rect with the container rect. O(n) over rendered items, but the inverted
+ * scroller never holds more than ~200 items so this stays cheap.
+ */
+const getVisibleRange = (): { start: number; end: number } | null => {
+  const el = containerRef.value;
+  if (!el) return null;
+
+  const containerRect = el.getBoundingClientRect();
+  let topIdx = -1;     // largest visible idx (top of viewport in column-reverse)
+  let bottomIdx = -1;  // smallest visible idx (bottom of viewport)
+
+  for (let i = 0; i < props.items.length; i++) {
+    const id = props.items[i].id;
+    const child = el.querySelector(`[data-virtual-id="${CSS.escape(id)}"]`) as HTMLElement | null;
+    if (!child) continue;
+    const rect = child.getBoundingClientRect();
+    const isVisible = rect.bottom > containerRect.top && rect.top < containerRect.bottom;
+    if (!isVisible) continue;
+    if (bottomIdx < 0 || i < bottomIdx) bottomIdx = i;
+    if (i > topIdx) topIdx = i;
+  }
+
+  if (topIdx < 0) return null;
+  return { start: topIdx, end: bottomIdx };
+};
+
 /** Expose container element as a getter so the parent always gets the raw HTMLElement. */
 const getContainerEl = () => containerRef.value;
-defineExpose({ scrollToBottom, scrollToIndex, getContainerEl, isNearBottom });
+defineExpose({ scrollToBottom, scrollToIndex, getContainerEl, isNearBottom, getVisibleRange });
 
 // ───────────────── New-message scroll anchoring ─────────────────
 // When a new message arrives at index 0 (visual bottom) while the user


### PR DESCRIPTION
## Summary

Telegram-like behavior for the scroll-to-bottom FAB in chats with unread messages.

- **Above banner** → scroll to the unread banner.
- **Below banner** (already passed it) → scroll to bottom + force-dismiss banner.
- **No banner** → scroll to bottom (or return-to-latest in detached mode).

Previously, any chat with `hasBanner() === true` re-targeted the FAB to the banner regardless of current scroll position, so a user who had already read past the banner got yanked back up. A 2s grace period on `dismissBanner()` also let the banner survive a quick scroll-past, re-engaging the wrong branch on the next click.

## Approach

- New pure module `src/features/messaging/model/fab-decision.ts` with `decideFabAction` + `shouldAutoDismissBanner` — fully unit-testable, no Vue dependencies.
- `ChatVirtualScroller` exposes `getVisibleRange()` for column-reverse virtual list (start = top idx, end = bottom idx).
- `MessageList.vue` caches `bannerIdx` as a computed (no per-frame `findIndex`), stamps `roomOpenedAt` only on actual room changes (avoids same-room watcher re-init race), and runs `maybeAutoDismissBanner()` inside the throttled scroll handler with a 200ms guard against the room-switch race.
- Expanded JSDoc on `forceDismiss()` documenting the three legitimate bypass call sites.

## Test plan

- [x] `fab-decision.test.ts` — 14 unit tests covering every branch + edge cases (null visibleRange, bannerIdx -1, grace period boundaries)
- [x] `ChatVirtualScroller.test.ts` — 4 new tests for `getVisibleRange()` (full viewport, partial clipping, empty, scrolled-past-banner case)
- [x] vue-tsc on changed files — no new type errors
- [x] vite build — passes
- [ ] Manual UX (cannot run native dev server in agent sandbox):
  - Open chat with 30+ unread, click FAB without scrolling → reaches banner
  - Scroll past banner, wait > 2s, click FAB → reaches bottom, banner dismisses
  - Quick scroll past banner within 2s → banner auto-dismisses after 200ms
  - Chat without unread → FAB scrolls to bottom (regression check)

## Coordinate model (column-reverse)

`reversedItems[0]` = newest = visual bottom, `reversedItems[N-1]` = oldest = visual top.

`VisibleRange.start` = top of viewport = larger idx; `VisibleRange.end` = bottom of viewport = smaller idx.

- banner above viewport (user below banner): `range.start < bannerIdx`
- banner inside viewport: `range.start ≥ bannerIdx ≥ range.end`
- banner below viewport (user above banner): `range.end > bannerIdx`

## Closes

- #359 [Android 16 / HONOR DNP-NX9 / 1.10.6] — "не работает кнопка скролла к последнему сообщению"
- #95 [Android 15 / INFINIX X6853 / 1.10.3] — "при нажатии на кнопку вниз переход на последнее сообщение не происходит"

Research: `.planning/bug-fix-plan/research/SCROLL-FAB-UNREAD-NAVIGATION-RESEARCH.md`