### PR TITLE
fix(rooms): public group + freshly-created group stay in sidebar (Session 28)

### DIFF
--- a/src/entities/chat/lib/preserve-pending-rooms.test.ts
+++ b/src/entities/chat/lib/preserve-pending-rooms.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { preservePendingRooms, PENDING_GRACE_MS } from "./preserve-pending-rooms";
+import type { ChatRoom } from "../model/types";
+
+function makeRoom(overrides: Partial<ChatRoom> = {}): ChatRoom {
+  return {
+    id: "!room:server",
+    name: "Room",
+    unreadCount: 0,
+    members: ["a"],
+    isGroup: true,
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("preservePendingRooms", () => {
+  const NOW = 1_000_000_000_000;
+
+  it("preserves a recently-added room missing from the new SDK snapshot", () => {
+    const fresh = makeRoom({ id: "!fresh:s", updatedAt: NOW - 1000 });
+    const old = makeRoom({ id: "!old:s", updatedAt: NOW - 60_000 });
+    const existing = [fresh, old];
+    const incoming = [makeRoom({ id: "!old:s", updatedAt: NOW - 60_000 })];
+    const incomingIds = new Set(incoming.map(r => r.id));
+
+    const preserved = preservePendingRooms({
+      existingRooms: existing,
+      incomingRoomIds: incomingIds,
+      nowMs: NOW,
+    });
+
+    expect(preserved.map(r => r.id)).toEqual(["!fresh:s"]);
+  });
+
+  it("drops rooms older than the grace window", () => {
+    const stale = makeRoom({
+      id: "!stale:s",
+      updatedAt: NOW - PENDING_GRACE_MS - 1000,
+    });
+    const incomingIds = new Set<string>();
+
+    const preserved = preservePendingRooms({
+      existingRooms: [stale],
+      incomingRoomIds: incomingIds,
+      nowMs: NOW,
+    });
+
+    expect(preserved).toEqual([]);
+  });
+
+  it("does not preserve rooms already present in the SDK snapshot", () => {
+    const recent = makeRoom({ id: "!recent:s", updatedAt: NOW - 100 });
+    const incomingIds = new Set(["!recent:s"]);
+
+    const preserved = preservePendingRooms({
+      existingRooms: [recent],
+      incomingRoomIds: incomingIds,
+      nowMs: NOW,
+    });
+
+    expect(preserved).toEqual([]);
+  });
+
+  it("treats missing updatedAt as ancient (drops it)", () => {
+    const noTs = makeRoom({ id: "!nots:s" });
+    // Force missing field to verify the ?? 0 fallback drops it.
+    delete (noTs as unknown as Record<string, unknown>).updatedAt;
+    const incomingIds = new Set<string>();
+
+    const preserved = preservePendingRooms({
+      existingRooms: [noTs],
+      incomingRoomIds: incomingIds,
+      nowMs: NOW,
+    });
+
+    expect(preserved).toEqual([]);
+  });
+
+  it("returns rooms in the order they appear in existingRooms", () => {
+    const a = makeRoom({ id: "!a:s", updatedAt: NOW - 500 });
+    const b = makeRoom({ id: "!b:s", updatedAt: NOW - 100 });
+    const c = makeRoom({ id: "!c:s", updatedAt: NOW - 200 });
+
+    const preserved = preservePendingRooms({
+      existingRooms: [a, b, c],
+      incomingRoomIds: new Set<string>(),
+      nowMs: NOW,
+    });
+
+    expect(preserved.map(r => r.id)).toEqual(["!a:s", "!b:s", "!c:s"]);
+  });
+
+  it("PENDING_GRACE_MS is 30 seconds", () => {
+    // Pin the constant — Matrix /sync typically delivers within 1-30s; this
+    // window covers the worst case while still dropping genuinely-failed
+    // creates so they don't linger in the sidebar forever.
+    expect(PENDING_GRACE_MS).toBe(30_000);
+  });
+});

--- a/src/entities/chat/lib/preserve-pending-rooms.ts
+++ b/src/entities/chat/lib/preserve-pending-rooms.ts
@@ -1,0 +1,43 @@
+import type { ChatRoom } from "../model/types";
+
+/**
+ * Grace window for rooms that were locally added (e.g. via `createGroup`)
+ * but haven't been delivered to the Matrix SDK by `/sync` yet. The full
+ * room refresh otherwise atomically replaces `rooms.value` with whatever
+ * the SDK currently knows about — dropping the optimistic entry until the
+ * next sync wins it back. With this window the entry stays visible for up
+ * to 30s, which covers the worst-case sync latency observed in the field.
+ */
+export const PENDING_GRACE_MS = 30_000;
+
+interface PreservePendingRoomsArgs {
+  /** Current rooms tracked by the store (`rooms.value`). */
+  existingRooms: ChatRoom[];
+  /** Set of room ids the SDK currently knows about (post-filter). */
+  incomingRoomIds: Set<string>;
+  /** Reference time used for the grace check. */
+  nowMs: number;
+}
+
+/**
+ * Returns the subset of `existingRooms` that should be preserved despite
+ * being absent from the incoming SDK snapshot, because they were added
+ * recently enough that the SDK may still be catching up via `/sync`.
+ *
+ * Pure function — easy to test in isolation. The caller (`fullRoomRefresh`)
+ * appends the result to `newRooms` before the atomic publish.
+ */
+export function preservePendingRooms({
+  existingRooms,
+  incomingRoomIds,
+  nowMs,
+}: PreservePendingRoomsArgs): ChatRoom[] {
+  const cutoff = nowMs - PENDING_GRACE_MS;
+  const out: ChatRoom[] = [];
+  for (const r of existingRooms) {
+    if (incomingRoomIds.has(r.id)) continue;
+    if ((r.updatedAt ?? 0) <= cutoff) continue;
+    out.push(r);
+  }
+  return out;
+}

--- a/src/entities/chat/model/__tests__/set-room-public-visibility.test.ts
+++ b/src/entities/chat/model/__tests__/set-room-public-visibility.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression tests for Session 28 — public group / freshly-created group
+ * disappearing from sidebar.
+ *
+ * Bug U1-U3: Session 21 (PR #71) added a write of
+ * `m.room.history_visibility = "world_readable"` whenever a room is toggled
+ * public. The pre-existing sidebar filter `isStreamHistoryVisibility` treats
+ * `world_readable` as a broadcast/stream marker and excludes those rooms —
+ * so every newly-toggled-public group disappeared from the chat list.
+ *
+ * Fix: stop writing `world_readable` on public toggle; on `public→private`,
+ * revert any legacy `world_readable` back to `shared` so previously-broken
+ * rooms become visible again. Bastyon-chat reference (vuex/store.js:790-791)
+ * confirms `world_readable` is reserved for broadcast/stream rooms only.
+ *
+ * These tests pin source-code wiring so the regression cannot silently come
+ * back. See `.planning/bug-fix-plan/research/PUBLIC-GROUP-DISAPPEARS-FROM-SIDEBAR-RESEARCH.md`.
+ */
+
+const chatStoreSource = readFileSync(
+  resolve(__dirname, "../chat-store.ts"),
+  "utf-8",
+);
+
+function getSetRoomPublicBody(): string {
+  const startIdx = chatStoreSource.indexOf("const setRoomPublic");
+  if (startIdx < 0) throw new Error("setRoomPublic not found in chat-store.ts");
+  // Function ends at the next top-level const declaration. setRoomPublic is
+  // followed by joinRoomById per current layout; bound on that to be safe.
+  const endIdx = chatStoreSource.indexOf("const joinRoomById", startIdx);
+  if (endIdx < 0) throw new Error("joinRoomById not found after setRoomPublic");
+  return chatStoreSource.slice(startIdx, endIdx);
+}
+
+describe("setRoomPublic — does NOT write world_readable on public toggle (Session 28)", () => {
+  it("public branch never sends history_visibility=world_readable", () => {
+    const body = getSetRoomPublicBody();
+
+    // Locate the `if (isPublic)` branch (the public-write path) and assert
+    // it does NOT contain the world_readable write that Session 21 added.
+    const publicBranchIdx = body.indexOf("if (isPublic)");
+    // It's OK if the branch has been removed entirely — the assertion below
+    // covers that case via the negative regex over the whole body.
+    if (publicBranchIdx >= 0) {
+      // Extract a generous slice from `if (isPublic)` until the closing
+      // brace of setRoomPublic. We just need to make sure no `world_readable`
+      // string lives inside the public branch.
+      const publicSlice = body.slice(publicBranchIdx);
+      expect(publicSlice).not.toMatch(
+        /sendStateEvent\([^)]*history_visibility[^)]*world_readable/s,
+      );
+    }
+
+    // Belt + suspenders: a write payload `history_visibility: "world_readable"`
+    // must not appear anywhere in the function body. The literal string is
+    // only allowed inside a `currentHv === "world_readable"` comparison
+    // (used to detect legacy rooms during revert).
+    const writeMatches = body.match(
+      /history_visibility\s*:\s*"world_readable"/g,
+    );
+    expect(writeMatches).toBeNull();
+  });
+});
+
+describe("setRoomPublic — reverts legacy world_readable to shared on public→private (Session 28)", () => {
+  it("private branch sends history_visibility=shared when current is world_readable", () => {
+    const body = getSetRoomPublicBody();
+
+    // The fix introduces a private-side branch that detects legacy
+    // world_readable and reverts it to "shared" so previously-affected
+    // public groups become visible again after the user toggles them
+    // private then public.
+    expect(body).toMatch(/if \(!isPublic\)/);
+    expect(body).toMatch(/history_visibility\s*:\s*"shared"/);
+
+    // The revert must be guarded by `currentHv === "world_readable"` so we
+    // don't redundantly write `shared` when the room already has it.
+    expect(body).toMatch(/currentHv\s*===\s*"world_readable"/);
+  });
+});
+
+describe("setRoomPublic — preserves SDK power-level gate from Session 27", () => {
+  it("still uses canSendStateEvent on m.room.join_rules", () => {
+    const body = getSetRoomPublicBody();
+    // Don't break legacy admin compat (Session 27).
+    expect(body).toContain('canSendStateEvent(matrixRoom, "m.room.join_rules"');
+  });
+});

--- a/src/entities/chat/model/__tests__/sidebar-filter-public-group.test.ts
+++ b/src/entities/chat/model/__tests__/sidebar-filter-public-group.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Pin tests for the sidebar `world_readable` filter (Session 28).
+ *
+ * The filter `isStreamHistoryVisibility` correctly excludes
+ * broadcast/stream rooms (Bastyon channels) from the chat list. The Session
+ * 28 fix touches the WRITE path in `setRoomPublic` (no longer producing
+ * `world_readable` for public groups) — the READ-side filter logic stays
+ * exactly as-is.
+ *
+ * These tests pin the filter wiring so a future refactor cannot
+ * accidentally drop the broadcast-exclusion behavior, which would cause
+ * Bastyon channels to flood the regular chat sidebar.
+ */
+
+const chatStoreSource = readFileSync(
+  resolve(__dirname, "../chat-store.ts"),
+  "utf-8",
+);
+
+describe("isStreamHistoryVisibility — pure check", () => {
+  it("treats only world_readable as a stream marker", () => {
+    // Locate the helper definition. It's a module-level function near the
+    // top of chat-store.ts and the body is one return statement.
+    const startIdx = chatStoreSource.indexOf(
+      "function isStreamHistoryVisibility",
+    );
+    expect(startIdx).toBeGreaterThan(-1);
+    // Slice through the body — a single-line return.
+    const slice = chatStoreSource.slice(startIdx, startIdx + 200);
+    expect(slice).toMatch(/return\s+hv\s*===\s*"world_readable"\s*;/);
+  });
+});
+
+describe("shouldExcludeLocalRoomFromSidebar — applies stream filter first", () => {
+  it("returns true for any room with world_readable historyVisibility", () => {
+    const startIdx = chatStoreSource.indexOf(
+      "shouldExcludeLocalRoomFromSidebar",
+    );
+    expect(startIdx).toBeGreaterThan(-1);
+    // Find the actual function definition (skip the JSDoc-comment occurrence).
+    const fnStart = chatStoreSource.indexOf(
+      "const shouldExcludeLocalRoomFromSidebar",
+    );
+    expect(fnStart).toBeGreaterThan(-1);
+    // Body bounded by the next top-level `// Outbound watermark...` comment.
+    const fnEnd = chatStoreSource.indexOf(
+      "// Outbound watermark for active room",
+      fnStart,
+    );
+    expect(fnEnd).toBeGreaterThan(fnStart);
+    const body = chatStoreSource.slice(fnStart, fnEnd);
+
+    // Stream check is the very first guard — must be in the body.
+    expect(body).toMatch(
+      /isStreamHistoryVisibility\(lr\.historyVisibility[^)]*\)\)\s*return\s+true/s,
+    );
+  });
+});
+
+describe("Sync loops — skip stream rooms while iterating local-db rooms", () => {
+  it("dexieRoomMap unread aggregation skips stream rooms", () => {
+    // The aggregator at chat-store:1517-1518 uses `continue` on stream rooms
+    // so their unread counts don't pollute the sidebar badge.
+    const aggregatorIdx = chatStoreSource.indexOf("for (const r of dexieRoomMap.values())");
+    expect(aggregatorIdx).toBeGreaterThan(-1);
+    const slice = chatStoreSource.slice(aggregatorIdx, aggregatorIdx + 300);
+    expect(slice).toMatch(/isStreamHistoryVisibility[^)]*\)\)\s*continue/s);
+  });
+});

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -8,6 +8,7 @@ import { parseEditBody } from "../lib/parse-edit";
 import { sortMessagesTimelineAsc } from "../lib/message-utils";
 import { resetPowerLevel, isUserBanned } from "../lib/room-guards";
 import { categorizeJoinError, validateRoomId, type JoinRoomResult } from "../lib/join-error";
+import { preservePendingRooms } from "../lib/preserve-pending-rooms";
 import {
   readJoinRule,
   getMyPowerLevel,
@@ -1943,6 +1944,18 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       if (prevActiveRoom && !newRooms.some(r => r.id === prevActiveRoom.id)) {
         newRooms.push(prevActiveRoom);
       }
+      // Preserve recently-added rooms not yet in the SDK snapshot — covers
+      // the race between local createGroup/addRoom and Matrix /sync arrival.
+      // Without this, a freshly created group disappears from the sidebar
+      // as soon as the user switches active chat (because prevActiveRoom is
+      // no longer the new room and the SDK hasn't caught up).
+      const newRoomIds = new Set(newRooms.map(r => r.id));
+      const preserved = preservePendingRooms({
+        existingRooms: rooms.value,
+        incomingRoomIds: newRoomIds,
+        nowMs: Date.now(),
+      });
+      if (preserved.length > 0) newRooms.push(...preserved);
       rooms.value = newRooms;
       rebuildRoomsMap();
     }

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -3675,15 +3675,20 @@ export const useChatStore = defineStore(NAMESPACE, () => {
 
   /** Toggle room between public/private join rules (admin only).
    *
-   *  The up-front PL check now delegates to matrix-js-sdk's
+   *  The up-front PL check delegates to matrix-js-sdk's
    *  `RoomState.maySendStateEvent` (via `canSendStateEvent`) instead of
    *  rolling our own `users[myUserId] >= requiredPl` math. The self-rolled
    *  variant silently failed in legacy bastyon-chat groups whose
    *  `power_levels.users` map was keyed by a different Matrix domain —
    *  admins saw the toggle button but every click was a no-op.
    *
-   *  When enabling public we also set history_visibility=world_readable
-   *  (required for newly-joined users to see prior messages). */
+   *  Public group keeps default `history_visibility=shared`. The marker
+   *  `world_readable` is reserved for broadcast/stream rooms (Bastyon
+   *  channels) and the sidebar filter `isStreamHistoryVisibility` excludes
+   *  such rooms — writing it for a regular public group would hide it from
+   *  the chat list. Non-joined preview before join is handled by
+   *  `JoinRoomPreviewModal` (Session 21) which reads name/topic/member
+   *  count via the Matrix preview API. */
   const setRoomPublic = async (roomId: string, isPublic: boolean): Promise<boolean> => {
     try {
       const matrixService = getMatrixClientService();
@@ -3699,18 +3704,18 @@ export const useChatStore = defineStore(NAMESPACE, () => {
         join_rule: isPublic ? "public" : "invite",
       }, "");
 
-      // Public rooms need world_readable history so users can browse the log
-      // before joining. Skip the write if it's already set — avoids a
-      // redundant state event on every toggle.
-      if (isPublic) {
+      if (!isPublic) {
+        // Toggling back to private: revert any legacy `world_readable` to
+        // `shared` so previously-affected public groups (created between
+        // PR #71 and this fix) become visible in the sidebar again.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const hvEvent = (matrixRoom as any)?.currentState?.getStateEvents?.("m.room.history_visibility", "");
         const currentHv =
           hvEvent?.getContent?.()?.history_visibility ??
           hvEvent?.event?.content?.history_visibility;
-        if (currentHv !== "world_readable") {
+        if (currentHv === "world_readable") {
           await matrixService.sendStateEvent(roomId, "m.room.history_visibility", {
-            history_visibility: "world_readable",
+            history_visibility: "shared",
           }, "");
         }
       }

--- a/src/entities/matrix/model/__tests__/wait-for-room-in-sdk.test.ts
+++ b/src/entities/matrix/model/__tests__/wait-for-room-in-sdk.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { waitForRoomInSdk } from "../matrix-room-sync";
+
+describe("waitForRoomInSdk", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves immediately when the room is already in the SDK", async () => {
+    const room = { roomId: "!ready:s" };
+    const getRoom = vi.fn().mockReturnValue(room);
+
+    await expect(waitForRoomInSdk(getRoom, "!ready:s", 5000)).resolves.toBe(room);
+    // The fast-path should not need polling.
+    expect(getRoom).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves once the room appears mid-flight", async () => {
+    let stored: unknown = null;
+    const getRoom = vi.fn(() => stored);
+
+    const promise = waitForRoomInSdk(getRoom, "!late:s", 5000, 50);
+    // First check: not there yet.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(getRoom).toHaveBeenCalled();
+
+    // Inject the room and let one polling tick fire.
+    stored = { roomId: "!late:s" };
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expect(promise).resolves.toEqual({ roomId: "!late:s" });
+  });
+
+  it("rejects with a descriptive error on timeout", async () => {
+    const getRoom = vi.fn(() => null);
+    const promise = waitForRoomInSdk(getRoom, "!nope:s", 200, 50);
+    // Attach the rejection handler BEFORE advancing fake timers so the
+    // rejection isn't briefly unhandled when the watchdog fires.
+    const expectation = expect(promise).rejects.toThrow(/timeout.*!nope:s/i);
+    await vi.advanceTimersByTimeAsync(250);
+    await expectation;
+  });
+
+  it("clears interval after resolving (no leaks)", async () => {
+    let stored: unknown = null;
+    const getRoom = vi.fn(() => stored);
+
+    const promise = waitForRoomInSdk(getRoom, "!x:s", 5000, 50);
+    stored = { roomId: "!x:s" };
+    await vi.advanceTimersByTimeAsync(50);
+    await promise;
+
+    const callsAfterResolve = getRoom.mock.calls.length;
+    // No further polling once resolved.
+    await vi.advanceTimersByTimeAsync(500);
+    expect(getRoom.mock.calls.length).toBe(callsAfterResolve);
+  });
+
+  it("clears interval after rejecting (no leaks)", async () => {
+    const getRoom = vi.fn(() => null);
+    const promise = waitForRoomInSdk(getRoom, "!x:s", 100, 50);
+    const expectation = expect(promise).rejects.toThrow();
+    await vi.advanceTimersByTimeAsync(150);
+    await expectation;
+
+    const callsAfterReject = getRoom.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(500);
+    expect(getRoom.mock.calls.length).toBe(callsAfterReject);
+  });
+});

--- a/src/entities/matrix/model/matrix-room-sync.ts
+++ b/src/entities/matrix/model/matrix-room-sync.ts
@@ -1,0 +1,44 @@
+/** Lookup function — typically `client.getRoom.bind(client)`. */
+type GetRoomFn = (roomId: string) => unknown;
+
+/**
+ * Wait until a room appears in the matrix-js-sdk room store.
+ *
+ * Used after `createRoom` to avoid the race between the local store's
+ * optimistic `addRoom` and the SDK's first `/sync` that delivers the new
+ * room state. Without this, `fullRoomRefresh` may drop the optimistic
+ * entry — see `preservePendingRooms` for the read-side safety net.
+ *
+ * Implementation is a simple poll with a fast path for the case where the
+ * room is already present (covers the homeserver echoing the create response
+ * before we get here). The poll interval is configurable so the test suite
+ * can drive it with fake timers.
+ *
+ * @returns the SDK Room object once available
+ * @throws Error('waitForRoomInSdk timeout for ${roomId}') after timeoutMs
+ */
+export function waitForRoomInSdk(
+  getRoom: GetRoomFn,
+  roomId: string,
+  timeoutMs = 5000,
+  pollIntervalMs = 100,
+): Promise<unknown> {
+  const immediate = getRoom(roomId);
+  if (immediate) return Promise.resolve(immediate);
+
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const interval = setInterval(() => {
+      const room = getRoom(roomId);
+      if (room) {
+        clearInterval(interval);
+        resolve(room);
+        return;
+      }
+      if (Date.now() - start >= timeoutMs) {
+        clearInterval(interval);
+        reject(new Error(`waitForRoomInSdk timeout for ${roomId}`));
+      }
+    }, pollIntervalMs);
+  });
+}

--- a/src/features/group-creation/model/use-group-creation.ts
+++ b/src/features/group-creation/model/use-group-creation.ts
@@ -2,6 +2,7 @@ import { ref, computed } from "vue";
 import { useContacts } from "@/features/contacts/model/use-contacts";
 import { useChatStore } from "@/entities/chat";
 import { getMatrixClientService } from "@/entities/matrix";
+import { waitForRoomInSdk } from "@/entities/matrix/model/matrix-room-sync";
 import { hexEncode } from "@/shared/lib/matrix/functions";
 import { MATRIX_SERVER } from "@/shared/config";
 
@@ -115,6 +116,22 @@ export function useGroupCreation() {
       });
 
       const roomId = result.room_id;
+
+      // Wait for the SDK to receive the new room via /sync. Without this,
+      // `fullRoomRefresh` can drop the optimistic addRoom entry as soon as
+      // the user switches active chat (the SDK snapshot doesn't include
+      // the new room yet, and only `prevActiveRoom` is preserved). The
+      // 30s grace window in `preservePendingRooms` is the read-side
+      // safety net; this wait is the primary defence so the sidebar shows
+      // the room immediately after creation.
+      try {
+        await waitForRoomInSdk((id) => matrixService.getRoom(id), roomId, 5000);
+      } catch (waitErr) {
+        console.warn(
+          "[useGroupCreation] room not in SDK after 5s, relying on grace window:",
+          waitErr,
+        );
+      }
 
       // Add room to local store
       const memberHexIds = [...selectedMembers.value.values()].map(


### PR DESCRIPTION
## Summary

Двойной фикс одной user-видимой проблемы: «группа исчезает из списка чатов».

**Часть A — `world_readable` regression от Session 21 (PR #71)**
- `setRoomPublic(true)` больше не пишет `m.room.history_visibility=world_readable`. Этот флаг — broadcast/stream marker, который sidebar-фильтр `isStreamHistoryVisibility` отсекает (по правилу bastyon-chat). Newly-public группа возвращается в sidebar.
- При public→private — ревёртим legacy `world_readable→shared`, так что старые публичные группы (созданные между PR #71 и этим фиксом) становятся видимыми после private→public toggle.

**Часть B — race на свежесозданной group**
- `useGroupCreation.createGroup` await-ит `waitForRoomInSdk(roomId, 5000)` до `addRoom` — primary защита: к моменту первого `fullRoomRefresh` SDK уже знает про комнату.
- `fullRoomRefresh` теперь зовёт `preservePendingRooms` — safety net: рекантли-добавленные rooms (< 30s по `updatedAt`) сохраняются в `rooms.value` даже когда SDK snapshot их ещё не содержит. После 30s окна — drop'аются естественно.
- Новый standalone helper `waitForRoomInSdk(getRoom, roomId, timeoutMs, pollIntervalMs)` опубликован в `entities/matrix/model/matrix-room-sync.ts`.

## Root causes

**Часть A:** `vuex/store.js:790-791` в bastyon-chat показывает: `world_readable === stream`, public group ≠ `world_readable`. Session 21 ввела write этого флага для pre-join preview, но pre-existing filter `isStreamHistoryVisibility` (chat-store.ts:93) исключает такие rooms из sidebar — несовместимая семантика. Pre-join preview корректно работает через `JoinRoomPreviewModal` (name/topic/member-count) без `world_readable`.

**Часть B:** `fullRoomRefresh` атомарно перезаписывает `rooms.value = newRooms` (chat-store.ts:1946). Свежая room оптимистично добавлена через `addRoom`, но Matrix `/sync` доставляет её 1-30 секунд. В этом окне `interactiveRooms` без неё; preserve есть только для `prevActiveRoom`. Если user переключает active chat — group пропадает.

## Test plan

**New tests (17, все passes):**
- [x] `set-room-public-visibility.test.ts` — pin source-code: no `world_readable` write на public-toggle, revert-to-shared на private (3 теста, паттерн Session 27)
- [x] `sidebar-filter-public-group.test.ts` — pin filter wiring: `isStreamHistoryVisibility`, `shouldExcludeLocalRoomFromSidebar`, sync-loop skip (3 теста)
- [x] `preserve-pending-rooms.test.ts` — pure-function unit tests: preserve recent missing rooms, drop stale, skip rooms already в snapshot, missing `updatedAt` фоллбэк, order, `PENDING_GRACE_MS=30_000` pin (6 тестов)
- [x] `wait-for-room-in-sdk.test.ts` — fast-path immediate, mid-flight resolve, timeout reject, no-leak after resolve/reject (5 тестов с fake timers)

**Build/type checks:**
- [x] `vite build` — green
- [x] `vue-tsc --noEmit` — no errors в touched файлах
- [x] Code review агент `superpowers:code-reviewer` — APPROVE без CRITICAL/HIGH

**Pre-existing failures (НЕ связаны с этим PR):** 9-10 тестов в `video-embed.test.ts`, `open-profile-url.test.ts`, `chat-helpers.test.ts`, `display-result.test.ts`, флакающий `sync-engine-online.test.ts` — воспроизводятся идентично на master без моих изменений.

**Manual UX verification — required перед merge** (не выполнено в этой сессии — нужна сборка на устройстве):
- [ ] **Сценарий A**: создать group → toggle "Make public" → swap chat → swap back → group остаётся в sidebar; toggle обратно "Make private" → группа всё ещё видна.
- [ ] **Сценарий B**: создать group → БЕЗ toggle public → сразу switch на personal chat → switch back → group видна; подождать 30+ сек → group остаётся видимой (теперь через /sync).
- [ ] **Сценарий C (legacy)**: если есть public group созданная между 1.10.x и этим релизом — toggle make-private → make-public → группа возвращается в sidebar.

## Out of scope (документировано)

**Не делаем one-time auto-migration** для legacy `world_readable` rooms. Старые публичные группы (созданные между PR #71 и этим фиксом) остаются скрытыми до того как admin вручную переключит **Make Private → Make Public** (revert+set путь нового кода). Это compromise: миграция требует admin PL и риска лишних state events на startup. Если нужна — отдельная Session 28b.

## Files changed

**Часть A** (commit `984c4de`):
- `src/entities/chat/model/chat-store.ts` — `setRoomPublic` (~line 3687)
- `src/entities/chat/model/__tests__/set-room-public-visibility.test.ts` (new)
- `src/entities/chat/model/__tests__/sidebar-filter-public-group.test.ts` (new)

**Часть B** (commit `47b3a43`):
- `src/entities/chat/lib/preserve-pending-rooms.ts` (new) + `.test.ts` (new)
- `src/entities/chat/model/chat-store.ts` — `fullRoomRefresh` atomic publish block
- `src/entities/matrix/model/matrix-room-sync.ts` (new) + `__tests__/wait-for-room-in-sdk.test.ts` (new)
- `src/features/group-creation/model/use-group-creation.ts` — wait перед `addRoom`

## References

- Research: `.planning/bug-fix-plan/research/PUBLIC-GROUP-DISAPPEARS-FROM-SIDEBAR-RESEARCH.md`
- Session prompt: `.planning/bug-fix-plan/SESSION-PROMPTS/28-public-group-sidebar-visibility.md`
- Bastyon-chat reference: `vuex/store.js:790-791` (stream === world_readable)

Closes #577 (web «группу создаю, а она потом исчезает»). Likely closes #553 (Android 16 / Pixel 6 Pro «создаю группу — она не появляется»).