### PR TITLE
fix(rooms): separate invited and joined members + reliable kick (Session 29)

### DIFF
--- a/src/entities/chat/model/__tests__/members-membership-split.test.ts
+++ b/src/entities/chat/model/__tests__/members-membership-split.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression tests for Session 29 — invited vs joined members in groups.
+ *
+ * Bug: `getRoomMembers` returns all membership states (join, invite, leave,
+ * ban) intentionally for tetatet-detection, but `matrixRoomToChatRoom` then
+ * mapped them flat into `room.members: string[]` without preserving membership
+ * info. The UI rendered every state identically, so:
+ *   1. Invited (pending) members appeared as if already joined.
+ *   2. Left/banned members reappeared after the next refresh because the
+ *      optimistic `room.members.filter(...)` mutation was overwritten on the
+ *      next `matrixRoomToChatRoom` pass.
+ *   3. The MEMBERS(N) counter (server-side joined count) didn't match the list
+ *      length (all states).
+ *
+ * Fix: split members by `m.membership` in `matrixRoomToChatRoom`:
+ *   - `join`   → `room.members`
+ *   - `invite` → `room.invitedMembers`
+ *   - `leave` / `ban` → excluded from both (banned tracked separately).
+ * `kickMember` / `banMember` / `inviteMember` update both arrays
+ * optimistically so a refresh doesn't resurrect a kicked invitee.
+ *
+ * See `.planning/bug-fix-plan/research/INVITED-VS-JOINED-MEMBERS-RESEARCH.md`.
+ */
+
+const chatStoreSource = readFileSync(
+  resolve(__dirname, "../chat-store.ts"),
+  "utf-8",
+);
+
+const typesSource = readFileSync(
+  resolve(__dirname, "../types.ts"),
+  "utf-8",
+);
+
+const chatInfoPanelSource = readFileSync(
+  resolve(__dirname, "../../../../features/chat-info/ui/ChatInfoPanel.vue"),
+  "utf-8",
+);
+
+describe("ChatRoom type — invitedMembers field", () => {
+  it("declares invitedMembers as optional string array", () => {
+    // Optional for backwards-compat with cached/Dexie ChatRoom records.
+    expect(typesSource).toMatch(/invitedMembers\?\s*:\s*string\[\]/);
+  });
+});
+
+describe("matrixRoomToChatRoom — splits members by membership", () => {
+  // Locate the function body — bounded by the first `}` at column 0
+  // (top-level function close), or just slice the function-scope.
+  const startIdx = chatStoreSource.indexOf("function matrixRoomToChatRoom");
+  const fnEndIdx = chatStoreSource.indexOf("\nexport const useChatStore", startIdx);
+  const block = chatStoreSource.slice(startIdx, fnEndIdx);
+
+  it("function exists in chat-store.ts", () => {
+    expect(startIdx).toBeGreaterThan(-1);
+    expect(fnEndIdx).toBeGreaterThan(startIdx);
+  });
+
+  it("does NOT flatten getRoomMembers into a flat string array via .map", () => {
+    // The buggy form: `members.map((m) => getmatrixid(m.userId as string))`
+    // We now iterate to split — no `.map(...).map(...)` flatten on userId only.
+    expect(block).not.toMatch(/members\.map\([^)]*=>\s*getmatrixid\(m\.userId\s+as\s+string\)\)/);
+  });
+
+  it("reads m.membership when classifying each member", () => {
+    expect(block).toMatch(/m\.membership/);
+  });
+
+  it("classifies into join and invite buckets", () => {
+    // Both literal "join" and "invite" should appear as classification branches.
+    expect(block).toMatch(/===\s*"join"/);
+    expect(block).toMatch(/===\s*"invite"/);
+  });
+
+  it("returns invitedMembers in the ChatRoom object", () => {
+    expect(block).toMatch(/invitedMembers\s*:/);
+  });
+});
+
+describe("kickMember — optimistic remove from BOTH joined and invited", () => {
+  const startIdx = chatStoreSource.indexOf("const kickMember = async");
+  const endIdx = chatStoreSource.indexOf("\n  /**", startIdx + 10);
+  const block = chatStoreSource.slice(startIdx, endIdx);
+
+  it("kickMember function exists", () => {
+    expect(startIdx).toBeGreaterThan(-1);
+    expect(endIdx).toBeGreaterThan(startIdx);
+  });
+
+  it("removes from room.members", () => {
+    expect(block).toMatch(/room\.members\s*=\s*room\.members\.filter/);
+  });
+
+  it("removes from room.invitedMembers as well", () => {
+    expect(block).toMatch(/invitedMembers/);
+    expect(block).toMatch(/room\.invitedMembers\s*=/);
+  });
+});
+
+describe("banMember — optimistic remove from BOTH joined and invited", () => {
+  const startIdx = chatStoreSource.indexOf("const banMember = async");
+  const endIdx = chatStoreSource.indexOf("\n  /**", startIdx + 10);
+  const block = chatStoreSource.slice(startIdx, endIdx);
+
+  it("banMember function exists", () => {
+    expect(startIdx).toBeGreaterThan(-1);
+    expect(endIdx).toBeGreaterThan(startIdx);
+  });
+
+  it("removes from room.members", () => {
+    expect(block).toMatch(/room\.members\s*=\s*room\.members\.filter/);
+  });
+
+  it("removes from room.invitedMembers as well", () => {
+    expect(block).toMatch(/room\.invitedMembers\s*=/);
+  });
+});
+
+describe("inviteMember — optimistic add to invitedMembers (not members)", () => {
+  const startIdx = chatStoreSource.indexOf("const inviteMember = async");
+  const endIdx = chatStoreSource.indexOf("\n  /**", startIdx + 10);
+  const block = chatStoreSource.slice(startIdx, endIdx);
+
+  it("inviteMember function exists", () => {
+    expect(startIdx).toBeGreaterThan(-1);
+    expect(endIdx).toBeGreaterThan(startIdx);
+  });
+
+  it("does NOT push hexId straight into room.members anymore", () => {
+    // The buggy form: `room.members = [...room.members, hexId]` — invited
+    // member was treated as joined. New behaviour writes to invitedMembers.
+    expect(block).not.toMatch(/room\.members\s*=\s*\[\s*\.\.\.\s*room\.members\s*,\s*hexId\s*\]/);
+  });
+
+  it("writes the hexId to room.invitedMembers", () => {
+    expect(block).toMatch(/room\.invitedMembers\s*=/);
+  });
+});
+
+describe("ChatInfoPanel — renders invited members in a separate block", () => {
+  it("renders v-for over room.invitedMembers", () => {
+    expect(chatInfoPanelSource).toMatch(/v-for="member in [^"]*invitedMembers/);
+  });
+
+  it("uses a distinct :key prefix to avoid collisions with joined", () => {
+    // Joined and invited may share hexIds across the union; render keys must
+    // be disambiguated so Vue doesn't reuse the wrong DOM node.
+    expect(chatInfoPanelSource).toMatch(/:key="`invite-/);
+  });
+
+  it("references the new info.invited i18n key for the badge", () => {
+    expect(chatInfoPanelSource).toMatch(/t\(\s*["']info\.invited["']/);
+  });
+});

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -102,9 +102,29 @@ function matrixRoomToChatRoom(room: any, kit: MatrixKit, myUserId: string, nameH
   const isGroup = !kit.isTetatetChat(room);
   const membership = (room.selfMembership ?? room.getMyMembership?.()) as "join" | "invite" | undefined;
 
-  // Get members
+  // Get members. `getRoomMembers` returns ALL membership states (join,
+  // invite, leave, ban) — that's intentional for tetatet-detection
+  // (`isTetatetChat`), but the UI needs joined and invited surfaced
+  // separately:
+  //   - "join"   → `members` (default render: kick/admin actions visible)
+  //   - "invite" → `invitedMembers` (rendered with "Invited" badge,
+  //     same actions but a refresh won't resurrect a kicked invitee
+  //     because the optimistic mutation now hits both arrays)
+  //   - "leave" / "ban" → excluded from both (banned tracked separately
+  //     via getBannedMembers)
+  // Without the split, kick of an invited member appeared to "do nothing"
+  // because the next `matrixRoomToChatRoom` pass would re-add him from
+  // his still-`invite` membership state. See Session 29 research.
   const members = kit.getRoomMembers(room);
-  const memberIds = members.map((m: Record<string, unknown>) => getmatrixid(m.userId as string));
+  const memberIds: string[] = [];
+  const invitedMemberIds: string[] = [];
+  for (const m of members) {
+    const id = getmatrixid(m.userId as string);
+    const membership = (m.membership as string | undefined) ?? "leave";
+    if (membership === "join") memberIds.push(id);
+    else if (membership === "invite") invitedMemberIds.push(id);
+    // leave / ban — drop
+  }
 
   // Unread notification count
   const unreadCount = (room.getUnreadNotificationCount?.("total") as number) ?? 0;
@@ -331,6 +351,7 @@ function matrixRoomToChatRoom(room: any, kit: MatrixKit, myUserId: string, nameH
     lastMessage,
     unreadCount,
     members: memberIds,
+    invitedMembers: invitedMemberIds,
     isGroup,
     updatedAt: lastTs || (() => {
       // For invites, try to extract origin_server_ts from the invite event itself
@@ -1899,11 +1920,15 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     const prevNameMap = new Map<string, string>();
     const prevLastMessageMap = new Map<string, Message | undefined>();
     const prevMembersMap = new Map<string, string[]>();
+    const prevInvitedMembersMap = new Map<string, string[]>();
     const prevAvatarMap = new Map<string, string>();
     for (const r of rooms.value) {
       prevNameMap.set(r.id, r.name);
       prevLastMessageMap.set(r.id, r.lastMessage);
       prevMembersMap.set(r.id, r.members);
+      if (r.invitedMembers && r.invitedMembers.length > 0) {
+        prevInvitedMembersMap.set(r.id, r.invitedMembers);
+      }
       if (r.avatar) prevAvatarMap.set(r.id, r.avatar);
     }
     const prevActiveRoom = activeRoomId.value ? getRoomById(activeRoomId.value) : undefined;
@@ -1926,6 +1951,12 @@ export const useChatStore = defineStore(NAMESPACE, () => {
           room.members = prevMembers;
           const prevAvatar = prevAvatarMap.get(room.id);
           if (prevAvatar) room.avatar = prevAvatar;
+        }
+        // Same lazy-load shrink protection for pending invitations.
+        const prevInvited = prevInvitedMembersMap.get(room.id);
+        const newInvitedLen = room.invitedMembers?.length ?? 0;
+        if (prevInvited && prevInvited.length > newInvitedLen) {
+          room.invitedMembers = prevInvited;
         }
         newRooms.push(room);
       }
@@ -3378,10 +3409,17 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       await resetPowerLevel(roomId, targetMatrixId);
       await matrixService.kick(roomId, targetMatrixId);
 
-      // Optimistic: remove member from local room data immediately
+      // Optimistic: remove member from BOTH joined and invited lists.
+      // Matrix `kick` API works for invited members too — server-side
+      // it withdraws the invite. Without invitedMembers cleanup the
+      // user reappeared after the next `matrixRoomToChatRoom` pass
+      // (his membership state was still `invite` if `kick` raced).
       const room = getRoomById(roomId);
       if (room) {
         room.members = room.members.filter(m => m !== hexId);
+        if (room.invitedMembers) {
+          room.invitedMembers = room.invitedMembers.filter(m => m !== hexId);
+        }
       }
 
       return true;
@@ -3490,10 +3528,16 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       // Security: reset power level before ban
       await resetPowerLevel(roomId, targetMatrixId);
       await matrixService.ban(roomId, targetMatrixId);
-      // Optimistic: remove from members
+      // Optimistic: remove from both joined and invited lists.
+      // Matrix `ban` works for invited users too (server treats it as
+      // disinvite + ban), so we must clear both arrays — otherwise the
+      // banned user lingers as "invited" until the next full refresh.
       const room = getRoomById(roomId);
       if (room) {
         room.members = room.members.filter(m => m !== hexId);
+        if (room.invitedMembers) {
+          room.invitedMembers = room.invitedMembers.filter(m => m !== hexId);
+        }
       }
       return true;
     } catch (e) {
@@ -3569,10 +3613,19 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       }
       await matrixService.invite(roomId, targetMatrixId);
 
-      // Optimistic: add member to local room data immediately
+      // Optimistic: stage the invitee under invitedMembers (NOT members).
+      // They only land in `members` once they accept and the SDK reports
+      // their membership as "join". Surfacing them as joined immediately
+      // (the old behaviour) was the root of the "phantom member" bug —
+      // user appeared in the list, could be assigned admin / kicked, but
+      // operations seemed to silently no-op until the next refresh.
       const room = getRoomById(roomId);
-      if (room && !room.members.includes(hexId)) {
-        room.members = [...room.members, hexId];
+      if (room) {
+        const alreadyJoined = room.members.includes(hexId);
+        const existing = room.invitedMembers ?? [];
+        if (!alreadyJoined && !existing.includes(hexId)) {
+          room.invitedMembers = [...existing, hexId];
+        }
       }
 
       return true;

--- a/src/entities/chat/model/types.ts
+++ b/src/entities/chat/model/types.ts
@@ -3,7 +3,13 @@ export interface ChatRoom {
   name: string;
   lastMessage?: Message;
   unreadCount: number;
+  /** Joined members only — UI default rendering (kick/admin actions visible).
+   *  Filtered from `getRoomMembers` by `membership === "join"` in `matrixRoomToChatRoom`. */
   members: string[];
+  /** Pending invitations — rendered separately with "Invited" badge.
+   *  Optional for backwards-compat with cached/Dexie ChatRoom records that
+   *  predate Session 29. Treat absent as empty array at the read site. */
+  invitedMembers?: string[];
   avatar?: string;
   isGroup: boolean;
   updatedAt: number;

--- a/src/features/chat-info/ui/ChatInfoPanel.vue
+++ b/src/features/chat-info/ui/ChatInfoPanel.vue
@@ -462,10 +462,16 @@ const handleMoreAction = (action: string) => {
 };
 
 // ── Peer info (1:1 DM) ──
+// In a DM the peer can be either joined or still pending invitation. Search
+// across both lists so we can show the peer's profile even before they accept.
 const peerAddress = computed(() => {
   if (!room.value || room.value.isGroup) return null;
   const myHex = myHexId.value;
-  const other = room.value.members.find(m => m !== myHex);
+  const candidates = [
+    ...room.value.members,
+    ...(room.value.invitedMembers ?? []),
+  ];
+  const other = candidates.find(m => m !== myHex);
   return other ? hexDecode(other) : null;
 });
 
@@ -843,11 +849,12 @@ const openGallery = (tab: "media" | "files" | "links" | "voice" = "media") => {
                 </div>
               </div>
 
-              <!-- Member list -->
+              <!-- Member list — joined first, invited (pending) below with badge -->
               <div class="flex flex-col gap-1">
+                <!-- Joined members -->
                 <div
                   v-for="member in room.members"
-                  :key="member"
+                  :key="`join-${member}`"
                   class="flex items-center gap-3 rounded-lg px-2 py-2 transition-colors"
                   :class="isAdmin && member !== myHexId ? 'cursor-pointer hover:bg-neutral-grad-0' : ''"
                   @click="(e: MouseEvent) => openMemberMenu(e, member)"
@@ -867,6 +874,27 @@ const openGallery = (tab: "media" | "files" | "links" | "voice" = "media") => {
                     class="shrink-0 rounded bg-color-bg-ac/15 px-1.5 py-0.5 text-[10px] font-medium text-color-bg-ac"
                   >
                     {{ t("info.admin") }}
+                  </span>
+                </div>
+
+                <!-- Invited (pending) members. Same menu — Matrix `kick` API
+                     is server-side disinvite for invitees, so admin can
+                     cancel an invitation through the existing flow. -->
+                <div
+                  v-for="member in (room.invitedMembers ?? [])"
+                  :key="`invite-${member}`"
+                  class="flex items-center gap-3 rounded-lg px-2 py-2 opacity-60 transition-colors"
+                  :class="isAdmin ? 'cursor-pointer hover:bg-neutral-grad-0' : ''"
+                  @click="(e: MouseEvent) => openMemberMenu(e, member)"
+                >
+                  <UserAvatar :address="hexDecode(member)" size="sm" />
+                  <span class="min-w-0 flex-1 truncate text-sm text-text-color">
+                    {{ chatStore.getDisplayName(member) }}
+                  </span>
+                  <span
+                    class="shrink-0 rounded bg-yellow-500/15 px-1.5 py-0.5 text-[10px] font-medium text-yellow-600"
+                  >
+                    {{ t("info.invited") }}
                   </span>
                 </div>
               </div>

--- a/src/features/chat-info/ui/UserProfilePanel.vue
+++ b/src/features/chat-info/ui/UserProfilePanel.vue
@@ -61,7 +61,9 @@ const copyAddress = async () => {
 const navigateToChat = () => {
   const hexAddr = hexEncode(props.address).toLowerCase();
   const existingRoom = chatStore.sortedRooms.find(
-    (r) => !r.isGroup && r.members.includes(hexAddr),
+    (r) =>
+      !r.isGroup &&
+      (r.members.includes(hexAddr) || (r.invitedMembers ?? []).includes(hexAddr)),
   );
   if (existingRoom) {
     chatStore.setActiveRoom(existingRoom.id);
@@ -72,7 +74,9 @@ const navigateToChat = () => {
 const startCall = (type: "voice" | "video") => {
   const hexAddr = hexEncode(props.address).toLowerCase();
   const existingRoom = chatStore.sortedRooms.find(
-    (r) => !r.isGroup && r.members.includes(hexAddr),
+    (r) =>
+      !r.isGroup &&
+      (r.members.includes(hexAddr) || (r.invitedMembers ?? []).includes(hexAddr)),
   );
   if (existingRoom) {
     callService.startCall(existingRoom.id, type);

--- a/src/features/contacts/ui/ContactList.vue
+++ b/src/features/contacts/ui/ContactList.vue
@@ -116,9 +116,16 @@ function cachedHexDecode(hex: string): string {
 
 /** Resolve member names — checks Pocketnet profiles first, then Matrix displaynames.
  *  Matrix displaynames come from m.room.member state events (free, already in sync)
- *  and are available instantly without any RPC call. */
+ *  and are available instantly without any RPC call.
+ *
+ *  Walks BOTH joined and invited, otherwise the contact list shows a blank
+ *  name for DMs whose peer hasn't accepted the invite yet (`members` would
+ *  only contain the inviter). */
 function _resolveMemberNames(room: ChatRoom, allUsers: Record<string, any>, myHexId: string): string[] {
-  const otherMembers = room.members.filter(m => m !== myHexId);
+  const otherMembers = [
+    ...room.members,
+    ...(room.invitedMembers ?? []),
+  ].filter(m => m !== myHexId);
 
   const names: string[] = [];
   for (const hexId of otherMembers) {

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -392,6 +392,7 @@ export const en = {
   "info.unban": "Unban",
   "info.banned": "Banned ({count})",
   "info.muted": "muted",
+  "info.invited": "Invited",
   "info.editDescription": "Edit description",
   "info.addDescription": "Add description",
   "info.changePhoto": "Change photo",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -394,6 +394,7 @@ export const ru: Record<TranslationKey, string> = {
   "info.unban": "Разблокировать",
   "info.banned": "Заблокированные ({count})",
   "info.muted": "заглушён",
+  "info.invited": "Приглашён",
   "info.editDescription": "Изменить описание",
   "info.addDescription": "Добавить описание",
   "info.changePhoto": "Изменить фото",

--- a/src/widgets/chat-window/ChatWindow.vue
+++ b/src/widgets/chat-window/ChatWindow.vue
@@ -141,11 +141,15 @@ const isAdmin = computed(() => {
 
 const { resolve: resolveRoomName } = useResolvedRoomName();
 
-/** Trigger lazy-loading of missing user profiles for active room members */
+/** Trigger lazy-loading of missing user profiles for active room members.
+ *  Walks both joined and invited so the DM header / chat title can resolve a
+ *  pending invitee's name before they accept (otherwise getDisplayName would
+ *  fall back to the raw hex id). */
 function _ensureActiveMembers(room: NonNullable<typeof chatStore.activeRoom>): void {
   const myHex = authStore.address ? hexEncode(authStore.address) : "";
-  const otherMembers = room.members.filter(m => m !== myHex);
-  for (const hexId of otherMembers) {
+  const allHexIds = [...room.members, ...(room.invitedMembers ?? [])];
+  for (const hexId of allHexIds) {
+    if (hexId === myHex) continue;
     const addr = hexDecode(hexId);
     if (/^[A-Za-z0-9]+$/.test(addr)) userStore.loadUserIfMissing(addr);
   }
@@ -219,12 +223,15 @@ const openUserProfile = (address: string) => {
 provide("openUserProfile", openUserProfile);
 
 /** Get the other member's Pocketnet address in a 1:1 chat.
- *  room.members stores hex-encoded addresses; we compare in hex then decode to Base58. */
+ *  room.members stores hex-encoded addresses (joined only); invitedMembers
+ *  carries pending invitations. Look in both so the chat header can show
+ *  the peer name even before they accept the invite. */
 const otherMemberAddress = computed(() => {
   const room = chatStore.activeRoom;
   if (!room || room.isGroup) return "";
   const myHex = authStore.address ? hexEncode(authStore.address) : "";
-  const hexAddr = room.members.find((m) => m !== myHex) ?? "";
+  const candidates = [...room.members, ...(room.invitedMembers ?? [])];
+  const hexAddr = candidates.find((m) => m !== myHex) ?? "";
   return hexAddr ? hexDecode(hexAddr) : "";
 });
 


### PR DESCRIPTION
## Summary

Fixes a UX irritant in every group with pending invitations: invited users were rendered indistinguishably from joined members, kick on an invited *appeared* to do nothing (next refresh resurrected him), and the MEMBERS(N) counter never matched the visible list.

Root cause: `getRoomMembers` returns **all** membership states (intentionally — `isTetatetChat` depends on it), but `matrixRoomToChatRoom` flattened the result into `room.members: string[]` and dropped `m.membership`. The UI had no signal to render differently, and the optimistic `room.members.filter(...)` after kick was reversed by the next `matrixRoomToChatRoom` pass.

Reference: bastyon-chat stores members as `{ userId, membership, powerLevel }` and renders `:class="user.membership"` for distinct visual treatment.

## Fix

| Layer | Change |
|---|---|
| `types.ts` | `ChatRoom.invitedMembers?: string[]` (optional — back-compat with cached/Dexie records) |
| `chat-store.ts` (`matrixRoomToChatRoom`) | Iterate `getRoomMembers`, classify by `m.membership`: `join` → `members`, `invite` → `invitedMembers`, `leave`/`ban` → drop |
| `chat-store.ts` (`kickMember`/`banMember`) | Optimistic remove from **both** arrays — Matrix `kick` API is server-side disinvite for invitees |
| `chat-store.ts` (`inviteMember`) | Stage invitee in `invitedMembers` (NOT `members`) — they only land in `members` on accept |
| `chat-store.ts` (`fullRoomRefresh`) | Preserve `invitedMembers` across SDK lazy-load shrinks (parallels existing `prevMembersMap`) |
| `ChatInfoPanel.vue` | Render invited section separately with opacity-60 + "Invited" badge; distinct `:key="invite-${member}"` to prevent Vue node reuse collisions |
| `ChatInfoPanel.vue` / `ChatWindow.vue` / `UserProfilePanel.vue` / `ContactList.vue` | DM peer lookup spans both lists so the peer's name resolves before they accept |
| `i18n` (en/ru) | New `info.invited` key |

## Test plan

- [x] `members-membership-split.test.ts` — 18 source-based assertions (matches `power-levels-legacy-compat.test.ts` pattern). Verified RED → GREEN.
- [x] Type check (`vue-tsc --noEmit`) — no new errors in changed files.
- [x] Full test suite — 1600 pass (the 9 failures are pre-existing on master).
- [ ] Manual UX:
  - [ ] Create a group, invite friend B who hasn't accepted → MEMBERS section lists me (admin) + B with **opacity-60 + "Invited" badge**.
  - [ ] Kick B → he disappears immediately. Reload page → he is **still gone** (server-side disinvite landed).
  - [ ] B accepts invite → moves into joined section, badge disappears, normal kick/admin actions apply.
  - [ ] DM with pending peer → name still resolves in chat header / contact list.

## Refs

- Spec: `.planning/bug-fix-plan/SESSION-PROMPTS/29-invited-vs-joined-members.md`
- Research: `.planning/bug-fix-plan/research/INVITED-VS-JOINED-MEMBERS-RESEARCH.md`