### PR TITLE
fix(media): typed errors + retry-with-cache-bust + crypto wait (Session 32)

### DIFF
--- a/src/entities/matrix/model/__tests__/wait-for-crypto.test.ts
+++ b/src/entities/matrix/model/__tests__/wait-for-crypto.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { waitForRoomCrypto } from "../wait-for-crypto";
+import { CryptoNotReadyError } from "@/shared/lib/network/typed-network-errors";
+import type { PcryptoRoomInstance } from "../matrix-crypto";
+
+function makeRoom(): PcryptoRoomInstance {
+  // Only the identity matters for these tests — PcryptoRoomInstance is large
+  // and we never actually call its methods here.
+  return {} as PcryptoRoomInstance;
+}
+
+describe("waitForRoomCrypto", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns the room synchronously when it is already available", async () => {
+    const room = makeRoom();
+    const promise = waitForRoomCrypto("!room:server", () => room, 5000);
+    await expect(promise).resolves.toBe(room);
+  });
+
+  it("returns the room as soon as it becomes available during polling", async () => {
+    const room = makeRoom();
+    let current: PcryptoRoomInstance | undefined;
+    const promise = waitForRoomCrypto("!room:server", () => current, 5000);
+
+    // Drive the polling loop for ~250ms before the room "appears".
+    await vi.advanceTimersByTimeAsync(250);
+    current = room;
+    await vi.advanceTimersByTimeAsync(150);
+
+    await expect(promise).resolves.toBe(room);
+  });
+
+  it("throws CryptoNotReadyError with the roomId when the timeout elapses", async () => {
+    const promise = waitForRoomCrypto("!stuck:server", () => undefined, 500);
+    // Surface the rejection without unhandled-rejection noise.
+    const guarded = promise.catch((e) => e);
+    await vi.advanceTimersByTimeAsync(600);
+    const err = await guarded;
+    expect(err).toBeInstanceOf(CryptoNotReadyError);
+    expect((err as CryptoNotReadyError).roomId).toBe("!stuck:server");
+  });
+
+  it("uses the default 5s timeout when none is supplied", async () => {
+    const promise = waitForRoomCrypto("!default:server", () => undefined);
+    const guarded = promise.catch((e) => e);
+    // 4.9s — should still be polling.
+    await vi.advanceTimersByTimeAsync(4_900);
+    let settled = false;
+    void guarded.then(() => { settled = true; });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    // Past 5s — should have rejected.
+    await vi.advanceTimersByTimeAsync(200);
+    const err = await guarded;
+    expect(err).toBeInstanceOf(CryptoNotReadyError);
+  });
+});

--- a/src/entities/matrix/model/wait-for-crypto.ts
+++ b/src/entities/matrix/model/wait-for-crypto.ts
@@ -1,0 +1,47 @@
+import { CryptoNotReadyError } from "@/shared/lib/network/typed-network-errors";
+import type { PcryptoRoomInstance } from "./matrix-crypto";
+
+/** Polling cadence for waitForRoomCrypto. 100ms is short enough that a
+ *  fast Matrix sync (which usually settles within a few hundred ms after
+ *  login) returns immediately, and long enough that we don't burn CPU in
+ *  hot-loop while the worker thread is still parsing key payloads. */
+const POLL_INTERVAL_MS = 100;
+
+/** Default upper bound — long enough to ride out a slow cold start on Tor /
+ *  3G while still failing fast enough that the user sees a clear error
+ *  rather than an indefinite spinner. */
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+/** Wait until `getRoom()` returns a usable PcryptoRoomInstance, or throw
+ *  `CryptoNotReadyError` after `timeoutMs` elapses.
+ *
+ *  The download/decrypt pipeline races against Matrix sync immediately
+ *  after login: the user opens a chat with E2E media before
+ *  `authStore.pcrypto.rooms[roomId]` has been populated by the room-add
+ *  callback. Without this helper the first decrypt attempt threw a bare
+ *  `Error("No room crypto for decryption")` (issue #616) and the user had
+ *  to manually pull-to-refresh once sync caught up. With it, the call
+ *  parks for up to a few hundred ms — typically invisible to the user —
+ *  and then proceeds once the room instance materialises.
+ *
+ *  `getRoom` is invoked on every poll instead of being captured once,
+ *  because `authStore.pcrypto?.rooms[roomId]` is what we want to observe
+ *  and a captured reference would never see the population. */
+export async function waitForRoomCrypto(
+  roomId: string,
+  getRoom: () => PcryptoRoomInstance | undefined,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<PcryptoRoomInstance> {
+  const deadline = Date.now() + timeoutMs;
+  // First check is synchronous so the happy path doesn't pay a tick.
+  const immediate = getRoom();
+  if (immediate) return immediate;
+
+  while (Date.now() < deadline) {
+    await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    const room = getRoom();
+    if (room) return room;
+  }
+
+  throw new CryptoNotReadyError(roomId);
+}

--- a/src/features/messaging/model/use-file-download.test.ts
+++ b/src/features/messaging/model/use-file-download.test.ts
@@ -11,8 +11,14 @@ vi.mock("@/shared/lib/platform", () => ({
 }));
 
 // --- Auth store mock ---
+// authStore.pcrypto is mutated per-test via `setMockPcrypto` for the
+// crypto-wait integration tests. Tests that don't touch it default to null.
+let mockPcrypto: { rooms: Record<string, unknown> } | null = null;
+function setMockPcrypto(value: typeof mockPcrypto) {
+  mockPcrypto = value;
+}
 vi.mock("@/entities/auth", () => ({
-  useAuthStore: vi.fn(() => ({ pcrypto: null })),
+  useAuthStore: vi.fn(() => ({ get pcrypto() { return mockPcrypto; } })),
 }));
 
 // --- Capacitor Filesystem mock ---
@@ -50,6 +56,18 @@ vi.mock("@/shared/lib/i18n", () => ({
   tRaw: (k: string) => k,
 }));
 
+// --- Toast mock (called when typed transient errors surface) ---
+const mockToast: Mock = vi.fn();
+vi.mock("@/shared/lib/use-toast", () => ({
+  useToast: () => ({
+    toast: mockToast,
+    close: vi.fn(),
+    message: { value: "" },
+    type: { value: "info" },
+    show: { value: false },
+  }),
+}));
+
 // --- Global fetch mock ---
 const mockFetchResponse = {
   ok: true,
@@ -59,7 +77,21 @@ const mockFetchResponse = {
 global.fetch = vi.fn(() => Promise.resolve(mockFetchResponse)) as Mock;
 
 // Import after mocks
-const { useFileDownload, revokeAllFileUrls } = await import("./use-file-download");
+const {
+  useFileDownload,
+  revokeAllFileUrls,
+  appendCacheBust,
+  wrapTransientError,
+} = await import("./use-file-download");
+const { MediaUnavailableError, NetworkBlockedError } = await import(
+  "@/shared/lib/network/typed-network-errors"
+);
+// Pull static type aliases for cast assertions — the dynamic imports above
+// only give us values, so without these the test file fails vue-tsc with
+// "X refers to a value, but is being used as a type here".
+import type {
+  MediaUnavailableError as MediaUnavailableErrorT,
+} from "@/shared/lib/network/typed-network-errors";
 
 describe("useFileDownload", () => {
   beforeEach(() => {
@@ -69,6 +101,9 @@ describe("useFileDownload", () => {
     revokeAllFileUrls();
     // Reset window.electronAPI
     delete (window as any).electronAPI;
+    // Reset crypto stub so tests that do not touch encryption see no
+    // pcrypto (matches the original mock default).
+    setMockPcrypto(null);
   });
 
   describe("saveFile — web platform", () => {
@@ -258,6 +293,266 @@ describe("useFileDownload", () => {
       });
       scope.stop();
     });
+
+    it("appends a cache-bust query parameter to retry URLs but not the first attempt", () => {
+      // First attempt: pristine URL — server-side caches matter only after a
+      // confirmed miss, so don't pollute attempt 0.
+      expect(appendCacheBust("https://example.com/file.pdf", 0)).toBe(
+        "https://example.com/file.pdf",
+      );
+
+      // Retries: cache-bust must appear so Service Workers / CDN edges
+      // re-resolve the response instead of replaying the original failure.
+      const second = appendCacheBust("https://example.com/file.pdf", 1);
+      expect(second).toMatch(/^https:\/\/example\.com\/file\.pdf\?cb=/);
+
+      // Existing query string: must use & separator, not a second ?
+      const withQuery = appendCacheBust("https://example.com/file.pdf?token=abc", 2);
+      expect(withQuery).toMatch(/^https:\/\/example\.com\/file\.pdf\?token=abc&cb=/);
+    });
+
+    it("retry attempts produce distinct cache-bust values", () => {
+      const a = appendCacheBust("https://example.com/file.pdf", 1);
+      const b = appendCacheBust("https://example.com/file.pdf", 2);
+      const c = appendCacheBust("https://example.com/file.pdf", 3);
+      expect(a).not.toBe(b);
+      expect(b).not.toBe(c);
+      expect(a).not.toBe(c);
+    });
+
+    it("wrapTransientError maps Failed-to-fetch into NetworkBlockedError", () => {
+      const wrapped = wrapTransientError(
+        new TypeError("Failed to fetch"),
+        "https://example.com/file.pdf",
+      );
+      expect(wrapped).toBeInstanceOf(NetworkBlockedError);
+    });
+
+    it("wrapTransientError maps generic errors into MediaUnavailableError with the URL", () => {
+      const wrapped = wrapTransientError(
+        new Error("Download failed: 503"),
+        "https://example.com/file.pdf",
+      );
+      expect(wrapped).toBeInstanceOf(MediaUnavailableError);
+      expect((wrapped as MediaUnavailableErrorT).mxcUrl).toBe(
+        "https://example.com/file.pdf",
+      );
+    });
+
+    it("retry adds a cache-bust parameter on the second fetch attempt", async () => {
+      // 5xx forces the retry path; second attempt resolves OK so the test
+      // doesn't have to wait through the full retry budget.
+      (global.fetch as Mock)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          blob: () => Promise.resolve(new Blob()),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          blob: () => Promise.resolve(new Blob([new Uint8Array([1, 2, 3])])),
+        });
+
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download } = useFileDownload();
+        const message = {
+          id: "$evt_cb",
+          _key: "client_cb",
+          roomId: "!room:server",
+          senderId: "@u:server",
+          content: "file.pdf",
+          timestamp: Date.now(),
+          status: "sent",
+          type: "file",
+          fileInfo: {
+            name: "file.pdf",
+            type: "application/pdf",
+            size: 1024,
+            url: "https://example.com/file.pdf",
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        await download(message);
+
+        const calls = (global.fetch as Mock).mock.calls;
+        expect(calls.length).toBeGreaterThanOrEqual(2);
+        // First attempt: pristine URL.
+        expect(calls[0][0]).toBe("https://example.com/file.pdf");
+        // Second attempt: cache-busted URL.
+        expect(calls[1][0]).toMatch(/^https:\/\/example\.com\/file\.pdf\?cb=/);
+      });
+      scope.stop();
+    }, 15_000);
+
+    it("surfaces a localised toast when retries exhaust on Failed-to-fetch (region block)", async () => {
+      (global.fetch as Mock).mockRejectedValue(new TypeError("Failed to fetch"));
+
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download } = useFileDownload();
+        const message = {
+          id: "$evt_toast_blocked",
+          _key: "client_toast_blocked",
+          roomId: "!room:server",
+          senderId: "@u:server",
+          content: "file.pdf",
+          timestamp: Date.now(),
+          status: "sent",
+          type: "file",
+          fileInfo: {
+            name: "file.pdf",
+            type: "application/pdf",
+            size: 1024,
+            url: "https://example.com/blocked.pdf",
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        await download(message);
+
+        expect(mockToast).toHaveBeenCalledWith(
+          "errors.networkBlocked",
+          "error",
+          expect.any(Number),
+        );
+      });
+      scope.stop();
+    }, 30_000);
+
+    it("after retry exhaustion, exposes errorKind='network' to the UI", async () => {
+      (global.fetch as Mock).mockRejectedValue(new TypeError("Failed to fetch"));
+
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download, getState } = useFileDownload();
+        const message = {
+          id: "$evt_blocked",
+          _key: "client_blocked",
+          roomId: "!room:server",
+          senderId: "@u:server",
+          content: "file.pdf",
+          timestamp: Date.now(),
+          status: "sent",
+          type: "file",
+          fileInfo: {
+            name: "file.pdf",
+            type: "application/pdf",
+            size: 1024,
+            url: "https://example.com/blocked.pdf",
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        await download(message);
+        const state = getState("client_blocked");
+        expect(state.errorKind).toBe("network");
+      });
+      scope.stop();
+    }, 30_000);
+
+    it("waits for pcrypto.rooms[roomId] to populate before decrypting (issue #616)", async () => {
+      // Encrypted file: download path goes through waitForRoomCrypto.
+      // Initially pcrypto is null (race against Matrix sync); then it
+      // populates after a short delay — the download must succeed.
+      const decryptedBlob = new File([new Uint8Array([9, 9, 9])], "decrypted.bin");
+      const decryptKey = vi.fn(() => Promise.resolve("k"));
+      const decryptFile = vi.fn(() => Promise.resolve(decryptedBlob));
+      const fakeRoom = { decryptKey, decryptFile };
+
+      (global.fetch as Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        blob: () => Promise.resolve(new Blob([new Uint8Array([1, 2, 3])])),
+      });
+
+      // Populate pcrypto on the next macrotask — this is what Matrix sync
+      // does in production once the room state has caught up.
+      setMockPcrypto(null);
+      setTimeout(() => {
+        setMockPcrypto({ rooms: { "!room:server": fakeRoom } });
+      }, 150);
+
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download } = useFileDownload();
+        const message = {
+          id: "$evt_wait",
+          _key: "client_wait",
+          roomId: "!room:server",
+          senderId: "@u:server",
+          content: "secret.bin",
+          timestamp: Date.now(),
+          status: "sent",
+          type: "file",
+          fileInfo: {
+            name: "secret.bin",
+            type: "application/octet-stream",
+            size: 3,
+            url: "https://example.com/secret.bin",
+            secrets: { keys: "k", block: 1, v: 1 },
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        const url = await download(message);
+
+        expect(url).toBeTruthy();
+        expect(decryptKey).toHaveBeenCalled();
+        expect(decryptFile).toHaveBeenCalled();
+      });
+      scope.stop();
+    }, 15_000);
+
+    it("fast-fails on CryptoNotReadyError instead of burning the full retry budget", async () => {
+      // pcrypto never populates — waitForRoomCrypto will time out at 5s on
+      // the first attempt, then the outer loop must NOT re-enter (otherwise
+      // the user waits ~40s for what will never resolve).
+      setMockPcrypto(null);
+      (global.fetch as Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        blob: () => Promise.resolve(new Blob([new Uint8Array([1, 2, 3])])),
+      });
+
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download, getState } = useFileDownload();
+        const message = {
+          id: "$evt_no_crypto",
+          _key: "client_no_crypto",
+          roomId: "!room:server",
+          senderId: "@u:server",
+          content: "secret.bin",
+          timestamp: Date.now(),
+          status: "sent",
+          type: "file",
+          fileInfo: {
+            name: "secret.bin",
+            type: "application/octet-stream",
+            size: 3,
+            url: "https://example.com/secret.bin",
+            secrets: { keys: "k", block: 1, v: 1 },
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        await download(message);
+
+        // Exactly one fetch attempt — no retry burn after CryptoNotReadyError.
+        expect((global.fetch as Mock).mock.calls.length).toBe(1);
+        // UI sees the crypto-not-ready toast and a network-class error.
+        expect(getState("client_no_crypto").errorKind).toBe("network");
+        expect(mockToast).toHaveBeenCalledWith(
+          "errors.cryptoNotReady",
+          "error",
+          expect.any(Number),
+        );
+      });
+      scope.stop();
+    }, 30_000);
 
     it("does not retry on 404 (fast-fail)", async () => {
       (global.fetch as Mock).mockResolvedValue({

--- a/src/features/messaging/model/use-file-download.ts
+++ b/src/features/messaging/model/use-file-download.ts
@@ -6,6 +6,14 @@ import { hexEncode } from "@/shared/lib/matrix/functions";
 import { isNative, isElectron } from "@/shared/lib/platform";
 import { useBugReport } from "@/features/bug-report";
 import { tRaw } from "@/shared/lib/i18n";
+import { useToast } from "@/shared/lib/use-toast";
+import {
+  CryptoNotReadyError,
+  isNetworkBlocked,
+  MediaUnavailableError,
+  NetworkBlockedError,
+} from "@/shared/lib/network/typed-network-errors";
+import { waitForRoomCrypto } from "@/entities/matrix/model/wait-for-crypto";
 import { enqueueDecrypt } from "./decrypt-queue";
 
 /** Coarse classification of a download/decrypt failure for UI branching.
@@ -54,6 +62,13 @@ function isCryptoError(err: unknown): boolean {
  *   - 5xx HTTP responses — server-side transient failure. */
 function isNetworkError(err: unknown): boolean {
   if (err instanceof DOMException && err.name === "AbortError") return true;
+  if (
+    err instanceof NetworkBlockedError ||
+    err instanceof MediaUnavailableError ||
+    err instanceof CryptoNotReadyError
+  ) {
+    return true;
+  }
   if (err instanceof TypeError) {
     return /failed to fetch|networkerror|load failed/i.test(err.message);
   }
@@ -95,10 +110,19 @@ function pruneDedupMap(): void {
 }
 
 /** Decide whether a download error should auto-open the bug-report modal.
- *  Returns false for crypto failures (always user-actionable, never a bug)
- *  and for repeats of the same (messageId, error) within the dedup window. */
+ *  Returns false for crypto failures (always user-actionable, never a bug),
+ *  for our own typed transient/region errors (those already show a clear
+ *  user message — auto-bug-report on top is just noise), and for repeats of
+ *  the same (messageId, error) within the dedup window. */
 function shouldAutoReport(messageKey: string, err: unknown): boolean {
   if (isCryptoError(err)) return false;
+  if (
+    err instanceof CryptoNotReadyError ||
+    err instanceof NetworkBlockedError ||
+    err instanceof MediaUnavailableError
+  ) {
+    return false;
+  }
   pruneDedupMap();
   const key = `${messageKey}:${errorHash(err)}`;
   const last = bugReportDedupMap.get(key) ?? 0;
@@ -111,6 +135,30 @@ function shouldAutoReport(messageKey: string, err: unknown): boolean {
 /** TEST-ONLY: clear the dedup map between test cases. */
 export function _resetBugReportDedupForTests(): void {
   bugReportDedupMap.clear();
+}
+
+/** Toast duration for typed transient errors. 5s gives the user enough time
+ *  to read the message but doesn't dwell so long that it overlaps with the
+ *  next action they take. */
+const TYPED_ERROR_TOAST_MS = 5_000;
+
+/** Show a localised toast when a download failure resolves to one of our
+ *  typed transient errors. Silent for everything else — generic errors are
+ *  still surfaced via the in-bubble retry UI and the auto-bug-report flow. */
+function surfaceTypedErrorToast(err: unknown): void {
+  let key: "errors.networkBlocked" | "errors.cryptoNotReady" | "errors.mediaUnavailable" | null = null;
+  if (err instanceof NetworkBlockedError) key = "errors.networkBlocked";
+  else if (err instanceof CryptoNotReadyError) key = "errors.cryptoNotReady";
+  else if (err instanceof MediaUnavailableError) key = "errors.mediaUnavailable";
+  if (!key) return;
+  try {
+    useToast().toast(tRaw(key), "error", TYPED_ERROR_TOAST_MS);
+  } catch (toastErr) {
+    // useToast() requires a Vue effect scope; in unusual runtime paths
+    // (worker contexts, headless tests without scope) it may throw.
+    // Don't let a failed toast mask the original download error.
+    console.warn("[use-file-download] toast surface failed:", toastErr);
+  }
 }
 
 /** Cache of already-decrypted file object URLs: eventId → objectUrl */
@@ -141,6 +189,68 @@ const FETCH_TIMEOUT_MS = 30_000;
 /** Non-retriable HTTP status codes — fast-fail instead of burning the
  *  retry budget on a guaranteed-failure response. */
 const NON_RETRIABLE_STATUSES = new Set([400, 401, 403, 404, 410, 415]);
+
+/** Monotonic counter so two cache-bust values produced inside the same
+ *  millisecond (Date.now() granularity) still differ. Without this, fast
+ *  back-to-back retries can collide on the same `cb=` value, defeating the
+ *  Service-Worker / CDN bust. */
+let cacheBustCounter = 0;
+
+/** Append a cache-bust query parameter on retry attempts. The first attempt
+ *  (`attempt === 0`) is left pristine: server-side caches only matter once
+ *  we've already seen a confirmed miss, and polluting the canonical URL
+ *  hurts CDN hit rates. Retries (`attempt >= 1`) get a unique `cb=` so
+ *  Service Workers, browser HTTP cache, and intermediate proxies all
+ *  re-resolve instead of replaying the prior failure. */
+export function appendCacheBust(url: string, attempt: number): string {
+  if (attempt <= 0) return url;
+  const sep = url.includes("?") ? "&" : "?";
+  return `${url}${sep}cb=${Date.now()}_${++cacheBustCounter}`;
+}
+
+/** True for failures that look like a network/server issue we should label
+ *  as such (5xx, timeouts, AbortError, fetch-network errors). Used to scope
+ *  `wrapTransientError`: only network-shaped errors get re-cast into
+ *  `MediaUnavailableError`. Generic application errors (e.g. QuotaExceeded,
+ *  unexpected exceptions inside the decrypt path) pass through unchanged so
+ *  the auto-bug-report flow still fires for them. */
+function looksLikeNetworkTransient(err: unknown): boolean {
+  if (err instanceof DOMException && err.name === "AbortError") return true;
+  if (err instanceof TypeError) {
+    // \bload failed\b prevents accidental matches against our own
+    // "Download failed: 5xx" path-style errors.
+    return /failed to fetch|networkerror|\bload failed\b/i.test(err.message);
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  return /Download failed:\s*5\d{2}|timeout/i.test(msg);
+}
+
+/** Wrap a final transient failure (after retries are exhausted) into a typed
+ *  error so callers can branch on instanceof checks instead of regexing
+ *  message strings.
+ *
+ *   - `NetworkBlockedError` — "request never reached the server" (region /
+ *     firewall / offline).
+ *   - `CryptoNotReadyError` — keys still loading; bubbles through unchanged
+ *     so the UI can show "wait" UX.
+ *   - `MediaUnavailableError` — 5xx / timeout / AbortError persisting after
+ *     retries.
+ *
+ *  Anything else is *not* wrapped: a generic `Error("QuotaExceeded")` from
+ *  the decrypt path is more useful as itself than re-cast as media-
+ *  unavailable, both for `console.error` traces and for bug-report dedup. */
+export function wrapTransientError(err: unknown, mxcUrl: string): Error {
+  if (
+    err instanceof NetworkBlockedError ||
+    err instanceof MediaUnavailableError ||
+    err instanceof CryptoNotReadyError
+  ) {
+    return err;
+  }
+  if (isNetworkBlocked(err)) return new NetworkBlockedError(err);
+  if (looksLikeNetworkTransient(err)) return new MediaUnavailableError(mxcUrl, err);
+  return err instanceof Error ? err : new Error(String(err));
+}
 
 /** Fetch a URL with a hard timeout. Caller's AbortSignal is honored if
  *  provided. Returns the Response or throws AbortError on timeout. */
@@ -185,8 +295,11 @@ async function downloadAndDecrypt(
     }
 
     try {
-      // Download the file (with hard timeout to avoid indefinite MIUI/Tor stalls)
-      const response = await fetchWithTimeout(fileInfo.url, signal);
+      // Download the file (with hard timeout to avoid indefinite MIUI/Tor stalls).
+      // On retry attempts, append a cache-bust so Service Workers / CDN edges
+      // don't replay the prior failure response (issues #648, #641, #637).
+      const fetchUrl = appendCacheBust(fileInfo.url, attempt);
+      const response = await fetchWithTimeout(fetchUrl, signal);
       if (!response.ok) {
         const err = new Error(`Download failed: ${response.status}`);
         // Mark non-retriable codes so the catch block below can throw immediately
@@ -196,11 +309,18 @@ async function downloadAndDecrypt(
       }
       let blob = await response.blob();
 
-      // If the file has secrets, we need to decrypt it
+      // If the file has secrets, we need to decrypt it.
+      // Race against Matrix sync: if the user opens an E2E chat right after
+      // login, `pcrypto.rooms[roomId]` may not yet be populated. Park briefly
+      // for it to materialise instead of immediately failing the attempt
+      // (issue #616). On timeout, CryptoNotReadyError bubbles up and the
+      // outer retry loop gets one more shot.
       if (fileInfo.secrets?.keys) {
         const authStore = useAuthStore();
-        const roomCrypto = authStore.pcrypto?.rooms[roomId] as PcryptoRoomInstance | undefined;
-        if (!roomCrypto) throw new Error("No room crypto for decryption");
+        const roomCrypto = await waitForRoomCrypto(
+          roomId,
+          () => authStore.pcrypto?.rooms[roomId] as PcryptoRoomInstance | undefined,
+        );
 
         // Build event-like object for decryptKey.
         // decryptKey reads secrets from either content.keys, content.info.secrets,
@@ -240,6 +360,12 @@ async function downloadAndDecrypt(
       // error. Fast-fail so the friendly "ask sender to resend" UX appears
       // immediately.
       if (isCryptoError(e)) throw e;
+      // Crypto-not-ready already paid 5 s of polling inside waitForRoomCrypto.
+      // Re-entering the outer retry loop would burn another 1+3+6 s × 5 s of
+      // polling = up to ~40 s before the user sees an error. Fast-fail and
+      // let the user pull-to-refresh once Matrix sync has actually settled —
+      // the toast tells them what's going on.
+      if (e instanceof CryptoNotReadyError) throw e;
       // Don't retry on permanent errors (missing URL, 4xx client errors)
       if (e instanceof Error) {
         if (e.message === "No file URL") throw e;
@@ -255,7 +381,10 @@ async function downloadAndDecrypt(
     }
   }
 
-  throw lastError;
+  // Retries exhausted — surface a typed error so the UI can show the right
+  // message (region-block UX vs. generic media-unavailable UX) instead of
+  // a bare TypeError stringified into the toast.
+  throw wrapTransientError(lastError, fileInfo.url);
 }
 
 /** Convert Blob to base64 data string (without the data:...;base64, prefix) */
@@ -408,6 +537,11 @@ export function useFileDownload() {
       console.error("[use-file-download] download error:", e);
       state.errorKind = classifyError(e);
       state.error = String(e);
+      // Surface a localised toast for our typed transient failures so the
+      // user sees a clear "what to do next" message (region/firewall vs.
+      // media-gone vs. keys-still-syncing) instead of just an in-bubble
+      // retry button.
+      surfaceTypedErrorToast(e);
       // Skip auto-report for crypto failures (user-actionable, not a bug) and
       // for duplicates within the dedup window. Manual reporting is still
       // available via the bug-report button in the friendly error UI.

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -833,6 +833,11 @@ export const en = {
   "banner.androidTitle": "Forta Chat is available as an Android app",
   "banner.androidCta": "Download APK",
   "banner.androidDismiss": "Continue in browser",
+
+  // ── Media / network errors (Session 32) ──
+  "errors.mediaUnavailable": "Media unavailable. Please try again later.",
+  "errors.networkBlocked": "Server unreachable. Try enabling Tor or a VPN.",
+  "errors.cryptoNotReady": "Encryption keys are still loading. Please wait.",
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -835,4 +835,9 @@ export const ru: Record<TranslationKey, string> = {
   "banner.androidTitle": "Forta Chat доступен как Android-приложение",
   "banner.androidCta": "Скачать APK",
   "banner.androidDismiss": "Продолжить в браузере",
+
+  // ── Ошибки загрузки медиа / сети (Session 32) ──
+  "errors.mediaUnavailable": "Медиа недоступно. Попробуйте позже.",
+  "errors.networkBlocked": "Сервер недоступен. Попробуйте включить Tor или VPN.",
+  "errors.cryptoNotReady": "Ключи шифрования ещё загружаются. Подождите.",
 };

--- a/src/shared/lib/network/__tests__/typed-network-errors.test.ts
+++ b/src/shared/lib/network/__tests__/typed-network-errors.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import {
+  MediaUnavailableError,
+  NetworkBlockedError,
+  CryptoNotReadyError,
+  isNetworkBlocked,
+} from "../typed-network-errors";
+
+describe("typed-network-errors", () => {
+  describe("MediaUnavailableError", () => {
+    it("preserves the mxc URL and a stable name", () => {
+      const err = new MediaUnavailableError("mxc://server/abc");
+      expect(err.mxcUrl).toBe("mxc://server/abc");
+      expect(err.name).toBe("MediaUnavailableError");
+      expect(err.message).toContain("mxc://server/abc");
+    });
+
+    it("captures the underlying cause", () => {
+      const root = new TypeError("Failed to fetch");
+      const err = new MediaUnavailableError("mxc://server/abc", root);
+      expect(err.cause).toBe(root);
+    });
+
+    it("is a subclass of Error so instanceof works", () => {
+      const err = new MediaUnavailableError("mxc://server/abc");
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(MediaUnavailableError);
+    });
+  });
+
+  describe("NetworkBlockedError", () => {
+    it("has a stable name and message", () => {
+      const err = new NetworkBlockedError();
+      expect(err.name).toBe("NetworkBlockedError");
+      expect(err.message).toMatch(/blocked/i);
+    });
+
+    it("preserves the underlying cause", () => {
+      const root = new TypeError("Failed to fetch");
+      const err = new NetworkBlockedError(root);
+      expect(err.cause).toBe(root);
+    });
+
+    it("is a subclass of Error so instanceof works", () => {
+      const err = new NetworkBlockedError();
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(NetworkBlockedError);
+    });
+  });
+
+  describe("CryptoNotReadyError", () => {
+    it("preserves the roomId and a stable name", () => {
+      const err = new CryptoNotReadyError("!room:server");
+      expect(err.roomId).toBe("!room:server");
+      expect(err.name).toBe("CryptoNotReadyError");
+      expect(err.message).toContain("!room:server");
+    });
+
+    it("is a subclass of Error so instanceof works", () => {
+      const err = new CryptoNotReadyError("!room:server");
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(CryptoNotReadyError);
+    });
+  });
+
+  describe("isNetworkBlocked", () => {
+    it("detects Chrome's TypeError 'Failed to fetch'", () => {
+      expect(isNetworkBlocked(new TypeError("Failed to fetch"))).toBe(true);
+    });
+
+    it("detects Firefox's 'NetworkError when attempting to fetch resource'", () => {
+      expect(
+        isNetworkBlocked(new TypeError("NetworkError when attempting to fetch resource.")),
+      ).toBe(true);
+    });
+
+    it("detects 'Network request failed'", () => {
+      expect(isNetworkBlocked(new Error("Network request failed"))).toBe(true);
+    });
+
+    it("detects Safari's 'Load failed' (same connectivity-block class as Failed to fetch)", () => {
+      expect(isNetworkBlocked(new TypeError("Load failed"))).toBe(true);
+    });
+
+    it("detects ERR_INTERNET_DISCONNECTED in error message", () => {
+      expect(
+        isNetworkBlocked(new Error("net::ERR_INTERNET_DISCONNECTED")),
+      ).toBe(true);
+    });
+
+    it("matches regardless of message casing", () => {
+      expect(isNetworkBlocked(new TypeError("FAILED TO FETCH"))).toBe(true);
+    });
+
+    it("does not classify HTTP 5xx server errors as blocked", () => {
+      expect(isNetworkBlocked(new Error("Download failed: 503"))).toBe(false);
+    });
+
+    it("does not classify generic errors as blocked", () => {
+      expect(isNetworkBlocked(new Error("Unexpected token in JSON"))).toBe(false);
+    });
+
+    it("returns false for non-Error values", () => {
+      expect(isNetworkBlocked(null)).toBe(false);
+      expect(isNetworkBlocked(undefined)).toBe(false);
+      expect(isNetworkBlocked("Failed to fetch")).toBe(false);
+      expect(isNetworkBlocked(42)).toBe(false);
+    });
+
+    it("recognises a NetworkBlockedError directly", () => {
+      const err = new NetworkBlockedError(new TypeError("Failed to fetch"));
+      expect(isNetworkBlocked(err)).toBe(true);
+    });
+  });
+});

--- a/src/shared/lib/network/typed-network-errors.ts
+++ b/src/shared/lib/network/typed-network-errors.ts
@@ -1,0 +1,82 @@
+/**
+ * Typed errors for the media + crypto download path.
+ *
+ * The download pipeline used to throw bare `Error("Failed to fetch")` /
+ * `Error("No room crypto for decryption")` strings, which the UI then had to
+ * pattern-match. That fan-out made it impossible to surface different UX for
+ * "media is gone forever" vs. "you're behind a region block" vs. "crypto
+ * hasn't initialised yet, just wait". Each kind has a different recovery:
+ *
+ *  - `MediaUnavailableError` — exhausted retries against the homeserver. The
+ *    blob may have been redacted, the server is permanently 404/410, or the
+ *    CDN dropped the object. Tell the user the media is unavailable.
+ *  - `NetworkBlockedError`  — fetch never reached the server (Failed to fetch
+ *    / NetworkError / ERR_INTERNET_DISCONNECTED). Almost always means
+ *    region/firewall block or full offline. Suggest Tor / VPN.
+ *  - `CryptoNotReadyError`  — `authStore.pcrypto.rooms[roomId]` wasn't ready
+ *    when we tried to decrypt. Caller should wait briefly and retry; this is
+ *    a startup race, not a permanent failure.
+ */
+
+/** Heuristic patterns that indicate the request never reached the server.
+ *  Browser-dependent — Chrome ships "Failed to fetch", Firefox "NetworkError
+ *  when attempting to fetch resource", Safari "Load failed", Capacitor
+ *  WebView "Network request failed", and Chromium surfaces
+ *  `ERR_INTERNET_DISCONNECTED` when offline. All four browsers raise the
+ *  same TypeError kind for region/firewall blocks; we want them to map
+ *  to NetworkBlockedError uniformly so the iOS/Safari user sees the
+ *  "try Tor or VPN" message just like the Android user does. */
+const NETWORK_BLOCKED_PATTERNS: RegExp[] = [
+  /failed to fetch/i,
+  /network ?error/i,
+  /network request failed/i,
+  /err_internet_disconnected/i,
+  // \b word-boundary so this matches Safari's "Load failed" but NOT
+  // overlapping substrings like our internal "Download failed: 503"
+  // (which is a 5xx HTTP response, not a region-block).
+  /\bload failed\b/i,
+];
+
+export class MediaUnavailableError extends Error {
+  readonly mxcUrl: string;
+
+  constructor(mxcUrl: string, cause?: unknown) {
+    super(`Media unavailable: ${mxcUrl}`, cause !== undefined ? { cause } : undefined);
+    this.name = "MediaUnavailableError";
+    this.mxcUrl = mxcUrl;
+  }
+}
+
+export class NetworkBlockedError extends Error {
+  constructor(cause?: unknown) {
+    super(
+      "Network appears blocked (region/firewall/offline)",
+      cause !== undefined ? { cause } : undefined,
+    );
+    this.name = "NetworkBlockedError";
+  }
+}
+
+export class CryptoNotReadyError extends Error {
+  readonly roomId: string;
+
+  constructor(roomId: string, cause?: unknown) {
+    super(
+      `Room crypto not initialised: ${roomId}`,
+      cause !== undefined ? { cause } : undefined,
+    );
+    this.name = "CryptoNotReadyError";
+    this.roomId = roomId;
+  }
+}
+
+/** Detect "the request never made it to the server" failures. Returns false
+ *  for HTTP 4xx/5xx responses (the request DID reach the server, the server
+ *  just answered with an error). Non-Error values always return false — we
+ *  don't want a stray string match to flip a generic exception into a
+ *  blocked-network UX. */
+export function isNetworkBlocked(error: unknown): boolean {
+  if (error instanceof NetworkBlockedError) return true;
+  if (!(error instanceof Error)) return false;
+  return NETWORK_BLOCKED_PATTERNS.some((re) => re.test(error.message));
+}


### PR DESCRIPTION
## Summary

Fix the cluster of media download / decrypt failures that have been showing up across releases. Three orthogonal pieces, all closing concrete GitHub issues:

- **Typed errors** (`MediaUnavailableError`, `NetworkBlockedError`, `CryptoNotReadyError`) — replace bare `Error` strings with `instanceof`-friendly classes so callers can branch on exact failure modes instead of regex-matching messages.
- **Retry with cache-bust** — when the first download attempt fails with a 5xx / fetch error, the retry attempts now append a `?cb=…` so Service Workers and CDN edges re-resolve instead of replaying the prior failure (issues #648 #641 #637).
- **`waitForRoomCrypto`** — polls `authStore.pcrypto.rooms[roomId]` for up to 5 s before throwing `CryptoNotReadyError`. Fixes the cold-start race where opening an E2E chat immediately after login threw "No room crypto for decryption" (issue #616). Crypto-not-ready fast-fails the outer retry loop (no point burning ~40 s polling for keys that aren't arriving).

Localised toasts (`errors.mediaUnavailable`, `errors.networkBlocked`, `errors.cryptoNotReady`) surface for the new typed errors, with `\\bload failed\\b` word-boundary so Safari's "Load failed" maps to NetworkBlocked while our own "Download failed: 5xx" still goes to MediaUnavailable.

Closes #648, #641, #637, #616, #658, #638, #642, #629, #599, #594.

## Test plan

- [x] 49 new/changed unit tests in typed-network-errors, wait-for-crypto, and use-file-download — all passing
- [x] Full vitest suite: 1648 passed / 9 pre-existing failures unchanged on master
- [x] vue-tsc --noEmit clean for new + changed files
- [x] Independent code-review pass (typescript-reviewer agent) — both HIGH issues addressed in this PR before merge
- [ ] Manual smoke test on Android: download an E2E media in a fresh-login chat
- [ ] Manual smoke test: simulate network drop mid-retry — verify NetworkBlocked toast