### PR TITLE
fix(messaging): unblock send button + actionable peer-keys banner (Session 35)

### DIFF
--- a/src/entities/auth/model/__tests__/republish-keys-from-ui.test.ts
+++ b/src/entities/auth/model/__tests__/republish-keys-from-ui.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression tests pinning the safety contract of `republishKeysFromUi()`.
+ *
+ * The original `verifyAndRepublishKeys()` flips `registrationPending` and
+ * starts a registration poll on a republish-needed path — that's correct for
+ * login but a foot-gun when the same call is wired to a chat-room banner
+ * button (App.vue mounts RegistrationStepper as a full-screen overlay
+ * whenever `registrationPending` is truthy). The UI variant must broadcast
+ * keys without touching that registration-pending state.
+ */
+
+const storesSource = readFileSync(
+  resolve(__dirname, "../stores.ts"),
+  "utf-8",
+);
+
+function extractFunctionBody(name: string): string {
+  const startIdx = storesSource.indexOf(`const ${name} = async (`);
+  if (startIdx === -1) throw new Error(`function ${name} not found`);
+  // Look ahead for the closing `};` at indent 0 ("\n  };") — every
+  // store-scoped const ends with two-space `};`.
+  const endMarker = "\n  };";
+  const endIdx = storesSource.indexOf(endMarker, startIdx);
+  if (endIdx === -1) throw new Error(`end of ${name} not found`);
+  return storesSource.slice(startIdx, endIdx);
+}
+
+describe("republishKeysFromUi safety", () => {
+  it("does not flip registrationPending on the republish path", () => {
+    const body = extractFunctionBody("republishKeysFromUi");
+    expect(body).not.toContain("setRegistrationPending(true)");
+    expect(body).not.toContain("startRegistrationPoll(");
+    expect(body).not.toContain("setPendingRegProfile(");
+  });
+
+  it("returns a typed result with all four UI-relevant states", () => {
+    const body = extractFunctionBody("republishKeysFromUi");
+    expect(body).toContain('state: "already-ok"');
+    expect(body).toContain('state: "republished"');
+    expect(body).toContain('state: "needs-funds"');
+    expect(body).toContain('state: "broadcast-failed"');
+  });
+
+  it("guards against running while a real registration is already in flight", () => {
+    const body = extractFunctionBody("republishKeysFromUi");
+    // If registrationPending is already true (login flow re-publishing), the
+    // UI variant must short-circuit instead of racing the legitimate poll.
+    expect(body).toContain("registrationPending.value");
+    expect(body).toContain('state: "skipped"');
+  });
+
+  it("is exported from the auth store", () => {
+    // The store's return block must list republishKeysFromUi so the
+    // ChatWindow banner can reach it.
+    const returnBlockIdx = storesSource.lastIndexOf("return {");
+    expect(returnBlockIdx).toBeGreaterThan(-1);
+    const returnBlock = storesSource.slice(returnBlockIdx);
+    expect(returnBlock).toContain("republishKeysFromUi");
+  });
+});
+
+describe("verifyAndRepublishKeys (login path) is intact", () => {
+  it("still flips registrationPending on the republish path", () => {
+    // Sanity check — the login path needs the registration overlay so the
+    // user sees the poll progress. Don't accidentally degrade it while
+    // refactoring the UI variant.
+    const body = extractFunctionBody("verifyAndRepublishKeys");
+    expect(body).toContain("setRegistrationPending(true)");
+    expect(body).toContain("startRegistrationPoll(");
+  });
+});

--- a/src/entities/auth/model/stores.ts
+++ b/src/entities/auth/model/stores.ts
@@ -837,6 +837,79 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
     }
   };
 
+  /** UI-safe variant of {@link verifyAndRepublishKeys}. Same verify step,
+   *  but on a republish-needed path it broadcasts directly without flipping
+   *  `registrationPending` (which would mount RegistrationStepper over the
+   *  running session — see App.vue). Caller-friendly result lets the UI
+   *  show a toast instead of swallowing state changes. */
+  type RepublishResult =
+    | { state: "already-ok"; keys: number }
+    | { state: "republished" }
+    | { state: "needs-funds" }
+    | { state: "broadcast-failed"; reason: string }
+    | { state: "skipped"; reason: string };
+
+  const republishKeysFromUi = async (): Promise<RepublishResult> => {
+    if (!address.value || !privateKey.value) {
+      return { state: "skipped", reason: "no-credentials" };
+    }
+    if (registrationPending.value || pendingRegProfile.value) {
+      return { state: "skipped", reason: "registration-in-progress" };
+    }
+
+    const userData = appInitializer.getUserData(address.value);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cachedKeys: string[] = (userData as any)?.keys ?? [];
+    if (cachedKeys.length >= 12) {
+      return { state: "already-ok", keys: cachedKeys.length };
+    }
+
+    let blockchainKeys: string[] = [];
+    try {
+      const rawProfiles = await appInitializer.loadUsersInfoRaw([address.value]);
+      const rawProfile = rawProfiles[0];
+      if (rawProfile) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const rawKeys = (rawProfile as any).k ?? (rawProfile as any).keys ?? "";
+        if (Array.isArray(rawKeys)) {
+          blockchainKeys = rawKeys.filter((k: string) => k);
+        } else if (typeof rawKeys === "string" && rawKeys) {
+          blockchainKeys = rawKeys.split(",").filter((k: string) => k);
+        }
+      }
+    } catch (e) {
+      return { state: "broadcast-failed", reason: e instanceof Error ? e.message : "rpc-failed" };
+    }
+    if (blockchainKeys.length >= 12) {
+      return { state: "already-ok", keys: blockchainKeys.length };
+    }
+
+    const hasUnspents = await appInitializer.checkUnspents(address.value);
+    if (!hasUnspents) {
+      return { state: "needs-funds" };
+    }
+
+    const encKeys = generateEncryptionKeys(privateKey.value);
+    const encPublicKeys = encKeys.map(k => k.public);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const name = (userData as any)?.name ?? "";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const language = (userData as any)?.language ?? "en";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const about = (userData as any)?.about ?? "";
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const image = (userData as any)?.image ?? "";
+
+    try {
+      await appInitializer.syncNodeTime();
+      await appInitializer.registerUserProfile(address.value, { name, language, about }, encPublicKeys, image);
+      return { state: "republished" };
+    } catch (e) {
+      console.error("[auth] republishKeysFromUi broadcast failed:", e);
+      return { state: "broadcast-failed", reason: e instanceof Error ? e.message : "broadcast-failed" };
+    }
+  };
+
   const { execute: login, isLoading: isLoggingIn } = useAsyncOperation(
     async (cryptoCredential: string) => {
       try {
@@ -1583,6 +1656,7 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
     submitCaptcha,
     submitComment,
     submitUpvote,
-    userInfo
+    userInfo,
+    republishKeysFromUi
   };
 });

--- a/src/features/messaging/model/peer-keys-ok.test.ts
+++ b/src/features/messaging/model/peer-keys-ok.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { isPeerKeysOk, type PeerKeysOkInput } from "./peer-keys-ok";
+
+const base: PeerKeysOkInput = {
+  status: "available",
+  isGroupOrPublic: false,
+  inGracePeriod: false,
+};
+
+describe("isPeerKeysOk", () => {
+  it("private 1:1 with available keys allows send", () => {
+    expect(isPeerKeysOk(base)).toBe(true);
+  });
+
+  // Regression #597/#598/#639: send button stayed disabled forever after the
+  // 1.10.16 update because peer keys did not propagate. Group/public rooms
+  // never had to block — they fall back to plaintext anyway.
+  it("group room never blocks send (allows plaintext fallback)", () => {
+    expect(
+      isPeerKeysOk({ ...base, status: "missing", isGroupOrPublic: true }),
+    ).toBe(true);
+  });
+
+  // Grace period: when the user just opened a chat, peer-keys may still be
+  // loading. Block button only after the grace period to avoid the
+  // "permanently disabled" UX.
+  it("grace period unblocks send while peer keys are still loading", () => {
+    expect(
+      isPeerKeysOk({ ...base, status: "missing", inGracePeriod: true }),
+    ).toBe(true);
+  });
+
+  it("private 1:1 with missing keys after grace blocks send", () => {
+    expect(isPeerKeysOk({ ...base, status: "missing" })).toBe(false);
+  });
+
+  it("private 1:1 with not-encrypted (large room) allows send", () => {
+    expect(isPeerKeysOk({ ...base, status: "not-encrypted" })).toBe(true);
+  });
+
+  it("private 1:1 with unknown status (crypto not initialised) allows send", () => {
+    expect(isPeerKeysOk({ ...base, status: "unknown" })).toBe(true);
+  });
+
+  it("undefined status (peerKeysStatus not yet set) allows send", () => {
+    expect(isPeerKeysOk({ ...base, status: undefined })).toBe(true);
+  });
+
+  it("group room with missing keys + grace + sending — still ok", () => {
+    expect(
+      isPeerKeysOk({
+        status: "missing",
+        isGroupOrPublic: true,
+        inGracePeriod: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/features/messaging/model/peer-keys-ok.ts
+++ b/src/features/messaging/model/peer-keys-ok.ts
@@ -1,0 +1,33 @@
+/** Peer-keys readiness gate for the send button.
+ *
+ *  Two regression contexts shaped this gate:
+ *  - 1.10.16 reports of the send button stuck disabled with
+ *    "Собеседник не опубликовал ключи шифрования" (issues #597/#598/#639).
+ *    Root cause: peerKeysStatus stayed "missing" because peer keys never
+ *    propagated, so the previous `status !== "missing"` UI gate locked the
+ *    button forever and the user had no escape hatch.
+ *  - Group rooms never required the gate to begin with — encryption falls
+ *    back to plaintext for ≥50 members and is not mandatory for groups, yet
+ *    the same gate blocked them too.
+ *
+ *  Resolution: only block in private 1:1 rooms AFTER a short grace period.
+ *  Group/public rooms always allow send. Grace period gives peer keys time
+ *  to land before the user perceives the button as broken. */
+export type PeerKeysStatus =
+  | "available"
+  | "missing"
+  | "not-encrypted"
+  | "unknown"
+  | undefined;
+
+export interface PeerKeysOkInput {
+  status: PeerKeysStatus;
+  isGroupOrPublic: boolean;
+  inGracePeriod: boolean;
+}
+
+export function isPeerKeysOk(input: PeerKeysOkInput): boolean {
+  if (input.isGroupOrPublic) return true;
+  if (input.inGracePeriod) return true;
+  return input.status !== "missing";
+}

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -21,7 +21,10 @@ import { useMobile } from "@/shared/lib/composables/use-media-query";
 import { useResolvedRoomName } from "@/entities/chat/lib/use-resolved-room-name";
 import { shouldSendOnEnter } from "../model/enter-key-behavior";
 import { isSendButtonVisible, isSendButtonDisabled } from "../model/send-button-state";
+import { isPeerKeysOk } from "../model/peer-keys-ok";
 import { isNative } from "@/shared/lib/platform";
+
+const PEER_KEYS_GRACE_MS = 2000;
 
 const isMobile = useMobile();
 
@@ -132,6 +135,10 @@ onBeforeUnmount(() => {
     setTyping(false, roomId);
   }
   resetTypingTimers();
+  if (peerKeysGraceTimer) {
+    clearTimeout(peerKeysGraceTimer);
+    peerKeysGraceTimer = null;
+  }
   // Clean up any lingering recording mouse/move listeners
   document.removeEventListener("mouseup", handleGlobalMouseUp);
   document.removeEventListener("mousemove", handleGlobalMouseMove);
@@ -160,13 +167,38 @@ watch(() => chatStore.forwardingMessage, (fwd) => {
   if (fwd) nextTick(() => textareaRef.value?.focus({ preventScroll: true }));
 });
 
+// Grace period after switching rooms: peer-keys may still be loading,
+// so don't gate the button on `peerKeysStatus` for the first PEER_KEYS_GRACE_MS.
+// Without this the user perceives the button as permanently broken every time
+// the peer-keys propagation lags (regression #597/#598/#639 after 1.10.16).
+const peerKeysGraceActive = ref(false);
+let peerKeysGraceTimer: ReturnType<typeof setTimeout> | null = null;
+watch(() => chatStore.activeRoomId, (roomId) => {
+  if (peerKeysGraceTimer) {
+    clearTimeout(peerKeysGraceTimer);
+    peerKeysGraceTimer = null;
+  }
+  if (!roomId) {
+    peerKeysGraceActive.value = false;
+    return;
+  }
+  peerKeysGraceActive.value = true;
+  peerKeysGraceTimer = setTimeout(() => {
+    peerKeysGraceActive.value = false;
+    peerKeysGraceTimer = null;
+  }, PEER_KEYS_GRACE_MS);
+}, { immediate: true });
+
 const peerKeysOk = computed(() => {
   const roomId = chatStore.activeRoomId;
   if (!roomId) return true;
-  const status = chatStore.peerKeysStatus.get(roomId);
-  // Block send only when peers are missing keys in a private room.
-  // "not-encrypted" rooms (public / large) allow plain-text send.
-  return status !== "missing";
+  const room = chatStore.activeRoom;
+  const isGroupOrPublic = !!room?.isGroup || chatStore.isRoomPublic(roomId);
+  return isPeerKeysOk({
+    status: chatStore.peerKeysStatus.get(roomId),
+    isGroupOrPublic,
+    inGracePeriod: peerKeysGraceActive.value,
+  });
 });
 
 const isEditing = computed(() => !!chatStore.editingMessage);

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -741,7 +741,14 @@ export const en = {
 
   // ── Misc ──
   "chat.messageNotFound": "Message not found",
-  "chat.peerKeysMissing": "Peer hasn't published encryption keys yet. Messaging is temporarily unavailable.",
+  "chat.peerKeysMissing": "Peer hasn't published encryption keys yet — your messages will stay unencrypted until they do. You can retry now or republish your own keys.",
+  "chat.peerKeysRetry": "Retry",
+  "chat.republishKeys": "Republish my keys",
+  "chat.republishKeysInProgress": "Republishing…",
+  "chat.republishKeysSuccess": "Encryption keys republished",
+  "chat.republishKeysError": "Failed to republish keys",
+  "chat.republishKeysAlreadyOk": "Your keys are already published",
+  "chat.republishKeysNeedsFunds": "Not enough PKOIN to broadcast keys",
   "chat.unencryptedRoom": "Messages in this room are not encrypted",
   "tor.disable": "Disable Tor",
   "register.registrationFailed": "Registration failed",
@@ -833,6 +840,11 @@ export const en = {
   "banner.androidTitle": "Forta Chat is available as an Android app",
   "banner.androidCta": "Download APK",
   "banner.androidDismiss": "Continue in browser",
+
+  // ── Media / network errors (Session 32) ──
+  "errors.mediaUnavailable": "Media unavailable. Please try again later.",
+  "errors.networkBlocked": "Server unreachable. Try enabling Tor or a VPN.",
+  "errors.cryptoNotReady": "Encryption keys are still loading. Please wait.",
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -743,7 +743,14 @@ export const ru: Record<TranslationKey, string> = {
 
   // ── Misc ──
   "chat.messageNotFound": "Сообщение не найдено",
-  "chat.peerKeysMissing": "Собеседник ещё не опубликовал ключи шифрования. Отправка сообщений временно недоступна.",
+  "chat.peerKeysMissing": "Собеседник ещё не опубликовал ключи шифрования — пока не опубликует, сообщения отправятся без шифрования. Можно попробовать снова или переопубликовать свои ключи.",
+  "chat.peerKeysRetry": "Повторить",
+  "chat.republishKeys": "Опубликовать мои ключи",
+  "chat.republishKeysInProgress": "Публикуем…",
+  "chat.republishKeysSuccess": "Ключи шифрования опубликованы",
+  "chat.republishKeysError": "Не удалось опубликовать ключи",
+  "chat.republishKeysAlreadyOk": "Ваши ключи уже опубликованы",
+  "chat.republishKeysNeedsFunds": "Недостаточно PKOIN для публикации ключей",
   "chat.unencryptedRoom": "Сообщения в этой комнате не шифруются",
   "tor.disable": "Отключить Tor",
   "register.registrationFailed": "Ошибка регистрации",
@@ -835,4 +842,9 @@ export const ru: Record<TranslationKey, string> = {
   "banner.androidTitle": "Forta Chat доступен как Android-приложение",
   "banner.androidCta": "Скачать APK",
   "banner.androidDismiss": "Продолжить в браузере",
+
+  // ── Ошибки загрузки медиа / сети (Session 32) ──
+  "errors.mediaUnavailable": "Медиа недоступно. Попробуйте позже.",
+  "errors.networkBlocked": "Сервер недоступен. Попробуйте включить Tor или VPN.",
+  "errors.cryptoNotReady": "Ключи шифрования ещё загружаются. Подождите.",
 };

--- a/src/widgets/chat-window/ChatWindow.vue
+++ b/src/widgets/chat-window/ChatWindow.vue
@@ -99,11 +99,73 @@ const peerKeysMissing = computed(() => {
   const roomId = chatStore.activeRoomId;
   if (!roomId) return false;
   const status = chatStore.peerKeysStatus.get(roomId);
-  // Show warning only when peers lack keys (not for public/large rooms)
+  // Show warning only when peers lack keys (not for public/large rooms).
+  // Mirror the same suppression that MessageInput.vue applies to peerKeysOk —
+  // group AND public rooms must both stay banner-free, otherwise the user sees
+  // an enabled send button next to a "messaging unavailable" warning.
   if (chatStore.activeRoom?.isGroup) return false;
+  if (chatStore.isRoomPublic(roomId)) return false;
   return status === "missing";
 });
 
+const { toast } = useToast();
+const { t } = useI18n();
+
+// Retry/republish handlers for the peer-keys banner. The banner is no longer
+// a hard blocker (regression #597/#598/#639) — it now offers two escape
+// hatches so a stuck "missing" state never traps the user.
+const peerKeysRetrying = ref(false);
+const peerKeysRepublishing = ref(false);
+
+const retryPeerKeys = async () => {
+  const roomId = chatStore.activeRoomId;
+  if (!roomId || peerKeysRetrying.value) return;
+  peerKeysRetrying.value = true;
+  try {
+    const roomCrypto = authStore.pcrypto?.rooms[roomId];
+    if (roomCrypto) await roomCrypto.prepare();
+    await chatStore.checkPeerKeys(roomId);
+  } catch (e) {
+    console.warn("[ChatWindow] peer-keys retry failed:", e);
+  } finally {
+    peerKeysRetrying.value = false;
+  }
+};
+
+const republishMyKeys = async () => {
+  if (peerKeysRepublishing.value) return;
+  peerKeysRepublishing.value = true;
+  try {
+    const result = await authStore.republishKeysFromUi();
+    if (result.state === "republished" || result.state === "already-ok") {
+      const roomId = chatStore.activeRoomId;
+      if (roomId) {
+        const roomCrypto = authStore.pcrypto?.rooms[roomId];
+        if (roomCrypto) await roomCrypto.prepare();
+        await chatStore.checkPeerKeys(roomId);
+      }
+      toast(
+        result.state === "already-ok"
+          ? t("chat.republishKeysAlreadyOk")
+          : t("chat.republishKeysSuccess"),
+        "success",
+      );
+    } else if (result.state === "needs-funds") {
+      toast(t("chat.republishKeysNeedsFunds"), "error");
+    } else if (result.state === "broadcast-failed") {
+      console.error("[ChatWindow] republish keys broadcast failed:", result.reason);
+      toast(t("chat.republishKeysError"), "error");
+    } else {
+      // skipped (no creds / registration in progress) — show generic error
+      toast(t("chat.republishKeysError"), "error");
+    }
+  } catch (e) {
+    console.error("[ChatWindow] republish keys failed:", e);
+    toast(t("chat.republishKeysError"), "error");
+  } finally {
+    peerKeysRepublishing.value = false;
+  }
+};
 
 watch(() => chatStore.activeRoomId, async (roomId) => {
   if (roomId) {
@@ -130,9 +192,6 @@ watch(() => chatStore.activeRoomId, (roomId) => {
     }
   }, 30_000);
 }, { immediate: true });
-const { toast } = useToast();
-
-const { t } = useI18n();
 
 const isAdmin = computed(() => {
   if (!chatStore.activeRoom) return false;
@@ -581,11 +640,31 @@ onUnmounted(() => {
           />
         </transition>
         <PinnedBar :is-admin="isAdmin" @scroll-to="handleScrollToMessage" />
-        <div v-if="peerKeysMissing" class="mx-4 my-2 rounded-lg bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 px-4 py-3 text-sm text-amber-800 dark:text-amber-200 flex items-center gap-2">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0 text-amber-500">
+        <div v-if="peerKeysMissing" class="mx-4 my-2 rounded-lg bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 px-4 py-3 text-sm text-amber-800 dark:text-amber-200 flex items-start gap-2">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0 mt-0.5 text-amber-500">
             <path d="M12 9v4m0 4h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
           </svg>
-          <span>{{ t("chat.peerKeysMissing") }}</span>
+          <div class="flex-1 min-w-0">
+            <p class="leading-snug">{{ t("chat.peerKeysMissing") }}</p>
+            <div class="mt-2 flex flex-wrap gap-2">
+              <button
+                type="button"
+                class="rounded-md border border-amber-300 dark:border-amber-700 bg-white/60 dark:bg-amber-950/40 px-3 py-1 text-xs font-medium text-amber-900 dark:text-amber-100 hover:bg-white dark:hover:bg-amber-900/60 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                :disabled="peerKeysRetrying"
+                @click="retryPeerKeys"
+              >
+                {{ t("chat.peerKeysRetry") }}
+              </button>
+              <button
+                type="button"
+                class="rounded-md border border-amber-300 dark:border-amber-700 bg-white/60 dark:bg-amber-950/40 px-3 py-1 text-xs font-medium text-amber-900 dark:text-amber-100 hover:bg-white dark:hover:bg-amber-900/60 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                :disabled="peerKeysRepublishing"
+                @click="republishMyKeys"
+              >
+                {{ peerKeysRepublishing ? t("chat.republishKeysInProgress") : t("chat.republishKeys") }}
+              </button>
+            </div>
+          </div>
         </div>
         <MessageList ref="messageListRef" />
         <SelectionBar

--- a/src/widgets/chat-window/__tests__/ChatWindow.test.ts
+++ b/src/widgets/chat-window/__tests__/ChatWindow.test.ts
@@ -66,6 +66,7 @@ vi.mock("@/entities/chat", async () => {
       getTypingUsers: vi.fn(() => []),
       getDisplayName: vi.fn(() => ""),
       getRoomMemberCount: vi.fn(() => 0),
+      isRoomPublic: vi.fn(() => false),
     }),
   };
 });


### PR DESCRIPTION
## Summary

Closes the post-1.10.16 send-button regressions reported in #597, #598, #639 — _«Собеседник не опубликовал ключи шифрования»_ followed by a permanently disabled send button with no way out.

**Root cause:** UI gate `peerKeysOk` blocked the button synchronously on `peerKeysStatus === "missing"`. A single missed peer-key propagation locked the input forever — no grace period, no group/public bypass, no actionable escape hatch in the warning banner.

## Changes

- **`peer-keys-ok.ts`** — extracted UI gate into a pure function with three inputs (`status`, `isGroupOrPublic`, `inGracePeriod`). Group/public always allow send; 2 s grace period after switching rooms keeps the button enabled while peer keys load. 8 unit tests pin the contract.
- **`MessageInput.vue`** — uses the new pure fn, manages grace timer with proper cleanup on unmount + room switch.
- **`ChatWindow.vue`** — peer-keys banner now has two action buttons:
  - **Retry** — re-prepares `roomCrypto` and re-checks peer keys
  - **Republish my keys** — calls a new safe `auth.republishKeysFromUi()`

  Banner suppression now matches the MessageInput gate (group OR public).
- **`auth/stores.ts`** — added `republishKeysFromUi()` that broadcasts via `registerUserProfile` directly, **without** flipping `registrationPending` (that flag mounts the RegistrationStepper overlay over the running session). Returns a typed `RepublishResult` for distinct toasts (`already-ok` / `republished` / `needs-funds` / `broadcast-failed` / `skipped`). The login-flow `verifyAndRepublishKeys()` is unchanged.
- **i18n (en + ru)** — banner text + 7 new keys for action buttons and toast states.
- **Tests** — `peer-keys-ok.test.ts` (8/8), `republish-keys-from-ui.test.ts` (5/5), updated `ChatWindow.test.ts` mock for `isRoomPublic`.

## Test plan

- [x] Unit tests pass: `npm test` → 1625 passed / 9 failed (same 9 pre-existing master fails, unrelated)
- [x] Vite build OK (`✓ built in 25 s`)
- [x] `vue-tsc`: no new type errors in changed code (only pre-existing master errors remain in unrelated files)
- [x] Code-review pass: previous CRITICAL × 2 + HIGH × 1 fully resolved
- [ ] Manual smoke on Android 1.10.16 — send button enables in 1:1 with confirmed keys; banner appears with action buttons in 1:1 with truly missing keys; group/public chats never block send
- [ ] Toast UX check — Republish shows distinct toast for `already-ok`, `republished`, `needs-funds`, `broadcast-failed`