### PR TITLE
fix(channels): dedup + filter to remove phantom gaps in list (Session 37)

### DIFF
--- a/src/entities/channel/model/__tests__/channel-store-dedup.test.ts
+++ b/src/entities/channel/model/__tests__/channel-store-dedup.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+
+import { useChannelStore } from "../channel-store";
+import { useAuthStore } from "@/entities/auth";
+
+vi.mock("@/entities/auth", () => ({
+  useAuthStore: vi.fn(),
+}));
+
+describe("channel-store — fetchChannels dedup + filter", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.mocked(useAuthStore).mockReset();
+  });
+
+  it("dedupes channel.address across pagination pages", async () => {
+    // Backend returns full pages (>= 20) so hasMoreChannels stays true and
+    // page 1 actually gets fetched. Page 1 includes addr_0 from page 0 to
+    // simulate the offset-shift overlap that triggers the phantom-gap bug.
+    const page0 = Array.from({ length: 20 }, (_, i) => ({
+      address: `addr_${i}`,
+      name: `Ch${i}`,
+    }));
+    const page1 = [
+      { address: "addr_0", name: "Ch0" }, // дубль из page 0
+      ...Array.from({ length: 19 }, (_, i) => ({
+        address: `addr_${20 + i}`,
+        name: `Ch${20 + i}`,
+      })),
+    ];
+
+    const mockGetSubs = vi
+      .fn()
+      .mockResolvedValueOnce({ channels: page0, height: 1000 })
+      .mockResolvedValueOnce({ channels: page1, height: 1000 });
+
+    vi.mocked(useAuthStore).mockReturnValue({
+      address: "me",
+      getSubscribesChannels: mockGetSubs,
+    } as unknown as ReturnType<typeof useAuthStore>);
+
+    const store = useChannelStore();
+    await store.fetchChannels(true);
+    await store.fetchChannels(false);
+
+    const addrs = store.channels.map((c) => c.address);
+    // 20 unique from page 0 + 19 unique fresh from page 1 (addr_0 dropped)
+    expect(addrs.length).toBe(39);
+    expect(new Set(addrs).size).toBe(39);
+    expect(addrs[0]).toBe("addr_0");
+    expect(addrs[20]).toBe("addr_20");
+    expect(addrs[addrs.length - 1]).toBe("addr_38");
+  });
+
+  it("filters entries without address or name", async () => {
+    const mockGetSubs = vi.fn().mockResolvedValueOnce({
+      channels: [
+        { address: "addr_A", name: "A" },
+        { address: undefined, name: "broken" }, // no address
+        { address: "addr_C", name: "" },          // empty name
+        { address: "addr_D", name: "D" },
+      ],
+      height: 1000,
+    });
+
+    vi.mocked(useAuthStore).mockReturnValue({
+      address: "me",
+      getSubscribesChannels: mockGetSubs,
+    } as unknown as ReturnType<typeof useAuthStore>);
+
+    const store = useChannelStore();
+    await store.fetchChannels(true);
+
+    const addrs = store.channels.map((c) => c.address);
+    expect(addrs).toEqual(["addr_A", "addr_D"]);
+  });
+
+  it("dedupes within a single page (defensive)", async () => {
+    const mockGetSubs = vi.fn().mockResolvedValueOnce({
+      channels: [
+        { address: "addr_A", name: "A" },
+        { address: "addr_A", name: "A duplicate same page" },
+        { address: "addr_B", name: "B" },
+      ],
+      height: 1000,
+    });
+
+    vi.mocked(useAuthStore).mockReturnValue({
+      address: "me",
+      getSubscribesChannels: mockGetSubs,
+    } as unknown as ReturnType<typeof useAuthStore>);
+
+    const store = useChannelStore();
+    await store.fetchChannels(true);
+
+    const addrs = store.channels.map((c) => c.address);
+    expect(addrs).toEqual(["addr_A", "addr_B"]);
+  });
+});

--- a/src/entities/channel/model/channel-store.ts
+++ b/src/entities/channel/model/channel-store.ts
@@ -5,6 +5,8 @@ import { useAuthStore } from "@/entities/auth";
 
 import type { Channel, ChannelPost } from "./types";
 
+const CHANNELS_PAGE_SIZE = 20;
+
 function tryDecode(val: unknown): string {
   if (typeof val !== "string") return "";
   try {
@@ -98,7 +100,7 @@ export const useChannelStore = defineStore("channel", () => {
         addr,
         blockHeight.value,
         channelsPage.value,
-        20
+        CHANNELS_PAGE_SIZE
       );
 
       if (!result) {
@@ -108,12 +110,16 @@ export const useChannelStore = defineStore("channel", () => {
 
       blockHeight.value = result.height ?? blockHeight.value;
 
-      // Drop entries with empty address or name. RecycleScroller uses
-      // address as key-field; empty / duplicate keys collide and Vue stops
-      // rendering the duplicates, leaving phantom empty slots in the list.
-      const rawParsed = (result.channels ?? []).map((raw: any) => parseChannel(raw));
+      // Drop entries with empty address or name (treated as broken-output,
+      // not "channel without a display name"). RecycleScroller uses address
+      // as key-field; empty / duplicate keys collide and Vue stops rendering
+      // the duplicates, leaving phantom empty slots in the list.
+      const rawList = (result.channels ?? []) as Array<Record<string, unknown>>;
+      const rawParsed = rawList.map((raw) => parseChannel(raw));
       const parsed = rawParsed.filter((c) => Boolean(c.address) && Boolean(c.name));
-      const pageHadFullCount = rawParsed.length >= 20;
+      // Use the raw page size, not the filtered size, so a partially-broken
+      // page doesn't prematurely stop pagination.
+      const pageHadFullCount = rawParsed.length >= CHANNELS_PAGE_SIZE;
 
       // Dedup-by-address — page 0 and page 1 may overlap when a new channel
       // appears between requests and shifts the offset, producing the same

--- a/src/entities/channel/model/channel-store.ts
+++ b/src/entities/channel/model/channel-store.ts
@@ -107,15 +107,34 @@ export const useChannelStore = defineStore("channel", () => {
       }
 
       blockHeight.value = result.height ?? blockHeight.value;
-      const parsed = (result.channels ?? []).map((raw: any) => parseChannel(raw));
 
-      if (reset) {
-        channels.value = parsed;
-      } else {
-        channels.value = [...channels.value, ...parsed];
+      // Drop entries with empty address or name. RecycleScroller uses
+      // address as key-field; empty / duplicate keys collide and Vue stops
+      // rendering the duplicates, leaving phantom empty slots in the list.
+      const rawParsed = (result.channels ?? []).map((raw: any) => parseChannel(raw));
+      const parsed = rawParsed.filter((c) => Boolean(c.address) && Boolean(c.name));
+      const pageHadFullCount = rawParsed.length >= 20;
+
+      // Dedup-by-address — page 0 and page 1 may overlap when a new channel
+      // appears between requests and shifts the offset, producing the same
+      // address in both pages.
+      const existingAddrs = new Set(
+        reset ? [] : channels.value.map((c) => c.address)
+      );
+      const fresh: Channel[] = [];
+      for (const channel of parsed) {
+        if (existingAddrs.has(channel.address)) continue;
+        existingAddrs.add(channel.address);
+        fresh.push(channel);
       }
 
-      hasMoreChannels.value = parsed.length >= 20;
+      if (reset) {
+        channels.value = fresh;
+      } else {
+        channels.value = [...channels.value, ...fresh];
+      }
+
+      hasMoreChannels.value = pageHadFullCount;
       channelsPage.value += 1;
     } catch (e) {
       console.error("[channel-store] fetchChannels error:", e);

--- a/src/features/channels/ui/ChannelList.vue
+++ b/src/features/channels/ui/ChannelList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, nextTick, onMounted, onUnmounted, watch } from "vue";
+import { computed, ref, nextTick, onMounted, onUnmounted, watch } from "vue";
 import { useChannelStore } from "@/entities/channel";
 import type { Channel } from "@/entities/channel";
 import { useChatStore } from "@/entities/chat";
@@ -23,6 +23,14 @@ onMounted(() => {
     nextTick(prefetchVisiblePosts);
   }
   attachScrollListener();
+});
+
+// Defensive: if duplicate addresses ever leak past channel-store dedup,
+// RecycleScroller renders empty slots for the duplicates. Surface a "refresh"
+// affordance so the user can self-recover without reinstalling the app.
+const hasDetectedDuplicates = computed(() => {
+  const addrs = channelStore.channels.map((c) => c.address);
+  return new Set(addrs).size !== addrs.length;
 });
 
 const handleSelect = (channel: Channel) => {
@@ -145,6 +153,21 @@ onUnmounted(() => {
       </div>
       <p class="text-sm text-text-on-main-bg-color">{{ t("channels.noChannels") }}</p>
       <p class="text-xs text-text-on-main-bg-color/60">{{ t("channels.noChannelsHint") }}</p>
+    </div>
+
+    <!-- Defensive recovery banner — visible only if duplicate addresses
+         somehow slipped past channel-store dedup. Hidden in normal use. -->
+    <div
+      v-if="hasDetectedDuplicates"
+      class="mx-3 mt-2 flex items-center justify-between gap-2 rounded-lg bg-color-bad/10 px-3 py-2 text-xs text-color-bad"
+    >
+      <span class="truncate">{{ t("channels.listGlitch") }}</span>
+      <button
+        class="shrink-0 rounded-md bg-color-bad/15 px-2 py-1 text-[11px] font-medium hover:bg-color-bad/25"
+        @click="channelStore.fetchChannels(true)"
+      >
+        {{ t("channels.resetCache") }}
+      </button>
     </div>
 
     <!-- Channel list -->

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -69,6 +69,8 @@ export const en = {
   "channels.retry": "Retry",
   "channels.openInApp": "Open",
   "channels.address": "Channel address",
+  "channels.listGlitch": "Channel list looks broken",
+  "channels.resetCache": "Refresh",
 
   // ── Settings panel ──
   "settings.title": "Settings",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -71,6 +71,8 @@ export const ru: Record<TranslationKey, string> = {
   "channels.retry": "Повторить",
   "channels.openInApp": "Открыть",
   "channels.address": "Адрес канала",
+  "channels.listGlitch": "Список каналов отображается некорректно",
+  "channels.resetCache": "Обновить",
 
   // ── Settings panel ──
   "settings.title": "Настройки",


### PR DESCRIPTION
## Summary

Убирает UX-bug «пустые слоты в списке каналов» — после которого помогала только полная переустановка приложения.

**Корень бага:** `fetchChannels` объединял pagination pages без deduplication и без валидации address/name. `RecycleScroller` использует `key-field=\"address\"`; пустые или дублирующиеся ключи Vue молча отбрасывает, оставляя пустые слоты на экране (~700px gap).

## Что сделано

- **Filter**: parsed entries без `address` или `name` отбрасываются до push в массив (broken backend output, не «канал без имени»).
- **Dedup-by-address**: единый `Set`, заполняемый по мере итерации — закрывает и cross-page overlap (новый канал между запросами сдвигает offset), и in-page duplicates (защита от глюков SDK).
- **Pagination signal**: `hasMoreChannels` теперь смотрит на raw page count, а не на отфильтрованный — частично-сломанная страница не останавливает pagination преждевременно.
- **Constant `CHANNELS_PAGE_SIZE = 20`** вместо magic number.
- **Defensive UI banner** в `ChannelList.vue`: hidden-by-default плашка над списком, видима только при `Set(addrs).size !== addrs.length`. Кнопка «Обновить» вызывает `fetchChannels(true)` — self-recovery без переустановки, если что-то всё-таки протекло.

## Файлы

- `src/entities/channel/model/channel-store.ts` — fetchChannels: filter + dedup + constant
- `src/entities/channel/model/__tests__/channel-store-dedup.test.ts` (new) — 3 регрессии
- `src/features/channels/ui/ChannelList.vue` — recovery banner + computed hasDetectedDuplicates
- `src/shared/lib/i18n/locales/{ru,en}.ts` — `channels.listGlitch`, `channels.resetCache`

## Test plan

- [x] Regression: cross-page pagination overlap → addresses unique
- [x] Regression: invalid entries (empty address / empty name) отфильтрованы
- [x] Regression: duplicate address внутри одной страницы дедуплицирован
- [x] Полный test suite — без новых регрессий (4 pre-existing fails в display-result/sync-engine присутствуют и на master)
- [x] `vue-tsc --noEmit` — 45 errors, все pre-existing, ноль в моих файлах
- [x] `vite build` — PASS
- [x] Code-review (superpowers:code-reviewer) — clean, MEDIUM/LOW замечания применены
- [ ] Manual UX: открыть приложение с >40 subscribed channels, проскроллить 5 раз, убедиться что gaps не появляются

## Out of scope

- Backend pagination API (server-side overlap fix)
- Замена RecycleScroller на DynamicScroller
- Persist channels в Dexie (offline-first)
- Hardcoded `blockHeight = 4675546` в `fetchChannels(reset=true)` — отдельный известный bug

Closes Session 37 user-feedback (2026-05-05).

Research: [.planning/bug-fix-plan/research/CHANNEL-LIST-PHANTOM-GAPS-RESEARCH.md](.planning/bug-fix-plan/research/CHANNEL-LIST-PHANTOM-GAPS-RESEARCH.md)