### PR TITLE
fix(media): persist mxc URL + parallel multi-upload + share-target + pinch-zoom (Session 33)

### DIFF
--- a/src/features/messaging/model/pinch-zoom.test.ts
+++ b/src/features/messaging/model/pinch-zoom.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { touchDistance, nextScale, MIN_SCALE, MAX_SCALE } from "./pinch-zoom";
+
+describe("pinch-zoom math", () => {
+  describe("touchDistance", () => {
+    it("returns euclidean distance between two points", () => {
+      expect(touchDistance([0, 0], [3, 4])).toBe(5);
+      expect(touchDistance([10, 10], [10, 10])).toBe(0);
+    });
+
+    it("is symmetric", () => {
+      expect(touchDistance([1, 2], [4, 6])).toBe(touchDistance([4, 6], [1, 2]));
+    });
+  });
+
+  describe("nextScale", () => {
+    it("returns current scale on the very first pinch step (no last distance)", () => {
+      expect(nextScale(1, 0, 200)).toBe(1);
+      expect(nextScale(2, -1, 200)).toBe(2);
+    });
+
+    it("scales up when fingers spread apart", () => {
+      // From distance 100 to 200 → factor 2 → scale 1 → 2
+      expect(nextScale(1, 100, 200)).toBe(2);
+    });
+
+    it("scales down when fingers come together", () => {
+      // 200 → 100 = factor 0.5 → scale 2 → 1
+      expect(nextScale(2, 200, 100)).toBe(1);
+    });
+
+    it("clamps to MAX_SCALE so a fast pinch can't shoot the image off-screen", () => {
+      // Aggressive 10x factor — must clamp to MAX
+      expect(nextScale(2, 100, 1000)).toBe(MAX_SCALE);
+    });
+
+    it("clamps to MIN_SCALE so the image never shrinks below 1x", () => {
+      // 0.1x factor would land at 0.1 — must clamp to 1
+      expect(nextScale(1, 1000, 100)).toBe(MIN_SCALE);
+    });
+
+    it("guards against zero/negative current distance (degenerate touch payload)", () => {
+      expect(nextScale(2, 100, 0)).toBe(2);
+      expect(nextScale(2, 100, -5)).toBe(2);
+    });
+  });
+});

--- a/src/features/messaging/model/pinch-zoom.ts
+++ b/src/features/messaging/model/pinch-zoom.ts
@@ -1,0 +1,30 @@
+/** Pure pinch-zoom math — no DOM, no Vue. Lets us unit-test the gesture
+ *  without spinning up a touch-capable browser.
+ *
+ *  Production callers feed in TouchList-derived [x, y] pairs and the prior
+ *  scale; the helper returns the next scale clamped to MIN/MAX_SCALE so a
+ *  too-fast pinch can't escape the bounds and lock the image off-screen. */
+
+export const MIN_SCALE = 1;
+export const MAX_SCALE = 4;
+
+export function touchDistance(a: [number, number], b: [number, number]): number {
+  const dx = a[0] - b[0];
+  const dy = a[1] - b[1];
+  return Math.hypot(dx, dy);
+}
+
+/** Compute the scale after a single pinch step.
+ *  - `lastDistance <= 0` means we're starting a new pinch — return the
+ *    current scale unchanged so the first move doesn't snap.
+ *  - Otherwise scale ∝ currentDistance / lastDistance, clamped to bounds. */
+export function nextScale(
+  currentScale: number,
+  lastDistance: number,
+  currentDistance: number,
+): number {
+  if (lastDistance <= 0 || currentDistance <= 0) return currentScale;
+  const factor = currentDistance / lastDistance;
+  const next = currentScale * factor;
+  return Math.max(MIN_SCALE, Math.min(MAX_SCALE, next));
+}

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -317,18 +317,22 @@ export function useMessages() {
     });
   }
 
-  /** Send a file/image/video/audio message */
-  const sendFile = async (file: File) => {
+  /** Send a file/image/video/audio message.
+   *  Returns true if an optimistic message landed in the UI (the user sees
+   *  it, even when subsequent enqueue fails), false when the call was
+   *  silently dropped before any visible side effect (caller can then
+   *  preserve the share/forward intent or restore the input). */
+  const sendFile = async (file: File): Promise<boolean> => {
     const roomId = chatStore.activeRoomId;
-    if (!roomId || !file) return;
+    if (!roomId || !file) return false;
 
     if (file.size > MAX_UPLOAD_SIZE) {
       console.warn(`[use-messages] File too large: ${file.name} (${(file.size / 1024 / 1024).toFixed(1)} MB)`);
-      return;
+      return false;
     }
 
     const matrixService = getMatrixClientService();
-    if (!matrixService.isReady()) return;
+    if (!matrixService.isReady()) return false;
 
     // Determine message type from MIME (with fallback for HEIC/extension-only files)
     const mime = normalizeMime(resolveMime(file));
@@ -341,7 +345,7 @@ export function useMessages() {
       // safer than leaking a never-completing toast on a dead pipeline.
       console.error("[use-messages] sendFile: chat DB not ready");
       URL.revokeObjectURL(localBlobUrl);
-      return;
+      return false;
     }
 
     const dbKit = getChatDb();
@@ -381,15 +385,20 @@ export function useMessages() {
       },
       localMsg.clientId,
     );
+    return true;
   };
 
-  /** Send an image message (m.image event — compatible with bastyon-chat) */
-  const sendImage = async (file: File, options: { caption?: string; captionAbove?: boolean } = {}) => {
+  /** Send an image message (m.image event — compatible with bastyon-chat).
+   *  See sendFile for the boolean return contract. */
+  const sendImage = async (
+    file: File,
+    options: { caption?: string; captionAbove?: boolean } = {},
+  ): Promise<boolean> => {
     const roomId = chatStore.activeRoomId;
-    if (!roomId || !file) return;
+    if (!roomId || !file) return false;
 
     const matrixService = getMatrixClientService();
-    if (!matrixService.isReady()) return;
+    if (!matrixService.isReady()) return false;
 
     const dimensions = await getImageDimensions(file);
     const imageMime = resolveMime(file);
@@ -398,7 +407,7 @@ export function useMessages() {
     if (!isChatDbReady()) {
       console.error("[use-messages] sendImage: chat DB not ready");
       URL.revokeObjectURL(localBlobUrl);
-      return;
+      return false;
     }
 
     const dbKit = getChatDb();
@@ -450,15 +459,20 @@ export function useMessages() {
       },
       localMsg.clientId,
     );
+    return true;
   };
 
-  /** Send an audio/voice message (m.audio event — compatible with bastyon-chat) */
-  const sendAudio = async (file: File, options: { duration?: number; waveform?: number[] } = {}) => {
+  /** Send an audio/voice message (m.audio event — compatible with bastyon-chat).
+   *  See sendFile for the boolean return contract. */
+  const sendAudio = async (
+    file: File,
+    options: { duration?: number; waveform?: number[] } = {},
+  ): Promise<boolean> => {
     const roomId = chatStore.activeRoomId;
-    if (!roomId || !file) return;
+    if (!roomId || !file) return false;
 
     const matrixService = getMatrixClientService();
-    if (!matrixService.isReady()) return;
+    if (!matrixService.isReady()) return false;
 
     const audioMime = resolveMime(file);
     const localBlobUrl = URL.createObjectURL(file);
@@ -466,7 +480,7 @@ export function useMessages() {
     if (!isChatDbReady()) {
       console.error("[use-messages] sendAudio: chat DB not ready");
       URL.revokeObjectURL(localBlobUrl);
-      return;
+      return false;
     }
 
     const dbKit = getChatDb();
@@ -516,6 +530,7 @@ export function useMessages() {
       },
       localMsg.clientId,
     );
+    return true;
   };
 
   /** Send a video circle (video note) message — circular video like Telegram */

--- a/src/features/messaging/ui/MediaViewer.vue
+++ b/src/features/messaging/ui/MediaViewer.vue
@@ -5,6 +5,7 @@ import { useChatStore, MessageType } from "@/entities/chat";
 import { useFileDownload } from "../model/use-file-download";
 import { useAndroidBackHandler } from "@/shared/lib/composables/use-android-back-handler";
 import { useVideoStatePreservation } from "@/shared/lib/composables/use-video-state-preservation";
+import { touchDistance, nextScale, MIN_SCALE } from "../model/pinch-zoom";
 
 interface Props {
   show: boolean;
@@ -75,12 +76,23 @@ const goPrev = () => {
   }
 };
 
-// Swipe navigation
+// Swipe navigation + pinch-to-zoom. Two-finger gestures take priority; one-
+// finger swipes only run when not zoomed so a horizontal pan inside a zoomed
+// image doesn't accidentally jump to the previous/next photo.
 let touchStartX = 0;
 let touchStartY = 0;
 let touchDeltaX = 0;
+let pinchLastDistance = 0;
 
 const onTouchstart = (e: TouchEvent) => {
+  if (e.touches.length === 2) {
+    pinchLastDistance = touchDistance(
+      [e.touches[0].clientX, e.touches[0].clientY],
+      [e.touches[1].clientX, e.touches[1].clientY],
+    );
+    touchDeltaX = 0;
+    return;
+  }
   if (scale.value > 1) return; // Don't swipe when zoomed
   touchStartX = e.touches[0].clientX;
   touchStartY = e.touches[0].clientY;
@@ -88,6 +100,15 @@ const onTouchstart = (e: TouchEvent) => {
 };
 
 const onTouchmove = (e: TouchEvent) => {
+  if (e.touches.length === 2) {
+    const d = touchDistance(
+      [e.touches[0].clientX, e.touches[0].clientY],
+      [e.touches[1].clientX, e.touches[1].clientY],
+    );
+    scale.value = nextScale(scale.value, pinchLastDistance, d);
+    pinchLastDistance = d;
+    return;
+  }
   if (scale.value > 1) return;
   touchDeltaX = e.touches[0].clientX - touchStartX;
   const deltaY = e.touches[0].clientY - touchStartY;
@@ -99,7 +120,14 @@ const onTouchmove = (e: TouchEvent) => {
   }
 };
 
-const onTouchend = () => {
+const onTouchend = (e: TouchEvent) => {
+  // Reset pinch tracker once one finger lifts so the next two-finger touch
+  // starts fresh instead of inheriting the previous distance.
+  if (e.touches.length < 2) pinchLastDistance = 0;
+  // Snap back to 1x if a tiny over-pinch left a barely-visible scale change.
+  if (scale.value < MIN_SCALE + 0.05 && scale.value !== MIN_SCALE) {
+    resetTransform();
+  }
   if (scale.value > 1) return;
   if (touchDeltaX > 60) goPrev();
   else if (touchDeltaX < -60) goNext();

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -23,6 +23,7 @@ import { shouldSendOnEnter } from "../model/enter-key-behavior";
 import { isSendButtonVisible, isSendButtonDisabled } from "../model/send-button-state";
 import { isPeerKeysOk } from "../model/peer-keys-ok";
 import { isNative } from "@/shared/lib/platform";
+import { readShareUriAsBlob } from "@/shared/lib/share-target";
 
 const PEER_KEYS_GRACE_MS = 2000;
 
@@ -43,7 +44,7 @@ const pasteDrop = usePasteDrop({
   onMediaFiles: (files) => mediaUpload.addFiles(files),
   onOtherFiles: async (files) => {
     sending.value = true;
-    try { for (const file of files) await sendFile(file); }
+    try { await Promise.allSettled(files.map((file) => sendFile(file))); }
     finally { sending.value = false; }
   },
 });
@@ -272,13 +273,20 @@ const handleSend = async () => {
     } else if (chatStore.forwardingMessage) {
       const fwd = chatStore.forwardingMessage;
 
-      // External share with file: send file directly instead of text forward
+      // External share with file: send file directly instead of text forward.
+      // Android Share Sheet hands us a content:// URI that the WebView's
+      // fetch() can't open directly — readShareUriAsBlob routes through the
+      // Capacitor Filesystem bridge so the upload pipeline gets real bytes
+      // instead of a TypeError (#650).
       if (fwd.isExternalShare && fwd.fileInfo?.url) {
         try {
-          const response = await fetch(fwd.fileInfo.url);
-          const blob = await response.blob();
+          const mime = fwd.fileInfo.type || "application/octet-stream";
+          const blob = await readShareUriAsBlob(fwd.fileInfo.url, mime);
           const fileName = fwd.fileInfo.name || "shared_file";
-          const file = new File([blob], fileName, { type: fwd.fileInfo.type || blob.type });
+          // Prefer the explicit mime we already had — `blob.type` from the
+          // web fetch fallback can downgrade Bastyon-served URLs to
+          // application/octet-stream which then poisons messageTypeFromMime.
+          const file = new File([blob], fileName, { type: mime || blob.type });
 
           if (fwd.type === MessageType.image) {
             inserted = await sendImage(file);
@@ -379,8 +387,12 @@ const handleFileSelect = async (e: Event) => {
   const target = e.target as HTMLInputElement;
   if (!target.files?.length) return;
   sending.value = true;
-  try { for (const file of Array.from(target.files)) await sendFile(file); }
-  finally { sending.value = false; target.value = ""; }
+  try {
+    // Multi-pick: kick off every send concurrently. Each call only does an
+    // optimistic Dexie insert + enqueue; the real upload is serialised by
+    // SyncEngine. allSettled keeps one failed enqueue from blocking the rest.
+    await Promise.allSettled(Array.from(target.files).map((file) => sendFile(file)));
+  } finally { sending.value = false; target.value = ""; }
 };
 
 const handleMediaSend = async () => {
@@ -388,14 +400,17 @@ const handleMediaSend = async () => {
   mediaUpload.sending.value = true;
   try {
     const files = mediaUpload.files.value;
-    for (let i = 0; i < files.length; i++) {
-      const f = files[i];
-      const isLast = i === files.length - 1;
-      const captionOpts = isLast && mediaUpload.caption.value
-        ? { caption: mediaUpload.caption.value, captionAbove: mediaUpload.captionAbove.value } : {};
-      if (f.type === "image") await sendImage(f.file, captionOpts);
-      else await sendFile(f.file);
-    }
+    // Caption travels on the LAST file so the chat reads as a single
+    // gallery; precompute the index here and dispatch the rest in parallel.
+    const lastIdx = files.length - 1;
+    await Promise.allSettled(
+      files.map((f, i) => {
+        const captionOpts = i === lastIdx && mediaUpload.caption.value
+          ? { caption: mediaUpload.caption.value, captionAbove: mediaUpload.captionAbove.value }
+          : {};
+        return f.type === "image" ? sendImage(f.file, captionOpts) : sendFile(f.file);
+      }),
+    );
   } finally { mediaUpload.clear(); }
 };
 
@@ -766,7 +781,7 @@ defineExpose({
   addMediaFiles: (files: File[]) => mediaUpload.addFiles(files),
   sendOtherFiles: async (files: File[]) => {
     sending.value = true;
-    try { for (const file of files) await sendFile(file); }
+    try { await Promise.allSettled(files.map((file) => sendFile(file))); }
     finally { sending.value = false; }
   },
 });

--- a/src/shared/lib/__tests__/share-target.test.ts
+++ b/src/shared/lib/__tests__/share-target.test.ts
@@ -1,9 +1,31 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { saveShareData, consumeShareData, type ExternalShareData } from "../share-target";
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  saveShareData,
+  consumeShareData,
+  readShareUriAsBlob,
+  type ExternalShareData,
+} from "../share-target";
+
+// Mocks for the platform + Filesystem bridge. Each test sets the platform
+// flag explicitly via vi.doMock + dynamic re-import so we don't have to
+// fight a frozen module graph.
+const mockReadFile = vi.fn();
+vi.mock("@capacitor/filesystem", () => ({
+  Filesystem: { readFile: (...args: unknown[]) => mockReadFile(...args) },
+}));
+
+vi.mock("@/shared/lib/platform", () => ({
+  isNative: true, // toggled per-test by importing fresh modules
+}));
 
 describe("share-target", () => {
   beforeEach(() => {
     localStorage.clear();
+    mockReadFile.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   describe("saveShareData / consumeShareData", () => {
@@ -37,6 +59,65 @@ describe("share-target", () => {
     it("handles corrupted localStorage gracefully", () => {
       localStorage.setItem("bastyon-chat-share-data", "not-json{{{");
       expect(consumeShareData()).toBeNull();
+    });
+  });
+
+  describe("readShareUriAsBlob", () => {
+    it("routes content:// URIs through Capacitor Filesystem (not fetch) on native", async () => {
+      // base64 for "hello"
+      mockReadFile.mockResolvedValueOnce({ data: "aGVsbG8=" });
+
+      const fetchSpy = vi.fn();
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const blob = await readShareUriAsBlob(
+        "content://com.android.providers.media/external/123",
+        "image/jpeg",
+      );
+
+      expect(mockReadFile).toHaveBeenCalledWith({
+        path: "content://com.android.providers.media/external/123",
+      });
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(blob.type).toBe("image/jpeg");
+      expect(await blob.text()).toBe("hello");
+    });
+
+    it("routes file:// URIs through Filesystem (legacy OEM share path)", async () => {
+      mockReadFile.mockResolvedValueOnce({ data: "d29ybGQ=" }); // "world"
+      const fetchSpy = vi.fn();
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const blob = await readShareUriAsBlob("file:///sdcard/photo.jpg", "image/jpeg");
+
+      expect(mockReadFile).toHaveBeenCalled();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(await blob.text()).toBe("world");
+    });
+
+    it("falls back to fetch for http(s) URIs (web PWA share)", async () => {
+      const fetchBlob = new Blob(["fetched"], { type: "image/png" });
+      const fetchSpy = vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        blob: async () => fetchBlob,
+      }));
+      vi.stubGlobal("fetch", fetchSpy);
+
+      const blob = await readShareUriAsBlob("https://cdn.example.com/file.png", "image/png");
+
+      expect(fetchSpy).toHaveBeenCalledWith("https://cdn.example.com/file.png");
+      expect(mockReadFile).not.toHaveBeenCalled();
+      expect(blob).toBe(fetchBlob);
+    });
+
+    it("surfaces fetch failures so the UI can show an error", async () => {
+      const fetchSpy = vi.fn(async () => ({ ok: false, status: 404, blob: async () => new Blob() }));
+      vi.stubGlobal("fetch", fetchSpy);
+
+      await expect(
+        readShareUriAsBlob("https://cdn.example.com/missing.png", "image/png"),
+      ).rejects.toThrow(/Share fetch failed: 404/);
     });
   });
 });

--- a/src/shared/lib/local-db/__tests__/sync-engine-media.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-media.test.ts
@@ -99,6 +99,7 @@ interface Harness {
   engine: SyncEngine;
   messageRepo: {
     confirmSent: ReturnType<typeof vi.fn>;
+    confirmMediaSent: ReturnType<typeof vi.fn>;
     updateStatus: ReturnType<typeof vi.fn>;
     getByEventId: ReturnType<typeof vi.fn>;
     updateReactions: ReturnType<typeof vi.fn>;
@@ -109,14 +110,19 @@ interface Harness {
   getRoomCrypto: ReturnType<typeof vi.fn>;
 }
 
-function makeHarness(name: string, encrypted: boolean): Harness {
+function makeHarness(
+  name: string,
+  encrypted: boolean,
+  opts: { existingMsg?: Partial<LocalMessage> } = {},
+): Harness {
   const db = new TestDb(name);
   const messageRepo = {
     confirmSent: vi.fn(async () => undefined),
+    confirmMediaSent: vi.fn(async () => undefined),
     updateStatus: vi.fn(async () => undefined),
     getByEventId: vi.fn(async () => undefined),
     updateReactions: vi.fn(async () => undefined),
-    getByClientId: vi.fn(async () => undefined),
+    getByClientId: vi.fn(async (..._args: unknown[]) => opts.existingMsg as LocalMessage | undefined),
     updateUploadProgress: vi.fn(async () => undefined),
   };
   const roomRepo = { updateRoom: vi.fn(async () => undefined) };
@@ -281,10 +287,66 @@ describe("SyncEngine.syncSendFile — full media pipeline", () => {
     expect(att?.status).toBe("uploaded");
     expect(att?.remoteUrl).toMatch(/^https?:\/\//);
 
-    expect(h.messageRepo.confirmSent).toHaveBeenCalledWith(
-      "cli_ok",
-      "$server_event_id",
+    // Media path uses confirmMediaSent (which atomically clears localBlobUrl
+    // and persists the mxc URL into fileInfo) — not confirmSent, which would
+    // leave the bubble pointing at a soon-to-be-revoked blob: URL.
+    expect(h.messageRepo.confirmSent).not.toHaveBeenCalled();
+    expect(h.messageRepo.confirmMediaSent).toHaveBeenCalledTimes(1);
+    const [clientId, eventId, fileInfo, roomId] =
+      h.messageRepo.confirmMediaSent.mock.calls[0];
+    expect(clientId).toBe("cli_ok");
+    expect(eventId).toBe("$server_event_id");
+    expect(roomId).toBe("!room:server");
+    expect((fileInfo as { url: string }).url).toMatch(/^https?:\/\//);
+  });
+
+  it("preserves per-type fileInfo metadata (w/h/duration) and overwrites only url + secrets", async () => {
+    h = makeHarness(
+      `media-fileinfo-${Date.now()}-${Math.random()}`,
+      true,
+      {
+        existingMsg: {
+          clientId: "cli_image",
+          fileInfo: {
+            name: "photo.jpg",
+            type: "image/jpeg",
+            size: 300,
+            url: "blob:http://localhost/abc",
+            w: 1920,
+            h: 1080,
+            caption: "Sunset",
+            captionAbove: false,
+          },
+          localBlobUrl: "blob:http://localhost/abc",
+        } as Partial<LocalMessage>,
+      },
     );
+    await h.db.open();
+
+    const attachmentId = await seedAttachment(h.db);
+    await seedFileOp(h.db, {
+      clientId: "cli_image",
+      encrypted: true,
+      attachmentId,
+    });
+
+    await h.engine.processQueue();
+    await waitForProcessed(h.db);
+
+    expect(h.messageRepo.confirmMediaSent).toHaveBeenCalledTimes(1);
+    const [, , fileInfo] = h.messageRepo.confirmMediaSent.mock.calls[0];
+    const fi = fileInfo as Record<string, unknown>;
+    // url replaced with the mxc/server URL
+    expect(typeof fi.url).toBe("string");
+    expect(fi.url as string).not.toMatch(/^blob:/);
+    expect(fi.url as string).toMatch(/^https?:\/\//);
+    // metadata retained
+    expect(fi.w).toBe(1920);
+    expect(fi.h).toBe(1080);
+    expect(fi.caption).toBe("Sunset");
+    expect(fi.captionAbove).toBe(false);
+    // encrypted upload attaches secrets
+    expect(fi.secrets).toBeDefined();
   });
 });
 
@@ -337,10 +399,9 @@ describe("SyncEngine.recoverStrandedOps — send_file crash recovery", () => {
     await waitForProcessed(h.db);
 
     expect(mockMatrix.uploadContent).toHaveBeenCalledTimes(1);
-    expect(h.messageRepo.confirmSent).toHaveBeenCalledWith(
-      "cli_crashed",
-      "$server_event_id",
-    );
+    expect(h.messageRepo.confirmMediaSent).toHaveBeenCalledTimes(1);
+    expect(h.messageRepo.confirmMediaSent.mock.calls[0][0]).toBe("cli_crashed");
+    expect(h.messageRepo.confirmMediaSent.mock.calls[0][1]).toBe("$server_event_id");
   });
 });
 

--- a/src/shared/lib/local-db/__tests__/sync-engine-txnid.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-txnid.test.ts
@@ -91,10 +91,12 @@ interface Harness {
   engine: SyncEngine;
   messageRepo: {
     confirmSent: ReturnType<typeof vi.fn>;
+    confirmMediaSent: ReturnType<typeof vi.fn>;
     updateStatus: ReturnType<typeof vi.fn>;
     getByEventId: ReturnType<typeof vi.fn>;
     updateReactions: ReturnType<typeof vi.fn>;
     getByClientId: ReturnType<typeof vi.fn>;
+    updateUploadProgress: ReturnType<typeof vi.fn>;
   };
   roomRepo: { updateRoom: ReturnType<typeof vi.fn> };
   getRoomCrypto: ReturnType<typeof vi.fn>;
@@ -104,10 +106,12 @@ function makeHarness(name: string, opts: { encrypted: boolean }): Harness {
   const db = new TestDb(name);
   const messageRepo = {
     confirmSent: vi.fn(async () => undefined),
+    confirmMediaSent: vi.fn(async () => undefined),
     updateStatus: vi.fn(async () => undefined),
     getByEventId: vi.fn(async () => undefined),
     updateReactions: vi.fn(async () => undefined),
     getByClientId: vi.fn(async () => undefined),
+    updateUploadProgress: vi.fn(async () => undefined),
   };
   const roomRepo = { updateRoom: vi.fn(async () => undefined) };
   const roomCrypto = opts.encrypted

--- a/src/shared/lib/local-db/sync-engine.ts
+++ b/src/shared/lib/local-db/sync-engine.ts
@@ -532,11 +532,52 @@ export class SyncEngine {
         "Media send event",
       );
 
-      await this.messageRepo.confirmSent(op.clientId, serverEventId);
-      await this.roomRepo.updateRoom(op.roomId, {
-        lastMessageLocalStatus: "synced" as import("./schema").LocalMessageStatus,
-        lastMessageEventId: serverEventId,
-      });
+      // Persist the mxc URL on the local message. Without this the bubble
+      // keeps a blob: URL that becomes invalid the moment the document is
+      // unloaded — closing the chat or reloading the app paints a broken
+      // image (issues #655, #629, #636). confirmMediaSent also clears
+      // localBlobUrl and updates the room preview status atomically.
+      const existing = await this.messageRepo.getByClientId(op.clientId);
+      const baseFileInfo: LocalMessage["fileInfo"] = existing?.fileInfo ?? {
+        name: payload.fileName,
+        type: payload.mimeType,
+        size: attachment.size,
+        url,
+      };
+      const serverFileInfo: LocalMessage["fileInfo"] = {
+        ...baseFileInfo,
+        url,
+        ...(secrets
+          ? { secrets: secrets as { block: number; keys: string; v: number } }
+          : {}),
+      };
+      await this.messageRepo.confirmMediaSent(
+        op.clientId,
+        serverEventId,
+        serverFileInfo,
+        op.roomId,
+      );
+
+      // Release the optimistic blob URL after a short grace window so any
+      // in-flight render with that source can complete before the browser
+      // invalidates it. Without this revoke the blob lingers in memory for
+      // the lifetime of the document and slowly leaks as users send more
+      // photos in the same session.
+      const optimisticBlob = existing?.localBlobUrl;
+      if (
+        optimisticBlob &&
+        typeof URL !== "undefined" &&
+        typeof URL.revokeObjectURL === "function"
+      ) {
+        setTimeout(() => {
+          try {
+            URL.revokeObjectURL(optimisticBlob);
+          } catch {
+            // Some test envs (e.g. happy-dom without object URLs) throw —
+            // best-effort cleanup, ignore.
+          }
+        }, 5_000);
+      }
     } finally {
       // Release the controller slot regardless of outcome so a retry can
       // register a fresh one.

--- a/src/shared/lib/share-target.ts
+++ b/src/shared/lib/share-target.ts
@@ -9,6 +9,38 @@ export interface ExternalShareData {
   mimeType?: string;
 }
 
+/** Read a shared file URI into a Blob.
+ *
+ *  Android Share Sheet hands us `content://` URIs (and occasionally
+ *  `file://` paths from older OEMs) which the WebView's `fetch()` cannot
+ *  open — `fetch` returns a `TypeError: Failed to fetch` and the upload
+ *  silently dies (issue #650). Routing through Capacitor Filesystem reads
+ *  the bytes via the native bridge, then we wrap them in a Blob the rest
+ *  of the upload pipeline already knows how to handle.
+ *
+ *  On the web (browser PWA) the URL is a regular http(s) — fall through
+ *  to plain `fetch`. */
+export async function readShareUriAsBlob(uri: string, mimeType: string): Promise<Blob> {
+  const isNativeUri = uri.startsWith("content://") || uri.startsWith("file://");
+  if (isNativeUri && isNative) {
+    const { Filesystem } = await import("@capacitor/filesystem");
+    const result = await Filesystem.readFile({ path: uri });
+    // On native, `data` is base64-encoded; on the web fallback it's already a Blob.
+    if (typeof result.data === "string") {
+      const binary = atob(result.data);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      return new Blob([bytes], { type: mimeType });
+    }
+    return result.data;
+  }
+  const response = await fetch(uri);
+  if (!response.ok) {
+    throw new Error(`Share fetch failed: ${response.status}`);
+  }
+  return response.blob();
+}
+
 /** Save share data to localStorage for deferred processing (cold start / not authed) */
 export function saveShareData(data: ExternalShareData): void {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(data));


### PR DESCRIPTION
## Summary
- Photos no longer disappear after closing/reopening a chat or reloading the app — `syncSendFile` now persists the server `mxc` URL into `fileInfo` via `confirmMediaSent`, replacing the optimistic blob URL that became invalid the moment the document unloaded.
- Multi-pick (gallery, file picker, paste/drop, share-target hand-off) dispatches uploads concurrently via `Promise.allSettled` so every bubble appears at once instead of one-per-await.
- Android Share Sheet now actually works: `content://` URIs are routed through `@capacitor/filesystem` (`readShareUriAsBlob`) because the WebView's `fetch()` can't open them.
- `MediaViewer` gains two-finger pinch-to-zoom (1x..4x) backed by a small, unit-tested `pinch-zoom.ts` helper.
- `sendFile`/`sendImage`/`sendAudio` now return `Promise<boolean>` so callers (notably the external-share flow) can tell silent guard drops apart from real success.
- Optimistic blob URLs are revoked 5 s after a successful upload so the renderer can finish, then memory is reclaimed.

Closes #655, #629, #636, #650, #657, #656.

## Test plan
- [x] `npx vitest run src/shared/lib/local-db/__tests__/sync-engine-media.test.ts` (covers `confirmMediaSent` switch, fileInfo metadata preservation, encrypted secrets cast)
- [x] `npx vitest run src/shared/lib/local-db/__tests__/sync-engine-txnid.test.ts` (regression — txnId still flows through)
- [x] `npx vitest run src/shared/lib/__tests__/share-target.test.ts` (covers Filesystem path for `content://` and `file://`, `fetch` fallback for http(s), error surface)
- [x] `npx vitest run src/features/messaging/model/pinch-zoom.test.ts` (clamps, degenerate inputs, scale/scale-down)
- [ ] Manual: send photo → close & reopen chat → photo still loads.
- [ ] Manual: pick 5 photos → all bubbles appear instantly, uploads complete.
- [ ] Manual on Android: share JPG from Photos → Forta Chat → file lands in chosen room.
- [ ] Manual on Android: pinch-zoom in MediaViewer; swipe-down still dismisses.

## Notes
- Build still surfaces a handful of pre-existing TS errors on `master` (`MessageBubble.vue:907`, `DownloadPage.vue:23`, `rtc-peer-connection-proxy.ts:162`, two `*.test.ts` files lacking vitest globals). None are introduced by this PR; the two former `MessageInput.vue:289/291` `void → boolean` errors are fixed here as a side-effect of the new return contract.
- Pinch handler: when one finger of a two-finger pinch lifts, `scale` stays >1 and the remaining single-finger swipe-down is suppressed until the user fully releases. Documented as the intended behavior — proper panning is a follow-up.
- Multi-upload uses `Date.now()` per `createLocal` call. Concurrent dispatch can yield identical millisecond timestamps; ordering then falls back to Dexie auto-increment `localId`. Acceptable for typical pick sizes; revisit if users ship 10+ at once.