### PR TITLE
fix(calls): dedup Call.incoming + bind VOICE_CALL volume keys (Session 31)

### DIFF
--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallActivity.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallActivity.kt
@@ -169,6 +169,15 @@ class CallActivity : Activity(), SensorEventListener {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        // Session 31 (#644 Xiaomi 12X / 14T): bind hardware volume keys to
+        // STREAM_VOICE_CALL while the in-call surface is on screen. Without
+        // this the keys default to STREAM_MUSIC and pressing volume-up/down
+        // during a VoIP call is silently ignored — the in-call audio volume
+        // can only be changed via the system slider, which most users never
+        // discover. setVolumeControlStream is per-Activity and is reset
+        // automatically when this Activity is destroyed.
+        volumeControlStream = AudioManager.STREAM_VOICE_CALL
+
         // Keep screen on, show over lock screen
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallPlugin.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallPlugin.kt
@@ -394,6 +394,18 @@ class CallPlugin : Plugin() {
     fun startAudioRouting(call: PluginCall) {
         val callType = call.getString("callType") ?: "voice"
         audioRouter?.start(callType)
+
+        // Session 31 (#644): bind MainActivity's hardware volume keys to
+        // STREAM_VOICE_CALL for the duration of the call. CallActivity sets
+        // its own volumeControlStream in onCreate(), but the user can navigate
+        // back to the Vue/MainActivity surface (e.g. minimised call window)
+        // and still expect the volume rocker to control the call. Per-Activity
+        // setting, applied on the UI thread.
+        bridge?.activity?.let { activity ->
+            activity.runOnUiThread {
+                activity.volumeControlStream = AudioManager.STREAM_VOICE_CALL
+            }
+        }
         call.resolve()
     }
 
@@ -410,6 +422,20 @@ class CallPlugin : Plugin() {
             } catch (e: Exception) {
                 Log.e(TAG, "stopAudioRouting threw", e)
             }
+
+            // Session 31 (#644): restore the activity's volume rocker AFTER
+            // AudioRouter.stop() has flipped the system back to MODE_NORMAL.
+            // Done in this order so a volume-key press during the teardown
+            // window still lands on STREAM_VOICE_CALL while the call is
+            // technically alive — flipping it earlier would lose the binding
+            // mid-call. Posted to the UI thread because volumeControlStream
+            // must be touched there.
+            bridge?.activity?.let { activity ->
+                activity.runOnUiThread {
+                    activity.volumeControlStream = AudioManager.USE_DEFAULT_STREAM_TYPE
+                }
+            }
+
             call.resolve()
         }
     }
@@ -432,6 +458,17 @@ class CallPlugin : Plugin() {
             } catch (e: Exception) {
                 Log.e(TAG, "forceStopAudio threw", e)
             }
+
+            // Session 31 (#644): unbind the activity's volume rocker after
+            // the brute-force audio reset. Same ordering as stopAudioRouting:
+            // restore happens once the system is back to MODE_NORMAL so a
+            // racing volume-key press never lands on a half-torn-down state.
+            bridge?.activity?.let { activity ->
+                activity.runOnUiThread {
+                    activity.volumeControlStream = AudioManager.USE_DEFAULT_STREAM_TYPE
+                }
+            }
+
             call.resolve()
         }
     }

--- a/src/features/video-calls/model/call-service.ts
+++ b/src/features/video-calls/model/call-service.ts
@@ -24,6 +24,11 @@ import {
 import { ensureCallPermissions, PermissionDeniedError, callPermissionError } from "./permissions";
 import { finalizeCall } from "./finalize-call";
 import { isLegacyWebView, MIN_CHROMIUM_MAJOR_FOR_MODERN_WEBRTC } from "./webview-compatibility";
+import {
+  isIncomingCallSeen,
+  markIncomingCallSeen,
+  clearIncomingCallSeen,
+} from "./incoming-call-dedup";
 
 /**
  * One-shot guard so the legacy-WebView toast fires only once per process,
@@ -289,6 +294,10 @@ function unwireCallEvents(call: MatrixCall) {
     diagnosticsWarningListener = null;
   }
   cleanupRemoteFeedListener();
+  // Session 31: release the dedup slot so a future invite with the same
+  // callId (e.g. caller re-invited after the original was rejected) is
+  // routed normally instead of being silently dropped.
+  if (call.callId) clearIncomingCallSeen(call.callId);
   if (!boundHandlers) return;
   try {
     call.off(CallEvent.State, boundHandlers.onState);
@@ -869,6 +878,36 @@ export function useCallService() {
       ", type=" + matrixCall.type,
     );
 
+    // Session 31 — Bastyon ↔ Forta interop dedup.
+    //
+    // Multi-client setups (Bastyon installed alongside Forta on the same
+    // device, same Matrix user) and FCM-ringer-vs-sync races can cause the
+    // SDK to emit Call.incoming twice for the same callId. Without this
+    // guard the user sees a phantom second incoming-call UI on top of the
+    // first — exactly what #644 reports on Xiaomi 12X / 14T.
+    //
+    // We silently skip duplicates instead of calling matrixCall.reject():
+    // the original MatrixCall object (which the user can still answer via
+    // the first ringer) handles the protocol-level lifecycle. Calling
+    // reject() on the duplicate object would queue a redundant m.call.hangup
+    // that the homeserver might fan out and confuse the caller's client.
+    // The dedup window auto-clears after CALL_TIMEOUT_MS so a legitimate
+    // re-invite minutes later still rings.
+    if (matrixCall.callId && isIncomingCallSeen(matrixCall.callId)) {
+      console.debug(
+        "[call-service] duplicate Call.incoming ignored:",
+        matrixCall.callId,
+      );
+      // Drop SDK-internal listeners on the orphan duplicate MatrixCall so
+      // it can be GC'd promptly instead of waiting on the SDK's idle timer.
+      try {
+        (matrixCall as unknown as { removeAllListeners?: () => void })
+          .removeAllListeners?.();
+      } catch { /* ignore */ }
+      return;
+    }
+    if (matrixCall.callId) markIncomingCallSeen(matrixCall.callId);
+
     // Check FIRST whether the user already declined this call in the
     // native ringer (before JS was running). If so, send the rejection
     // straight back to Matrix so the caller actually stops ringing.
@@ -889,6 +928,10 @@ export function useCallService() {
         } catch (e) {
           console.error("[call-service] matrixCall.reject() failed:", e);
         }
+        // Keep the dedup slot held: the user explicitly declined this
+        // callId via the native ringer, so a stray SDK re-emit should
+        // remain silent for the dedup window. The slot still auto-expires
+        // after CALL_TIMEOUT_MS, which lets a determined caller redial.
         return;
       }
     }
@@ -896,6 +939,11 @@ export function useCallService() {
     if (callStore.isInCall) {
       console.log("[call-service] handleIncomingCall: already in call, rejecting");
       matrixCall.reject();
+      // Release the dedup slot: when the current call ends the user is
+      // available again, and a legitimate re-invite from the same caller
+      // (rare same-callId retry) should ring through instead of being
+      // silently swallowed by the 60s window.
+      if (matrixCall.callId) clearIncomingCallSeen(matrixCall.callId);
       return;
     }
 
@@ -903,6 +951,10 @@ export function useCallService() {
     if (otherTabActive) {
       console.warn("[call-service] Another tab already has an active call, rejecting incoming");
       matrixCall.reject();
+      // Same rationale as the isInCall branch: ownership of the call is
+      // delegated to the other tab — releasing our dedup slot lets a
+      // future invite ring through normally if that tab closes.
+      if (matrixCall.callId) clearIncomingCallSeen(matrixCall.callId);
       return;
     }
 

--- a/src/features/video-calls/model/incoming-call-dedup.test.ts
+++ b/src/features/video-calls/model/incoming-call-dedup.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  INCOMING_CALL_DEDUP_WINDOW_MS,
+  isIncomingCallSeen,
+  markIncomingCallSeen,
+  clearIncomingCallSeen,
+  __resetIncomingCallDedupForTests,
+} from "./incoming-call-dedup";
+
+describe("incoming-call-dedup — registry of seen incoming m.call.invite IDs", () => {
+  beforeEach(() => {
+    __resetIncomingCallDedupForTests();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns false for an unseen callId", () => {
+    expect(isIncomingCallSeen("foo")).toBe(false);
+  });
+
+  it("returns true after markIncomingCallSeen", () => {
+    markIncomingCallSeen("foo");
+    expect(isIncomingCallSeen("foo")).toBe(true);
+  });
+
+  it("isolates state between callIds", () => {
+    markIncomingCallSeen("foo");
+    expect(isIncomingCallSeen("bar")).toBe(false);
+  });
+
+  it("clearIncomingCallSeen removes the entry so the same callId is acceptable again", () => {
+    markIncomingCallSeen("foo");
+    expect(isIncomingCallSeen("foo")).toBe(true);
+
+    clearIncomingCallSeen("foo");
+    expect(isIncomingCallSeen("foo")).toBe(false);
+  });
+
+  it("clearIncomingCallSeen on an unknown callId is a safe no-op", () => {
+    expect(() => clearIncomingCallSeen("unknown")).not.toThrow();
+    expect(isIncomingCallSeen("unknown")).toBe(false);
+  });
+
+  it("ignores empty / whitespace-only callIds (defensive — avoids polluting the set on bad SDK payloads)", () => {
+    markIncomingCallSeen("");
+    markIncomingCallSeen("   ");
+    expect(isIncomingCallSeen("")).toBe(false);
+    expect(isIncomingCallSeen("   ")).toBe(false);
+  });
+
+  it("auto-clears the entry after the dedup window elapses", () => {
+    vi.useFakeTimers();
+    markIncomingCallSeen("foo");
+    expect(isIncomingCallSeen("foo")).toBe(true);
+
+    vi.advanceTimersByTime(INCOMING_CALL_DEDUP_WINDOW_MS - 1);
+    expect(isIncomingCallSeen("foo")).toBe(true);
+
+    vi.advanceTimersByTime(2);
+    expect(isIncomingCallSeen("foo")).toBe(false);
+  });
+
+  it("repeated markIncomingCallSeen on the same callId resets the dedup timer", () => {
+    vi.useFakeTimers();
+    markIncomingCallSeen("foo");
+    vi.advanceTimersByTime(INCOMING_CALL_DEDUP_WINDOW_MS - 100);
+
+    // Second mark should reset the timeout, not stack a second one.
+    markIncomingCallSeen("foo");
+    vi.advanceTimersByTime(200);
+    // Original window already elapsed for first timer if it had stacked,
+    // but second mark moved the cutoff — entry must still be considered seen.
+    expect(isIncomingCallSeen("foo")).toBe(true);
+
+    vi.advanceTimersByTime(INCOMING_CALL_DEDUP_WINDOW_MS);
+    expect(isIncomingCallSeen("foo")).toBe(false);
+  });
+
+  it("__resetIncomingCallDedupForTests wipes state and pending timers", () => {
+    vi.useFakeTimers();
+    markIncomingCallSeen("foo");
+    markIncomingCallSeen("bar");
+    expect(isIncomingCallSeen("foo")).toBe(true);
+    expect(isIncomingCallSeen("bar")).toBe(true);
+
+    __resetIncomingCallDedupForTests();
+    expect(isIncomingCallSeen("foo")).toBe(false);
+    expect(isIncomingCallSeen("bar")).toBe(false);
+
+    // Pending timers must not resurrect entries after reset.
+    vi.advanceTimersByTime(INCOMING_CALL_DEDUP_WINDOW_MS * 2);
+    expect(isIncomingCallSeen("foo")).toBe(false);
+    expect(isIncomingCallSeen("bar")).toBe(false);
+  });
+});

--- a/src/features/video-calls/model/incoming-call-dedup.ts
+++ b/src/features/video-calls/model/incoming-call-dedup.ts
@@ -1,0 +1,76 @@
+/**
+ * Session 31 — Bastyon ↔ Forta call interop dedup.
+ *
+ * When a Forta user is also logged into Bastyon on the same device, or when
+ * Matrix re-emits the same `m.call.invite` event (sync retry, native FCM
+ * ringer + JS sync racing for the same callId), the SDK can fire
+ * `Call.incoming` more than once for a single underlying call. The second
+ * fire shows a phantom incoming-call UI on top of the original one, and the
+ * user has to dismiss two competing ringers — exactly what #644 reports on
+ * Xiaomi 12X / 14T.
+ *
+ * This registry keeps a short-lived in-memory record of every callId we have
+ * already routed through `handleIncomingCall`. The window is bounded so a
+ * legitimate retry of the same callId after the original ended (e.g. caller
+ * retried minutes later — extremely rare but not impossible if the homeserver
+ * retains the event id) can still ring through.
+ *
+ * Pure module-level state — no Vue / Pinia coupling — so unit tests can
+ * exercise it deterministically with `vi.useFakeTimers`.
+ */
+
+/**
+ * How long to remember a seen callId before allowing it through again.
+ * Mirrors the Matrix SDK's `CALL_TIMEOUT_MS` from
+ * `matrix-js-sdk-bastyon/lib/webrtc/call.js` (currently 60_000), so an
+ * invite that legitimately rings for the full minute and is then re-emitted
+ * by pathological homeservers will still be deduped. The SDK does NOT
+ * export this constant, so if the Bastyon fork ever bumps it this value
+ * needs a manual update — there is no compile-time link.
+ */
+export const INCOMING_CALL_DEDUP_WINDOW_MS = 60_000;
+
+const seenCallIds = new Set<string>();
+const pendingClearTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function isUsableCallId(callId: string): boolean {
+  return typeof callId === "string" && callId.trim().length > 0;
+}
+
+export function isIncomingCallSeen(callId: string): boolean {
+  if (!isUsableCallId(callId)) return false;
+  return seenCallIds.has(callId);
+}
+
+export function markIncomingCallSeen(callId: string): void {
+  if (!isUsableCallId(callId)) return;
+
+  // Replace any pending auto-clear so a re-mark resets the window. Without
+  // this a slow second invite arriving near the end of the original
+  // window would expire immediately, which would defeat the dedup.
+  const existing = pendingClearTimers.get(callId);
+  if (existing) clearTimeout(existing);
+
+  seenCallIds.add(callId);
+  const timer = setTimeout(() => {
+    seenCallIds.delete(callId);
+    pendingClearTimers.delete(callId);
+  }, INCOMING_CALL_DEDUP_WINDOW_MS);
+  pendingClearTimers.set(callId, timer);
+}
+
+export function clearIncomingCallSeen(callId: string): void {
+  if (!isUsableCallId(callId)) return;
+  const timer = pendingClearTimers.get(callId);
+  if (timer) {
+    clearTimeout(timer);
+    pendingClearTimers.delete(callId);
+  }
+  seenCallIds.delete(callId);
+}
+
+export function __resetIncomingCallDedupForTests(): void {
+  for (const timer of pendingClearTimers.values()) clearTimeout(timer);
+  pendingClearTimers.clear();
+  seenCallIds.clear();
+}


### PR DESCRIPTION
## Summary
- **Dedup duplicate `Call.incoming`** (Bastyon ↔ Forta interop, FCM ringer ↔ sync races) — new `incoming-call-dedup` module guards `handleIncomingCall` against repeat fires for the same `callId` with a 60 s auto-expiry window mirroring Matrix SDK `CALL_TIMEOUT_MS`. Duplicates are silently dropped (no redundant `matrixCall.reject()`) and the orphan SDK call's listeners are released immediately.
- **Bind hardware volume keys to `STREAM_VOICE_CALL`** so the volume rocker actually changes call audio on Xiaomi/MIUI and other affected ROMs. `CallActivity` sets `volumeControlStream` in `onCreate`; `CallPlugin.startAudioRouting` mirrors the binding on `bridge.activity` (covers the minimised Vue surface). `stopAudioRouting` / `forceStopAudio` restore the default stream **after** `AudioRouter.stop()` inside `cleanupExecutor`, on the UI thread — keeps the binding live through the teardown window.

Closes #644 (Xiaomi 12X / 14T duplicate ring + dead volume keys), partially #573 / #575 (HUAWEI MAR-LX1H invite-display dupes).

## Test Plan
- [x] 9 new unit tests in `incoming-call-dedup.test.ts` cover seen/clear/auto-expire/timer-reset/empty-callId
- [x] Full `src/features/video-calls/model/` suite — 115/115 pass
- [x] `vue-tsc --noEmit` — no new type errors in changed files
- [x] Code review (`superpowers:code-reviewer`) WARN-level findings addressed: slot-leak on early-return paths, GC leak on duplicate, volume-restore ordering inside `cleanupExecutor`, manual-sync note on dedup window
- [ ] Manual on Xiaomi MIUI: place a call from Bastyon while Forta is open — confirm Forta UI does not double-ring; press volume up/down during a call — confirm the slider tracks the in-call audio
- [ ] Manual on Android 7–10 (legacy `audioManager.setStreamVolume` path) — confirm volume restore on hangup does not leave the device stuck on `STREAM_VOICE_CALL`
- [ ] Manual back-to-back call: end a call, caller redials within 60 s — confirm the second invite rings (covers the early-return slot-clear)