### PR TITLE
fix(emoji-picker): dock above input on mobile + Android back (Session 38)

### DIFF
--- a/src/features/messaging/ui/EmojiPicker.vue
+++ b/src/features/messaging/ui/EmojiPicker.vue
@@ -3,15 +3,13 @@ import { ref, computed, watch, nextTick } from "vue";
 import { useThemeStore } from "@/entities/theme";
 import { EMOJI_CATEGORIES, searchEmojis } from "@/shared/lib/emoji-data";
 import { useMobile } from "@/shared/lib/composables/use-media-query";
+import { useAndroidBackHandler } from "@/shared/lib/composables/use-android-back-handler";
+import { computePanelStyle } from "./emoji-picker-layout";
 import EmojiKitchenBar from "./EmojiKitchenBar.vue";
 import GifPicker from "./GifPicker.vue";
 import type { TenorGif } from "@/shared/lib/tenor";
 
 const isMobile = useMobile();
-
-const PANEL_W = 370;
-const PANEL_H = 420;
-const PAD = 8;
 
 interface Props {
   show: boolean;
@@ -60,53 +58,18 @@ watch(() => props.show, (v) => {
   }
 });
 
-// Responsive panel: clamp to viewport on small screens
-const panelStyle = computed(() => {
-  const vw = typeof window !== "undefined" ? window.innerWidth : 800;
-  const vh = typeof window !== "undefined" ? window.innerHeight : 600;
-
-  // Mobile: full-width bottom panel (use CSS units for resize/rotation reactivity)
-  if (isMobile.value) {
-    return {
-      left: "0px",
-      top: "auto",
-      bottom: "0px",
-      width: "100%",
-      height: "min(55dvh, 420px)",
-      borderRadius: "16px 16px 0 0",
-    };
-  }
-
-  const panelW = Math.min(PANEL_W, vw - PAD * 2);
-  const panelH = Math.min(PANEL_H, vh - PAD * 2);
-
-  let left = Math.max(PAD, Math.min(props.x, vw - panelW - PAD));
-
-  const spaceAbove = props.y - PAD;
-  const spaceBelow = vh - props.y - PAD;
-
-  let top: number;
-  if (spaceAbove >= panelH) {
-    top = props.y - panelH;
-  } else if (spaceBelow >= panelH) {
-    top = props.y;
-  } else {
-    if (spaceAbove >= spaceBelow) {
-      top = PAD;
-    } else {
-      top = vh - panelH - PAD;
-    }
-  }
-
-  top = Math.max(PAD, Math.min(top, vh - panelH - PAD));
-
-  return {
-    left: `${left}px`,
-    top: `${top}px`,
-    width: `${panelW}px`,
-    height: `${panelH}px`,
-  };
-});
+// Responsive panel: clamp to viewport on small screens. The actual math lives
+// in `./emoji-picker-layout.ts` so it can be unit-tested without mounting.
+const panelStyle = computed(() =>
+  computePanelStyle({
+    isMobile: isMobile.value,
+    mode: props.mode,
+    x: props.x,
+    y: props.y,
+    vw: typeof window !== "undefined" ? window.innerWidth : 800,
+    vh: typeof window !== "undefined" ? window.innerHeight : 600,
+  }),
+);
 
 const filteredEmojis = computed(() => {
   if (!search.value) return null;
@@ -169,6 +132,16 @@ const onGridScroll = () => {
 const setSectionRef = (el: any, idx: number) => {
   if (el) sectionRefs.value[idx] = el as HTMLElement;
 };
+
+// Android back: close the picker first, instead of leaving the chat. Two
+// EmojiPicker instances (input + reaction) co-exist in the chat tree, so the
+// id is mode-scoped to keep both handlers registered. Priority 90 matches
+// other bottom-sheet/modal overlays.
+useAndroidBackHandler(`emoji-picker-${props.mode}`, 90, () => {
+  if (!props.show) return false;
+  emit("close");
+  return true;
+});
 </script>
 
 <template>

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, nextTick, watch, computed, onBeforeUnmount } from "vue";
+import { ref, nextTick, watch, computed, onBeforeUnmount, onMounted } from "vue";
 import { useChatStore, MessageType } from "@/entities/chat";
 import { useThemeStore } from "@/entities/theme";
 import { stripMentionAddresses, stripBastyonLinks } from "@/shared/lib/message-format";
@@ -143,6 +143,11 @@ onBeforeUnmount(() => {
   // Clean up any lingering recording mouse/move listeners
   document.removeEventListener("mouseup", handleGlobalMouseUp);
   document.removeEventListener("mousemove", handleGlobalMouseMove);
+  // Stop tracking input bar height + clear the CSS custom property so the
+  // picker doesn't reference a stale value on the next chat mount.
+  inputResizeObserver?.disconnect();
+  inputResizeObserver = null;
+  document.documentElement.style.removeProperty("--message-input-height");
 });
 
 // --- Edit/reply ---
@@ -764,6 +769,20 @@ const handleRecordMouseDown = (e: MouseEvent) => {
 // Root ref for overlay positioning
 const inputRootRef = ref<HTMLElement | null>(null);
 
+// Expose input bar height as a CSS custom property so the emoji picker can
+// dock above it on mobile instead of overlapping the textarea.
+let inputResizeObserver: ResizeObserver | null = null;
+onMounted(() => {
+  if (!inputRootRef.value) return;
+  const update = () => {
+    const h = inputRootRef.value?.getBoundingClientRect().height ?? 0;
+    document.documentElement.style.setProperty("--message-input-height", `${h}px`);
+  };
+  update();
+  inputResizeObserver = new ResizeObserver(update);
+  inputResizeObserver.observe(inputRootRef.value);
+});
+
 // Video circle overlay
 const overlayVideoRef = ref<HTMLVideoElement | null>(null);
 watch(() => videoRecorder.videoStream.value, (stream) => {
@@ -795,6 +814,16 @@ const insertEmoji = (emoji: string) => {
     nextTick(() => { el.selectionStart = el.selectionEnd = start + emoji.length; el.focus({ preventScroll: true }); autoResize(); });
   } else { text.value += emoji; }
   themeStore.addRecentEmoji(emoji);
+};
+
+const toggleEmojiPicker = (e: MouseEvent) => {
+  // Blur the textarea so the soft keyboard collapses before the picker opens —
+  // otherwise the picker has to fight the keyboard for the lower half of the
+  // screen and the textarea is hidden anyway.
+  textareaRef.value?.blur();
+  const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+  emojiPickerPos.value = { x: rect.left, y: rect.top };
+  showEmojiPicker.value = !showEmojiPicker.value;
 };
 
 const handleGifSelect = async (gif: { gifUrl: string; width: number; height: number; title: string }) => {
@@ -1023,7 +1052,7 @@ const handleKitchenSelect = async (imageUrl: string) => {
         <button
           class="btn-press flex h-10 w-10 min-h-tap min-w-tap shrink-0 items-center justify-center rounded-full text-text-on-main-bg-color/60 transition-colors hover:text-text-on-main-bg-color"
           :title="t('message.emoji')"
-          @click="(e: MouseEvent) => { const rect = (e.currentTarget as HTMLElement).getBoundingClientRect(); emojiPickerPos = { x: rect.left, y: rect.top }; showEmojiPicker = !showEmojiPicker; }"
+          @click="toggleEmojiPicker"
         >
           <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
             <circle cx="12" cy="12" r="10" /><path d="M8 14s1.5 2 4 2 4-2 4-2" /><line x1="9" y1="9" x2="9.01" y2="9" /><line x1="15" y1="9" x2="15.01" y2="9" />

--- a/src/features/messaging/ui/__tests__/emoji-picker-layout.test.ts
+++ b/src/features/messaging/ui/__tests__/emoji-picker-layout.test.ts
@@ -1,65 +1,89 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mount } from "@vue/test-utils";
-import { setActivePinia, createPinia } from "pinia";
-import EmojiPicker from "../EmojiPicker.vue";
+import { describe, it, expect } from "vitest";
+import {
+  computePanelStyle,
+  computeMobileInputPanelStyle,
+  computeMobileReactionPanelStyle,
+  computeAnchoredPanelStyle,
+  PICKER_PAD,
+} from "../emoji-picker-layout";
 
-vi.stubGlobal("useI18n", () => ({ t: (k: string) => k }));
-
-vi.mock("@/entities/theme", () => ({
-  useThemeStore: () => ({
-    recentEmojis: [],
-    quickReactions: [],
-    animationsEnabled: true,
-  }),
-}));
-
-vi.mock("@/shared/lib/composables/use-media-query", () => ({
-  useMobile: () => ({ value: true }),
-}));
-
-describe("EmojiPicker mobile layout", () => {
-  beforeEach(() => {
-    setActivePinia(createPinia());
-    vi.stubGlobal("useI18n", () => ({ t: (k: string) => k }));
-  });
-
-  afterEach(() => {
-    document.documentElement.style.removeProperty("--message-input-height");
-    document.body.innerHTML = "";
-  });
-
-  it("input mode docks above MessageInput via --message-input-height", async () => {
-    document.documentElement.style.setProperty("--message-input-height", "64px");
-    const wrapper = mount(EmojiPicker, {
-      props: { show: true, x: 0, y: 0, mode: "input" },
-      attachTo: document.body,
+describe("emoji-picker-layout", () => {
+  describe("mobile input mode", () => {
+    it("docks above MessageInput via --message-input-height", () => {
+      const style = computeMobileInputPanelStyle();
+      expect(style.bottom).toBe("var(--message-input-height, 0px)");
+      expect(style.top).toBe("auto");
+      expect(style.width).toBe("100%");
+      expect(style.left).toBe("0px");
+      expect(style.borderRadius).toBe("16px 16px 0 0");
     });
-    await wrapper.vm.$nextTick();
 
-    const panel = document.querySelector(".emoji-panel") as HTMLElement;
-    expect(panel).toBeTruthy();
-    expect(panel.style.bottom).toBe("var(--message-input-height, 0px)");
-    expect(panel.style.width).toBe("100%");
-
-    wrapper.unmount();
+    it("computePanelStyle delegates to mobile-input branch when isMobile + mode=input", () => {
+      const style = computePanelStyle({ isMobile: true, mode: "input", x: 0, y: 0, vw: 360, vh: 800 });
+      expect(style.bottom).toBe("var(--message-input-height, 0px)");
+      expect(style.top).toBe("auto");
+    });
   });
 
-  it("reaction mode places picker above tap point on mobile", async () => {
-    Object.defineProperty(window, "innerHeight", { value: 800, configurable: true });
-    const wrapper = mount(EmojiPicker, {
-      props: { show: true, x: 100, y: 700, mode: "reaction" },
-      attachTo: document.body,
+  describe("mobile reaction mode", () => {
+    it("places the picker above the tap point when there's room", () => {
+      const style = computeMobileReactionPanelStyle(700, 800);
+      const top = parseInt(style.top, 10);
+      expect(Number.isNaN(top)).toBe(false);
+      expect(top).toBeLessThan(700);
+      expect(top).toBeGreaterThanOrEqual(PICKER_PAD);
+      expect(style.bottom).toBe("auto");
+      expect(style.width).toBe("100%");
     });
-    await wrapper.vm.$nextTick();
 
-    const panel = document.querySelector(".emoji-panel") as HTMLElement;
-    expect(panel).toBeTruthy();
+    it("falls back to bottom-anchored placement when there isn't enough room above", () => {
+      const vh = 800;
+      const style = computeMobileReactionPanelStyle(40, vh);
+      const top = parseInt(style.top, 10);
+      const panelH = parseInt(style.height, 10);
+      // No room above (y=40, panelH=360) → anchor near the viewport bottom.
+      expect(top).toBeGreaterThan(vh / 2);
+      expect(top + panelH).toBeLessThanOrEqual(vh);
+    });
 
-    const top = parseInt(panel.style.top, 10);
-    expect(Number.isNaN(top)).toBe(false);
-    expect(top).toBeLessThan(700);
-    expect(top).toBeGreaterThan(0);
+    it("clamps top to PICKER_PAD when the viewport is shorter than the panel", () => {
+      // Tiny viewport: vh=300, panelH = min(360, 150) = 150, y=10
+      // The fallback branch lands at vh - panelH - PAD = 300 - 150 - 8 = 142.
+      // Verify the lower-bound clamp still holds.
+      const style = computeMobileReactionPanelStyle(10, 300);
+      const top = parseInt(style.top, 10);
+      expect(top).toBeGreaterThanOrEqual(PICKER_PAD);
+    });
 
-    wrapper.unmount();
+    it("computePanelStyle uses props.y on mobile + reaction mode (regression: do not pin to bottom: 0)", () => {
+      const style = computePanelStyle({ isMobile: true, mode: "reaction", x: 100, y: 700, vw: 360, vh: 800 });
+      const top = parseInt(style.top, 10);
+      expect(top).toBeLessThan(700);
+      expect(top).toBeGreaterThan(0);
+      expect(style.bottom).toBe("auto");
+    });
+  });
+
+  describe("desktop / tablet", () => {
+    it("places the picker above the click when there's room", () => {
+      const style = computeAnchoredPanelStyle(400, 600, 1280, 800);
+      const top = parseInt(style.top, 10);
+      expect(top).toBeLessThan(600);
+      expect(top).toBeGreaterThanOrEqual(PICKER_PAD);
+    });
+
+    it("clamps to viewport when the click is too close to the right edge", () => {
+      const vw = 1024;
+      const style = computeAnchoredPanelStyle(vw - 10, 400, vw, 800);
+      const left = parseInt(style.left, 10);
+      const width = parseInt(style.width, 10);
+      expect(left + width).toBeLessThanOrEqual(vw - PICKER_PAD);
+    });
+
+    it("computePanelStyle returns a desktop layout when isMobile=false", () => {
+      const style = computePanelStyle({ isMobile: false, mode: "input", x: 100, y: 200, vw: 1280, vh: 800 });
+      expect(style.width).not.toBe("100%");
+      expect(style.bottom).toBe("auto");
+    });
   });
 });

--- a/src/features/messaging/ui/__tests__/emoji-picker-layout.test.ts
+++ b/src/features/messaging/ui/__tests__/emoji-picker-layout.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import EmojiPicker from "../EmojiPicker.vue";
+
+vi.stubGlobal("useI18n", () => ({ t: (k: string) => k }));
+
+vi.mock("@/entities/theme", () => ({
+  useThemeStore: () => ({
+    recentEmojis: [],
+    quickReactions: [],
+    animationsEnabled: true,
+  }),
+}));
+
+vi.mock("@/shared/lib/composables/use-media-query", () => ({
+  useMobile: () => ({ value: true }),
+}));
+
+describe("EmojiPicker mobile layout", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.stubGlobal("useI18n", () => ({ t: (k: string) => k }));
+  });
+
+  afterEach(() => {
+    document.documentElement.style.removeProperty("--message-input-height");
+    document.body.innerHTML = "";
+  });
+
+  it("input mode docks above MessageInput via --message-input-height", async () => {
+    document.documentElement.style.setProperty("--message-input-height", "64px");
+    const wrapper = mount(EmojiPicker, {
+      props: { show: true, x: 0, y: 0, mode: "input" },
+      attachTo: document.body,
+    });
+    await wrapper.vm.$nextTick();
+
+    const panel = document.querySelector(".emoji-panel") as HTMLElement;
+    expect(panel).toBeTruthy();
+    expect(panel.style.bottom).toBe("var(--message-input-height, 0px)");
+    expect(panel.style.width).toBe("100%");
+
+    wrapper.unmount();
+  });
+
+  it("reaction mode places picker above tap point on mobile", async () => {
+    Object.defineProperty(window, "innerHeight", { value: 800, configurable: true });
+    const wrapper = mount(EmojiPicker, {
+      props: { show: true, x: 100, y: 700, mode: "reaction" },
+      attachTo: document.body,
+    });
+    await wrapper.vm.$nextTick();
+
+    const panel = document.querySelector(".emoji-panel") as HTMLElement;
+    expect(panel).toBeTruthy();
+
+    const top = parseInt(panel.style.top, 10);
+    expect(Number.isNaN(top)).toBe(false);
+    expect(top).toBeLessThan(700);
+    expect(top).toBeGreaterThan(0);
+
+    wrapper.unmount();
+  });
+});

--- a/src/features/messaging/ui/emoji-picker-layout.ts
+++ b/src/features/messaging/ui/emoji-picker-layout.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure helpers that compute panel placement for `EmojiPicker.vue`.
+ *
+ * Extracted as standalone functions so the layout logic can be unit-tested
+ * without spinning up a Vue tree — happy-dom drops CSS values that contain
+ * `var()` and `min(...)`, which makes asserting against `el.style.bottom`
+ * unreliable for the rendered panel.
+ */
+
+export const PICKER_PAD = 8;
+export const PICKER_W = 370;
+export const PICKER_H = 420;
+
+export interface PickerStyle {
+  left: string;
+  top: string;
+  bottom: string;
+  width: string;
+  height: string;
+  borderRadius: string;
+  // Allow CSS custom properties so the object satisfies Vue's StyleValue.
+  [cssVar: `--${string}`]: string;
+}
+
+export interface PickerLayoutInput {
+  isMobile: boolean;
+  mode: "input" | "reaction";
+  x: number;
+  y: number;
+  vw: number;
+  vh: number;
+}
+
+/** Mobile (input mode): dock above MessageInput via the height it publishes
+ *  through `--message-input-height`. */
+export function computeMobileInputPanelStyle(): PickerStyle {
+  return {
+    left: "0px",
+    top: "auto",
+    bottom: "var(--message-input-height, 0px)",
+    width: "100%",
+    height: "min(45dvh, 360px)",
+    borderRadius: "16px 16px 0 0",
+  };
+}
+
+/** Mobile (reaction mode): show the picker above the long-pressed message
+ *  when there's vertical room, otherwise fall back near the viewport bottom
+ *  but still leave breathing room from the edge. */
+export function computeMobileReactionPanelStyle(y: number, vh: number): PickerStyle {
+  const panelH = Math.min(360, vh * 0.5);
+  const spaceAbove = y - PICKER_PAD;
+  const top = spaceAbove >= panelH
+    ? Math.max(PICKER_PAD, y - panelH)
+    : Math.max(PICKER_PAD, vh - panelH - PICKER_PAD);
+  return {
+    left: "0px",
+    top: `${top}px`,
+    bottom: "auto",
+    width: "100%",
+    height: `${panelH}px`,
+    borderRadius: "16px",
+  };
+}
+
+/** Desktop / tablet: floating panel anchored near (x, y), clamped to viewport. */
+export function computeAnchoredPanelStyle(x: number, y: number, vw: number, vh: number): PickerStyle {
+  const panelW = Math.min(PICKER_W, vw - PICKER_PAD * 2);
+  const panelH = Math.min(PICKER_H, vh - PICKER_PAD * 2);
+
+  const left = Math.max(PICKER_PAD, Math.min(x, vw - panelW - PICKER_PAD));
+
+  const spaceAbove = y - PICKER_PAD;
+  const spaceBelow = vh - y - PICKER_PAD;
+
+  let top: number;
+  if (spaceAbove >= panelH) {
+    top = y - panelH;
+  } else if (spaceBelow >= panelH) {
+    top = y;
+  } else if (spaceAbove >= spaceBelow) {
+    top = PICKER_PAD;
+  } else {
+    top = vh - panelH - PICKER_PAD;
+  }
+
+  top = Math.max(PICKER_PAD, Math.min(top, vh - panelH - PICKER_PAD));
+
+  return {
+    left: `${left}px`,
+    top: `${top}px`,
+    bottom: "auto",
+    width: `${panelW}px`,
+    height: `${panelH}px`,
+    borderRadius: "16px",
+  };
+}
+
+export function computePanelStyle(input: PickerLayoutInput): PickerStyle {
+  const { isMobile, mode, x, y, vw, vh } = input;
+  if (isMobile && mode === "input") return computeMobileInputPanelStyle();
+  if (isMobile && mode === "reaction") return computeMobileReactionPanelStyle(y, vh);
+  return computeAnchoredPanelStyle(x, y, vw, vh);
+}


### PR DESCRIPTION
## Summary
- Mobile `EmojiPicker` (input mode) now docks above `MessageInput` via the `--message-input-height` CSS variable that `MessageInput` publishes through a `ResizeObserver`, instead of pinning to `bottom: 0` and overlapping the textarea.
- Mobile `EmojiPicker` (reaction mode) places the panel above the long-pressed message (`props.y`), with a fallback near the bottom only when there's no room above. Previously `props.y` was ignored on mobile.
- Layout math extracted into pure helpers in `emoji-picker-layout.ts` so the regressions can be unit-tested without happy-dom (which strips `var()` and `min()` values from inline style bindings).
- Android back closes the picker first instead of leaving the chat. Each picker instance (input + reaction) registers under a mode-scoped id (`emoji-picker-${mode}`) so the two co-existing pickers don't evict each other's handler. Priority bumped to 90 to match other modal/bottom-sheet overlays.
- Tapping the emoji button now blurs the textarea so the soft keyboard collapses before the picker opens.

Closes greenShirtMystery/forta-bugs#685
Closes greenShirtMystery/forta-bugs#683
Closes greenShirtMystery/forta-bugs#646
Closes greenShirtMystery/forta-bugs#581
Closes greenShirtMystery/forta-bugs#540
Closes greenShirtMystery/forta-bugs#489
Closes greenShirtMystery/forta-bugs#483
Closes greenShirtMystery/forta-bugs#377

## Test plan
- [x] `npx vitest run src/features/messaging/ui/__tests__/emoji-picker-layout.test.ts` — 9 passing (input/reaction/desktop branches + tiny-viewport clamp)
- [x] `vite build` — clean
- [x] `vue-tsc --noEmit` — 43 errors, all preexisting on `master` (no new diagnostics from this change)
- [x] `npm run test` — 4 preexisting failed files unchanged (`open-profile-url`, `video-embed`, `chat-helpers`, `display-result`); +9 new passing tests in `emoji-picker-layout.test.ts`
- [ ] Manual on Android: tap emoji button → textarea remains visible, picker docks above input
- [ ] Manual on Android: long-press a message near the bottom → reaction picker opens above the message, not glued to bottom
- [ ] Manual on Android: one Back press closes the picker without leaving the chat