### PR TITLE
feat(media): save photo/video to gallery via MediaViewer + ContextMenu (Session 43)

### DIFF
--- a/src/features/messaging/ui/MediaViewer.vue
+++ b/src/features/messaging/ui/MediaViewer.vue
@@ -15,8 +15,9 @@ interface Props {
 const props = defineProps<Props>();
 const emit = defineEmits<{ close: [] }>();
 
+const { t } = useI18n();
 const chatStore = useChatStore();
-const { getState, download } = useFileDownload();
+const { getState, download, saveFile } = useFileDownload();
 
 // Android back: close media viewer (highest overlay priority)
 useAndroidBackHandler("media-viewer", 100, () => {
@@ -161,6 +162,13 @@ watch(currentMessage, async (msg) => {
     await download(msg);
   }
 });
+
+const handleSaveCurrent = async () => {
+  const msg = currentMessage.value;
+  const url = currentUrl.value;
+  if (!msg || !msg.fileInfo || !url) return;
+  await saveFile(url, msg.fileInfo.name, msg.fileInfo.type);
+};
 </script>
 
 <template>
@@ -185,7 +193,20 @@ watch(currentMessage, async (msg) => {
           <span class="text-sm text-white/60">
             {{ currentIndex + 1 }} / {{ mediaMessages.length }}
           </span>
-          <div class="w-6" />
+          <button
+            data-testid="media-save"
+            class="text-white/80 transition-colors hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+            :disabled="!currentUrl"
+            :title="t('media.save')"
+            :aria-label="t('media.save')"
+            @click="handleSaveCurrent"
+          >
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="7 10 12 15 17 10" />
+              <line x1="12" y1="15" x2="12" y2="3" />
+            </svg>
+          </button>
         </div>
 
         <!-- Media content -->

--- a/src/features/messaging/ui/MessageContextMenu.vue
+++ b/src/features/messaging/ui/MessageContextMenu.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import type { Message } from "@/entities/chat";
+import { MessageType } from "@/entities/chat";
 import { useThemeStore } from "@/entities/theme";
 import { useMobile } from "@/shared/lib/composables/use-media-query";
 import { BottomSheet } from "@/shared/ui/bottom-sheet";
@@ -41,8 +42,15 @@ const ICONS = {
   edit:    svg('<path d="M17 3a2.83 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/>'),
   select:  svg('<polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>'),
   pin:     svg('<line x1="12" y1="17" x2="12" y2="22"/><path d="M5 17h14v-1.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V6h1a2 2 0 0 0 0-4H8a2 2 0 0 0 0 4h1v4.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24Z"/>'),
+  save:    svg('<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>'),
   delete:  svg('<path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/>'),
 };
+
+const isSavable = computed(() => {
+  const msg = props.message;
+  if (!msg || !msg.fileInfo) return false;
+  return msg.type === MessageType.image || msg.type === MessageType.video;
+});
 
 const menuItems = computed<ContextMenuItem[]>(() => {
   const items: ContextMenuItem[] = [
@@ -50,6 +58,9 @@ const menuItems = computed<ContextMenuItem[]>(() => {
     { label: t("contextMenu.copy"), icon: ICONS.copy, action: "copy" },
     { label: t("contextMenu.forward"), icon: ICONS.forward, action: "forward" },
   ];
+  if (isSavable.value) {
+    items.push({ label: t("media.save"), icon: ICONS.save, action: "save" });
+  }
   if (props.isOwn) {
     items.push({ label: t("contextMenu.edit"), icon: ICONS.edit, action: "edit" });
   }

--- a/src/features/messaging/ui/MessageList.vue
+++ b/src/features/messaging/ui/MessageList.vue
@@ -8,6 +8,7 @@ import { cleanMatrixIds, resolveSystemText } from "@/entities/chat/lib/chat-help
 import { formatDate } from "@/shared/lib/format";
 import { UserAvatar } from "@/entities/user";
 import { useMessages } from "../model/use-messages";
+import { useFileDownload } from "../model/use-file-download";
 import { useScrollToMessage, toMessage } from "../model/use-scroll-to-message";
 import { getChatDb, isChatDbReady } from "@/shared/lib/local-db";
 import { useToast } from "@/shared/lib/use-toast";
@@ -30,6 +31,7 @@ const chatStore = useChatStore();
 const authStore = useAuthStore();
 const themeStore = useThemeStore();
 const { loadMessages, toggleReaction, deleteMessage, deleteMessages, votePoll, endPoll, retryMediaUpload, retryMessage, cancelMediaUpload } = useMessages();
+const { getState: getFileState, download: downloadFile, saveFile } = useFileDownload();
 const { toast } = useToast();
 const { t } = useI18n();
 
@@ -149,8 +151,22 @@ const handleContextAction = (action: string, message: import("@/entities/chat").
     case "unpin":
       chatStore.unpinMessage(message.id);
       break;
+    case "save":
+      handleSaveMedia(message);
+      break;
   }
   closeContextMenu();
+};
+
+const handleSaveMedia = async (message: import("@/entities/chat").Message) => {
+  if (!message.fileInfo) return;
+  // Match the cache key used by MessageBubble + MediaViewer: stable clientId
+  // when available so an in-flight upload's blob URL is reused instead of
+  // re-decrypting the just-rendered file.
+  const cacheKey = message._key || message.id;
+  const url = getFileState(cacheKey).objectUrl ?? (await downloadFile(message));
+  if (!url) return;
+  await saveFile(url, message.fileInfo.name, message.fileInfo.type);
 };
 
 const handlePollVote = (messageId: string, optionId: string) => {

--- a/src/features/messaging/ui/__tests__/MediaViewer-save-button.test.ts
+++ b/src/features/messaging/ui/__tests__/MediaViewer-save-button.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression for missing "Save to gallery" affordance (issues #676, #376,
+ * #331, #158).
+ *
+ * Users expected a visible save button when viewing a photo/video — the
+ * MediaViewer top-bar previously only had close + counter, leaving the
+ * existing useFileDownload.saveFile path unreachable from photo/video
+ * messages. This test guards the wiring between the top-bar button and the
+ * download composable so a future refactor can't quietly remove it.
+ *
+ * Source-level assertion mirrors the pattern in
+ * message-bubble-decrypt-error-ux.test.ts: mounting MediaViewer requires
+ * mocking the chat store, useFileDownload, AndroidBackHandler and video
+ * state preservation, which is brittle relative to the one-line wiring we
+ * actually want to verify.
+ */
+const getSource = (): string =>
+  readFileSync(resolve(__dirname, "../MediaViewer.vue"), "utf-8");
+
+describe("MediaViewer — save-to-gallery button", () => {
+  it("renders a save button identified by data-testid='media-save'", () => {
+    const source = getSource();
+    expect(source).toMatch(/data-testid="media-save"/);
+  });
+
+  it("disables the save button when there is no current url", () => {
+    const source = getSource();
+    // The button must guard against missing media so a stray click during
+    // download (currentUrl === null) does not invoke saveFile with null.
+    const start = source.indexOf('data-testid="media-save"');
+    expect(start).toBeGreaterThan(-1);
+    const fragment = source.slice(start, start + 500);
+    expect(fragment).toMatch(/:disabled="!currentUrl"/);
+  });
+
+  it("wires the save button click to a handler that calls saveFile", () => {
+    const source = getSource();
+    // Pull saveFile out of useFileDownload alongside the existing getState/download.
+    expect(source).toMatch(/const\s*\{\s*[^}]*\bsaveFile\b[^}]*\}\s*=\s*useFileDownload\(\)/);
+    // The handler invoked by the button must call saveFile with the current
+    // url + filename + mime.
+    const fnStart = source.indexOf("const handleSaveCurrent");
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf("};", fnStart);
+    const fn = source.slice(fnStart, fnEnd);
+    expect(fn).toContain("saveFile");
+    expect(fn).toContain("currentUrl");
+    expect(fn).toContain("fileInfo");
+  });
+
+  it("uses media.save i18n key for the title/aria label", () => {
+    const source = getSource();
+    expect(source).toContain("media.save");
+  });
+});

--- a/src/features/messaging/ui/__tests__/MessageContextMenu-save-action.test.ts
+++ b/src/features/messaging/ui/__tests__/MessageContextMenu-save-action.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression for missing "Save" entry in the message long-press / right-click
+ * menu for photo and video messages (issues #676, #376, #331, #158).
+ *
+ * Long-pressing a photo bubble previously offered reply/copy/forward/etc but
+ * not save. The MediaViewer save button (Task 2) covers the in-viewer flow,
+ * but users who long-press without opening the viewer also need a path to
+ * trigger useFileDownload.saveFile.
+ *
+ * Source-level assertion mirrors message-bubble-decrypt-error-ux.test.ts —
+ * mounting MessageContextMenu requires Pinia, BottomSheet's portal, useMobile
+ * matchMedia, and the i18n stub, which is brittle for what amounts to
+ * verifying one menu item and one switch case.
+ */
+const getMenuSource = (): string =>
+  readFileSync(resolve(__dirname, "../MessageContextMenu.vue"), "utf-8");
+const getListSource = (): string =>
+  readFileSync(resolve(__dirname, "../MessageList.vue"), "utf-8");
+
+describe("MessageContextMenu — save action for image/video", () => {
+  it("includes a 'save' action in menuItems guarded by an image/video check", () => {
+    const source = getMenuSource();
+    // The action key must be exactly "save" so the parent switch in
+    // MessageList matches.
+    expect(source).toMatch(/action:\s*['"]save['"]/);
+    // The save entry must only appear for image or video messages with file
+    // info — otherwise the menu would offer Save on text/poll/transfer items
+    // where it would just no-op.
+    expect(source).toMatch(/MessageType\.image|message\.type === ['"]image['"]/);
+    expect(source).toMatch(/MessageType\.video|message\.type === ['"]video['"]/);
+  });
+
+  it("declares a save icon under ICONS so the menu renders consistently", () => {
+    const source = getMenuSource();
+    expect(source).toMatch(/save:\s*svg\(/);
+  });
+
+  it("uses media.save i18n key for the save menu label", () => {
+    const source = getMenuSource();
+    expect(source).toContain("media.save");
+  });
+});
+
+describe("MessageList — save action wires to useFileDownload.saveFile", () => {
+  it("destructures saveFile + download from useFileDownload", () => {
+    const source = getListSource();
+    expect(source).toMatch(/\bsaveFile\b/);
+    expect(source).toMatch(/useFileDownload\(\)/);
+  });
+
+  it("handles the 'save' action by downloading (if needed) and calling saveFile", () => {
+    const source = getListSource();
+    // Find the handleContextAction switch and confirm a 'save' branch exists.
+    const fnStart = source.indexOf("const handleContextAction");
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf("\n};", fnStart);
+    const fn = source.slice(fnStart, fnEnd);
+    expect(fn).toMatch(/case\s+['"]save['"]/);
+    // The save branch may either inline saveFile or delegate to a helper —
+    // either way, saveFile must be reachable from this file.
+    expect(source).toContain("saveFile");
+    // Ensure we honour cache-key parity with MessageBubble (use _key || id)
+    // so we don't kick off a duplicate decrypt for media that's already
+    // displayed in the bubble.
+    expect(source).toMatch(/_key\s*\|\|\s*[\w.]+\.id/);
+  });
+});

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -338,6 +338,7 @@ export const en = {
   "media.addCaption": "Add a caption...",
   "media.captionBelow": "Caption below",
   "media.captionAbove": "Caption above",
+  "media.save": "Save",
 
   // ── Drop overlay ──
   "drop.title": "Drop files here to send",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -340,6 +340,7 @@ export const ru: Record<TranslationKey, string> = {
   "media.addCaption": "Добавить подпись...",
   "media.captionBelow": "Подпись снизу",
   "media.captionAbove": "Подпись сверху",
+  "media.save": "Сохранить",
 
   // ── Drop overlay ──
   "drop.title": "Перетащите файлы сюда",


### PR DESCRIPTION
## Summary

Adds a user-facing "Save to gallery" affordance for image/video messages. The existing `useFileDownload.saveFile` path (Filesystem.writeFile + FileOpener with Share fallback) already worked for non-media files but was unreachable from photo/video bubbles.

- **MediaViewer top-bar:** download icon button (`data-testid="media-save"`) → `saveFile` with current url/name/mime; disabled while no `currentUrl`.
- **MessageContextMenu:** new "Сохранить" item gated by `isSavable` (image/video with `fileInfo`); ordered between Forward and Edit.
- **MessageList.handleContextAction:** new `case "save"` → `handleSaveMedia` uses the same `_key || id` cache key as `MessageBubble`, so a save click on already-rendered media does **not** kick a duplicate decrypt.
- **i18n:** new `media.save` key (RU: "Сохранить", EN: "Save").

Closes #676, #376, #331, #158.

## Tests

- 4 new tests in `MediaViewer-save-button.test.ts` (testid, disabled binding, saveFile wiring, i18n key) — all PASS.
- 5 new tests in `MessageContextMenu-save-action.test.ts` (action key, image/video gate, save icon, i18n key, cache-key parity in MessageList) — all PASS.
- Source-level assertions are consistent with the existing `message-bubble-decrypt-error-ux.test.ts` pattern in this repo (mounting MessageContextMenu requires Pinia + portals + matchMedia stubs that are brittle relative to verifying one menu item + one switch case).

## Verification

- [x] `npx vitest run src/features/messaging/ui/__tests__/MediaViewer-save-button.test.ts` — 4/4 PASS
- [x] `npx vitest run src/features/messaging/ui/__tests__/MessageContextMenu-save-action.test.ts` — 5/5 PASS
- [x] `npx vitest run src/features/messaging` — 229 PASS
- [x] `node_modules/.bin/vue-tsc --noEmit` — 43 pre-existing errors (identical to baseline; none in changed files)
- [x] `node_modules/.bin/vite build` — clean (~19s)
- [x] `superpowers:code-reviewer` — APPROVE, no CRITICAL/HIGH findings
- [ ] Manual on Android: open MediaViewer on photo → tap save icon → file in gallery (or system Share with "Save to Photos")
- [ ] Manual on Android: long-press photo bubble → context menu → "Сохранить" → save flow
- [ ] Manual on Android: same flow for video

## Out of scope

- Native MediaStore plugin for direct Pictures/Movies path (separate track)
- Custom album ("Forta Chat") on save
- Web SaveAs API (`useFileDownload.saveFile` already falls back to `<a download>`)