### PR TITLE
fix(calls): incoming-call ringer on Android 10+ + Huawei (Session 41)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -145,6 +145,10 @@
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.MANAGE_OWN_CALLS" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    <!-- Required to keep the device awake while ringing — without it the
+         full-screen-intent notification can fail to wake the screen on
+         some OEM ROMs (Huawei in particular). Session 41. -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />

--- a/android/app/src/main/java/com/forta/chat/FortaFirebaseMessagingService.kt
+++ b/android/app/src/main/java/com/forta/chat/FortaFirebaseMessagingService.kt
@@ -108,6 +108,12 @@ class FortaFirebaseMessagingService : FirebaseMessagingService() {
             Log.d(TAG, "Call ended remotely (type=$msgType), tearing down incoming UI")
             IncomingCallActivity.dismissIfShowing()
             com.forta.chat.plugins.calls.CallConnectionService.dismissIncomingCallNotification(this)
+            // Session 41: Telecom helper above only cancels its own id 9999;
+            // the FSI ringer notification posted by showSimpleCallNotification
+            // lives at ("call_$roomId".hashCode()) and would keep ringing
+            // (setOngoing=true blocks swipe-dismiss) until process death
+            // without an explicit cancel.
+            dismissPushCallNotification(this, roomId)
             try {
                 com.forta.chat.plugins.calls.CallConnectionService.currentConnection
                     ?.onDisconnect()
@@ -159,6 +165,12 @@ class FortaFirebaseMessagingService : FirebaseMessagingService() {
             val lifetimeMs = data["lifetime"]?.toLongOrNull()
             val nowMs = System.currentTimeMillis()
             val expired = InviteThrottleGuard.isExpired(sentTime, nowMs, lifetimeMs)
+            // Session 41 diagnostic: lets us split timestamp-loss reports
+            // (Huawei HMS-stub, FCM collapse) from genuinely stale invites
+            // without needing a custom build for the user.
+            Log.i(TAG, "Call invite: callId=$callId, eventId=${data["event_id"]}, " +
+                "sentTime=$sentTime, lifetime=$lifetimeMs, expired=$expired, " +
+                "age=${nowMs - sentTime}ms, buildSdk=${Build.VERSION.SDK_INT}")
             inviteTracker.append(
                 InviteThrottleTracker.Record(
                     receivedAtMs = nowMs,
@@ -261,7 +273,20 @@ class FortaFirebaseMessagingService : FirebaseMessagingService() {
     private fun showCallNotification(roomId: String, callerName: String, data: Map<String, String>) {
         val callId = data["call_id"] ?: data["event_id"] ?: ""
 
-        // Always show IncomingCallActivity directly — TelecomManager often rejects self-managed calls
+        // Session 41: post the full-screen-intent notification FIRST.
+        // This is the only ringer path that survives Android 10+ killed-app
+        // background-startActivity restrictions (no exception thrown — the
+        // launch is silently dropped). Posting the notification with
+        // setFullScreenIntent + CHANNEL_CALLS (IMPORTANCE_MAX, ringtone)
+        // wakes the screen and rings reliably from the locked screen on
+        // every device the system grants USE_FULL_SCREEN_INTENT to.
+        showSimpleCallNotification(roomId, callerName)
+
+        // Best-effort additional path: when the process is in foreground or
+        // recently stopped, startActivity succeeds and the user gets the
+        // richer IncomingCallActivity surface immediately. When it's blocked
+        // (Android 10+ killed app), the notification posted above keeps
+        // ringing — no silent miss.
         try {
             val intent = Intent(this, com.forta.chat.plugins.calls.IncomingCallActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
@@ -273,8 +298,7 @@ class FortaFirebaseMessagingService : FirebaseMessagingService() {
             startActivity(intent)
             Log.d(TAG, "Started IncomingCallActivity for $callerName")
         } catch (e: Exception) {
-            Log.w(TAG, "Could not start IncomingCallActivity: $e")
-            showSimpleCallNotification(roomId, callerName)
+            Log.w(TAG, "IncomingCallActivity.startActivity blocked, notification fallback active", e)
         }
 
         // Also try TelecomManager for system integration (call log, Bluetooth headset, etc.)
@@ -384,6 +408,22 @@ class FortaFirebaseMessagingService : FirebaseMessagingService() {
                 .edit()
                 .putString("sender_name_$sender", name)
                 .apply()
+        }
+
+        /**
+         * Dismiss the FSI ringer notification for [roomId] posted by
+         * [showSimpleCallNotification]. Idempotent — safe to call from
+         * multiple cleanup paths.
+         *
+         * Mirror of [CallConnectionService.dismissIncomingCallNotification]
+         * but for the push-side notification. Without this, the
+         * full-screen-intent ringer keeps ringing after the caller hangs
+         * up, after the user accepts, or after they decline — because
+         * the Telecom dismiss helper only cancels its own ID 9999.
+         */
+        fun dismissPushCallNotification(context: Context, roomId: String) {
+            val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            nm.cancel(NOTIF_TAG, "call_$roomId".hashCode())
         }
     }
 }

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallConnectionService.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallConnectionService.kt
@@ -72,6 +72,15 @@ class CallConnectionService : ConnectionService() {
 
         currentConnection = connection
 
+        // Session 41: Telecom is about to post its own FSI ringer notification
+        // (CHANNEL_INCOMING_CALLS, id 9999). The FCM service already posted
+        // one on the push path (CHANNEL_CALLS, "call_$roomId".hashCode()) —
+        // dismiss it now so we don't ring twice from two different channels.
+        if (roomId.isNotEmpty()) {
+            com.forta.chat.FortaFirebaseMessagingService
+                .dismissPushCallNotification(applicationContext, roomId)
+        }
+
         // Show native incoming call UI
         showIncomingCallUI(callId, callerName, hasVideo)
 

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/IncomingCallActivity.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/IncomingCallActivity.kt
@@ -22,6 +22,7 @@ import android.util.Log
 import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
+import com.forta.chat.FortaFirebaseMessagingService
 import com.forta.chat.MainActivity
 import com.forta.chat.R
 import com.forta.chat.plugins.locale.LocaleHelper
@@ -72,6 +73,16 @@ class IncomingCallActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         currentInstance = this
+
+        // Session 41: now that the FCM service posts the FSI notification
+        // unconditionally, both the channel ringtone and the activity's
+        // own startRingtone() would otherwise play in parallel. Dismiss
+        // the FSI as soon as the activity has surfaced — the activity
+        // itself is now the sole ringer source. Idempotent if it was
+        // never posted (no-op cancel).
+        intent.getStringExtra("roomId")?.let { rId ->
+            FortaFirebaseMessagingService.dismissPushCallNotification(this, rId)
+        }
 
         // H1: action extra from notification accept/decline PendingIntents.
         // The accept/decline actions attached to the CallStyle notification
@@ -214,6 +225,12 @@ class IncomingCallActivity : Activity() {
         startActivity(appBootIntent)
 
         CallConnectionService.dismissIncomingCallNotification(this)
+        // Belt-and-braces in case onCreate's dismiss missed (e.g. action=accept
+        // path that returned early before the dismiss block, or a race with the
+        // notification being re-posted by a retry push). Idempotent.
+        intent.getStringExtra("roomId")?.let { rId ->
+            FortaFirebaseMessagingService.dismissPushCallNotification(this, rId)
+        }
         finish()
     }
 
@@ -258,6 +275,9 @@ class IncomingCallActivity : Activity() {
         }
 
         CallConnectionService.dismissIncomingCallNotification(this)
+        intent.getStringExtra("roomId")?.let { rId ->
+            FortaFirebaseMessagingService.dismissPushCallNotification(this, rId)
+        }
         finish()
     }
 
@@ -270,6 +290,9 @@ class IncomingCallActivity : Activity() {
         CallConnection.pendingAnswerCallId = null
         CallConnection.pendingAnswerRoomId = null
         CallConnectionService.dismissIncomingCallNotification(this)
+        intent.getStringExtra("roomId")?.let { rId ->
+            FortaFirebaseMessagingService.dismissPushCallNotification(this, rId)
+        }
         finish()
     }
 

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/InviteThrottleGuard.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/InviteThrottleGuard.kt
@@ -36,9 +36,11 @@ object InviteThrottleGuard {
      * Returns true when the invite is older than `min(lifetime, MAX)`.
      *
      * @param sentTimeMs proxy for `event.origin_server_ts`. On the FCM
-     *   path use `RemoteMessage.sentTime`. Defensive: a non-positive
-     *   value is treated as expired so we never let a malformed invite
-     *   through.
+     *   path use `RemoteMessage.sentTime`. A non-positive value usually
+     *   means the timestamp was lost in transit — Huawei HMS-stub builds
+     *   pass 0, and FCM collapse_key dedup discards origin time on the
+     *   second delivery — so we treat it as live (Session 41). Otherwise
+     *   the user silently misses the call.
      * @param nowMs current wall clock. Production callers pass
      *   `System.currentTimeMillis()`; tests pass a fixed value.
      * @param lifetimeMs `event.content.lifetime`. Pass `null` to use
@@ -49,7 +51,7 @@ object InviteThrottleGuard {
         nowMs: Long,
         lifetimeMs: Long? = null,
     ): Boolean {
-        if (sentTimeMs <= 0L) return true
+        if (sentTimeMs <= 0L) return false
         val rawLifetime = lifetimeMs?.takeIf { it > 0L } ?: DEFAULT_INVITE_LIFETIME_MS
         val effective = rawLifetime.coerceAtMost(MAX_INVITE_LIFETIME_MS)
         val age = nowMs - sentTimeMs

--- a/android/app/src/test/java/com/forta/chat/plugins/calls/InviteThrottleGuardTest.kt
+++ b/android/app/src/test/java/com/forta/chat/plugins/calls/InviteThrottleGuardTest.kt
@@ -9,7 +9,10 @@ import org.junit.Test
  * dependencies, runs as part of `./gradlew test` (JVM unit tests).
  *
  * Mirrors `src/shared/lib/native-calls/__tests__/invite-ttl.test.ts`
- * so JS and native sides agree on the staleness window.
+ * for the lifetime/staleness window. Diverges on missing-timestamp
+ * handling: JS-side `originServerTs <= 0` is corrupt-event (treated
+ * expired); Kotlin-side `sentTime <= 0` is HMS-stub / FCM-collapse
+ * (treated live — Session 41).
  */
 class InviteThrottleGuardTest {
 
@@ -67,9 +70,25 @@ class InviteThrottleGuardTest {
     }
 
     @Test
-    fun nonPositiveTimestampTreatedAsExpired() {
-        assertTrue(InviteThrottleGuard.isExpired(sentTimeMs = 0L, nowMs = now))
-        assertTrue(InviteThrottleGuard.isExpired(sentTimeMs = -1L, nowMs = now))
+    fun `sentTime zero is treated as live invite (Huawei HMS-stub or FCM collapse)`() {
+        // Some delivery paths erase the timestamp:
+        //   - Huawei HMS-stub builds set RemoteMessage.sentTime to 0
+        //   - FCM collapse_key dedup discards origin time on the second delivery
+        // Treating these as expired silently dropped valid invites — Session 41
+        // restores them as live. The lifetime check still applies once a real
+        // sentTime is present, so this only relaxes the malformed-timestamp
+        // edge-case, not the staleness window itself.
+        assertFalse(
+            "sentTime=0 must be treated as live (FCM collapsed or HMS stub)",
+            InviteThrottleGuard.isExpired(sentTimeMs = 0L, nowMs = now, lifetimeMs = 60_000L)
+        )
+    }
+
+    @Test
+    fun `negative sentTime is treated as live invite`() {
+        assertFalse(
+            InviteThrottleGuard.isExpired(sentTimeMs = -1L, nowMs = now, lifetimeMs = 60_000L)
+        )
     }
 
     @Test

--- a/src/shared/lib/push/push-data-plugin.ts
+++ b/src/shared/lib/push/push-data-plugin.ts
@@ -11,6 +11,10 @@ export interface PushPayload {
   sender?: string;
   unread?: string;
   missed_calls?: string;
+  /** Stable Matrix m.call.* call_id. Persists across invite retries (each
+   *  retry has a new event_id). Prefer this over event_id for call
+   *  correlation. Session 41. */
+  call_id?: string;
 }
 
 interface PushDataPlugin extends Plugin {

--- a/src/shared/lib/push/push-service.ts
+++ b/src/shared/lib/push/push-service.ts
@@ -299,8 +299,11 @@ class PushService {
 
     // Handle calls
     if (data.msg_type === 'm.call.invite') {
+      // Prefer the stable Matrix call_id over event_id: caller clients
+      // resend m.call.invite with a new event_id each retry while keeping
+      // the call_id constant. Session 41.
       this.onCallPush?.({
-        callId: data.event_id || '',
+        callId: data.call_id || data.event_id || '',
         callerName: data.sender_display_name || tRaw('push.unknownSender'),
         roomId,
         hasVideo: false,


### PR DESCRIPTION
## Summary

- `InviteThrottleGuard.isExpired(sentTime <= 0)` теперь возвращает `live`, не `expired`. Huawei HMS-stub builds и FCM `collapse_key` dedup обнуляют timestamp — раньше валидные invites молча отбрасывались.
- FCM service постит full-screen-intent notification **первой**, `startActivity(IncomingCallActivity)` идёт best-effort. На Android 10+ killed app launch блокируется silently (без exception), поэтому старый `catch`-only fallback ни разу не срабатывал — notification теперь canonical ringer source.
- `dismissPushCallNotification` companion-helper + wired в hangup/reject branch + `IncomingCallActivity.onCreate/accept/decline/dismissByRemote` + Telecom path. Без этого FSI notification не очищалась после end-of-call.
- `WAKE_LOCK` permission для FSI screen-wake на OEM ROMs (Huawei).
- `PushPayload.call_id` typed; JS-side prefers `call_id` над `event_id` (retries reuse call_id, allocate new event_id).
- Diagnostic `Log.i` в FCM call-invite branch (callId/eventId/sentTime/lifetime/expired/age/SDK).

Closes #687, #663, #674, #438, #421.

## Test plan

- [x] \`./gradlew :app:testDebugUnitTest\` — PASS (включая 2 новых backtick-named тестов в \`InviteThrottleGuardTest\`)
- [x] \`npm run test\` — 9 failed pre-existing на master (master имеет 10), мои изменения не вносят новых
- [x] \`npx vue-tsc --noEmit\` — 0 ошибок в моих файлах
- [x] Code review (\`superpowers:code-reviewer\`) — все CRITICAL/HIGH/MEDIUM addressed (LOW #10/#11 оставлены follow-up)
- [ ] Manual: Huawei pure 70 ultra или другой Huawei с HMS-stub — incoming call rings
- [ ] Manual: Android 10+ device, force-stop app → caller dials → ringer fires from locked screen
- [ ] Manual: проверить что после accept/decline/hangup notification сразу пропадает (no leftover ringing)
- [ ] Manual: проверить что только один ringtone играет одновременно (не два)
- [ ] Manual: logcat показывает \`Call invite: callId=..., sentTime=..., expired=false, ...\`