### PR TITLE
fix(channels): iframe sandbox + back-button fullscreen handler (Session 46)

### DIFF
--- a/src/features/post-player/ui/VideoPlayer.vue
+++ b/src/features/post-player/ui/VideoPlayer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { App as CapacitorApp, type PluginListenerHandle } from "@capacitor/app";
 import { parseVideoUrl, fetchPeerTubeThumb } from "@/shared/lib/video-embed";
+import { useAndroidBackHandler } from "@/shared/lib/composables/use-android-back-handler";
 
 interface Props {
   url: string;
@@ -13,12 +13,9 @@ const videoInfo = computed(() => parseVideoUrl(props.url));
 const playing = ref(false);
 const error = ref(false);
 const peertubeThumb = ref("");
-const iframeRef = ref<HTMLIFrameElement | null>(null);
 const isFullscreen = ref(false);
 
 const thumbUrl = computed(() => peertubeThumb.value || videoInfo.value?.thumbUrl || "");
-
-let backListener: PluginListenerHandle | null = null;
 
 const onFullscreenChange = () => {
   isFullscreen.value = !!document.fullscreenElement;
@@ -26,19 +23,6 @@ const onFullscreenChange = () => {
 
 onMounted(async () => {
   document.addEventListener("fullscreenchange", onFullscreenChange);
-
-  // Android back: while iframe is in fullscreen, exit FS instead of closing post.
-  // Capacitor App is web-shim safe, but wrap defensively for test/SSR envs.
-  try {
-    backListener = await CapacitorApp.addListener("backButton", (e) => {
-      if (isFullscreen.value && document.exitFullscreen) {
-        document.exitFullscreen().catch(() => {});
-        e.canGoBack = false;
-      }
-    });
-  } catch {
-    // no-op: Capacitor plugin not available (e.g. unit tests, plain web preview)
-  }
 
   const info = videoInfo.value;
   if (info?.type === "peertube" && info.apiUrl) {
@@ -48,8 +32,16 @@ onMounted(async () => {
 
 onUnmounted(() => {
   document.removeEventListener("fullscreenchange", onFullscreenChange);
-  backListener?.remove().catch(() => {});
-  backListener = null;
+});
+
+// Android back: exit iframe fullscreen instead of closing the post.
+// Priority 100 matches other full-screen overlays (MediaViewer, CallWindow).
+useAndroidBackHandler("post-video-fullscreen", 100, () => {
+  if (isFullscreen.value && document.exitFullscreen) {
+    document.exitFullscreen().catch(() => {});
+    return true;
+  }
+  return false;
 });
 
 const play = () => {
@@ -70,7 +62,6 @@ const onIframeError = () => {
   >
     <iframe
       v-if="playing && !error"
-      ref="iframeRef"
       :src="videoInfo.embedUrl + '?autoplay=1'"
       class="absolute inset-0 h-full w-full"
       frameborder="0"

--- a/src/features/post-player/ui/VideoPlayer.vue
+++ b/src/features/post-player/ui/VideoPlayer.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { App as CapacitorApp, type PluginListenerHandle } from "@capacitor/app";
 import { parseVideoUrl, fetchPeerTubeThumb } from "@/shared/lib/video-embed";
 
 interface Props {
@@ -12,15 +13,43 @@ const videoInfo = computed(() => parseVideoUrl(props.url));
 const playing = ref(false);
 const error = ref(false);
 const peertubeThumb = ref("");
+const iframeRef = ref<HTMLIFrameElement | null>(null);
+const isFullscreen = ref(false);
 
 const thumbUrl = computed(() => peertubeThumb.value || videoInfo.value?.thumbUrl || "");
 
-// Fetch PeerTube thumbnail via API
+let backListener: PluginListenerHandle | null = null;
+
+const onFullscreenChange = () => {
+  isFullscreen.value = !!document.fullscreenElement;
+};
+
 onMounted(async () => {
+  document.addEventListener("fullscreenchange", onFullscreenChange);
+
+  // Android back: while iframe is in fullscreen, exit FS instead of closing post.
+  // Capacitor App is web-shim safe, but wrap defensively for test/SSR envs.
+  try {
+    backListener = await CapacitorApp.addListener("backButton", (e) => {
+      if (isFullscreen.value && document.exitFullscreen) {
+        document.exitFullscreen().catch(() => {});
+        e.canGoBack = false;
+      }
+    });
+  } catch {
+    // no-op: Capacitor plugin not available (e.g. unit tests, plain web preview)
+  }
+
   const info = videoInfo.value;
   if (info?.type === "peertube" && info.apiUrl) {
     peertubeThumb.value = await fetchPeerTubeThumb(info.apiUrl);
   }
+});
+
+onUnmounted(() => {
+  document.removeEventListener("fullscreenchange", onFullscreenChange);
+  backListener?.remove().catch(() => {});
+  backListener = null;
 });
 
 const play = () => {
@@ -41,10 +70,12 @@ const onIframeError = () => {
   >
     <iframe
       v-if="playing && !error"
+      ref="iframeRef"
       :src="videoInfo.embedUrl + '?autoplay=1'"
       class="absolute inset-0 h-full w-full"
       frameborder="0"
-      allow="autoplay; fullscreen; picture-in-picture"
+      sandbox="allow-same-origin allow-scripts allow-presentation allow-forms allow-popups"
+      allow="autoplay; picture-in-picture; fullscreen"
       allowfullscreen
       @error="onIframeError"
     />

--- a/src/features/post-player/ui/__tests__/VideoPlayer.test.ts
+++ b/src/features/post-player/ui/__tests__/VideoPlayer.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import VideoPlayer from "../VideoPlayer.vue";
+
+describe("VideoPlayer iframe security", () => {
+  it("renders iframe with sandbox attribute set after play is clicked", async () => {
+    const wrapper = mount(VideoPlayer, {
+      props: { url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ" },
+    });
+
+    expect(wrapper.find("iframe").exists()).toBe(false);
+
+    await wrapper.find("button").trigger("click");
+    await flushPromises();
+
+    const iframe = wrapper.find("iframe");
+    expect(iframe.exists()).toBe(true);
+
+    const sandbox = iframe.attributes("sandbox") ?? "";
+    expect(sandbox).toContain("allow-scripts");
+    expect(sandbox).toContain("allow-same-origin");
+    expect(sandbox).toContain("allow-presentation");
+  });
+});


### PR DESCRIPTION
## Summary

- `<iframe sandbox="allow-same-origin allow-scripts allow-presentation allow-forms allow-popups">` on the channel `VideoPlayer` to constrain YouTube/Vimeo/PeerTube embeds (best-effort; see caveat below).
- Track `document.fullscreenElement` via a `fullscreenchange` listener so the component knows when the iframe is in WebView fullscreen.
- Register through the project's centralized `useAndroidBackHandler` at priority 100 (same tier as `MediaViewer` / `CallWindow`): if the embed is in fullscreen on Android Back, exit fullscreen and consume the event — the channel post stays open.

Addresses #382 (back exits fullscreen, doesn't close post). Partial mitigation for #699 and #677.

## Caveat (per code review)

The `sandbox` attribute does not have an `allow-fullscreen` token in the HTML spec — fullscreen is gated by `allowfullscreen` + `allow="fullscreen"`. Whether Chromium WebView refuses to escalate to native Android Activity-level fullscreen because of `sandbox` is implementation-specific and not guaranteed by the spec. The full fix for #699 likely requires overriding `WebChromeClient.onShowCustomView` on the Android shell so the custom view attaches inside the Forta WebView container instead of the Activity decor view. That is out of scope for this session and will be a follow-up ticket.

The rotation crash (#677) is **not** addressed here — iframes don't expose `currentTime` so true state preservation is hard; this PR does not attempt it.

## Files

- `src/features/post-player/ui/VideoPlayer.vue` — sandbox attribute, `fullscreenchange` listener, `useAndroidBackHandler("post-video-fullscreen", 100, …)`.
- `src/features/post-player/ui/__tests__/VideoPlayer.test.ts` — regression test that the iframe is rendered with the sandbox tokens.

## Test plan

- [x] `npx vitest run src/features/post-player/ui/__tests__/VideoPlayer.test.ts` — PASS
- [x] Full suite: same pass/fail counts as master (no regressions; pre-existing failures unchanged)
- [x] vue-tsc --noEmit — same baseline error count as master (no new type errors)
- [ ] Manual on Android: open channel post → play YouTube → tap fullscreen icon → fullscreen stays inside Forta WebView (visually inside the app); Android Back exits fullscreen without closing post; rotation does not crash (acknowledged: not preserved); same path on Vimeo / PeerTube embeds