### PR TITLE
fix(audio): watchdog + retry-with-cache-bust for stuck encrypted playback (Session 44)

### DIFF
--- a/src/features/messaging/model/use-audio-playback.test.ts
+++ b/src/features/messaging/model/use-audio-playback.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from "vitest";
 
 // Mock platform detection
 vi.mock("@/shared/lib/platform", () => ({
@@ -340,5 +340,77 @@ describe("checkCodecSupport", () => {
     expect(support).toHaveProperty("wav");
     expect(support).toHaveProperty("aac");
     expect(typeof support.mp3).toBe("boolean");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Watchdog regression — Session 44
+// Reproduces issues #695, #671: voice message gets stuck in loading state
+// when the encrypted blob's <audio> never reaches loadedmetadata. Without a
+// watchdog, the user sees an infinite spinner; the cure is an 8s timeout
+// that flips state → "failed" so the retry button is shown.
+// ---------------------------------------------------------------------------
+describe("useAudioPlayback watchdog (Session 44)", () => {
+  let playback: ReturnType<typeof useAudioPlayback>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    playback = useAudioPlayback();
+    playback.stop();
+    mockPlay.mockClear();
+    mockPause.mockClear();
+    mockLoad.mockClear();
+    mockRemoveAttribute.mockClear();
+    (Audio as unknown as Mock).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("transitions to 'failed' if loadedmetadata never fires within 8s", async () => {
+    // Simulate hung encrypted blob: play() returns a never-resolving promise.
+    mockPlay.mockReturnValue(new Promise(() => {}));
+
+    // Don't await — play() will hang on the never-resolving promise.
+    void playback.play(baseInfo);
+    // Allow the synchronous part of play() to run (state = "loading", el = new Audio()).
+    await Promise.resolve();
+    expect(playback.state.value).toBe("loading");
+
+    // Advance past the 8s watchdog threshold.
+    await vi.advanceTimersByTimeAsync(8000);
+
+    expect(playback.state.value).toBe("failed");
+  });
+
+  it("does not transition to 'failed' if loadedmetadata fires before 8s", async () => {
+    mockPlay.mockResolvedValueOnce(undefined);
+
+    await playback.play(baseInfo);
+    expect(playback.state.value).toBe("playing");
+
+    // Fire loadedmetadata to clear the watchdog.
+    const onloaded = lastAudio.onloadedmetadata as ((this: unknown) => void) | null;
+    onloaded?.call(lastAudio);
+
+    await vi.advanceTimersByTimeAsync(8000);
+
+    expect(playback.state.value).not.toBe("failed");
+    expect(playback.state.value).toBe("playing");
+  });
+
+  it("does not transition to 'failed' on watchdog if state has already moved on", async () => {
+    mockPlay.mockResolvedValueOnce(undefined);
+
+    await playback.play(baseInfo);
+    // play() resolved → state = "playing"; user pauses before watchdog fires.
+    playback.pause();
+    expect(playback.state.value).toBe("paused");
+
+    await vi.advanceTimersByTimeAsync(8000);
+
+    // Watchdog must only flip state when it's still "loading".
+    expect(playback.state.value).toBe("paused");
   });
 });

--- a/src/features/messaging/model/use-audio-playback.test.ts
+++ b/src/features/messaging/model/use-audio-playback.test.ts
@@ -9,6 +9,17 @@ vi.mock("@/shared/lib/platform", () => ({
   isWeb: true,
 }));
 
+// Mock bug-report so we can assert that the watchdog path doesn't fire it.
+const mockBugReportOpen = vi.fn();
+vi.mock("@/features/bug-report", () => ({
+  useBugReport: () => ({ open: mockBugReportOpen }),
+}));
+
+// Mock i18n to keep error-context lookups deterministic.
+vi.mock("@/shared/lib/i18n", () => ({
+  tRaw: (k: string) => k,
+}));
+
 // --- Mock Audio (must use regular function for `new` operator) ---
 const mockPlay = vi.fn(() => Promise.resolve());
 const mockPause = vi.fn();
@@ -357,10 +368,13 @@ describe("useAudioPlayback watchdog (Session 44)", () => {
     vi.useFakeTimers();
     playback = useAudioPlayback();
     playback.stop();
+    // Reset rate so tests don't inherit cycleSpeed leftovers from other blocks.
+    playback.playbackRate.value = 1;
     mockPlay.mockClear();
     mockPause.mockClear();
     mockLoad.mockClear();
     mockRemoveAttribute.mockClear();
+    mockBugReportOpen.mockClear();
     (Audio as unknown as Mock).mockClear();
   });
 
@@ -412,5 +426,37 @@ describe("useAudioPlayback watchdog (Session 44)", () => {
 
     // Watchdog must only flip state when it's still "loading".
     expect(playback.state.value).toBe("paused");
+  });
+
+  it("does not open the bug-report modal when the watchdog wins the race", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    // Simulate the encrypted-blob hang: play() never resolves on its own.
+    // After the watchdog calls pause()/removeAttribute("src")/load(), the
+    // browser would normally reject the play() promise with AbortError.
+    let rejectPlay: (e: Error) => void = () => {};
+    mockPlay.mockReturnValue(new Promise((_, reject) => { rejectPlay = reject; }));
+
+    void playback.play(baseInfo);
+    await Promise.resolve();
+    expect(playback.state.value).toBe("loading");
+
+    // Watchdog fires.
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(playback.state.value).toBe("failed");
+
+    // Now the browser rejects play() (deferred AbortError after src cleared).
+    rejectPlay(new DOMException("The play() request was interrupted", "AbortError"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Must not show a bug-report modal — the watchdog already surfaced
+    // the failure, and the AbortError is its own doing.
+    expect(mockBugReportOpen).not.toHaveBeenCalled();
+    expect(playback.state.value).toBe("failed");
+
+    consoleSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
   });
 });

--- a/src/features/messaging/model/use-audio-playback.ts
+++ b/src/features/messaging/model/use-audio-playback.ts
@@ -109,7 +109,22 @@ const playbackRate = ref(1);
 
 let onEndedCallback: ((messageId: string, roomId: string) => void) | null = null;
 
+// Watchdog timeout for the loading → playing transition. encrypted blobs
+// occasionally hang `<audio>` such that neither loadedmetadata nor an error
+// event fires (issues #695, #671). 8s is long enough for slow Tor / 3G
+// pipelines but short enough for the user to retry without confusion.
+const LOADING_WATCHDOG_MS = 8_000;
+let loadingWatchdog: ReturnType<typeof setTimeout> | null = null;
+
+function clearLoadingWatchdog() {
+  if (loadingWatchdog !== null) {
+    clearTimeout(loadingWatchdog);
+    loadingWatchdog = null;
+  }
+}
+
 function cleanup() {
+  clearLoadingWatchdog();
   if (audio.value) {
     audio.value.pause();
     audio.value.removeAttribute("src");
@@ -137,6 +152,7 @@ function setupAudioListeners(el: HTMLAudioElement) {
     }
   };
   el.onerror = () => {
+    clearLoadingWatchdog();
     const err = el.error;
     console.error("[audio] playback error:", {
       code: err?.code,
@@ -149,6 +165,7 @@ function setupAudioListeners(el: HTMLAudioElement) {
     state.value = "failed";
   };
   el.onloadedmetadata = () => {
+    clearLoadingWatchdog();
     // Only update if finite — Chromium reports Infinity for webm blobs
     if (Number.isFinite(el.duration) && el.duration > 0) {
       duration.value = el.duration;
@@ -197,6 +214,24 @@ export function useAudioPlayback() {
     currentRoomId.value = info.roomId;
     duration.value = info.duration;
 
+    // Arm a watchdog before the play() promise — if loadedmetadata / error
+    // never fires (encrypted blob race, sw cache miss), flip to "failed" so
+    // the retry UI surfaces instead of an indefinite spinner.
+    loadingWatchdog = setTimeout(() => {
+      loadingWatchdog = null;
+      if (state.value === "loading") {
+        console.warn(
+          "[audio] watchdog: loading > 8s, marking failed (msg=" + info.messageId + ")",
+        );
+        state.value = "failed";
+        if (audio.value) {
+          try { audio.value.pause(); } catch { /* ignore */ }
+          try { audio.value.removeAttribute("src"); } catch { /* ignore */ }
+          try { audio.value.load(); } catch { /* ignore */ }
+        }
+      }
+    }, LOADING_WATCHDOG_MS);
+
     try {
       const el = new Audio();
       el.playbackRate = playbackRate.value;
@@ -207,8 +242,10 @@ export function useAudioPlayback() {
       // The browser binds the play() Promise to the current user activation.
       el.src = info.objectUrl;
       await el.play();
+      clearLoadingWatchdog();
       state.value = "playing";
     } catch (e: unknown) {
+      clearLoadingWatchdog();
       const err = e as Error;
       console.error("[audio] play() rejected:", err.name, err.message);
 

--- a/src/features/messaging/model/use-audio-playback.ts
+++ b/src/features/messaging/model/use-audio-playback.ts
@@ -255,8 +255,14 @@ export function useAudioPlayback() {
         console.error("[audio] User gesture likely expired before play(). " +
           "Ensure no async operations between click and play().");
       }
-      useBugReport().open({ context: tRaw("bugReport.ctx.audioPlayback"), error: e });
-      state.value = "failed";
+      // If the watchdog already flipped state to "failed", the play() promise
+      // rejection that follows is the watchdog's own abort (pause +
+      // removeAttribute("src") + load()). Don't open a duplicate bug-report
+      // modal in that case — the user already sees the retry UI.
+      if (state.value !== "failed") {
+        useBugReport().open({ context: tRaw("bugReport.ctx.audioPlayback"), error: e });
+        state.value = "failed";
+      }
     }
   }
 

--- a/src/features/messaging/model/use-file-download.test.ts
+++ b/src/features/messaging/model/use-file-download.test.ts
@@ -590,4 +590,91 @@ describe("useFileDownload", () => {
       scope.stop();
     });
   });
+
+  // -------------------------------------------------------------------------
+  // forceRefetch — Session 44
+  // Voice-message retry button needs to bypass the per-message media cache
+  // so a stuck encrypted blob can be re-fetched + re-decrypted with a fresh
+  // objectUrl (issues #695, #671).
+  // -------------------------------------------------------------------------
+  describe("download — forceRefetch (Session 44)", () => {
+    const baseMessage = {
+      id: "$evt_force",
+      _key: "client_force",
+      roomId: "!room:server",
+      senderId: "@u:server",
+      content: "voice.ogg",
+      timestamp: Date.now(),
+      status: "sent",
+      type: "audio",
+      fileInfo: {
+        name: "voice.ogg",
+        type: "audio/ogg",
+        size: 512,
+        url: "https://example.com/voice.ogg",
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    beforeEach(() => {
+      (global.fetch as Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        blob: () => Promise.resolve(new Blob([new Uint8Array([1, 2, 3])])),
+      });
+    });
+
+    it("returns the cached objectUrl on a second call without forceRefetch", async () => {
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download } = useFileDownload();
+
+        const first = await download(baseMessage);
+        const callsAfterFirst = (global.fetch as Mock).mock.calls.length;
+
+        const second = await download(baseMessage);
+
+        expect(second).toBe(first);
+        // Cache hit — no extra fetch.
+        expect((global.fetch as Mock).mock.calls.length).toBe(callsAfterFirst);
+      });
+      scope.stop();
+    });
+
+    it("bypasses the cache and re-fetches when forceRefetch=true", async () => {
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download } = useFileDownload();
+
+        await download(baseMessage);
+        const callsAfterFirst = (global.fetch as Mock).mock.calls.length;
+
+        await download(baseMessage, undefined, { forceRefetch: true });
+
+        expect((global.fetch as Mock).mock.calls.length).toBeGreaterThan(callsAfterFirst);
+      });
+      scope.stop();
+    });
+
+    it("revokes the prior objectUrl and produces a fresh one when forceRefetch=true", async () => {
+      const revokeSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+      try {
+        const scope = effectScope();
+        await scope.run(async () => {
+          const { download } = useFileDownload();
+
+          const first = await download(baseMessage);
+          revokeSpy.mockClear();
+
+          const second = await download(baseMessage, undefined, { forceRefetch: true });
+
+          expect(revokeSpy).toHaveBeenCalledWith(first);
+          expect(second).not.toBe(first);
+        });
+        scope.stop();
+      } finally {
+        revokeSpy.mockRestore();
+      }
+    });
+  });
 });

--- a/src/features/messaging/model/use-file-download.ts
+++ b/src/features/messaging/model/use-file-download.ts
@@ -31,6 +31,14 @@ interface FileDownloadState {
   blob: Blob | null;
 }
 
+/** Options for `download()`. `forceRefetch` is the retry-after-watchdog
+ *  escape hatch: when a stuck encrypted blob never reaches loadedmetadata,
+ *  the user clicks retry and the call site sets this flag to drop the
+ *  cached objectUrl and rerun fetch + decrypt with a fresh URL. */
+export interface DownloadOpts {
+  forceRefetch?: boolean;
+}
+
 /** Errors that mean "this ciphertext cannot be decrypted with the keys we
  *  have" — the sender's room state and ours diverged, or they encrypted to
  *  the wrong recipient set. Surfacing these as bug-reports drowns the actual
@@ -488,13 +496,39 @@ export function useFileDownload() {
   /** Download (and decrypt if needed) a file message.
    *  @param signal — optional AbortSignal. Callers that want the download
    *                  to stop when their scope unmounts (e.g. MediaGrid on
-   *                  chat switch) should pass `onScopeDispose`-tied signal. */
-  const download = async (message: Message, signal?: AbortSignal) => {
+   *                  chat switch) should pass `onScopeDispose`-tied signal.
+   *  @param opts.forceRefetch — when true, drops the cached objectUrl,
+   *                  revokes the prior blob URL, and re-runs the full
+   *                  fetch + decrypt pipeline. Used by the voice-message
+   *                  retry button after a watchdog timeout (Session 44). */
+  const download = async (
+    message: Message,
+    signal?: AbortSignal,
+    opts: DownloadOpts = {},
+  ) => {
     if (!message.fileInfo) return null;
 
     // Use _key (stable clientId) if available, otherwise fall back to id.
     // This prevents cache misses when id flips from clientId to eventId after send confirmation.
     const cacheKey = message._key || message.id;
+
+    // forceRefetch — drop the prior cache entry and revoke the old blob URL
+    // before re-running the pipeline. Without revoking, the previous
+    // objectUrl would leak (no one else holds a reference to it).
+    if (opts.forceRefetch) {
+      const previousUrl = cache.get(cacheKey);
+      if (previousUrl) {
+        try { URL.revokeObjectURL(previousUrl); } catch { /* ignore */ }
+      }
+      cache.delete(cacheKey);
+      const existingState = states.value[cacheKey];
+      if (existingState) {
+        existingState.objectUrl = null;
+        existingState.blob = null;
+        existingState.error = null;
+        existingState.errorKind = null;
+      }
+    }
 
     // Already cached
     if (cache.has(cacheKey)) {

--- a/src/features/messaging/ui/VoiceMessage.vue
+++ b/src/features/messaging/ui/VoiceMessage.vue
@@ -151,17 +151,23 @@ const generateWaveform = async (url: string) => {
 // (line 38-48), so objectUrl should be available by the time user taps play.
 // If not yet ready, we kick off the download and return — user taps again.
 const handleTogglePlay = async () => {
-  // If playback previously failed, reset error state on retry
-  if (playback.state.value === "failed" && playback.currentMessageId.value === stableId.value) {
+  const playbackFailed =
+    playback.state.value === "failed" &&
+    playback.currentMessageId.value === stableId.value;
+  // Retry path: a stuck blob (watchdog timed out, decode failed) gets a
+  // fresh fetch + decrypt with cache-bust. Without this, retry hits the
+  // cached objectUrl that was stuck in the first place.
+  const forceRefetch = playbackFailed || !!fileState.value.error;
+
+  if (playbackFailed) {
     playback.stop();
   }
 
-  let url = fileState.value.objectUrl;
+  let url = forceRefetch ? null : fileState.value.objectUrl;
 
   if (!url) {
-    // File not yet downloaded — trigger download and auto-play when done
-    const downloadedUrl = await download(props.message);
-    if (!downloadedUrl) return; // Download failed — error state is shown via fileState.error
+    const downloadedUrl = await download(props.message, undefined, { forceRefetch });
+    if (!downloadedUrl) return;
     url = downloadedUrl;
   }
 


### PR DESCRIPTION
## Summary

Closes #695, #671. Mitigates #118, #28.

Encrypted голосовые / аудиофайлы на Android-WebView иногда зависают в `loading`: `<audio>` получает encrypted blob раньше декрипта, `loadedmetadata` и `error` события не срабатывают, `el.play()` promise не резолвится — UI показывает бесконечный спиннер. Через 24ч кэш SW/blob инвалидируется и повторная загрузка получает уже decoded blob — отсюда жалобы "через сутки заработало".

Этот PR не переписывает на Web Audio API (как в bastyon-chat) — крупный рефактор. Вместо этого вводит две точечные защиты:

1. **8-секундный watchdog** в `use-audio-playback.ts` — флипает state из `loading` в `failed` если transition не наступил, чтобы UI показал retry вместо спиннера.
2. **`forceRefetch` opt** в `use-file-download.ts` — кнопка retry в `VoiceMessage.vue` прокидывает её, чтобы пробить per-message media cache (cached objectUrl и есть тот самый stuck blob), revoke старый URL, и заново отработать fetch + decrypt.

## Changes

- `src/features/messaging/model/use-audio-playback.ts`: module-level `LOADING_WATCHDOG_MS = 8_000` + singleton handle. Watchdog ставится перед `await el.play()`, очищается из `cleanup()`, `el.onloadedmetadata`, `el.onerror`, успешного play(), и catch-блока. Catch гейтится на `state.value !== "failed"` — чтобы AbortError от watchdog'a (pause + removeAttribute + load) не открыл дублирующий bug-report modal.
- `src/features/messaging/model/use-file-download.ts`: новый `DownloadOpts` interface + третий аргумент `download(message, signal?, opts: DownloadOpts = {})`. `forceRefetch: true` → `cache.delete` + `URL.revokeObjectURL(prev)` + reset state, потом полный re-fetch+decrypt. Backward compat: `signal` остался 2-м позиц. аргументом.
- `src/features/messaging/ui/VoiceMessage.vue`: `handleTogglePlay` детектит `playbackFailed || fileState.error` → передаёт `forceRefetch: true` и игнорирует кэшированный URL.

## Test plan

- [x] `npx vitest run src/features/messaging/model/use-audio-playback.test.ts` — 28/28 PASS, включая 4 watchdog-кейса (transition, no-transition, no-flip-on-paused, no-bug-report-on-watchdog-race).
- [x] `npx vitest run src/features/messaging/model/use-file-download.test.ts` — 22/22 PASS, включая 3 forceRefetch-кейса (cache hit, bypass, revoke prior url).
- [x] Touched test suite combined: **50/50 PASS**.
- [x] Full project test suite: 9 pre-existing failures на master (URL parsing в `open-profile-url`, `video-embed`, `chat-helpers`, `display-result`) — не связаны с Session 44.
- [x] Code review через `superpowers:code-reviewer` — нашёл 1 HIGH (duplicate bug-report on watchdog race), пофикшен + покрыт regression тестом.
- [ ] Manual UX (вручную после merge):
  - Encrypted DM голосовое сообщение → получатель сразу жмёт play → loading → через 8с failed → retry → играет.
  - Unencrypted audio (public room) играет без задержек как раньше.
  - Double-retry в течение 100ms не приводит к крашу (state.loading guard).

## Out of scope

- Не переписываем на Web Audio API — крупный рефактор bastyon-chat-style, отдельная задача.
- Out-of-order audio (#118, #28) — отдельная Matrix sync ordering задача.
- iOS WKWebView visibilitychange-paused timer — defer (видеосигнал MVP).

## Notes for reviewers

- Watchdog single-flight на global singleton state. Если параллельно стартанёт `play()` другого сообщения, `cleanup()` тушит предыдущий watchdog первым делом.
- `forceRefetch` revoke безопасен — guard на `cache.get(cacheKey)` отсеивает undefined.
- `loadingWatchdog` и `cacheBustCounter` уже module-level singletons — pattern консистентен с прочим кодом.