### PR TITLE
fix(profile): sync nickname + avatar to Matrix profile (Session 45)

### DIFF
--- a/src/entities/auth/lib/__tests__/sync-profile-to-matrix.test.ts
+++ b/src/entities/auth/lib/__tests__/sync-profile-to-matrix.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { syncProfileToMatrix, type MatrixProfileSync } from "../sync-profile-to-matrix";
+
+/**
+ * Behavioral tests for syncProfileToMatrix — best-effort Matrix profile sync
+ * after a successful Pocketnet blockchain edit (Session 45).
+ *
+ * Closes #595, #591, #375, #368, #121: peers must see the user's chosen
+ * nickname + avatar instead of a truncated wallet address.
+ */
+describe("syncProfileToMatrix", () => {
+  let setDisplayName: ReturnType<typeof vi.fn>;
+  let uploadAvatar: ReturnType<typeof vi.fn>;
+  let setAvatarMxc: ReturnType<typeof vi.fn>;
+  let originalFetch: typeof fetch | undefined;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    setDisplayName = vi.fn().mockResolvedValue(undefined);
+    uploadAvatar = vi.fn().mockResolvedValue("mxc://server/abc");
+    setAvatarMxc = vi.fn().mockResolvedValue(undefined);
+    originalFetch = globalThis.fetch;
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (originalFetch) globalThis.fetch = originalFetch;
+    warnSpy.mockRestore();
+  });
+
+  const matrix = (): MatrixProfileSync => ({ setDisplayName, uploadAvatar, setAvatarMxc }) as unknown as MatrixProfileSync;
+
+  it("calls setDisplayName when a name is provided", async () => {
+    await syncProfileToMatrix(matrix(), { name: "Alice" });
+
+    expect(setDisplayName).toHaveBeenCalledTimes(1);
+    expect(setDisplayName).toHaveBeenCalledWith("Alice");
+  });
+
+  it("calls setDisplayName('') when name is explicitly cleared", async () => {
+    // user removed their nickname; peers must see it cleared in Matrix too
+    await syncProfileToMatrix(matrix(), { name: "" });
+
+    expect(setDisplayName).toHaveBeenCalledTimes(1);
+    expect(setDisplayName).toHaveBeenCalledWith("");
+  });
+
+  it("skips setDisplayName when name field was not provided at all", async () => {
+    await syncProfileToMatrix(matrix(), {});
+
+    expect(setDisplayName).not.toHaveBeenCalled();
+  });
+
+  it("fetches the avatar URL, uploads the blob, and writes mxc to profile", async () => {
+    const blob = new Blob(["fake-png-bytes"], { type: "image/png" });
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(blob),
+    }) as unknown as typeof fetch;
+
+    await syncProfileToMatrix(matrix(), { image: "https://cdn/avatar.png" });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith("https://cdn/avatar.png");
+    expect(uploadAvatar).toHaveBeenCalledTimes(1);
+    expect(uploadAvatar).toHaveBeenCalledWith(blob);
+    expect(setAvatarMxc).toHaveBeenCalledTimes(1);
+    expect(setAvatarMxc).toHaveBeenCalledWith("mxc://server/abc");
+  });
+
+  it("skips avatar upload when blob exceeds 5 MB Matrix limit", async () => {
+    const oversize = new Blob([new Uint8Array(5 * 1024 * 1024 + 1)], { type: "image/png" });
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(oversize),
+    }) as unknown as typeof fetch;
+
+    await syncProfileToMatrix(matrix(), { image: "https://cdn/large.png" });
+
+    expect(uploadAvatar).not.toHaveBeenCalled();
+    expect(setAvatarMxc).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("uploads avatar up to 5 MB Matrix limit", async () => {
+    const atLimit = new Blob([new Uint8Array(5 * 1024 * 1024)], { type: "image/png" });
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(atLimit),
+    }) as unknown as typeof fetch;
+
+    await syncProfileToMatrix(matrix(), { image: "https://cdn/atlimit.png" });
+
+    expect(uploadAvatar).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows avatar fetch errors so Pocketnet save still succeeds", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("network down")) as unknown as typeof fetch;
+
+    await expect(
+      syncProfileToMatrix(matrix(), { image: "https://cdn/x.png" }),
+    ).resolves.toBeUndefined();
+    expect(uploadAvatar).not.toHaveBeenCalled();
+    expect(setAvatarMxc).not.toHaveBeenCalled();
+  });
+
+  it("swallows non-2xx fetch responses without uploading", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      blob: () => Promise.resolve(new Blob()),
+    }) as unknown as typeof fetch;
+
+    await syncProfileToMatrix(matrix(), { image: "https://cdn/missing.png" });
+
+    expect(uploadAvatar).not.toHaveBeenCalled();
+    expect(setAvatarMxc).not.toHaveBeenCalled();
+  });
+
+  it("clears avatar via setAvatarMxc('') when image is explicitly empty", async () => {
+    // user removed their avatar; peers must see it cleared in Matrix too
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+
+    await syncProfileToMatrix(matrix(), { image: "" });
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(uploadAvatar).not.toHaveBeenCalled();
+    expect(setAvatarMxc).toHaveBeenCalledTimes(1);
+    expect(setAvatarMxc).toHaveBeenCalledWith("");
+  });
+
+  it("skips avatar entirely when image field was not provided", async () => {
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+
+    await syncProfileToMatrix(matrix(), { name: "Alice" });
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(uploadAvatar).not.toHaveBeenCalled();
+    expect(setAvatarMxc).not.toHaveBeenCalled();
+  });
+
+  it("syncs both name and avatar when both are provided", async () => {
+    const blob = new Blob(["x"], { type: "image/jpeg" });
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      blob: () => Promise.resolve(blob),
+    }) as unknown as typeof fetch;
+
+    await syncProfileToMatrix(matrix(), { name: "Bob", image: "https://cdn/b.jpg" });
+
+    expect(setDisplayName).toHaveBeenCalledWith("Bob");
+    expect(uploadAvatar).toHaveBeenCalledWith(blob);
+    expect(setAvatarMxc).toHaveBeenCalledWith("mxc://server/abc");
+  });
+});

--- a/src/entities/auth/lib/index.ts
+++ b/src/entities/auth/lib/index.ts
@@ -2,3 +2,4 @@ export * from "./get-address-from-pub-key";
 export * from "./proxy-rotator";
 export * from "./poll-timer";
 export * from "./mnemonic-storage";
+export * from "./sync-profile-to-matrix";

--- a/src/entities/auth/lib/sync-profile-to-matrix.ts
+++ b/src/entities/auth/lib/sync-profile-to-matrix.ts
@@ -1,0 +1,72 @@
+/**
+ * Best-effort Matrix profile sync after a Pocketnet UserInfo edit.
+ *
+ * forta.chat keeps Pocketnet blockchain as the authoritative profile source.
+ * Matrix room state events (m.room.member.displayname, avatar_url) drive what
+ * peers see in chat. Without this sync, peers fall back to a truncated wallet
+ * address — see Session 45 issues #595, #591, #375, #368, #121.
+ *
+ * Failures must never block the calling Pocketnet save: we swallow them and
+ * surface a console.warn so the user still sees a successful save.
+ *
+ * Semantics: an `undefined` field means "caller didn't touch this — leave
+ * Matrix alone"; an empty string means "user explicitly cleared this field —
+ * mirror the clear into Matrix" so peers don't see a stale name/avatar.
+ */
+
+/** Matrix homeserver upload limit. Synapse default is 50 MB; Pocketnet uploads
+ *  cap avatars at 5 MB (see shared/lib/upload-image.ts), so we mirror that. */
+const MAX_AVATAR_BYTES = 5 * 1024 * 1024;
+
+/** Subset of MatrixClientService used here — keeps the helper trivially testable. */
+export interface MatrixProfileSync {
+  setDisplayName(name: string): Promise<void>;
+  uploadAvatar(blob: Blob): Promise<string>;
+  setAvatarMxc(mxcUrl: string): Promise<void>;
+}
+
+export interface SyncProfileParams {
+  name?: string;
+  image?: string;
+}
+
+export async function syncProfileToMatrix(
+  matrix: MatrixProfileSync,
+  params: SyncProfileParams,
+): Promise<void> {
+  if (params.name !== undefined) {
+    try {
+      await matrix.setDisplayName(params.name);
+    } catch (e) {
+      console.warn("[profile] setDisplayName failed:", e);
+    }
+  }
+
+  if (params.image === undefined) return;
+
+  if (params.image === "") {
+    try {
+      await matrix.setAvatarMxc("");
+    } catch (e) {
+      console.warn("[profile] setAvatarMxc clear failed:", e);
+    }
+    return;
+  }
+
+  try {
+    const response = await fetch(params.image);
+    if (!response.ok) {
+      console.warn("[profile] avatar fetch returned non-2xx:", response.status);
+      return;
+    }
+    const blob = await response.blob();
+    if (blob.size > MAX_AVATAR_BYTES) {
+      console.warn("[profile] avatar exceeds Matrix size limit, skipping");
+      return;
+    }
+    const mxc = await matrix.uploadAvatar(blob);
+    await matrix.setAvatarMxc(mxc);
+  } catch (e) {
+    console.warn("[profile] Matrix avatar sync failed:", e);
+  }
+}

--- a/src/entities/auth/model/__tests__/profile-matrix-sync.test.ts
+++ b/src/entities/auth/model/__tests__/profile-matrix-sync.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Source-level regression: auth store's editUserData callback must trigger a
+ * best-effort Matrix profile sync after the Pocketnet edit succeeds.
+ *
+ * Behavioral coverage of the helper itself lives in
+ * src/entities/auth/lib/__tests__/sync-profile-to-matrix.test.ts.
+ */
+const getStoresSource = () =>
+  readFileSync(resolve(__dirname, "../stores.ts"), "utf-8");
+
+describe("auth store editUserData triggers Matrix profile sync (Session 45)", () => {
+  it("imports syncProfileToMatrix from ../lib", () => {
+    const src = getStoresSource();
+    expect(src).toMatch(/syncProfileToMatrix/);
+    expect(src).toMatch(/from\s+["']\.\.\/lib["']/);
+  });
+
+  it("calls syncProfileToMatrix inside the editUserData useAsyncOperation callback", () => {
+    const src = getStoresSource();
+    const start = src.indexOf("const { execute: editUserData");
+    expect(start).toBeGreaterThan(-1);
+    const block = src.slice(start, start + 1500);
+    expect(block).toMatch(/syncProfileToMatrix\(/);
+  });
+
+  it("guards Matrix sync behind matrixReady so we don't sync before login completes", () => {
+    const src = getStoresSource();
+    const start = src.indexOf("const { execute: editUserData");
+    const block = src.slice(start, start + 1500);
+    expect(block).toMatch(/matrixReady/);
+  });
+
+  it("only syncs when blockchain edit succeeded", () => {
+    const src = getStoresSource();
+    const start = src.indexOf("const { execute: editUserData");
+    const block = src.slice(start, start + 1500);
+    // Either explicit success === true check, or success !== false guard
+    expect(block).toMatch(/success\s*===\s*true|success\s*!==\s*false/);
+  });
+
+  it("fires Matrix sync without blocking the save (no await on syncProfileToMatrix)", () => {
+    const src = getStoresSource();
+    const start = src.indexOf("const { execute: editUserData");
+    const block = src.slice(start, start + 1500);
+    // Look for a `void syncProfileToMatrix(...)` fire-and-forget pattern.
+    // Plain `await syncProfileToMatrix` would re-introduce H3 (UI hang).
+    expect(block).toMatch(/void\s+syncProfileToMatrix\s*\(/);
+  });
+});

--- a/src/entities/auth/model/stores.ts
+++ b/src/entities/auth/model/stores.ts
@@ -42,6 +42,7 @@ import {
   saveMnemonic,
   loadMnemonic,
   clearMnemonic,
+  syncProfileToMatrix,
 } from "../lib";
 import { createKeyPair } from "./key-pair";
 
@@ -252,11 +253,29 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
   };
 
   const { execute: editUserData, isLoading: isEditingUserData } =
-    useAsyncOperation((userData: UserData) => {
-      return appInitializer.editUserData({
+    useAsyncOperation(async (userData: UserData) => {
+      const result = await appInitializer.editUserData({
         address: address.value!,
         userData: mergeObjects(userInfo.value!, userData)
       });
+
+      // Best-effort Matrix profile sync — ensures peers see the user's chosen
+      // nickname + avatar instead of a truncated wallet address. Pocketnet
+      // remains the authoritative source.
+      //
+      // Fire-and-forget: keeping it inside the await would extend the visible
+      // "Saving..." state by however long fetch + uploadContent + setAvatar
+      // take on the Matrix homeserver (potentially many seconds over Tor).
+      // The helper swallows its own errors; .catch is here only so an
+      // unexpected throw doesn't bubble up as an unhandled rejection.
+      if (result?.success === true && matrixReady.value) {
+        void syncProfileToMatrix(getMatrixClientService(), {
+          name: userData.name,
+          image: userData.image,
+        }).catch((e) => console.warn("[auth] Matrix profile sync failed:", e));
+      }
+
+      return result;
     });
 
   /** Initialize Matrix client, kit and crypto after login */

--- a/src/entities/matrix/model/__tests__/matrix-client-profile.test.ts
+++ b/src/entities/matrix/model/__tests__/matrix-client-profile.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MatrixClientService } from "../matrix-client";
+
+/**
+ * Tests for Matrix profile setter API on MatrixClientService.
+ *
+ * Closes Session 45 issues #595, #591, #375, #368, #121: forta.chat must call
+ * setDisplayName / setAvatarUrl after Pocketnet edit so peers see the user's
+ * nickname + avatar instead of a truncated wallet address.
+ */
+describe("MatrixClientService profile API", () => {
+  let service: MatrixClientService;
+
+  beforeEach(() => {
+    service = new MatrixClientService("test.invalid");
+  });
+
+  describe("setDisplayName", () => {
+    it("forwards name to underlying client.setDisplayName", async () => {
+      const setDisplayName = vi.fn().mockResolvedValue(undefined);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (service as any).client = { setDisplayName };
+
+      await service.setDisplayName("Alice");
+
+      expect(setDisplayName).toHaveBeenCalledTimes(1);
+      expect(setDisplayName).toHaveBeenCalledWith("Alice");
+    });
+
+    it("throws when client is not initialized", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (service as any).client = null;
+
+      await expect(service.setDisplayName("Alice")).rejects.toThrow();
+    });
+  });
+
+  describe("uploadAvatar", () => {
+    it("uploads blob via client.uploadContent and returns mxc URI", async () => {
+      const uploadContent = vi.fn().mockResolvedValue({ content_uri: "mxc://server/abc" });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (service as any).client = { uploadContent };
+
+      const blob = new Blob(["x"], { type: "image/png" });
+      const url = await service.uploadAvatar(blob);
+
+      expect(url).toBe("mxc://server/abc");
+      expect(uploadContent).toHaveBeenCalledTimes(1);
+      const [uploadedBlob, opts] = uploadContent.mock.calls[0];
+      expect(uploadedBlob).toBe(blob);
+      expect(opts).toMatchObject({ type: "image/png" });
+    });
+
+    it("throws when client is not initialized", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (service as any).client = null;
+
+      const blob = new Blob(["x"], { type: "image/png" });
+      await expect(service.uploadAvatar(blob)).rejects.toThrow();
+    });
+  });
+
+  describe("setAvatarMxc", () => {
+    it("forwards mxc URL to underlying client.setAvatarUrl", async () => {
+      const setAvatarUrl = vi.fn().mockResolvedValue(undefined);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (service as any).client = { setAvatarUrl };
+
+      await service.setAvatarMxc("mxc://server/abc");
+
+      expect(setAvatarUrl).toHaveBeenCalledTimes(1);
+      expect(setAvatarUrl).toHaveBeenCalledWith("mxc://server/abc");
+    });
+
+    it("throws when client is not initialized", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (service as any).client = null;
+
+      await expect(service.setAvatarMxc("mxc://abc")).rejects.toThrow();
+    });
+  });
+});

--- a/src/entities/matrix/model/matrix-client.ts
+++ b/src/entities/matrix/model/matrix-client.ts
@@ -562,6 +562,28 @@ export class MatrixClientService {
     return res.content_uri;
   }
 
+  /** Set the user's Matrix display name (m.room.member.displayname).
+   *  Peers receive this via room state events on next sync; required so other
+   *  users see the nickname instead of a truncated wallet address. */
+  async setDisplayName(name: string): Promise<void> {
+    if (!this.client) throw new Error("Client not initialized");
+    await this.client.setDisplayName(name);
+  }
+
+  /** Upload an avatar blob and return the raw mxc:// URI for use in setAvatarMxc. */
+  async uploadAvatar(blob: Blob): Promise<string> {
+    if (!this.client) throw new Error("Client not initialized");
+    const res = await this.client.uploadContent(blob, { type: blob.type });
+    return res.content_uri;
+  }
+
+  /** Set the user's Matrix avatar URL (m.room.member.avatar_url).
+   *  Pass an mxc:// URI returned by uploadAvatar. */
+  async setAvatarMxc(mxcUrl: string): Promise<void> {
+    if (!this.client) throw new Error("Client not initialized");
+    await this.client.setAvatarUrl(mxcUrl);
+  }
+
   /** Convert an mxc:// URI to an HTTP URL */
   mxcToHttp(mxcUrl: string): string | null {
     if (!this.client) return null;

--- a/src/entities/user/model/__tests__/merge-user-update.test.ts
+++ b/src/entities/user/model/__tests__/merge-user-update.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { mergeUserUpdate } from "../merge-user-update";
+import type { User } from "../types";
+
+/**
+ * mergeUserUpdate must NEVER overwrite a cached non-empty profile field with
+ * an empty value coming from the upstream Pocketnet response.
+ *
+ * Background (Session 45 — issue #368, "Аватарка ежедневно исчезает из
+ * профиля"): the periodic refreshStaleUsers cycle re-fetches profiles every
+ * 6 hours. When Pocketnet returns an empty `image` for a user (transient
+ * RPC issue, race after edit, etc.) the previous code overwrote the cached
+ * avatar with "" — peers then saw the user lose their picture daily.
+ */
+describe("mergeUserUpdate", () => {
+  const baseCached: User = {
+    address: "addr-1",
+    name: "Alice",
+    image: "https://cdn/alice.jpg",
+    about: "hi",
+    site: "https://alice.dev",
+    language: "en",
+    cachedAt: 1_000,
+  };
+
+  it("returns a new object — never mutates the cached entry", () => {
+    const fresh = { name: "Alice 2" };
+    const result = mergeUserUpdate(baseCached, fresh);
+
+    expect(result).not.toBe(baseCached);
+    expect(baseCached.name).toBe("Alice");
+  });
+
+  it("keeps cached image when fresh image is empty string", () => {
+    const result = mergeUserUpdate(baseCached, { image: "" });
+    expect(result.image).toBe("https://cdn/alice.jpg");
+  });
+
+  it("keeps cached image when fresh image is whitespace only", () => {
+    const result = mergeUserUpdate(baseCached, { image: "   " });
+    expect(result.image).toBe("https://cdn/alice.jpg");
+  });
+
+  it("keeps cached name when fresh name is empty string", () => {
+    const result = mergeUserUpdate(baseCached, { name: "" });
+    expect(result.name).toBe("Alice");
+  });
+
+  it("updates image when fresh image is a non-empty URL", () => {
+    const result = mergeUserUpdate(baseCached, { image: "https://cdn/new.jpg" });
+    expect(result.image).toBe("https://cdn/new.jpg");
+  });
+
+  it("updates name when fresh name is non-empty", () => {
+    const result = mergeUserUpdate(baseCached, { name: "Bob" });
+    expect(result.name).toBe("Bob");
+  });
+
+  it("preserves the address from the cached entry", () => {
+    const result = mergeUserUpdate(baseCached, { name: "Bob", image: "https://cdn/b.jpg" });
+    expect(result.address).toBe("addr-1");
+  });
+
+  it("refreshes cachedAt timestamp", () => {
+    const result = mergeUserUpdate(baseCached, { name: "Bob" }, 5_000);
+    expect(result.cachedAt).toBe(5_000);
+  });
+
+  it("uses Date.now() for cachedAt when not provided", () => {
+    const before = Date.now();
+    const result = mergeUserUpdate(baseCached, { name: "Bob" });
+    const after = Date.now();
+
+    expect(result.cachedAt).toBeGreaterThanOrEqual(before);
+    expect(result.cachedAt!).toBeLessThanOrEqual(after);
+  });
+
+  it("creates a fresh User when prev is null/undefined", () => {
+    const result = mergeUserUpdate(null, {
+      address: "addr-2",
+      name: "Carol",
+      image: "https://cdn/c.jpg",
+      about: "",
+      site: "",
+      language: "ru",
+    }, 7_000);
+
+    expect(result).toMatchObject({
+      address: "addr-2",
+      name: "Carol",
+      image: "https://cdn/c.jpg",
+      language: "ru",
+      cachedAt: 7_000,
+    });
+  });
+
+  it("falls back to '' for missing optional fields when prev is null", () => {
+    const result = mergeUserUpdate(null, {
+      address: "addr-3",
+      name: "Dave",
+    }, 9_000);
+
+    expect(result.image).toBe("");
+    expect(result.about).toBe("");
+    expect(result.site).toBe("");
+    expect(result.language).toBe("");
+  });
+});

--- a/src/entities/user/model/merge-user-update.ts
+++ b/src/entities/user/model/merge-user-update.ts
@@ -1,0 +1,42 @@
+import type { User } from "./types";
+
+/**
+ * Merge fresh profile data into a cached entry without overwriting non-empty
+ * cached fields with empty values from upstream.
+ *
+ * Pocketnet RPC sometimes returns an empty `image` (or `name`) for a known
+ * user — transient server state, race after edit, etc. The previous code in
+ * user-store.ts overwrote the cached avatar with "", which surfaced as
+ * #368 ("Аватарка ежедневно исчезает из профиля") on the daily revalidate.
+ */
+export function mergeUserUpdate(
+  prev: User | null | undefined,
+  fresh: Partial<User>,
+  now: number = Date.now(),
+): User {
+  if (!prev) {
+    return {
+      address: fresh.address ?? "",
+      name: fresh.name ?? "",
+      image: fresh.image ?? "",
+      about: fresh.about ?? "",
+      site: fresh.site ?? "",
+      language: fresh.language ?? "",
+      cachedAt: now,
+    };
+  }
+
+  return {
+    address: prev.address,
+    name: pick(fresh.name, prev.name),
+    image: pick(fresh.image, prev.image),
+    about: pick(fresh.about, prev.about),
+    site: pick(fresh.site, prev.site),
+    language: pick(fresh.language, prev.language),
+    cachedAt: now,
+  };
+}
+
+function pick(fresh: string | undefined, prev: string): string {
+  return fresh && fresh.trim() ? fresh : prev;
+}

--- a/src/entities/user/model/user-store.ts
+++ b/src/entities/user/model/user-store.ts
@@ -4,6 +4,7 @@ import { createAppInitializer } from "@/app/providers/initializers/app-initializ
 import { ProfileLoader, PROFILE_LOADER_BATCH_ACTIVE } from "@/shared/lib/profile-loader";
 import { PromisePool } from "@/shared/lib/promise-pool";
 
+import { mergeUserUpdate } from "./merge-user-update";
 import type { User } from "./types";
 
 const NAMESPACE = "user";
@@ -117,15 +118,14 @@ export const useUserStore = defineStore(NAMESPACE, () => {
         await appInit.initApi();
         const userData = await appInit.loadUserData([address]);
         if (userData) {
-          users.value[address] = {
+          users.value[address] = mergeUserUpdate(users.value[address], {
             address,
             name: userData.name ?? "",
             about: userData.about ?? "",
             image: userData.image ?? "",
             site: userData.site ?? "",
             language: userData.language ?? "",
-            cachedAt: Date.now(),
-          };
+          });
           debouncedTrigger();
           debouncedCacheUsers(users.value);
         }
@@ -176,15 +176,14 @@ export const useUserStore = defineStore(NAMESPACE, () => {
         for (const addr of uncached) {
           const userData = appInit.getUserData(addr);
           if (userData) {
-            users.value[addr] = {
+            users.value[addr] = mergeUserUpdate(users.value[addr], {
               address: addr,
               name: userData.name ?? "",
               about: userData.about ?? "",
               image: userData.image ?? "",
               site: userData.site ?? "",
               language: userData.language ?? "",
-              cachedAt: Date.now(),
-            };
+            });
             updated = true;
           }
         }
@@ -238,15 +237,14 @@ export const useUserStore = defineStore(NAMESPACE, () => {
           for (const addr of chunk) {
             const userData = appInit.getUserData(addr);
             if (userData) {
-              users.value[addr] = {
+              users.value[addr] = mergeUserUpdate(users.value[addr], {
                 address: addr,
                 name: userData.name ?? "",
                 about: userData.about ?? "",
                 image: userData.image ?? "",
                 site: userData.site ?? "",
                 language: userData.language ?? "",
-                cachedAt: Date.now(),
-              };
+              });
               updated = true;
             }
           }
@@ -300,15 +298,14 @@ export const useUserStore = defineStore(NAMESPACE, () => {
         for (const addr of batch) {
           const userData = appInit.getUserData(addr);
           if (userData) {
-            users.value[addr] = {
+            users.value[addr] = mergeUserUpdate(users.value[addr], {
               address: addr,
               name: userData.name ?? "",
               about: userData.about ?? "",
               image: userData.image ?? "",
               site: userData.site ?? "",
               language: userData.language ?? "",
-              cachedAt: now,
-            };
+            }, now);
             updated = true;
           }
         }


### PR DESCRIPTION
## Summary

forta.chat кэширует профиль только в Pocketnet blockchain, но peers видят имена/аватарки из Matrix room state events. Без sync'а получатели всегда видят truncated wallet address вместо ника.

- `MatrixClientService` получает обёртки `setDisplayName` / `uploadAvatar` / `setAvatarMxc`
- Новый best-effort helper `syncProfileToMatrix` запускается после успешного Pocketnet `editUserData` (fire-and-forget, swallowed errors, ограничение 5MB)
- `mergeUserUpdate` helper защищает кеш в `user-store` от затирания пустыми RPC ответами
- 33 новых unit-теста, никаких регрессий в затронутых директориях (237/237 pass)

Closes #595, #591, #375, #368, #121. Mitigates #481, #649, #9, #335.

## Code review fixes applied

Code review (superpowers:code-reviewer) выявил 3 critical/high и они учтены:
- **C1**: Empty name/image теперь propagate как explicit clear (peer'ы видят удалённые поля)
- **H1**: Avatar size cap поднят с 1MB до 5MB (соответствует Pocketnet uploadImage лимиту)
- **H3**: Matrix sync переведён на fire-and-forget — UI loading state больше не висит на медленном homeserver

## Test plan
- [x] vitest matrix-client-profile.test.ts — 6/6 PASS
- [x] vitest sync-profile-to-matrix.test.ts — 11/11 PASS
- [x] vitest profile-matrix-sync.test.ts — 5/5 PASS
- [x] vitest merge-user-update.test.ts — 11/11 PASS
- [x] vitest auth + user + matrix entities — 237/237 PASS (no regressions)
- [x] vue-tsc --noEmit — no errors in changed files
- [x] vite build — successful
- [ ] Manual: на двух аккаунтах A → B, A меняет ник + аватар → B видит обновление
- [ ] Manual: после рестарта приложения ник у A не "слетает" обратно
- [ ] Manual: A удаляет аватар → B видит удаление

## Out of scope (для будущих sessions)
- Recovery path если matrixReady=false когда происходит save
- Force-flush m.room.member событий в активных комнатах для немедленного peer-видения
- Полная миграция на Matrix как single source-of-truth