### PR TITLE
fix(sync): unstick outbound queue after wake + watchdog (Session 49)

### DIFF
--- a/src/entities/auth/model/stores.ts
+++ b/src/entities/auth/model/stores.ts
@@ -21,6 +21,7 @@ import { clearQueue } from "@/shared/lib/offline-queue";
 import { deleteLegacyCache } from "@/shared/lib/cache/chat-cache";
 import { clearAccountLocalStorage } from "@/shared/lib/clear-account-storage";
 import { isNative } from "@/shared/lib/platform";
+import { onConnectivityChange } from "@/shared/lib/connectivity";
 import { useLocalStorage } from "@/shared/lib/browser";
 import { convertToHexString } from "@/shared/lib/convert-to-hex-string";
 import { mergeObjects } from "@/shared/lib/merge-objects";
@@ -129,8 +130,13 @@ function extractErrorCode(err: unknown): number | null {
 export type RegistrationPhase = 'init' | 'broadcasting' | 'confirming' | 'done' | 'error';
 
 // Store-level references for cleanup on logout
-let _onlineHandler: (() => void) | null = null;
-let _offlineHandler: (() => void) | null = null;
+//
+// _connectivityUnsub: unified subscription to onConnectivityChange (which
+// fans in @capacitor/network on native + window.online/offline on web).
+// Replaces the previous raw window.online/offline listeners — those alone
+// did not fire reliably on Android WebView after device sleep+wake, leaving
+// the SyncEngine stuck offline forever (#705, #496).
+let _connectivityUnsub: (() => void) | null = null;
 let _appStateHandle: { remove: () => Promise<void> } | null = null;
 let _blockHeightInterval: ReturnType<typeof setInterval> | null = null;
 // Per-room debounce timers for peer-keys recheck after member events.
@@ -413,16 +419,18 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
       );
       chatStore.setChatDbKit(chatDbKit);
 
-      // Wire SyncEngine connectivity (store refs for cleanup on logout)
-      if (typeof window !== "undefined") {
-        // Remove previous listeners if any (re-login without full page reload)
-        if (_onlineHandler) window.removeEventListener("online", _onlineHandler);
-        if (_offlineHandler) window.removeEventListener("offline", _offlineHandler);
-        _onlineHandler = () => chatDbKit.syncEngine.setOnline(true);
-        _offlineHandler = () => chatDbKit.syncEngine.setOnline(false);
-        window.addEventListener("online", _onlineHandler);
-        window.addEventListener("offline", _offlineHandler);
+      // Wire SyncEngine connectivity through the unified connectivity layer.
+      // onConnectivityChange fires on @capacitor/network transitions as well
+      // as window.online/offline, so Android WebView wake-ups and WiFi↔cellular
+      // handovers both feed the engine. Drop any prior subscription first
+      // (re-login without a full page reload).
+      if (_connectivityUnsub) {
+        _connectivityUnsub();
+        _connectivityUnsub = null;
       }
+      _connectivityUnsub = onConnectivityChange(({ connected }) => {
+        chatDbKit.syncEngine.setOnline(connected);
+      });
       chatStore.setHelpers(matrixKit.value!, cryptoInstance);
 
       // Wire Pcrypto key-load → decryption retry + peer-keys banner refresh.
@@ -987,11 +995,8 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
       pcrypto.value = null;
     }
 
-    // ── 3. Clean up window listeners & intervals ──
-    if (typeof window !== "undefined") {
-      if (_onlineHandler) { window.removeEventListener("online", _onlineHandler); _onlineHandler = null; }
-      if (_offlineHandler) { window.removeEventListener("offline", _offlineHandler); _offlineHandler = null; }
-    }
+    // ── 3. Clean up listeners & intervals ──
+    if (_connectivityUnsub) { _connectivityUnsub(); _connectivityUnsub = null; }
     if (_blockHeightInterval) { clearInterval(_blockHeightInterval); _blockHeightInterval = null; }
     for (const t of _peerKeysRecheckTimers.values()) clearTimeout(t);
     _peerKeysRecheckTimers.clear();
@@ -1580,10 +1585,7 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
       }
 
       // Cleanup listeners
-      if (typeof window !== "undefined") {
-        if (_onlineHandler) { window.removeEventListener("online", _onlineHandler); _onlineHandler = null; }
-        if (_offlineHandler) { window.removeEventListener("offline", _offlineHandler); _offlineHandler = null; }
-      }
+      if (_connectivityUnsub) { _connectivityUnsub(); _connectivityUnsub = null; }
       if (_blockHeightInterval) { clearInterval(_blockHeightInterval); _blockHeightInterval = null; }
       for (const t of _peerKeysRecheckTimers.values()) clearTimeout(t);
       _peerKeysRecheckTimers.clear();

--- a/src/shared/lib/local-db/__tests__/sync-engine-txnid.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-txnid.test.ts
@@ -181,6 +181,9 @@ describe("SyncEngine txnId propagation (regression)", () => {
   });
 
   afterEach(async () => {
+    // Stop the watchdog interval before the DB closes so any pending tick
+    // doesn't surface as an unhandled DatabaseClosedError after teardown.
+    h.engine.dispose();
     await h.db.delete();
   });
 

--- a/src/shared/lib/local-db/__tests__/sync-engine-watchdog.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-watchdog.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Regression: SyncEngine watchdog timer must force `setOnline(true)` when:
+ *   - there is at least one pending/syncing op
+ *   - `this.online` is `false`
+ *   - `navigator.onLine` is `true`
+ *
+ * Without this, Android WebView users can be stuck after a device sleep+wake
+ * where `window.online` never fires: the queue holds forever until the user
+ * kills and restarts the app (issues #705, #496).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Dexie from "dexie";
+import "fake-indexeddb/auto";
+import { SyncEngine } from "../sync-engine";
+import type { PendingOperation, LocalMessage, LocalRoom } from "../schema";
+
+// --- Matrix mock -------------------------------------------------------------
+
+const mockMatrix = {
+  sendEncryptedText: vi.fn<
+    (roomId: string, content: unknown, txnId?: string) => Promise<string>
+  >(async () => "$server_event_id"),
+  sendText: vi.fn<(roomId: string, text: string, txnId?: string) => Promise<string>>(
+    async () => "$server_event_id",
+  ),
+  sendReaction: vi.fn<(roomId: string, eventId: string, emoji: string) => Promise<string>>(
+    async () => "$reaction_id",
+  ),
+  redactEvent: vi.fn<(roomId: string, eventId: string) => Promise<void>>(async () => undefined),
+  sendPollStart: vi.fn<(roomId: string, content: unknown) => Promise<string>>(
+    async () => "$poll_id",
+  ),
+  sendPollResponse: vi.fn<(roomId: string, content: unknown) => Promise<void>>(
+    async () => undefined,
+  ),
+  uploadContentMxc: vi.fn<(blob: Blob) => Promise<string>>(async () => "mxc://server/file"),
+  uploadContent: vi.fn<
+    (
+      blob: Blob,
+      progress?: (p: { loaded: number; total: number }) => void,
+      signal?: AbortSignal,
+    ) => Promise<string>
+  >(async () => "https://server/_matrix/media/r0/download/server/abc"),
+};
+
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: () => mockMatrix,
+}));
+
+// --- Test DB -----------------------------------------------------------------
+
+class TestDb extends Dexie {
+  messages!: Dexie.Table<LocalMessage, number>;
+  rooms!: Dexie.Table<LocalRoom, string>;
+  pendingOps!: Dexie.Table<PendingOperation, number>;
+  attachments!: Dexie.Table<{ id?: number }, number>;
+  users!: Dexie.Table<{ address: string }, string>;
+  syncState!: Dexie.Table<{ key: string; value: string | number }, string>;
+  decryptionQueue!: Dexie.Table<{ id?: number; status: string }, number>;
+  listenedMessages!: Dexie.Table<{ messageId: string }, string>;
+
+  constructor(name: string) {
+    super(name, { indexedDB, IDBKeyRange });
+    this.version(1).stores({
+      messages:
+        "++localId, eventId, clientId, [roomId+timestamp], [roomId+status], senderId",
+      rooms: "id, updatedAt, membership, isDeleted",
+      pendingOps:
+        "++id, [roomId+createdAt], status, clientId, [status+nextAttemptAt]",
+      attachments: "++id, messageLocalId, status",
+      users: "address, updatedAt",
+      syncState: "key",
+      decryptionQueue: "++id, status, [status+nextAttemptAt]",
+      listenedMessages: "messageId",
+    });
+  }
+}
+
+interface Harness {
+  db: TestDb;
+  engine: SyncEngine;
+}
+
+function makeHarness(name: string): Harness {
+  const db = new TestDb(name);
+  const messageRepo = {
+    confirmSent: vi.fn(async () => undefined),
+    confirmMediaSent: vi.fn(async () => undefined),
+    updateStatus: vi.fn(async () => undefined),
+    getByEventId: vi.fn(async () => undefined),
+    updateReactions: vi.fn(async () => undefined),
+    getByClientId: vi.fn(async () => undefined),
+    updateUploadProgress: vi.fn(async () => undefined),
+  };
+  const roomRepo = { updateRoom: vi.fn(async () => undefined) };
+  const engine = new SyncEngine(
+    db as never,
+    messageRepo as never,
+    roomRepo as never,
+    async () => undefined,
+  );
+  return { db, engine };
+}
+
+async function seedPendingOp(db: TestDb): Promise<void> {
+  await db.pendingOps.add({
+    type: "send_message",
+    roomId: "!room:server",
+    payload: { content: "stuck" },
+    status: "pending",
+    retries: 0,
+    maxRetries: 5,
+    createdAt: Date.now(),
+    clientId: "cli_stuck_1",
+    nextAttemptAt: 0,
+  } as PendingOperation);
+}
+
+/**
+ * Helper: flush microtasks and let fake-indexeddb's real setTimeouts settle.
+ * The watchdog tick reads from IDB asynchronously, then calls setOnline(true).
+ * A few short real-timer waits drain the chain without racing.
+ */
+async function flushAsync(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("SyncEngine — watchdog forces online when queue stuck", () => {
+  let h: Harness;
+  const originalOnLine = Object.getOwnPropertyDescriptor(
+    Object.getPrototypeOf(globalThis.navigator),
+    "onLine",
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Fake ONLY setInterval/clearInterval — keep setTimeout real so
+    // fake-indexeddb's internal queue and our flushAsync helper still work.
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+  });
+
+  afterEach(async () => {
+    h?.engine.dispose();
+    await h?.db.delete();
+    vi.useRealTimers();
+    if (originalOnLine) {
+      Object.defineProperty(globalThis.navigator, "onLine", originalOnLine);
+    }
+  });
+
+  it("forces setOnline(true) when pending ops + navigator.onLine + engine.online=false", async () => {
+    h = makeHarness(`watchdog-${Date.now()}-${Math.random()}`);
+    await h.db.open();
+
+    // Engine starts with online=true. Simulate the bug state: the device
+    // dropped offline, no "online" event fired, but the browser-level
+    // navigator.onLine actually flipped back to true after wake.
+    h.engine.setOnline(false);
+    await seedPendingOp(h.db);
+
+    Object.defineProperty(globalThis.navigator, "onLine", {
+      value: true,
+      writable: true,
+      configurable: true,
+    });
+
+    // The watchdog runs every 30s. Advance past one tick.
+    await vi.advanceTimersByTimeAsync(30_000);
+    await flushAsync();
+
+    // Engine must have probed navigator.onLine and resumed.
+    const onlineNow = (h.engine as unknown as { online: boolean }).online;
+    expect(onlineNow).toBe(true);
+  });
+});

--- a/src/shared/lib/local-db/__tests__/sync-engine.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine.test.ts
@@ -295,6 +295,9 @@ describe("SyncEngine — transactional op claim", () => {
     await waitTicks(5);
 
     expect(mockMatrix.sendEncryptedText).toHaveBeenCalledTimes(1);
+    // engineB lives outside the harness; dispose it so its watchdog interval
+    // stops before afterEach closes the DB.
+    engineB.dispose();
   });
 });
 

--- a/src/shared/lib/local-db/sync-engine-online.test.ts
+++ b/src/shared/lib/local-db/sync-engine-online.test.ts
@@ -32,12 +32,18 @@ vi.mock("@/entities/matrix", () => ({
 
 describe("SyncEngine.setOnline — retryAllFailed on transition to online", () => {
   let db: TestDb;
+  let engine: SyncEngine | null = null;
 
   beforeEach(() => {
     db = new TestDb();
+    engine = null;
   });
 
   afterEach(async () => {
+    // Dispose first so the watchdog interval stops touching the DB before we
+    // close it — otherwise vitest surfaces a stray DatabaseClosedError from a
+    // tick scheduled after teardown.
+    engine?.dispose();
     await db.delete();
   });
 
@@ -79,7 +85,7 @@ describe("SyncEngine.setOnline — retryAllFailed on transition to online", () =
       updateRoom: vi.fn(),
     };
 
-    const engine = new SyncEngine(
+    engine = new SyncEngine(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       db as any,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/shared/lib/local-db/sync-engine.ts
+++ b/src/shared/lib/local-db/sync-engine.ts
@@ -11,6 +11,14 @@ type OnChangeCallback = (roomId: string) => void;
 const MAX_BACKOFF_MS = 30_000;
 const MIN_BACKOFF_MS = 1_000;
 
+/** Watchdog tick interval. The watchdog is a safety net for cases where the
+ *  connectivity layer fails to deliver a "back online" signal — most commonly
+ *  Android WebView after device sleep+wake, where `window.online` may never
+ *  fire even though `navigator.onLine` has already flipped to true. Once per
+ *  tick we look for stuck pending ops and resume the queue if the underlying
+ *  network is actually available. */
+const WATCHDOG_INTERVAL_MS = 30_000;
+
 /** Per-phase media pipeline timeouts. Splitting one 5-minute cap into
  *  per-phase caps lets retries surface phase-specific failures (e.g. crypto
  *  hang vs. upload stall) instead of a generic "timed out" after 5 min. */
@@ -67,6 +75,9 @@ export class SyncEngine {
   private scheduled = false;
   private disposed = false;
   private scheduledTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Watchdog interval handle. Drains stuck queues even when no
+   *  connectivity transition signal arrives (Android WebView sleep+wake). */
+  private watchdogTimer: ReturnType<typeof setInterval> | null = null;
   /** AbortControllers for in-flight media uploads, keyed by clientId.
    *  Populated by syncSendFile at the start of each execution, drained in
    *  its finally block. cancelMediaUpload() signals through this map to
@@ -89,6 +100,7 @@ export class SyncEngine {
   ) {
     this.getRoomCrypto = getRoomCrypto;
     this.onChange = onChange;
+    this.startWatchdog();
   }
 
   /** Update online/offline state. Resumes queue on reconnect and
@@ -181,7 +193,56 @@ export class SyncEngine {
       clearTimeout(this.scheduledTimer);
       this.scheduledTimer = null;
     }
+    if (this.watchdogTimer !== null) {
+      clearInterval(this.watchdogTimer);
+      this.watchdogTimer = null;
+    }
     this.scheduled = false;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Watchdog — last-resort recovery when no connectivity signal arrives
+  // ---------------------------------------------------------------------------
+
+  private startWatchdog(): void {
+    if (this.watchdogTimer || this.disposed) return;
+    this.watchdogTimer = setInterval(() => {
+      if (this.disposed) return;
+      this.watchdogCheck().catch((e) =>
+        console.warn("[SyncEngine] watchdog tick failed:", e),
+      );
+    }, WATCHDOG_INTERVAL_MS);
+  }
+
+  /**
+   * Per-tick safety check. Three states matter:
+   *  1. No queued work — nothing to do.
+   *  2. Engine thinks it is offline but `navigator.onLine` is true — the
+   *     connectivity transition was missed (Android sleep+wake bug);
+   *     force `setOnline(true)` so retryAllFailed + processQueue run.
+   *  3. Engine is online but scheduler is idle — probably a race where a
+   *     wake-up timer was cleared; kick a fresh tick.
+   */
+  private async watchdogCheck(): Promise<void> {
+    const pending = await this.db.pendingOps
+      .where("status")
+      .anyOf(["pending", "syncing"])
+      .count();
+    if (pending === 0) return;
+
+    if (!this.online) {
+      if (typeof navigator !== "undefined" && navigator.onLine) {
+        console.info(
+          `[SyncEngine] watchdog: ${pending} ops stuck while navigator.onLine=true, forcing setOnline(true)`,
+        );
+        this.setOnline(true);
+      }
+      return;
+    }
+
+    if (!this.scheduled && !this.processing) {
+      this.kickScheduler(0);
+    }
   }
 
   /** Schedule processTick after `delayMs` unless a tick is already pending. */


### PR DESCRIPTION
## Summary
- Wire `SyncEngine` to `@capacitor/network` via the unified `onConnectivityChange` layer — closes the gap where Android WebView never fires `window.online` after device sleep+wake, so the outbound queue used to stay offline until the user killed the app.
- Add a 30s watchdog inside `SyncEngine`: if pending ops exist, `engine.online` is `false`, and `navigator.onLine` is `true`, force `setOnline(true)`. Last-resort recovery when no connectivity transition signal arrives. If online but the scheduler has fallen idle, kick a fresh tick.
- `op.clientId` was already being passed as the Matrix `txnId` and is covered by an existing regression test (`sync-engine-txnid.test.ts`), so `recoverStrandedOps` retransmits do not duplicate (#675).
- Tests: new `sync-engine-watchdog.test.ts`; existing harnesses now `dispose()` engines in `afterEach` so the new watchdog interval doesn't surface a stray `DatabaseClosedError` after teardown.

Closes #705, #675, #496, partially #566.

## Test plan
- [x] `npx vitest run src/shared/lib/local-db` — 165 / 165 PASS, no unhandled rejection.
- [x] Full vitest run — 1766 PASS / 9 pre-existing fails (display/url/video helpers, unrelated to this PR).
- [x] Architectural review via code-reviewer agent — APPROVE, 0 CRITICAL / 0 HIGH. MEDIUM items analyzed and confirmed safe.
- [ ] **Manual (Android):** airplane mode → send 2 messages while offline → lock screen 5 min → airplane off → messages drain automatically within 30s **without restart**.
- [ ] **Manual (Android):** force-kill mid-send → reopen → no duplicate on recipient side (covered by stable txnId).

## Follow-up out of scope
`decryptionWorker` is still wired through a raw `window.addEventListener("online", ...)` in `src/shared/lib/local-db/index.ts:137` — same Android WebView issue. Worth a separate ticket.