### PR TITLE
fix(share): restore Android Share Target send flow (Session 48)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -55,7 +55,14 @@
                 <data android:scheme="forta" />
             </intent-filter>
 
-            <!-- Share Target: receive content from other apps -->
+            <!-- Share Target: receive content from other apps.
+                 Specific MIME filters are kept so the IntentResolver ranks
+                 us higher for the common types (it picks the most-specific
+                 match regardless of declaration order in this manifest).
+                 The `*/*` fallback exists to keep Forta visible in the
+                 share sheet for exotic payloads we don't enumerate —
+                 image/heic from WhatsApp/iOS exports, vendor archives,
+                 application/x-… types, etc. (Session 48 / #713 #706). -->
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -75,6 +82,11 @@
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="application/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="*/*" />
             </intent-filter>
 
         </activity>

--- a/src/features/messaging/model/__tests__/send-button-external-share.test.ts
+++ b/src/features/messaging/model/__tests__/send-button-external-share.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { isSendButtonDisabled } from "../send-button-state";
+
+// Regression for Session 48: Android Share Sheet → Forta → pick a fresh DM →
+// peerKeysStatus for that target room is still "missing" past the grace
+// window. Before the fix, the gate stayed disabled and Send tapped silently
+// did nothing — the user perceived the share flow as broken. External share
+// must bypass peerKeysOk because the user already explicitly picked a target
+// and SyncEngine queues the op until keys arrive.
+describe("send-button — external share bypasses peerKeysOk", () => {
+  it("enabled when external share + peerKeysOk=false (forward preview visible)", () => {
+    expect(
+      isSendButtonDisabled({
+        text: "",
+        sending: false,
+        showForwardPreview: true,
+        showBulkForwardPreview: false,
+        peerKeysOk: false,
+        isExternalShare: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("disabled when normal forward + peerKeysOk=false", () => {
+    expect(
+      isSendButtonDisabled({
+        text: "hi",
+        sending: false,
+        showForwardPreview: false,
+        showBulkForwardPreview: false,
+        peerKeysOk: false,
+        isExternalShare: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("still disabled while sending even for external share", () => {
+    expect(
+      isSendButtonDisabled({
+        text: "",
+        sending: true,
+        showForwardPreview: true,
+        showBulkForwardPreview: false,
+        peerKeysOk: false,
+        isExternalShare: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("still disabled when external share with no sendable content", () => {
+    expect(
+      isSendButtonDisabled({
+        text: "",
+        sending: false,
+        showForwardPreview: false,
+        showBulkForwardPreview: false,
+        peerKeysOk: false,
+        isExternalShare: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("isExternalShare omitted preserves existing behavior (default false)", () => {
+    expect(
+      isSendButtonDisabled({
+        text: "hi",
+        sending: false,
+        showForwardPreview: false,
+        showBulkForwardPreview: false,
+        peerKeysOk: false,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/features/messaging/model/send-button-state.ts
+++ b/src/features/messaging/model/send-button-state.ts
@@ -4,6 +4,13 @@ export interface SendButtonState {
   showForwardPreview: boolean;
   showBulkForwardPreview: boolean;
   peerKeysOk: boolean;
+  /** Active external share from Android Share Sheet — bypass peerKeysOk gate
+   *  because the user explicitly picked the target room. SyncEngine retries
+   *  the encrypted send with exponential backoff while peer keys propagate,
+   *  and on terminal failure the message lands as a "failed" bubble with a
+   *  visible retry — strictly better UX than the previous silent no-op when
+   *  the user tapped Send before keys arrived (Session 48 / #717 #710 #706). */
+  isExternalShare?: boolean;
 }
 
 const hasSendableContent = (s: Pick<SendButtonState, "text" | "showForwardPreview" | "showBulkForwardPreview">): boolean =>
@@ -14,5 +21,8 @@ export function isSendButtonVisible(s: SendButtonState): boolean {
 }
 
 export function isSendButtonDisabled(s: SendButtonState): boolean {
-  return !hasSendableContent(s) || s.sending || !s.peerKeysOk;
+  if (!hasSendableContent(s)) return true;
+  if (s.sending) return true;
+  if (s.isExternalShare) return false;
+  return !s.peerKeysOk;
 }

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -24,6 +24,7 @@ import { isSendButtonVisible, isSendButtonDisabled } from "../model/send-button-
 import { isPeerKeysOk } from "../model/peer-keys-ok";
 import { isNative } from "@/shared/lib/platform";
 import { readShareUriAsBlob } from "@/shared/lib/share-target";
+import { useToast } from "@/shared/lib/use-toast";
 
 const PEER_KEYS_GRACE_MS = 2000;
 
@@ -38,6 +39,7 @@ const emit = defineEmits<{ donate: [] }>();
 const chatStore = useChatStore();
 const themeStore = useThemeStore();
 const { t } = useI18n();
+const { toast } = useToast();
 const { sendMessage, sendFile, sendImage, sendAudio, sendVideoCircle, sendReply, sendForward, forwardMessages, editMessage, setTyping, sendPoll, sendGif } = useMessages();
 const mediaUpload = useMediaUpload();
 const pasteDrop = usePasteDrop({
@@ -207,6 +209,13 @@ const peerKeysOk = computed(() => {
   });
 });
 
+// External share = user picked Forta from Android Share Sheet and chose this
+// room. Bypass peerKeysOk gate (Session 48 / #717 #710 #706): SyncEngine
+// retries the send with exponential backoff while peer keys propagate, and on
+// terminal failure the bubble lands as "failed" with a visible retry — both
+// are strictly better than the previous silent Send-tap-does-nothing UX.
+const isExternalShareActive = computed(() => chatStore.forwardingMessage?.isExternalShare === true);
+
 const isEditing = computed(() => !!chatStore.editingMessage);
 
 const cancelEdit = () => {
@@ -243,7 +252,11 @@ const autoResize = autoGrow;
 const showSecondaryActions = computed(() => !isMobile.value || !text.value.trim());
 
 const handleSend = async () => {
-  if ((!text.value.trim() && !showForwardPreview.value && !showBulkForwardPreview.value) || !peerKeysOk.value) return;
+  if (!text.value.trim() && !showForwardPreview.value && !showBulkForwardPreview.value) return;
+  // External share bypasses peerKeysOk — the user already picked the target,
+  // SyncEngine queues the op. Without this branch the Send tap was a silent
+  // no-op for fresh DMs where peer keys haven't propagated yet (Session 48).
+  if (!isExternalShareActive.value && !peerKeysOk.value) return;
   const rawText = mention.resolveText();
   const savedText = text.value;
 
@@ -299,7 +312,12 @@ const handleSend = async () => {
             inserted = await sendFile(file);
           }
         } catch (e) {
+          // Without a visible toast the user just sees the Send tap "do
+          // nothing" — same UX surface as the silent peerKeysOk gate this
+          // session also unsticks. Surface every failure so the user can
+          // retry (Session 48 / #710 #706).
           console.error("[MessageInput] Failed to send external share file:", e);
+          toast(t("share.sendFailed"), "error");
           inserted = false;
         }
         if (inserted !== false) chatStore.cancelForward();
@@ -464,6 +482,7 @@ const sendButtonDisabled = computed(() => isSendButtonDisabled({
   showForwardPreview: showForwardPreview.value,
   showBulkForwardPreview: showBulkForwardPreview.value,
   peerKeysOk: peerKeysOk.value,
+  isExternalShare: isExternalShareActive.value,
 }));
 
 const bulkForwardCount = computed(() => chatStore.forwardingMessages.length);

--- a/src/shared/lib/__tests__/share-target-cache-copy.test.ts
+++ b/src/shared/lib/__tests__/share-target-cache-copy.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mocks live at module scope — vitest hoists vi.mock() calls. Each test
+// resets the underlying spies via the exposed handles.
+const readFile = vi.fn();
+const writeFile = vi.fn();
+const getUri = vi.fn();
+
+vi.mock("@capacitor/filesystem", () => ({
+  Filesystem: {
+    readFile: (...args: unknown[]) => readFile(...args),
+    writeFile: (...args: unknown[]) => writeFile(...args),
+    getUri: (...args: unknown[]) => getUri(...args),
+  },
+  Directory: { Cache: "CACHE" },
+}));
+
+const addListener = vi.fn();
+vi.mock("@capgo/capacitor-share-target", () => ({
+  CapacitorShareTarget: {
+    addListener: (...args: unknown[]) => addListener(...args),
+  },
+}));
+
+vi.mock("@/shared/lib/platform", () => ({ isNative: true }));
+
+// We must re-import the SUT after resetting mocks so the module's internal
+// `listenerRegistered` flag goes back to false between tests.
+async function loadShareTarget() {
+  vi.resetModules();
+  return await import("../share-target");
+}
+
+describe("share-target — immediate cache copy (Session 48)", () => {
+  beforeEach(() => {
+    readFile.mockReset();
+    writeFile.mockReset();
+    getUri.mockReset();
+    addListener.mockReset();
+  });
+
+  it("copies shared content:// file into private cache before dispatching", async () => {
+    readFile.mockResolvedValue({ data: "aGVsbG8=" }); // "hello" base64
+    writeFile.mockResolvedValue(undefined);
+    getUri.mockResolvedValue({ uri: "file:///data/data/app/cache/share-1234-photo.jpg" });
+
+    const { initShareTargetListener } = await loadShareTarget();
+
+    let received: { fileUri?: string; fileName?: string; mimeType?: string } | undefined;
+    await initShareTargetListener((d) => {
+      received = d;
+    });
+
+    expect(addListener).toHaveBeenCalledWith("shareReceived", expect.any(Function));
+    const listener = addListener.mock.calls[0][1] as (e: unknown) => Promise<void>;
+
+    await listener({
+      texts: [],
+      files: [{ uri: "content://media/external/123", name: "photo.jpg", mimeType: "image/jpeg" }],
+    });
+
+    expect(readFile).toHaveBeenCalledWith({ path: "content://media/external/123" });
+    expect(writeFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: "aGVsbG8=",
+        directory: "CACHE",
+        path: expect.stringMatching(/^share-\d+-photo\.jpg$/),
+      }),
+    );
+    expect(received?.fileUri).toBe("file:///data/data/app/cache/share-1234-photo.jpg");
+    expect(received?.fileName).toBe("photo.jpg");
+    expect(received?.mimeType).toBe("image/jpeg");
+  });
+
+  it("falls back to original URI when cache copy fails (low-RAM OOM)", async () => {
+    readFile.mockRejectedValue(new Error("OOM"));
+
+    const { initShareTargetListener } = await loadShareTarget();
+
+    let received: { fileUri?: string } | undefined;
+    await initShareTargetListener((d) => {
+      received = d;
+    });
+    const listener = addListener.mock.calls[0][1] as (e: unknown) => Promise<void>;
+
+    await listener({
+      texts: [],
+      files: [{ uri: "content://media/external/big-video", name: "video.mp4", mimeType: "video/mp4" }],
+    });
+
+    expect(received?.fileUri).toBe("content://media/external/big-video");
+  });
+
+  it("sanitizes filenames with path separators / odd characters", async () => {
+    readFile.mockResolvedValue({ data: "QUJD" });
+    writeFile.mockResolvedValue(undefined);
+    getUri.mockResolvedValue({ uri: "file:///cache/share-1-_etc_passwd" });
+
+    const { initShareTargetListener } = await loadShareTarget();
+    await initShareTargetListener(() => undefined);
+    const listener = addListener.mock.calls[0][1] as (e: unknown) => Promise<void>;
+
+    await listener({
+      texts: [],
+      files: [{ uri: "content://x", name: "../../etc/passwd", mimeType: "text/plain" }],
+    });
+
+    const writeCall = writeFile.mock.calls[0][0] as { path: string };
+    expect(writeCall.path).not.toContain("/");
+    expect(writeCall.path).not.toContain("..");
+  });
+
+  it("idempotent: second invocation does not register a second listener", async () => {
+    const { initShareTargetListener } = await loadShareTarget();
+    await initShareTargetListener(() => undefined);
+    await initShareTargetListener(() => undefined);
+    expect(addListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing on web (isNative=false)", async () => {
+    vi.resetModules();
+    vi.doMock("@/shared/lib/platform", () => ({ isNative: false }));
+    const { initShareTargetListener } = await import("../share-target");
+    await initShareTargetListener(() => undefined);
+    expect(addListener).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -637,6 +637,7 @@ export const en = {
   "share.linkCopied": "Link copied to clipboard",
   "share.copyFailed": "Failed to copy link",
   "share.nativeShare": "Share via...",
+  "share.sendFailed": "Failed to send file",
 
   // ── Share group link ──
   "shareGroup.inviteLink": "Invite Link",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -639,6 +639,7 @@ export const ru: Record<TranslationKey, string> = {
   "share.linkCopied": "Ссылка скопирована",
   "share.copyFailed": "Не удалось скопировать ссылку",
   "share.nativeShare": "Поделиться через...",
+  "share.sendFailed": "Не удалось отправить файл",
 
   // ── Share group link ──
   "shareGroup.inviteLink": "Ссылка-приглашение",

--- a/src/shared/lib/share-target.ts
+++ b/src/shared/lib/share-target.ts
@@ -58,16 +58,58 @@ export function consumeShareData(): ExternalShareData | null {
   }
 }
 
+/** Copy a shared file into the app's private cache directory and return the
+ *  new file URI. Android 14+ revokes the content:// UriPermission grant as
+ *  soon as the calling app loses foreground — by the time the user picks a
+ *  target room and taps Send, the original URI can already be `Permission
+ *  Denied`. Copying once at `shareReceived` time freezes the bytes inside
+ *  our own sandbox so they survive both the UriPermission revoke and the
+ *  ForwardPicker hop (Session 48 / #710 #717). */
+async function copyShareToCache(file: { uri: string; name: string }): Promise<string> {
+  const { Filesystem, Directory } = await import("@capacitor/filesystem");
+  // Sanitize filename — Filesystem rejects path separators, and a leaked
+  // `..` would let a hostile sender write outside CacheDirectory.
+  const safeName =
+    file.name
+      .replace(/[^a-zA-Z0-9._-]/g, "_")
+      .replace(/\.{2,}/g, "_")
+      .replace(/^\.+/, "") || "shared_file";
+  const cachedName = `share-${Date.now()}-${safeName}`;
+  const read = await Filesystem.readFile({ path: file.uri });
+  // Native Filesystem.readFile always returns base64-encoded string on
+  // Android. A Blob here means we're on a web path that shouldn't be
+  // hitting this function — bail loudly so the outer try/catch falls back
+  // to the original URI instead of silently writing an empty cache file.
+  if (typeof read.data !== "string") {
+    throw new Error("share-target: expected base64 string from Filesystem.readFile, got Blob");
+  }
+  await Filesystem.writeFile({
+    path: cachedName,
+    data: read.data,
+    directory: Directory.Cache,
+  });
+  const cached = await Filesystem.getUri({ path: cachedName, directory: Directory.Cache });
+  return cached.uri;
+}
+
+let listenerRegistered = false;
+
 /** Initialize the share target listener (call once on app mount, native only).
- *  Calls `onShare` when content is received from Android Share Sheet. */
+ *  Calls `onShare` when content is received from Android Share Sheet.
+ *
+ *  Idempotent — `singleTask` launchMode can re-deliver Intents to an existing
+ *  MainActivity, so the bootstrap path may run twice in one process. Without
+ *  the guard the capgo bridge ends up with two listeners and dispatches
+ *  `onShare` twice per share. */
 export async function initShareTargetListener(
   onShare: (data: ExternalShareData) => void,
 ): Promise<void> {
-  if (!isNative) return;
+  if (!isNative || listenerRegistered) return;
+  listenerRegistered = true;
 
   const { CapacitorShareTarget } = await import("@capgo/capacitor-share-target");
 
-  await CapacitorShareTarget.addListener("shareReceived", (event) => {
+  await CapacitorShareTarget.addListener("shareReceived", async (event) => {
     const data: ExternalShareData = {};
 
     // Text / URL
@@ -78,7 +120,15 @@ export async function initShareTargetListener(
     // First file only (single-file sharing)
     if (event.files?.length) {
       const file = event.files[0];
-      data.fileUri = file.uri;
+      try {
+        data.fileUri = await copyShareToCache(file);
+      } catch (e) {
+        // Best-effort: large videos can OOM Filesystem.readFile on low-RAM
+        // devices; fall back to the original URI so the sender at least has
+        // a chance to read it before the permission revoke kicks in.
+        console.error("[share-target] cache copy failed, falling back to original URI:", e);
+        data.fileUri = file.uri;
+      }
       data.fileName = file.name;
       data.mimeType = file.mimeType;
     }
@@ -87,4 +137,12 @@ export async function initShareTargetListener(
       onShare(data);
     }
   });
+}
+
+/** Reset the idempotent guard so successive tests can re-register the
+ *  listener against a fresh capgo mock. Production code must not call this —
+ *  it bypasses the singleton protection the singleTask launchMode relies on.
+ *  @internal */
+export function __resetShareTargetListenerForTests(): void {
+  listenerRegistered = false;
 }


### PR DESCRIPTION
## Summary

Four cumulative regressions in the Android Share Sheet → Forta → pick chat → Send flow that surfaced massively after 1.10.20. Closes #717, #713, #710, #706, #702, #678, #487.

- **Bypass `peerKeysOk` for external share** — fresh DMs picked from the share sheet have no peer keys propagated yet, so the gate silently refused every Send tap. With `forwardingMessage.isExternalShare === true` the button proceeds; SyncEngine retries the encrypted send while keys propagate, and on terminal failure the bubble lands as "failed" with a visible retry — strictly better than silent no-op.
- **Immediate cache copy on `shareReceived`** — Android 14+ revokes the `content://` UriPermission as soon as the source app loses foreground; by the time the user picks a target room, `Filesystem.readFile` throws Permission Denied. We now copy bytes into `Directory.Cache` synchronously when the listener fires; cached URI survives both the revoke and the ForwardPicker hop. Filename is sanitized (`[^a-zA-Z0-9._-]` → `_`, `..` collapsed, leading dots stripped) so a hostile sender can't path-traverse.
- **Toast on send failure** — new i18n key `share.sendFailed` ("Не удалось отправить файл" / "Failed to send file") so the user can retry instead of guessing.
- **`*/*` fallback intent-filter** — keeps Forta visible in the share sheet for exotic MIME types we don't enumerate (image/heic, vendor archives, application/x-…). Specific filters remain so IntentResolver still ranks Forta higher for common types.

Also: idempotent `initShareTargetListener` registration (module-scope `listenerRegistered` flag) so `singleTask` re-launch doesn't accumulate duplicate capgo listeners.

## Files

| File | Change |
|------|--------|
| `src/features/messaging/model/send-button-state.ts` | new `isExternalShare?` field; `isSendButtonDisabled` short-circuits peer-keys check |
| `src/features/messaging/ui/MessageInput.vue` | computed `isExternalShareActive`, passed into helper, gated early-return in `handleSend`, toast in external-share catch |
| `src/shared/lib/share-target.ts` | extracted `copyShareToCache()` + sanitization, idempotent listener, `__resetShareTargetListenerForTests` (`@internal`) |
| `android/app/src/main/AndroidManifest.xml` | appended `<data android:mimeType="*/*" />` fallback |
| `src/shared/lib/i18n/locales/{ru,en}.ts` | `share.sendFailed` key |
| `src/features/messaging/model/__tests__/send-button-external-share.test.ts` | 5 new regression tests |
| `src/shared/lib/__tests__/share-target-cache-copy.test.ts` | 5 new regression tests (cache copy, OOM fallback, sanitization, idempotency, web no-op) |

## Test plan

- [x] `npx vitest run src/features/messaging src/shared/lib/__tests__` — 334/334 PASS, includes 10 new regression cases
- [x] `npx vue-tsc --noEmit` clean on Session 48 files (pre-existing baseline errors in unrelated files verified to exist on master)
- [x] Full `vitest run` — 1775/1784 (9 pre-existing failures present on master, not in touched files)
- [x] `superpowers:code-reviewer` agent — APPROVED after addressing H1 (comment accuracy re: SyncEngine retry semantics), M1 (manifest comment), M2 (writeFile Blob → throw), L4 (`@internal` JSDoc)
- [ ] Manual Android device: Gallery → Share → Forta visible → pick fresh DM → Send button active → file lands
- [ ] Manual Android device: WhatsApp `image/heic` → Forta visible in share sheet
- [ ] Manual Android device: kill share-target bridge mid-flow → `share.sendFailed` toast appears
- [ ] Manual Android device: double-resume MainActivity (singleTask) → listener registered exactly once

## Out of scope

- iOS share-target (no capgo plugin under iOS)
- MediaViewer pinch-zoom / filename without `.jpg` extension (#693, #694) — separate session
- ForwardPicker UI redesign — only the error/failure flow is touched