### PR TITLE
fix(forward): re-upload media on internal forward — fix «Image» placeholder bug (Session 52)

### DIFF
--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -591,6 +591,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       fileInfo: message.fileInfo,
       forwardedFrom: message.forwardedFrom,
       withSenderInfo: true,
+      sourceTimestamp: message.timestamp,
     };
   };
 

--- a/src/entities/chat/model/types.ts
+++ b/src/entities/chat/model/types.ts
@@ -76,6 +76,11 @@ export interface ForwardingMessage {
   withSenderInfo: boolean;
   /** True when message originates from Android Share Sheet (not internal forward) */
   isExternalShare?: boolean;
+  /** Original event timestamp — only meaningful for internal forwards of
+   *  real messages (initForward). Used by the media re-upload path to
+   *  derive the right decryption context. Omitted for synthetic
+   *  ForwardingMessages (external share, channel post share). */
+  sourceTimestamp?: number;
 }
 
 /** Open Graph metadata for URL link previews */

--- a/src/features/messaging/model/__tests__/forward-bulk-media.test.ts
+++ b/src/features/messaging/model/__tests__/forward-bulk-media.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Bulk forward — selecting multiple media + text messages and forwarding
+ * them must produce per-type events on the target side: m.image for images,
+ * m.file for documents, m.text for text. Pre-fix everything collapsed into
+ * text bubbles (see forward-media.test.ts for the root cause).
+ *
+ * Session 52 — closes the bulk path on the same bug.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { MessageType } from "@/entities/chat";
+
+const mocks = vi.hoisted(() => ({
+  createLocalSpy: vi.fn(),
+  enqueueSpy: vi.fn(),
+  attachmentsAddSpy: vi.fn(),
+  getDecryptedBlobSpy: vi.fn(),
+  fakeStoreMessages: {} as Record<string, unknown[]>,
+}));
+
+vi.mock("@/shared/lib/local-db", () => ({
+  isChatDbReady: vi.fn(() => true),
+  getChatDb: vi.fn(() => ({
+    messages: {
+      createLocal: mocks.createLocalSpy,
+      markFailed: vi.fn(),
+      getByClientId: vi.fn(),
+      updateUploadProgress: vi.fn(),
+      confirmMediaSent: vi.fn(),
+    },
+    syncEngine: { enqueue: mocks.enqueueSpy },
+    db: {
+      attachments: { add: mocks.attachmentsAddSpy },
+      messages: { where: vi.fn(() => ({ equals: vi.fn(() => ({ modify: vi.fn() })) })) },
+    },
+    eventWriter: {},
+  })),
+}));
+
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: vi.fn(() => ({
+    isReady: () => true,
+    uploadContent: vi.fn(),
+    sendEncryptedText: vi.fn(),
+    setTyping: vi.fn(),
+  })),
+}));
+
+vi.mock("@/entities/matrix/model/matrix-crypto", () => ({
+  ENCRYPTION_REQUIRED_NO_KEYS: "ENCRYPTION_REQUIRED_NO_KEYS",
+}));
+
+vi.mock("@/entities/auth", () => ({
+  useAuthStore: () => ({
+    address: "0xme",
+    pcrypto: { rooms: {} },
+  }),
+}));
+
+vi.mock("@/entities/chat", async () => {
+  const actual = await vi.importActual<typeof import("@/entities/chat")>("@/entities/chat");
+  return {
+    ...actual,
+    useChatStore: () => ({
+      activeRoomId: "!target:server",
+      get messages() {
+        return mocks.fakeStoreMessages;
+      },
+      addMessage: vi.fn(),
+      updateMessageContent: vi.fn(),
+      updateMessageStatus: vi.fn(),
+      updateMessageIdAndStatus: vi.fn(),
+      removeMessage: vi.fn(),
+      getDisplayName: vi.fn((id: string) => `user-${id}`),
+      loadRoomMessages: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("../use-file-download", () => ({
+  getDecryptedBlobForMessage: mocks.getDecryptedBlobSpy,
+  invalidateDownloadCache: vi.fn(),
+}));
+
+vi.mock("@/features/bug-report", () => ({
+  useBugReport: () => ({ open: vi.fn() }),
+}));
+
+vi.mock("@/shared/lib/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock("@/shared/lib/i18n", () => ({ tRaw: (k: string) => k }));
+
+vi.mock("@/shared/lib/connectivity", () => ({
+  useConnectivity: () => ({ isOnline: { value: true } }),
+}));
+
+vi.mock("@/shared/lib/offline-queue", () => ({
+  enqueue: vi.fn(),
+  dequeue: vi.fn(),
+  getQueue: vi.fn(() => []),
+}));
+
+vi.mock("./use-link-preview", () => ({
+  detectUrl: vi.fn(() => null),
+  fetchPreview: vi.fn(),
+}));
+
+import { useMessages } from "../use-messages";
+
+describe("bulk forwardMessages — media + text mixed (Session 52)", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mocks.createLocalSpy.mockReset();
+    mocks.enqueueSpy.mockReset();
+    mocks.attachmentsAddSpy.mockReset();
+    mocks.getDecryptedBlobSpy.mockReset();
+    mocks.createLocalSpy.mockResolvedValue({ clientId: "client-xyz", localId: 42 });
+    mocks.enqueueSpy.mockResolvedValue(1);
+    mocks.attachmentsAddSpy.mockResolvedValue(7);
+    mocks.getDecryptedBlobSpy.mockResolvedValue(new Blob(["x"], { type: "image/jpeg" }));
+
+    class StubImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      naturalWidth = 320;
+      naturalHeight = 240;
+      private _src = "";
+      get src(): string { return this._src; }
+      set src(v: string) {
+        this._src = v;
+        queueMicrotask(() => this.onload?.());
+      }
+    }
+    // @ts-expect-error — override global Image
+    globalThis.Image = StubImage;
+  });
+
+  it("forwards 2 images + 1 text as 3 events with msgtypes m.image, m.image, m.text", async () => {
+    mocks.fakeStoreMessages["!source:server"] = [
+      {
+        id: "m1",
+        roomId: "!source:server",
+        senderId: "alice",
+        content: "img1",
+        timestamp: 100,
+        type: MessageType.image,
+        fileInfo: { name: "1.jpg", type: "image/jpeg", size: 1, url: "mxc://1" },
+      },
+      {
+        id: "m2",
+        roomId: "!source:server",
+        senderId: "alice",
+        content: "img2",
+        timestamp: 110,
+        type: MessageType.image,
+        fileInfo: { name: "2.jpg", type: "image/jpeg", size: 1, url: "mxc://2" },
+      },
+      {
+        id: "m3",
+        roomId: "!source:server",
+        senderId: "alice",
+        content: "hello world",
+        timestamp: 120,
+        type: MessageType.text,
+      },
+    ];
+
+    const { forwardMessages } = useMessages();
+    const result = await forwardMessages(
+      ["m1", "m2", "m3"],
+      "!target:server",
+      { withSenderInfo: true },
+    );
+
+    expect(result.succeeded).toBe(3);
+    expect(result.failed).toBe(0);
+
+    const ops = mocks.enqueueSpy.mock.calls.map((c) => c[0]);
+    // Two send_file (images) + one send_message (text), order may vary
+    expect(ops.filter((o) => o === "send_file")).toHaveLength(2);
+    expect(ops.filter((o) => o === "send_message")).toHaveLength(1);
+
+    // All enqueue invocations carry forwardedFrom attribution
+    for (const call of mocks.enqueueSpy.mock.calls) {
+      const payload = call[2] as { forwardedFrom?: unknown };
+      expect(payload.forwardedFrom).toEqual({ senderId: "alice", senderName: "user-alice" });
+    }
+  });
+
+  it("forwards a single pdf as one m.file event", async () => {
+    mocks.getDecryptedBlobSpy.mockResolvedValue(new Blob(["pdf"], { type: "application/pdf" }));
+    mocks.fakeStoreMessages["!source:server"] = [
+      {
+        id: "pdf1",
+        roomId: "!source:server",
+        senderId: "bob",
+        content: "doc.pdf",
+        timestamp: 200,
+        type: MessageType.file,
+        fileInfo: { name: "doc.pdf", type: "application/pdf", size: 3, url: "mxc://pdf" },
+      },
+    ];
+
+    const { forwardMessages } = useMessages();
+    const result = await forwardMessages(["pdf1"], "!target:server", { withSenderInfo: true });
+
+    expect(result.succeeded).toBe(1);
+    const [op, , payload] = mocks.enqueueSpy.mock.calls[0];
+    expect(op).toBe("send_file");
+    expect(payload).toMatchObject({ msgtype: "m.file" });
+  });
+});

--- a/src/features/messaging/model/__tests__/forward-media.test.ts
+++ b/src/features/messaging/model/__tests__/forward-media.test.ts
@@ -146,11 +146,9 @@ describe("forward media — internal forward re-uploads media (Session 52)", () 
 
     // URL.createObjectURL / revokeObjectURL no-op for the same reason.
     if (typeof URL.createObjectURL !== "function") {
-      // @ts-expect-error — stub if happy-dom omits it
       URL.createObjectURL = vi.fn(() => "blob:stub");
     }
     if (typeof URL.revokeObjectURL !== "function") {
-      // @ts-expect-error — stub if happy-dom omits it
       URL.revokeObjectURL = vi.fn();
     }
   });

--- a/src/features/messaging/model/__tests__/forward-media.test.ts
+++ b/src/features/messaging/model/__tests__/forward-media.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Forward media regression — internal forward (ForwardPicker) for media
+ * messages must re-upload and arrive as `m.image` / `m.file` / `m.audio` events
+ * with the actual attachment, not a text body «Image» without attachment.
+ *
+ * Root cause (pre-fix): `sendForward(content)` accepted only text and hardcoded
+ * `type: MessageType.text`, dropping all media fields on the API boundary.
+ * Fix: extend `sendForward(content, meta, source?)` with source-metadata
+ * (type, fileInfo, sourceMessageId) and dispatch through the existing
+ * `sendImage`/`sendFile`/`sendAudio` pipeline.
+ *
+ * Closes #311, #702.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { MessageType } from "@/entities/chat";
+
+// ── Spies captured across the test module (must be hoisted for vi.mock) ──
+const mocks = vi.hoisted(() => ({
+  createLocalSpy: vi.fn(),
+  enqueueSpy: vi.fn(),
+  attachmentsAddSpy: vi.fn(),
+  getDecryptedBlobSpy: vi.fn(),
+}));
+
+vi.mock("@/shared/lib/local-db", () => ({
+  isChatDbReady: vi.fn(() => true),
+  getChatDb: vi.fn(() => ({
+    messages: {
+      createLocal: mocks.createLocalSpy,
+      markFailed: vi.fn(),
+      getByClientId: vi.fn(),
+      updateUploadProgress: vi.fn(),
+      confirmMediaSent: vi.fn(),
+    },
+    syncEngine: { enqueue: mocks.enqueueSpy },
+    db: {
+      attachments: { add: mocks.attachmentsAddSpy },
+      messages: { where: vi.fn(() => ({ equals: vi.fn(() => ({ modify: vi.fn() })) })) },
+    },
+    eventWriter: {},
+  })),
+}));
+
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: vi.fn(() => ({
+    isReady: () => true,
+    uploadContent: vi.fn(),
+    sendEncryptedText: vi.fn(),
+    setTyping: vi.fn(),
+  })),
+}));
+
+vi.mock("@/entities/matrix/model/matrix-crypto", () => ({
+  ENCRYPTION_REQUIRED_NO_KEYS: "ENCRYPTION_REQUIRED_NO_KEYS",
+}));
+
+vi.mock("@/entities/auth", () => ({
+  useAuthStore: () => ({
+    address: "0xme",
+    pcrypto: { rooms: {} },
+  }),
+}));
+
+vi.mock("@/entities/chat", async () => {
+  const actual = await vi.importActual<typeof import("@/entities/chat")>("@/entities/chat");
+  return {
+    ...actual,
+    useChatStore: () => ({
+      activeRoomId: "!target:server",
+      messages: {},
+      addMessage: vi.fn(),
+      updateMessageContent: vi.fn(),
+      updateMessageStatus: vi.fn(),
+      updateMessageIdAndStatus: vi.fn(),
+      removeMessage: vi.fn(),
+      getDisplayName: vi.fn((id: string) => `user-${id}`),
+      loadRoomMessages: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("../use-file-download", () => ({
+  getDecryptedBlobForMessage: mocks.getDecryptedBlobSpy,
+  invalidateDownloadCache: vi.fn(),
+}));
+
+vi.mock("@/features/bug-report", () => ({
+  useBugReport: () => ({ open: vi.fn() }),
+}));
+
+vi.mock("@/shared/lib/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock("@/shared/lib/i18n", () => ({
+  tRaw: (k: string) => k,
+}));
+
+vi.mock("@/shared/lib/connectivity", () => ({
+  useConnectivity: () => ({ isOnline: { value: true } }),
+}));
+
+vi.mock("@/shared/lib/offline-queue", () => ({
+  enqueue: vi.fn(),
+  dequeue: vi.fn(),
+  getQueue: vi.fn(() => []),
+}));
+
+vi.mock("./use-link-preview", () => ({
+  detectUrl: vi.fn(() => null),
+  fetchPreview: vi.fn(),
+}));
+
+// ── Import the SUT after mocks are set up ──
+import { useMessages } from "../use-messages";
+
+describe("forward media — internal forward re-uploads media (Session 52)", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mocks.createLocalSpy.mockReset();
+    mocks.enqueueSpy.mockReset();
+    mocks.attachmentsAddSpy.mockReset();
+    mocks.getDecryptedBlobSpy.mockReset();
+    mocks.createLocalSpy.mockResolvedValue({ clientId: "client-xyz", localId: 42 });
+    mocks.enqueueSpy.mockResolvedValue(1);
+    mocks.attachmentsAddSpy.mockResolvedValue(7);
+  });
+
+  it("forwarding an image dispatches send_file enqueue with msgtype m.image (not send_message text)", async () => {
+    const blob = new Blob(["fake-jpeg"], { type: "image/jpeg" });
+    mocks.getDecryptedBlobSpy.mockResolvedValue(blob);
+
+    const { sendForward } = useMessages();
+    const ok = await sendForward(
+      "",
+      { senderId: "alice", senderName: "Alice" },
+      {
+        type: MessageType.image,
+        fileInfo: {
+          name: "photo.jpg",
+          type: "image/jpeg",
+          size: 9,
+          url: "mxc://orig/photo",
+        },
+        sourceMessageId: "$src:server",
+        roomId: "!source:server",
+      },
+    );
+
+    expect(ok).toBe(true);
+    expect(mocks.getDecryptedBlobSpy).toHaveBeenCalled();
+    expect(mocks.enqueueSpy).toHaveBeenCalled();
+    const [op, , payload] = mocks.enqueueSpy.mock.calls[0];
+    expect(op).toBe("send_file");
+    expect(payload).toMatchObject({ msgtype: "m.image" });
+  });
+
+  it("forwarding a pdf dispatches send_file enqueue with msgtype m.file", async () => {
+    const blob = new Blob(["%PDF-1.4"], { type: "application/pdf" });
+    mocks.getDecryptedBlobSpy.mockResolvedValue(blob);
+
+    const { sendForward } = useMessages();
+    const ok = await sendForward(
+      "",
+      { senderId: "bob", senderName: "Bob" },
+      {
+        type: MessageType.file,
+        fileInfo: {
+          name: "report.pdf",
+          type: "application/pdf",
+          size: 8,
+          url: "mxc://orig/pdf",
+        },
+        sourceMessageId: "$pdf:server",
+        roomId: "!source:server",
+      },
+    );
+
+    expect(ok).toBe(true);
+    const [op, , payload] = mocks.enqueueSpy.mock.calls[0];
+    expect(op).toBe("send_file");
+    expect(payload).toMatchObject({ msgtype: "m.file" });
+  });
+
+  it("forwarded media propagates forwardedFrom attribution into createLocal", async () => {
+    const blob = new Blob(["x"], { type: "image/jpeg" });
+    mocks.getDecryptedBlobSpy.mockResolvedValue(blob);
+
+    const { sendForward } = useMessages();
+    await sendForward(
+      "",
+      { senderId: "alice", senderName: "Alice" },
+      {
+        type: MessageType.image,
+        fileInfo: { name: "p.jpg", type: "image/jpeg", size: 1, url: "mxc://o" },
+        sourceMessageId: "$src",
+        roomId: "!src",
+      },
+    );
+
+    expect(mocks.createLocalSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: MessageType.image,
+        forwardedFrom: { senderId: "alice", senderName: "Alice" },
+      }),
+    );
+  });
+
+  it("forwarding plain text still goes through the legacy send_message path (no regression)", async () => {
+    const { sendForward } = useMessages();
+    const ok = await sendForward("hello world", { senderId: "alice", senderName: "Alice" });
+    expect(ok).toBe(true);
+    const [op, , payload] = mocks.enqueueSpy.mock.calls[0];
+    expect(op).toBe("send_message");
+    expect(payload).toMatchObject({ content: "hello world" });
+    expect(mocks.getDecryptedBlobSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns false when decrypted blob is unavailable (caller surfaces error)", async () => {
+    mocks.getDecryptedBlobSpy.mockResolvedValue(null);
+
+    const { sendForward } = useMessages();
+    const ok = await sendForward(
+      "",
+      undefined,
+      {
+        type: MessageType.image,
+        fileInfo: { name: "p.jpg", type: "image/jpeg", size: 1, url: "mxc://o" },
+        sourceMessageId: "$src",
+        roomId: "!src",
+      },
+    );
+
+    expect(ok).toBe(false);
+    expect(mocks.enqueueSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/messaging/model/__tests__/forward-media.test.ts
+++ b/src/features/messaging/model/__tests__/forward-media.test.ts
@@ -171,6 +171,8 @@ describe("forward media — internal forward re-uploads media (Session 52)", () 
         },
         sourceMessageId: "$src:server",
         roomId: "!source:server",
+        sourceSenderId: "alice",
+        sourceTimestamp: 100,
       },
     );
 
@@ -200,6 +202,8 @@ describe("forward media — internal forward re-uploads media (Session 52)", () 
         },
         sourceMessageId: "$pdf:server",
         roomId: "!source:server",
+        sourceSenderId: "bob",
+        sourceTimestamp: 200,
       },
     );
 
@@ -222,6 +226,8 @@ describe("forward media — internal forward re-uploads media (Session 52)", () 
         fileInfo: { name: "p.jpg", type: "image/jpeg", size: 1, url: "mxc://o" },
         sourceMessageId: "$src",
         roomId: "!src",
+        sourceSenderId: "alice",
+        sourceTimestamp: 300,
       },
     );
 
@@ -255,6 +261,8 @@ describe("forward media — internal forward re-uploads media (Session 52)", () 
         fileInfo: { name: "p.jpg", type: "image/jpeg", size: 1, url: "mxc://o" },
         sourceMessageId: "$src",
         roomId: "!src",
+        sourceSenderId: "alice",
+        sourceTimestamp: 400,
       },
     );
 

--- a/src/features/messaging/model/__tests__/forward-media.test.ts
+++ b/src/features/messaging/model/__tests__/forward-media.test.ts
@@ -125,6 +125,34 @@ describe("forward media — internal forward re-uploads media (Session 52)", () 
     mocks.createLocalSpy.mockResolvedValue({ clientId: "client-xyz", localId: 42 });
     mocks.enqueueSpy.mockResolvedValue(1);
     mocks.attachmentsAddSpy.mockResolvedValue(7);
+
+    // happy-dom's Image doesn't fire load/error for blob: URLs, so
+    // getImageDimensions hangs forever. Stub it with an Image-shaped mock
+    // that fires onload synchronously the moment .src is assigned.
+    class StubImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      naturalWidth = 320;
+      naturalHeight = 240;
+      private _src = "";
+      get src(): string { return this._src; }
+      set src(v: string) {
+        this._src = v;
+        queueMicrotask(() => this.onload?.());
+      }
+    }
+    // @ts-expect-error — override global Image for the test
+    globalThis.Image = StubImage;
+
+    // URL.createObjectURL / revokeObjectURL no-op for the same reason.
+    if (typeof URL.createObjectURL !== "function") {
+      // @ts-expect-error — stub if happy-dom omits it
+      URL.createObjectURL = vi.fn(() => "blob:stub");
+    }
+    if (typeof URL.revokeObjectURL !== "function") {
+      // @ts-expect-error — stub if happy-dom omits it
+      URL.revokeObjectURL = vi.fn();
+    }
   });
 
   it("forwarding an image dispatches send_file enqueue with msgtype m.image (not send_message text)", async () => {

--- a/src/features/messaging/model/use-file-download.ts
+++ b/src/features/messaging/model/use-file-download.ts
@@ -395,6 +395,48 @@ async function downloadAndDecrypt(
   throw wrapTransientError(lastError, fileInfo.url);
 }
 
+/** Resolve a decrypted Blob for a media message without touching the per-event
+ *  cache or rendering pipeline. Used by the forward path: when the user picks
+ *  «Forward» on an image/video/file message, we need the decrypted bytes so
+ *  we can wrap them in a `File` and re-upload through `sendImage`/`sendFile`
+ *  (preserving forward attribution). The download composable's public
+ *  `download()` is unsuitable because it returns an `objectUrl` and mutates
+ *  per-message UI state — forward is a one-shot byte access with no UI
+ *  side effects.
+ *
+ *  Returns null when there is no source bytes available (no fileInfo at all,
+ *  or a local blob URL whose object has already been revoked). Throws on
+ *  network/crypto failures so the caller can surface a clear toast. */
+export async function getDecryptedBlobForMessage(
+  message: Pick<Message, "fileInfo" | "roomId" | "senderId" | "timestamp">,
+  signal?: AbortSignal,
+): Promise<Blob | null> {
+  const fileInfo = message.fileInfo;
+  if (!fileInfo) return null;
+
+  // Local blob URL fast path: the original message was sent from this device
+  // and its optimistic blob is still alive. Fetching `blob:` is synchronous-ish
+  // and skips the whole download/decrypt loop.
+  if (fileInfo.url?.startsWith("blob:")) {
+    try {
+      const res = await fetch(fileInfo.url);
+      if (res.ok) return await res.blob();
+    } catch {
+      // Blob URL was revoked between snapshot and forward — fall through to
+      // server-side download below if there's anything to download.
+    }
+  }
+
+  // Server-side mxc URL — reuse the full retry + decrypt pipeline.
+  return await downloadAndDecrypt(
+    fileInfo,
+    message.roomId,
+    message.senderId,
+    message.timestamp,
+    signal,
+  );
+}
+
 /** Convert Blob to base64 data string (without the data:...;base64, prefix) */
 function blobToBase64(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/src/features/messaging/model/use-file-download.ts
+++ b/src/features/messaging/model/use-file-download.ts
@@ -419,9 +419,11 @@ export async function getDecryptedBlobForMessage(
   // and skips the whole download/decrypt loop.
   if (fileInfo.url?.startsWith("blob:")) {
     try {
-      const res = await fetch(fileInfo.url);
+      const res = await fetch(fileInfo.url, signal ? { signal } : undefined);
       if (res.ok) return await res.blob();
-    } catch {
+    } catch (e) {
+      // Caller cancellation is terminal — don't fall through to a server fetch.
+      if (e instanceof DOMException && e.name === "AbortError") throw e;
       // Blob URL was revoked between snapshot and forward — fall through to
       // server-side download below if there's anything to download.
     }

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -322,7 +322,10 @@ export function useMessages() {
    *  it, even when subsequent enqueue fails), false when the call was
    *  silently dropped before any visible side effect (caller can then
    *  preserve the share/forward intent or restore the input). */
-  const sendFile = async (file: File): Promise<boolean> => {
+  const sendFile = async (
+    file: File,
+    options: { forwardedFrom?: { senderId: string; senderName?: string } } = {},
+  ): Promise<boolean> => {
     const roomId = chatStore.activeRoomId;
     if (!roomId || !file) return false;
 
@@ -360,6 +363,7 @@ export function useMessages() {
         size: file.size,
         url: localBlobUrl,
       },
+      forwardedFrom: options.forwardedFrom,
       localBlobUrl,
       uploadProgress: 0,
     });
@@ -382,6 +386,7 @@ export function useMessages() {
         mimeType: mime,
         msgtype: "m.file",
         attachmentId,
+        ...(options.forwardedFrom ? { forwardedFrom: options.forwardedFrom } : {}),
       },
       localMsg.clientId,
     );
@@ -392,7 +397,11 @@ export function useMessages() {
    *  See sendFile for the boolean return contract. */
   const sendImage = async (
     file: File,
-    options: { caption?: string; captionAbove?: boolean } = {},
+    options: {
+      caption?: string;
+      captionAbove?: boolean;
+      forwardedFrom?: { senderId: string; senderName?: string };
+    } = {},
   ): Promise<boolean> => {
     const roomId = chatStore.activeRoomId;
     if (!roomId || !file) return false;
@@ -426,6 +435,7 @@ export function useMessages() {
         caption: options.caption,
         captionAbove: options.captionAbove,
       },
+      forwardedFrom: options.forwardedFrom,
       localBlobUrl,
       uploadProgress: 0,
     });
@@ -456,6 +466,7 @@ export function useMessages() {
           ...(options.caption ? { caption: options.caption } : {}),
           ...(options.captionAbove != null ? { captionAbove: options.captionAbove } : {}),
         },
+        ...(options.forwardedFrom ? { forwardedFrom: options.forwardedFrom } : {}),
       },
       localMsg.clientId,
     );
@@ -466,7 +477,11 @@ export function useMessages() {
    *  See sendFile for the boolean return contract. */
   const sendAudio = async (
     file: File,
-    options: { duration?: number; waveform?: number[] } = {},
+    options: {
+      duration?: number;
+      waveform?: number[];
+      forwardedFrom?: { senderId: string; senderName?: string };
+    } = {},
   ): Promise<boolean> => {
     const roomId = chatStore.activeRoomId;
     if (!roomId || !file) return false;
@@ -497,6 +512,7 @@ export function useMessages() {
         duration: options.duration,
         waveform: options.waveform,
       },
+      forwardedFrom: options.forwardedFrom,
       localBlobUrl,
       uploadProgress: 0,
     });
@@ -527,6 +543,7 @@ export function useMessages() {
           duration: options.duration ? Math.round(options.duration * 1000) : undefined,
           waveform: intWaveform,
         },
+        ...(options.forwardedFrom ? { forwardedFrom: options.forwardedFrom } : {}),
       },
       localMsg.clientId,
     );
@@ -534,7 +551,13 @@ export function useMessages() {
   };
 
   /** Send a video circle (video note) message — circular video like Telegram */
-  const sendVideoCircle = async (file: File, options: { duration?: number } = {}) => {
+  const sendVideoCircle = async (
+    file: File,
+    options: {
+      duration?: number;
+      forwardedFrom?: { senderId: string; senderName?: string };
+    } = {},
+  ) => {
     const roomId = chatStore.activeRoomId;
     if (!roomId || !file) return;
 
@@ -562,6 +585,7 @@ export function useMessages() {
             duration: options.duration,
             videoNote: true,
           },
+          forwardedFrom: options.forwardedFrom,
           localBlobUrl,
           uploadProgress: 0,
         });
@@ -630,6 +654,14 @@ export function useMessages() {
                 videoNote: true,
                 ...(secrets ? { secrets } : {}),
               },
+              ...(options.forwardedFrom
+                ? {
+                    forwarded_from: {
+                      sender_id: options.forwardedFrom.senderId,
+                      sender_name: options.forwardedFrom.senderName,
+                    },
+                  }
+                : {}),
             };
 
             const serverEventId = await withTimeout(

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -1019,6 +1019,14 @@ export function useMessages() {
       fileInfo: FileInfo;
       sourceMessageId: string;
       roomId: string;
+      /** Original sender's address on the source event. Needed to derive the
+       *  per-event decryption key for E2E rooms — `forwardMeta.senderId` is
+       *  only set when the user opted into «Show sender attribution». */
+      sourceSenderId: string;
+      /** Original event timestamp. Some Matrix key-rotation policies are
+       *  timestamp-sensitive, so passing the source event time (not
+       *  Date.now()) keeps decrypt correct for older messages. */
+      sourceTimestamp: number;
     },
   ): Promise<boolean> => {
     const roomId = chatStore.activeRoomId;
@@ -1126,6 +1134,8 @@ export function useMessages() {
       fileInfo: FileInfo;
       sourceMessageId: string;
       roomId: string;
+      sourceSenderId: string;
+      sourceTimestamp: number;
     },
   ): Promise<boolean> => {
     let blob: Blob | null;
@@ -1133,8 +1143,12 @@ export function useMessages() {
       blob = await getDecryptedBlobForMessage({
         fileInfo: source.fileInfo,
         roomId: source.roomId,
-        senderId: forwardMeta?.senderId ?? "",
-        timestamp: Date.now(),
+        // Pass the *source* sender + timestamp so downloadAndDecrypt builds
+        // the same event shape pcrypto used when the original was sent.
+        // Using Date.now() here was wrong — it would mismatch any timestamp-
+        // sensitive key resolution.
+        senderId: source.sourceSenderId,
+        timestamp: source.sourceTimestamp,
       });
     } catch (e) {
       console.error("[sendForward] Failed to fetch source blob:", e);
@@ -1163,11 +1177,18 @@ export function useMessages() {
           forwardedFrom: forwardMeta,
         });
       case MessageType.videoCircle:
-        await sendVideoCircle(file, {
-          duration: source.fileInfo.duration,
-          forwardedFrom: forwardMeta,
-        });
-        return true;
+        // sendVideoCircle returns void and swallows its own errors; wrap so
+        // a failed video-circle forward surfaces as `false` to the caller.
+        try {
+          await sendVideoCircle(file, {
+            duration: source.fileInfo.duration,
+            forwardedFrom: forwardMeta,
+          });
+          return true;
+        } catch (e) {
+          console.error("[sendForward] sendVideoCircle threw:", e);
+          return false;
+        }
       case MessageType.video:
       case MessageType.file:
         return await sendFile(file, { forwardedFrom: forwardMeta });
@@ -1350,11 +1371,28 @@ export function useMessages() {
         // re-uploads the original blob via sendImage/sendFile/sendAudio so
         // the recipient receives a real attachment, not a text body.
         if (src.type !== MessageType.text && src.fileInfo) {
+          // forwardMediaMessage dispatches through sendImage/sendFile, which
+          // read chatStore.activeRoomId. The current UI guarantees
+          // targetRoomId === activeRoomId (ForwardPicker switches the active
+          // room before invoking forwardMessages). Surface that invariant
+          // here so a future caller that forwards into a non-active room
+          // gets a clear error instead of silently posting into the wrong
+          // chat.
+          if (targetRoomId !== chatStore.activeRoomId) {
+            throw new Error(
+              "Bulk media forward requires targetRoomId === activeRoomId " +
+                "(sendImage/sendFile read activeRoomId). Switch the active " +
+                "room before calling forwardMessages, or thread a room " +
+                "override through the per-type send functions.",
+            );
+          }
           const ok = await forwardMediaMessage(src.content, fwdMeta, {
             type: src.type,
             fileInfo: src.fileInfo,
             sourceMessageId: src.id,
             roomId: src.roomId,
+            sourceSenderId: src.senderId,
+            sourceTimestamp: src.timestamp,
           });
           if (!ok) throw new Error(`forwardMedia failed for ${src.id}`);
           return;

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -1310,12 +1310,31 @@ export function useMessages() {
 
     // Collect source messages across all rooms (selection may span rooms in theory,
     // though the current UI path feeds us only the active room's selection).
+    // We need type + fileInfo + roomId so media forwards can re-upload through
+    // the per-type pipeline instead of collapsing into a text body «Image»
+    // without attachment (the pre-fix bug behind #311, #702).
     const idSet = new Set(sourceMessageIds);
-    const collected: Array<{ id: string; content: string; senderId: string; timestamp: number }> = [];
+    const collected: Array<{
+      id: string;
+      content: string;
+      senderId: string;
+      timestamp: number;
+      type: MessageType;
+      fileInfo?: FileInfo;
+      roomId: string;
+    }> = [];
     for (const roomMessages of Object.values(chatStore.messages)) {
       for (const m of roomMessages) {
         if (idSet.has(m.id)) {
-          collected.push({ id: m.id, content: m.content, senderId: m.senderId, timestamp: m.timestamp });
+          collected.push({
+            id: m.id,
+            content: m.content,
+            senderId: m.senderId,
+            timestamp: m.timestamp,
+            type: m.type,
+            fileInfo: m.fileInfo,
+            roomId: m.roomId,
+          });
         }
       }
     }
@@ -1326,6 +1345,20 @@ export function useMessages() {
       collected.map(async (src) => {
         const senderName = chatStore.getDisplayName(src.senderId);
         const fwdMeta = withSenderInfo ? { senderId: src.senderId, senderName } : undefined;
+
+        // Media branch — reuse the singular forwardMediaMessage path. It
+        // re-uploads the original blob via sendImage/sendFile/sendAudio so
+        // the recipient receives a real attachment, not a text body.
+        if (src.type !== MessageType.text && src.fileInfo) {
+          const ok = await forwardMediaMessage(src.content, fwdMeta, {
+            type: src.type,
+            fileInfo: src.fileInfo,
+            sourceMessageId: src.id,
+            roomId: src.roomId,
+          });
+          if (!ok) throw new Error(`forwardMedia failed for ${src.id}`);
+          return;
+        }
 
         if (isChatDbReady()) {
           try {

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -11,7 +11,7 @@ import { enqueue, dequeue, getQueue } from "@/shared/lib/offline-queue";
 import type { QueuedMessage } from "@/shared/lib/offline-queue";
 import { isChatDbReady, getChatDb } from "@/shared/lib/local-db";
 import { detectUrl, fetchPreview } from "./use-link-preview";
-import { invalidateDownloadCache } from "./use-file-download";
+import { invalidateDownloadCache, getDecryptedBlobForMessage } from "./use-file-download";
 import { registerUploadAbort, unregisterUploadAbort, abortUpload } from "./upload-abort-registry";
 import { withTimeout } from "@/shared/lib/with-timeout";
 import type { LocalMessageStatus } from "@/shared/lib/local-db/schema";
@@ -1000,15 +1000,36 @@ export function useMessages() {
     return true;
   };
 
-  /** Send a forwarded text message with optimistic UI. Returns true if insert succeeded.
-   *  Pass forwardMeta to include sender attribution; omit to send without attribution. */
+  /** Send a forwarded message with optimistic UI. Returns true if insert succeeded.
+   *  Pass forwardMeta to include sender attribution; omit to send without attribution.
+   *
+   *  Two branches:
+   *   - text (default): content is the body, hits the legacy send_message path.
+   *   - media: when `source.type !== text` and `source.fileInfo` is present,
+   *            re-downloads the original blob and dispatches through
+   *            sendImage/sendFile/sendAudio/sendVideoCircle. This is the
+   *            internal-forward path for photos/videos/voice/files — without
+   *            it the recipient would see «Image» / «Photo» as a text body
+   *            with no attachment (issues #311, #702). */
   const sendForward = async (
     content: string,
     forwardMeta?: { senderId: string; senderName?: string },
+    source?: {
+      type: MessageType;
+      fileInfo: FileInfo;
+      sourceMessageId: string;
+      roomId: string;
+    },
   ): Promise<boolean> => {
     const roomId = chatStore.activeRoomId;
-    if (!roomId || !content.trim()) return false;
+    if (!roomId) return false;
 
+    // Media branch — re-upload the original bytes through the per-type pipeline.
+    if (source && source.type !== MessageType.text && source.fileInfo) {
+      return await forwardMediaMessage(content, forwardMeta, source);
+    }
+
+    if (!content.trim()) return false;
     const trimmed = content.trim();
 
     // ── Dexie path: optimistic insert FIRST ──
@@ -1088,6 +1109,74 @@ export function useMessages() {
     } catch (e) {
       console.error("[sendForward] Legacy path failed:", e);
       return false;
+    }
+  };
+
+  /** Re-upload a media message into the active room as part of a forward.
+   *  Downloads the original blob (or reuses a local blob URL when the source
+   *  was sent from this device and is still cached), wraps it in a File, and
+   *  dispatches through the per-type send pipeline so the recipient gets a
+   *  real m.image / m.file / m.audio event with the attachment — not a text
+   *  body «Image» without payload (the pre-fix bug behind #311, #702). */
+  const forwardMediaMessage = async (
+    caption: string,
+    forwardMeta: { senderId: string; senderName?: string } | undefined,
+    source: {
+      type: MessageType;
+      fileInfo: FileInfo;
+      sourceMessageId: string;
+      roomId: string;
+    },
+  ): Promise<boolean> => {
+    let blob: Blob | null;
+    try {
+      blob = await getDecryptedBlobForMessage({
+        fileInfo: source.fileInfo,
+        roomId: source.roomId,
+        senderId: forwardMeta?.senderId ?? "",
+        timestamp: Date.now(),
+      });
+    } catch (e) {
+      console.error("[sendForward] Failed to fetch source blob:", e);
+      return false;
+    }
+    if (!blob) {
+      console.error("[sendForward] forwardMedia: source blob unavailable");
+      return false;
+    }
+
+    const fileName = source.fileInfo.name || "forwarded";
+    const fileType = source.fileInfo.type || blob.type || "application/octet-stream";
+    const file = new File([blob], fileName, { type: fileType });
+    const trimmedCaption = caption.trim();
+
+    switch (source.type) {
+      case MessageType.image:
+        return await sendImage(file, {
+          caption: trimmedCaption || undefined,
+          forwardedFrom: forwardMeta,
+        });
+      case MessageType.audio:
+        return await sendAudio(file, {
+          duration: source.fileInfo.duration,
+          waveform: source.fileInfo.waveform,
+          forwardedFrom: forwardMeta,
+        });
+      case MessageType.videoCircle:
+        await sendVideoCircle(file, {
+          duration: source.fileInfo.duration,
+          forwardedFrom: forwardMeta,
+        });
+        return true;
+      case MessageType.video:
+      case MessageType.file:
+        return await sendFile(file, { forwardedFrom: forwardMeta });
+      default:
+        console.warn(
+          "[sendForward] forwardMedia: unsupported source type, falling back to text:",
+          source.type,
+        );
+        return false;
     }
   };
 

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -307,8 +307,22 @@ const handleSend = async () => {
         const forwardMeta = fwd.withSenderInfo
           ? { senderId: fwd.senderId, senderName: fwd.senderName }
           : undefined;
-        const forwardContent = rawText || fwd.content || forwardPreviewText.value;
-        inserted = await sendForward(forwardContent, forwardMeta);
+        const isMedia = fwd.type !== MessageType.text && !!fwd.fileInfo;
+        if (isMedia) {
+          // Media forward — re-upload the original blob so the recipient
+          // receives a real m.image/m.file/m.audio event instead of a text
+          // body «Image» without attachment (the pre-fix bug behind #311,
+          // #702). The caption (if user typed any) lands as the body.
+          inserted = await sendForward(rawText, forwardMeta, {
+            type: fwd.type,
+            fileInfo: fwd.fileInfo!,
+            sourceMessageId: fwd.id,
+            roomId: fwd.roomId,
+          });
+        } else {
+          const forwardContent = rawText || fwd.content || forwardPreviewText.value;
+          inserted = await sendForward(forwardContent, forwardMeta);
+        }
         if (inserted !== false) chatStore.cancelForward();
       }
     } else if (chatStore.replyingTo) {

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -7,6 +7,7 @@ import { getDraft, saveDraft, clearDraft } from "@/shared/lib/drafts";
 import { useMessages } from "../model/use-messages";
 import { useLinkPreview } from "../model/use-link-preview";
 import { useI18n } from "@/shared/lib/i18n";
+import { useToast } from "@/shared/lib/use-toast";
 import { useMediaUpload } from "../model/use-media-upload";
 import { usePasteDrop } from "../model/use-paste-drop";
 import EmojiPicker from "./EmojiPicker.vue";
@@ -38,6 +39,7 @@ const emit = defineEmits<{ donate: [] }>();
 const chatStore = useChatStore();
 const themeStore = useThemeStore();
 const { t } = useI18n();
+const { toast } = useToast();
 const { sendMessage, sendFile, sendImage, sendAudio, sendVideoCircle, sendReply, sendForward, forwardMessages, editMessage, setTyping, sendPoll, sendGif } = useMessages();
 const mediaUpload = useMediaUpload();
 const pasteDrop = usePasteDrop({
@@ -319,6 +321,13 @@ const handleSend = async () => {
             sourceMessageId: fwd.id,
             roomId: fwd.roomId,
           });
+          if (inserted === false) {
+            // sendForward returns false when the source blob is unavailable
+            // (revoked local URL, missing decryption keys, network/region
+            // block on the mxc download). Tell the user explicitly — the
+            // forward sheet just closed and they'd otherwise think it worked.
+            toast(t("forward.mediaFailed"), "error", 5000);
+          }
         } else {
           const forwardContent = rawText || fwd.content || forwardPreviewText.value;
           inserted = await sendForward(forwardContent, forwardMeta);

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -320,6 +320,12 @@ const handleSend = async () => {
             fileInfo: fwd.fileInfo!,
             sourceMessageId: fwd.id,
             roomId: fwd.roomId,
+            // Pass through the source event's sender + timestamp so the
+            // decrypt path uses the right event-shape. Falls back to
+            // Date.now() / forwardMeta when ForwardingMessage is synthetic
+            // (e.g. channel-post forward — but those go through text path).
+            sourceSenderId: fwd.senderId,
+            sourceTimestamp: fwd.sourceTimestamp ?? Date.now(),
           });
           if (inserted === false) {
             // sendForward returns false when the source blob is unavailable

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -324,6 +324,7 @@ export const en = {
   "forward.cancelConfirm.cancel": "Cancel forwarding",
   "forward.resultSuccess": "Forwarded: {count}",
   "forward.resultSummary": "Forwarded {succeeded} of {total}",
+  "forward.mediaFailed": "Couldn't forward media — original unavailable or not decrypted",
   "forward.bulkTitle": "Forward {count} messages",
   "forward.bulkFrom": "From: {names}",
   "forward.bulkCancelConfirm.title": "{count} messages",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -326,6 +326,7 @@ export const ru: Record<TranslationKey, string> = {
   "forward.cancelConfirm.cancel": "Отменить пересылку",
   "forward.resultSuccess": "Переслано: {count}",
   "forward.resultSummary": "Переслано {succeeded} из {total}",
+  "forward.mediaFailed": "Не удалось переслать медиа — оригинал недоступен или не расшифрован",
   "forward.bulkTitle": "Переслать {count} сообщений",
   "forward.bulkFrom": "От: {names}",
   "forward.bulkCancelConfirm.title": "{count} сообщений",

--- a/src/shared/lib/local-db/sync-engine.ts
+++ b/src/shared/lib/local-db/sync-engine.ts
@@ -495,6 +495,11 @@ export class SyncEngine {
       /** Optional top-level event fields merged after msgtype — e.g.
        *  caption / captionAbove / bastyon-specific flags. */
       eventExtras?: Record<string, unknown>;
+      /** Forward attribution for the receiving side. When present the
+       *  outbound Matrix event gets a `forwarded_from` field so recipients
+       *  render «Forwarded from <name>» on top of the media bubble. Mirrors
+       *  syncSendMessage. */
+      forwardedFrom?: { senderId: string; senderName?: string };
     };
     const matrixService = getMatrixClientService();
 
@@ -585,6 +590,12 @@ export class SyncEngine {
         };
       } else if (secrets) {
         content.secrets = secrets;
+      }
+      if (payload.forwardedFrom) {
+        content.forwarded_from = {
+          sender_id: payload.forwardedFrom.senderId,
+          sender_name: payload.forwardedFrom.senderName,
+        };
       }
 
       const serverEventId = await withTimeout(


### PR DESCRIPTION
## Summary

Внутренний forward (через ForwardPicker) для фото/видео/voice/файлов теряет вложение — получатель видит body «Image» / «Photo» / filename без attachment. Фикс перестраивает API `sendForward` и dispatches через существующий media-upload pipeline с сохранением forward-attribution.

- **`sendForward(content, meta, source?)`** — расширен третьим опциональным аргументом `source-metadata`. Когда `source.type !== text`, новый helper `forwardMediaMessage` скачивает decrypted blob через `getDecryptedBlobForMessage`, оборачивает в `File` и dispatches через `sendImage` / `sendFile` / `sendAudio` / `sendVideoCircle`.
- **`sendFile` / `sendImage` / `sendAudio` / `sendVideoCircle`** — принимают опциональный `forwardedFrom`. Атрибуция «Forwarded from X» сохраняется и у отправителя (через `createLocal`), и у получателя (через `syncEngine` → `forwarded_from` поле на outbound Matrix event).
- **`syncSendFile`** в sync-engine — добавлен `forwarded_from` в content event (как уже было в `syncSendMessage`). Без этого recipient не видел бы атрибуцию media.
- **`getDecryptedBlobForMessage`** — новый публичный helper в use-file-download.ts. Local blob URL fast-path + fallback на `downloadAndDecrypt` (с retry + decrypt + cache-bust + signal forwarding).
- **`forwardMessages` bulk** — собирает type/fileInfo/roomId, dispatches per-type через тот же `forwardMediaMessage`. `Promise.allSettled` корректно считает failed media items. Явный invariant: `targetRoomId === activeRoomId` (sendImage/sendFile читают activeRoomId).
- **MessageInput call site** — branch на `fwd.type !== text && fwd.fileInfo`, caption из rawText, source-metadata прокидывается.
- **Toast при ошибке** — `forward.mediaFailed` (ru/en), показывается когда blob недоступен (revoked / no keys / network).
- **ForwardingMessage** — добавлен `sourceTimestamp` для корректного decryption-context при forward старых encrypted сообщений (вместо Date.now()).

Закрывает #311, #702. Resolves direct request from owner (Daniel_Satchkov).

## Code review

Прошёл `superpowers:code-reviewer`. HIGH findings (target/active room invariant, abort signal forwarding) и MEDIUM findings (source timestamp, sendVideoCircle error path) исправлены в commit 8567174.

## Test plan
- [x] forward-media.test.ts — 5/5 PASS
- [x] forward-bulk-media.test.ts — 2/2 PASS
- [x] Полный test suite — 1773 passed, 9 pre-existing failures (не связаны с PR)
- [x] vite build — успешно
- [x] vue-tsc — 0 новых TS errors на изменённых файлах
- [ ] Manual: forward image → recipient downloads OK
- [ ] Manual: forward video / audio / pdf / docx → корректные типы у получателя
- [ ] Manual: bulk select 3 фото + 1 текст → 4 события правильных типов
- [ ] Manual: forward в encrypted DM → media зашифрована session-key target room
- [ ] Manual: forward в public group → plaintext
- [ ] Manual: forward сообщения без ключа decryption → toast «Не удалось переслать»
- [ ] Manual: caption «Привет» в input при forward image → у получателя media + caption
- [ ] Manual: «Forwarded from Alice» виден на media у получателя