### PR TITLE
feat(contact-alias): local rename via getDisplayName + account_data sync (Session 51)

### DIFF
--- a/src/entities/auth/model/stores.ts
+++ b/src/entities/auth/model/stores.ts
@@ -413,6 +413,13 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
       );
       chatStore.setChatDbKit(chatDbKit);
 
+      // Contact aliases (Session 51): hydrate cache from Dexie immediately so
+      // chat list / headers do not flash raw addresses before /sync. The live
+      // account_data listener (onAccountData) takes over from there.
+      chatStore.loadLocalAliases().catch((e) => {
+        console.warn("[auth] loadLocalAliases failed:", e);
+      });
+
       // Wire SyncEngine connectivity (store refs for cleanup on logout)
       if (typeof window !== "undefined") {
         // Remove previous listeners if any (re-login without full page reload)
@@ -536,6 +543,13 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
         onRoomAccountData: (event: unknown, room: unknown) => {
           chatStore.handleRoomAccountData(event, room);
         },
+        onAccountData: (event: unknown) => {
+          // Cross-device contact-alias sync (Session 51) — and any other
+          // future global account_data hooks. Errors are swallowed inside.
+          chatStore.handleAccountDataEvent(event).catch((e) => {
+            console.warn("[auth] handleAccountDataEvent failed:", e);
+          });
+        },
         onIncomingCall: (call: unknown) => {
           try {
             const callService = useCallService();
@@ -566,6 +580,23 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
         bootStatus.setStep("sync");
         matrixReady.value = true;
         matrixError.value = null;
+
+        // Replay any contact_aliases already in the SDK's account_data cache
+        // (Session 51). The live "accountData" listener catches future
+        // changes; this covers the cold-start window before that fires.
+        try {
+          const initialAliases = matrixService.getAccountData("m.bastyon.contact_aliases");
+          if (initialAliases) {
+            chatStore.handleAccountDataEvent({
+              getType: () => "m.bastyon.contact_aliases",
+              getContent: () => initialAliases,
+            }).catch((e) => {
+              console.warn("[auth] initial contact_aliases replay failed:", e);
+            });
+          }
+        } catch (e) {
+          console.warn("[auth] contact_aliases cold-start read failed:", e);
+        }
 
         // Cache connection info for background sync
         const client = matrixService.client;

--- a/src/entities/chat/lib/use-resolved-room-name.test.ts
+++ b/src/entities/chat/lib/use-resolved-room-name.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia } from "pinia";
+import { createTestingPinia } from "@pinia/testing";
+import { useResolvedRoomName } from "./use-resolved-room-name";
+import { useChatStore } from "../model/chat-store";
+import { useUserStore } from "@/entities/user/model";
+import { useAuthStore } from "@/entities/auth";
+import { hexEncode } from "@/shared/lib/matrix/functions";
+import type { ChatRoom } from "../model/types";
+
+/**
+ * Regression test for the Session 51 bug "alias saves but chat list / header
+ * still show old name". Root cause: `resolveMemberNames` consulted
+ * `userStore.users[addr].name` directly without checking `localAliases`, so a
+ * Pocketnet-known user always rendered with their Pocketnet name regardless
+ * of the user's local rename. This test pins the new priority chain:
+ *
+ *     localAlias > Pocketnet user.name > Matrix displayname > address fallback
+ */
+
+function makeDmRoom(peerHex: string, name: string = "fallback name"): ChatRoom {
+  return {
+    id: "!room:server",
+    name,
+    isGroup: false,
+    members: [peerHex],
+    invitedMembers: [],
+    membership: "join",
+    unreadCount: 0,
+    lastReadInboundTs: 0,
+    lastReadOutboundTs: 0,
+    updatedAt: Date.now(),
+    syncedAt: Date.now(),
+    hasMoreHistory: true,
+    isDeleted: false,
+    deletedAt: null,
+    deleteReason: null,
+  } as ChatRoom;
+}
+
+describe("useResolvedRoomName — local alias priority (Session 51)", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    setActivePinia(createTestingPinia({ stubActions: false }));
+  });
+
+  it("returns Pocketnet displayname when no alias is set", () => {
+    const auth = useAuthStore();
+    auth.address = "PMyAddr";
+    const user = useUserStore();
+    const peer = "PPeerAddr";
+    user.users[peer] = { name: "Peer Pocketnet Name" } as any;
+
+    const room = makeDmRoom(hexEncode(peer));
+    const { resolve } = useResolvedRoomName();
+    expect(resolve(room)).toBe("Peer Pocketnet Name");
+  });
+
+  it("returns local alias when set, overriding Pocketnet displayname", () => {
+    const auth = useAuthStore();
+    auth.address = "PMyAddr";
+    const user = useUserStore();
+    const chat = useChatStore();
+    const peer = "PPeerAddr";
+    user.users[peer] = { name: "Peer Pocketnet Name" } as any;
+    chat.localAliases[peer] = "Дядя Петя";
+
+    const room = makeDmRoom(hexEncode(peer));
+    const { resolve } = useResolvedRoomName();
+    expect(resolve(room)).toBe("Дядя Петя");
+  });
+
+  it("falls back to Pocketnet after alias is cleared", async () => {
+    const auth = useAuthStore();
+    auth.address = "PMyAddr";
+    const user = useUserStore();
+    const chat = useChatStore();
+    const peer = "PPeerAddr";
+    user.users[peer] = { name: "Pocketnet Name" } as any;
+
+    await chat.setContactAlias(peer, "Custom");
+    const { resolve } = useResolvedRoomName();
+    const room = makeDmRoom(hexEncode(peer));
+    expect(resolve(room)).toBe("Custom");
+
+    await chat.setContactAlias(peer, null);
+    expect(resolve(room)).toBe("Pocketnet Name");
+  });
+});

--- a/src/entities/chat/lib/use-resolved-room-name.ts
+++ b/src/entities/chat/lib/use-resolved-room-name.ts
@@ -17,30 +17,49 @@ function cachedHexDecode(hex: string): string {
   return result;
 }
 
-/** Resolve member names for a room from the user store */
-function resolveMemberNames(room: ChatRoom, allUsers: Record<string, any>, myHexId: string): string[] {
+/** Resolve member names for a room. Honors user-set local aliases (Session 51)
+ *  before falling back to Pocketnet profile names — otherwise the alias gets
+ *  silently overridden by the Pocketnet displayname in the chat list/header.
+ *  `aliases` is read so Vue tracks reactivity at the calling computed. */
+function resolveMemberNames(
+  room: ChatRoom,
+  allUsers: Record<string, any>,
+  myHexId: string,
+  aliases: Record<string, string>,
+): string[] {
   const otherMembers = room.members.filter(m => m !== myHexId);
   const names: string[] = [];
   for (const hexId of otherMembers) {
     const addr = cachedHexDecode(hexId);
     if (/^[A-Za-z0-9]+$/.test(addr)) {
+      const alias = aliases[addr];
+      if (alias) { names.push(alias); continue; }
       const user = allUsers[addr];
       if (user?.name) { names.push(user.name); continue; }
     }
   }
-  // Fallback: try avatar address
+  // Fallback: try avatar address (single-peer DMs with empty members list)
   if (names.length === 0 && room.avatar?.startsWith("__pocketnet__:")) {
     const avatarAddr = room.avatar.slice("__pocketnet__:".length);
-    const user = allUsers[avatarAddr];
-    if (user?.name && user.name !== avatarAddr) names.push(user.name);
+    const alias = aliases[avatarAddr];
+    if (alias) names.push(alias);
+    else {
+      const user = allUsers[avatarAddr];
+      if (user?.name && user.name !== avatarAddr) names.push(user.name);
+    }
   }
   return names;
 }
 
 /** Resolve a single room's display name, returning empty string if unresolved */
-function resolveRoom(room: ChatRoom, allUsers: Record<string, any>, myHexId: string): string {
+function resolveRoom(
+  room: ChatRoom,
+  allUsers: Record<string, any>,
+  myHexId: string,
+  aliases: Record<string, string>,
+): string {
   if (!room.isGroup) {
-    const names = resolveMemberNames(room, allUsers, myHexId);
+    const names = resolveMemberNames(room, allUsers, myHexId, aliases);
     if (names.length > 0) return names.join(", ");
     // Fallback: address from avatar
     if (room.avatar?.startsWith("__pocketnet__:")) {
@@ -53,9 +72,11 @@ function resolveRoom(room: ChatRoom, allUsers: Record<string, any>, myHexId: str
     }
     return cleanMatrixIds(room.name);
   }
+  // Group rooms: respect Matrix room name unless it is itself unresolved.
+  // Aliases of individual members don't change the group's overall name.
   if (room.name?.startsWith("@")) return room.name.slice(1);
   if (!isUnresolvedName(room.name)) return cleanMatrixIds(room.name);
-  const names = resolveMemberNames(room, allUsers, myHexId);
+  const names = resolveMemberNames(room, allUsers, myHexId, aliases);
   if (names.length > 0) return names.join(", ");
   return cleanMatrixIds(room.name);
 }
@@ -68,13 +89,15 @@ function resolveRoom(room: ChatRoom, allUsers: Record<string, any>, myHexId: str
 export function useResolvedRoomName() {
   const userStore = useUserStore();
   const authStore = useAuthStore();
+  const chatStore = useChatStore();
 
   const myHexId = computed(() => authStore.address ? hexEncode(authStore.address) : "");
 
-  /** Resolve a room name reactively (depends on userStore.users) */
+  /** Resolve a room name reactively. Tracks userStore.users AND
+   *  chatStore.localAliases so changes to either trigger re-render. */
   function resolve(room: ChatRoom | null | undefined): string {
     if (!room) return "";
-    return resolveRoom(room, userStore.users, myHexId.value);
+    return resolveRoom(room, userStore.users, myHexId.value, chatStore.localAliases);
   }
 
   /** Check if a resolved name is still unresolved (should show skeleton) */

--- a/src/entities/chat/model/__tests__/contact-aliases-sync.test.ts
+++ b/src/entities/chat/model/__tests__/contact-aliases-sync.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia } from "pinia";
+import { createTestingPinia } from "@pinia/testing";
+import { useChatStore } from "../chat-store";
+
+/**
+ * Regression tests for Session 51 — cross-device alias sync.
+ *
+ * Aliases set on device A propagate to device B via the global
+ * m.bastyon.contact_aliases account_data event. Conflict resolution is
+ * last-write-wins by the embedded `updatedAt` timestamp:
+ *
+ *   - Incoming entry with updatedAt > local aliasUpdatedAt  → apply.
+ *   - Incoming entry with updatedAt <= local aliasUpdatedAt → ignore.
+ *
+ * Tombstones (incoming { name: "", updatedAt: ... }) clear the local alias
+ * when the timestamp is newer.
+ *
+ * The handler is exposed as chatStore.handleAccountDataEvent so the auth
+ * layer can wire it to both the SDK's "accountData" event AND the
+ * cold-start replay during login.
+ */
+
+/** Fake Matrix event-like object shaped for the handler. */
+function makeEvent(content: { aliases?: Record<string, { name: string; updatedAt: number }> }) {
+  return {
+    getType: () => "m.bastyon.contact_aliases",
+    getContent: () => content,
+  };
+}
+
+describe("contact aliases — cross-device account_data sync", () => {
+  let store: ReturnType<typeof useChatStore>;
+
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    setActivePinia(createTestingPinia({ stubActions: false }));
+    store = useChatStore();
+  });
+
+  it("exposes handleAccountDataEvent", () => {
+    expect(typeof store.handleAccountDataEvent).toBe("function");
+  });
+
+  it("ignores events of unrelated types", async () => {
+    store.localAliases["addr1"] = "Existing";
+    const ev = {
+      getType: () => "m.fully_read",
+      getContent: () => ({ aliases: { addr1: { name: "Should Not Apply", updatedAt: 9999 } } }),
+    };
+    await store.handleAccountDataEvent(ev);
+    expect(store.getLocalAlias("addr1")).toBe("Existing");
+  });
+
+  it("applies incoming alias when there is no local entry yet", async () => {
+    const ev = makeEvent({ aliases: { addr1: { name: "New", updatedAt: 2000 } } });
+    await store.handleAccountDataEvent(ev);
+    expect(store.getLocalAlias("addr1")).toBe("New");
+  });
+
+  it("applies incoming alias when newer than local (LWW)", async () => {
+    // Local set far in the past
+    await store.setContactAlias("addr1", "Old");
+    // Force the in-memory alias to mimic an aged record
+    store.localAliases["addr1"] = "Old";
+    const ev = makeEvent({ aliases: { addr1: { name: "New", updatedAt: Date.now() + 10_000 } } });
+    await store.handleAccountDataEvent(ev);
+    expect(store.getLocalAlias("addr1")).toBe("New");
+  });
+
+  it("ignores stale incoming alias (LWW — local timestamp is newer)", async () => {
+    await store.setContactAlias("addr1", "Local Newer");
+    const staleTs = Date.now() - 100_000;
+    const ev = makeEvent({ aliases: { addr1: { name: "Server Older", updatedAt: staleTs } } });
+    await store.handleAccountDataEvent(ev);
+    expect(store.getLocalAlias("addr1")).toBe("Local Newer");
+  });
+
+  it("applies tombstone (empty name + newer timestamp) by clearing alias", async () => {
+    store.localAliases["addr1"] = "Existing";
+    const ev = makeEvent({ aliases: { addr1: { name: "", updatedAt: Date.now() + 5000 } } });
+    await store.handleAccountDataEvent(ev);
+    expect(store.getLocalAlias("addr1")).toBeNull();
+  });
+
+  it("applies multiple aliases in one event", async () => {
+    const ev = makeEvent({
+      aliases: {
+        a1: { name: "Alice", updatedAt: 1000 },
+        a2: { name: "Bob", updatedAt: 2000 },
+        a3: { name: "Carol", updatedAt: 3000 },
+      },
+    });
+    await store.handleAccountDataEvent(ev);
+    expect(store.getLocalAlias("a1")).toBe("Alice");
+    expect(store.getLocalAlias("a2")).toBe("Bob");
+    expect(store.getLocalAlias("a3")).toBe("Carol");
+  });
+
+  it("no-ops on event with missing content", async () => {
+    store.localAliases["addr1"] = "Existing";
+    const ev = {
+      getType: () => "m.bastyon.contact_aliases",
+      getContent: () => null,
+    };
+    await store.handleAccountDataEvent(ev);
+    expect(store.getLocalAlias("addr1")).toBe("Existing");
+  });
+});

--- a/src/entities/chat/model/__tests__/get-display-name-alias.test.ts
+++ b/src/entities/chat/model/__tests__/get-display-name-alias.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia } from "pinia";
+import { createTestingPinia } from "@pinia/testing";
+import { useChatStore } from "../chat-store";
+import { hexEncode } from "@/shared/lib/matrix/functions";
+
+/**
+ * Regression tests for Session 51 — local contact alias priority.
+ *
+ * Goal: `getDisplayName(address)` must prioritize a user-set local alias over
+ * Matrix displayName, user-store profile, and address truncation. The alias
+ * is stored in chat-store.localAliases (mirror of Dexie users.localAlias).
+ * UI callsites (chat list, header, message bubbles, mentions, ForwardPicker,
+ * ChatSearch) all go through this chokepoint, so a single patch covers them
+ * all.
+ *
+ * Hex-encoded addresses (room.members format) must resolve to the same alias
+ * as the raw Bastyon address.
+ *
+ * `setContactAlias(addr, null)` clears the alias — the chain falls back to
+ * Matrix displayName → user store → truncated address.
+ */
+
+describe("getDisplayName — local alias priority", () => {
+  let store: ReturnType<typeof useChatStore>;
+
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    setActivePinia(createTestingPinia({ stubActions: false }));
+    store = useChatStore();
+  });
+
+  it("setContactAlias makes getDisplayName return the alias", async () => {
+    await store.setContactAlias("P9XYZ", "Дядя Петя");
+    expect(store.getDisplayName("P9XYZ")).toBe("Дядя Петя");
+  });
+
+  it("alias overrides Matrix displayName cache", async () => {
+    // Simulate Matrix /sync seeding userDisplayNames internally
+    store.localAliases["P9XYZ"] = "Local Alias";
+    expect(store.getDisplayName("P9XYZ")).toBe("Local Alias");
+  });
+
+  it("without alias, falls back to truncated address for long input", () => {
+    const longAddr = "P9XYZ_LONG_ADDRESS_FOR_TRUNCATION";
+    const result = store.getDisplayName(longAddr);
+    expect(result).toContain("…");
+    expect(result.length).toBeLessThan(longAddr.length);
+  });
+
+  it("hex-encoded address resolves to alias stored under raw address", async () => {
+    const raw = "PAddr1";
+    const hex = hexEncode(raw);
+    await store.setContactAlias(raw, "Mama");
+    // room.members stores hex-encoded IDs — the call site passes hex, but
+    // the alias should still resolve via the raw form
+    expect(store.getDisplayName(hex)).toBe("Mama");
+  });
+
+  it("setContactAlias(addr, null) removes the alias and falls back", async () => {
+    await store.setContactAlias("PRemove", "Temp Alias");
+    expect(store.getDisplayName("PRemove")).toBe("Temp Alias");
+    await store.setContactAlias("PRemove", null);
+    expect(store.getDisplayName("PRemove")).not.toBe("Temp Alias");
+  });
+
+  it("hasLocalAlias returns true after setContactAlias, false after clear", async () => {
+    expect(store.hasLocalAlias("PCheck")).toBe(false);
+    await store.setContactAlias("PCheck", "Friend");
+    expect(store.hasLocalAlias("PCheck")).toBe(true);
+    await store.setContactAlias("PCheck", null);
+    expect(store.hasLocalAlias("PCheck")).toBe(false);
+  });
+
+  it("setContactAlias trims whitespace; empty string clears alias", async () => {
+    await store.setContactAlias("PTrim", "   Trimmed   ");
+    expect(store.getDisplayName("PTrim")).toBe("Trimmed");
+    await store.setContactAlias("PTrim", "   ");
+    expect(store.getDisplayName("PTrim")).not.toBe("Trimmed");
+    expect(store.getDisplayName("PTrim")).not.toBe("   ");
+  });
+});

--- a/src/entities/chat/model/__tests__/get-display-name-alias.test.ts
+++ b/src/entities/chat/model/__tests__/get-display-name-alias.test.ts
@@ -79,4 +79,20 @@ describe("getDisplayName — local alias priority", () => {
     expect(store.getDisplayName("PTrim")).not.toBe("Trimmed");
     expect(store.getDisplayName("PTrim")).not.toBe("   ");
   });
+
+  it("clear via raw form clears alias set via hex form (H1 regression)", async () => {
+    // Bug class: dual-key (hex+raw) cache layout left stale entries when the
+    // user set via group panel (hex) and cleared via DM panel (raw) or vice
+    // versa. Aliases must canonicalize to raw form regardless of input shape.
+    const raw = "PCrossForm";
+    const hex = hexEncode(raw);
+    await store.setContactAlias(hex, "Cousin");
+    expect(store.getDisplayName(hex)).toBe("Cousin");
+    expect(store.getDisplayName(raw)).toBe("Cousin");
+    await store.setContactAlias(raw, null);
+    expect(store.getDisplayName(hex)).not.toBe("Cousin");
+    expect(store.getDisplayName(raw)).not.toBe("Cousin");
+    expect(store.hasLocalAlias(hex)).toBe(false);
+    expect(store.hasLocalAlias(raw)).toBe(false);
+  });
 });

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -653,20 +653,39 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       }
     }
 
-    // Matrix account_data (best-effort \u2014 peers do NOT see this; it only
-    // syncs to the same user's other devices via /sync).
-    try {
-      const matrix = getMatrixClientService();
-      const current = (matrix.getAccountData("m.bastyon.contact_aliases") ?? {}) as {
-        aliases?: Record<string, { name: string; updatedAt: number }>;
-      };
-      const aliases = { ...(current.aliases ?? {}) };
-      if (trimmed) aliases[raw] = { name: trimmed, updatedAt: now };
-      else delete aliases[raw];
-      await matrix.setAccountData("m.bastyon.contact_aliases", { aliases });
-    } catch (e) {
-      console.warn("[chat-store] setContactAlias: account_data sync failed:", e);
-    }
+    // Matrix account_data (best-effort, fire-and-forget \u2014 peers do NOT see
+    // this; it only syncs to the same user's other devices via /sync).
+    //
+    // We deliberately DO NOT await the network call here. The local write is
+    // the user-facing success criterion; the server-side replication is
+    // background. Awaiting would:
+    //   - Delay the dialog close on slow networks.
+    //   - Risk a stray rejection bubbling into a region-block toast if the
+    //     homeserver is blocked / rate-limited (a transient failure here is
+    //     not a download failure and should not pester the user).
+    // A 5s timeout race guards against the SDK hanging the promise forever.
+    void (async () => {
+      try {
+        const matrix = getMatrixClientService();
+        const current = (matrix.getAccountData("m.bastyon.contact_aliases") ?? {}) as {
+          aliases?: Record<string, { name: string; updatedAt: number }>;
+        };
+        const aliases = { ...(current.aliases ?? {}) };
+        if (trimmed) aliases[raw] = { name: trimmed, updatedAt: now };
+        else delete aliases[raw];
+        await Promise.race([
+          matrix.setAccountData("m.bastyon.contact_aliases", { aliases }),
+          new Promise<void>((_, reject) =>
+            setTimeout(() => reject(new Error("account_data sync timeout")), 5_000),
+          ),
+        ]);
+      } catch (e) {
+        // Swallow \u2014 the local write succeeded, other devices will catch up
+        // on their next /sync (or via a future setContactAlias call that
+        // takes hold during a more cooperative network window).
+        console.warn("[chat-store] setContactAlias: account_data sync failed (best-effort):", e);
+      }
+    })().catch(() => { /* belt-and-braces \u2014 the IIFE already swallows */ });
   };
 
   // Selection/forward state (Batch 4)

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -533,6 +533,11 @@ export const useChatStore = defineStore(NAMESPACE, () => {
    *  driven by the m.bastyon.contact_aliases global account_data event. */
   const localAliases = ref<Record<string, string>>({});
 
+  /** In-memory timestamp cache for alias entries (raw address → ms).
+   *  Mirrors Dexie users.aliasUpdatedAt so cross-device LWW conflict
+   *  resolution still works in test/dev contexts where Dexie is not wired. */
+  const aliasUpdatedAtCache = ref<Record<string, number>>({});
+
   /** Look up a user's display name; falls back to truncated address.
    *  Accepts both raw Bastyon addresses and hex-encoded IDs (from room.members).
    *  Resolution order:
@@ -603,9 +608,14 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     if (!kit) return;
     try {
       const all = await kit.users.getAllAliases();
-      const next: Record<string, string> = {};
-      for (const [addr, { alias }] of Object.entries(all)) next[addr] = alias;
-      localAliases.value = next;
+      const nameNext: Record<string, string> = {};
+      const tsNext: Record<string, number> = {};
+      for (const [addr, { alias, updatedAt }] of Object.entries(all)) {
+        nameNext[addr] = alias;
+        tsNext[addr] = updatedAt;
+      }
+      localAliases.value = nameNext;
+      aliasUpdatedAtCache.value = tsNext;
     } catch (e) {
       console.warn("[chat-store] loadLocalAliases failed:", e);
     }
@@ -632,6 +642,8 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       if (raw !== address) delete next[raw];
     }
     localAliases.value = next;
+    // Mirror timestamp so LWW conflict resolution sees this write
+    aliasUpdatedAtCache.value = { ...aliasUpdatedAtCache.value, [raw]: now };
 
     // Dexie (single source of truth \u2014 keyed by raw address)
     const kit = chatDbKitRef.value;
@@ -6282,6 +6294,65 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     }
   };
 
+  /** Handle global per-user account_data events — cross-device sync for
+   *  contact aliases (Session 51). LWW conflict resolution by embedded
+   *  `updatedAt` timestamp: only newer-than-local entries are applied.
+   *  Tombstones (empty name + newer ts) clear the local alias.
+   *
+   *  Wired from auth/stores.ts to:
+   *    - The SDK's "accountData" event (live cross-device updates).
+   *    - A one-shot replay on login (cold-start hydration before /sync). */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handleAccountDataEvent = async (event: any): Promise<void> => {
+    if (event?.getType?.() !== "m.bastyon.contact_aliases") return;
+    const content = event.getContent?.() as {
+      aliases?: Record<string, { name: string; updatedAt: number }>;
+    } | null;
+    if (!content?.aliases) return;
+    const kit = chatDbKitRef.value;
+
+    const memUpdates: Record<string, string | null> = {};
+    for (const [addr, entry] of Object.entries(content.aliases)) {
+      if (!addr || !entry || typeof entry.updatedAt !== "number") continue;
+      const incomingName = typeof entry.name === "string" ? entry.name.trim() : "";
+      const incomingTs = entry.updatedAt;
+
+      // LWW: take the newer of persisted-Dexie-ts and in-memory-ts. The
+      // in-memory cache covers the early-boot window before Dexie is
+      // hydrated and also test contexts where the kit is absent.
+      let dexieTs = 0;
+      if (kit) {
+        try {
+          dexieTs = await kit.users.getAliasUpdatedAt(addr);
+        } catch (e) {
+          console.warn("[chat-store] handleAccountDataEvent: getAliasUpdatedAt failed for", addr, e);
+        }
+      }
+      const memTs = aliasUpdatedAtCache.value[addr] ?? 0;
+      const existingTs = Math.max(dexieTs, memTs);
+      if (incomingTs <= existingTs) continue;
+
+      const nextValue = incomingName || null;
+      if (kit) {
+        try {
+          await kit.users.setAlias(addr, nextValue, incomingTs);
+        } catch (e) {
+          console.warn("[chat-store] handleAccountDataEvent: setAlias failed for", addr, e);
+        }
+      }
+      memUpdates[addr] = nextValue;
+      aliasUpdatedAtCache.value = { ...aliasUpdatedAtCache.value, [addr]: incomingTs };
+    }
+
+    if (Object.keys(memUpdates).length === 0) return;
+    const merged = { ...localAliases.value };
+    for (const [addr, name] of Object.entries(memUpdates)) {
+      if (name) merged[addr] = name;
+      else delete merged[addr];
+    }
+    localAliases.value = merged;
+  };
+
   /** Revive a tombstoned room (used when rejoining a previously-deleted room) */
   const clearDeletedRoom = (roomId: string) => {
     if (chatDbKitRef.value) {
@@ -6469,6 +6540,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     deletingMessages.value = [];
     userDisplayNames.value = {};
     localAliases.value = {};
+    aliasUpdatedAtCache.value = {};
     selectionMode.value = false;
     selectedMessageIds.value = new Set();
     forwardingMessage.value = null;
@@ -6538,6 +6610,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     getRoomPowerLevels,
     getMemberPowerLevelById,
     getTypingUsers,
+    handleAccountDataEvent,
     handleKicked,
     handleRoomAccountData,
     handleReceiptEvent,

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -527,34 +527,136 @@ export const useChatStore = defineStore(NAMESPACE, () => {
   // User display name cache: address → display name
   const userDisplayNames = ref<Record<string, string>>({});
 
+  /** User-set local alias cache: address → alias (Telegram-style "rename contact").
+   *  Mirrors Dexie users.localAlias. Populated by loadLocalAliases() on login
+   *  and updated optimistically by setContactAlias(). Cross-device sync is
+   *  driven by the m.bastyon.contact_aliases global account_data event. */
+  const localAliases = ref<Record<string, string>>({});
+
   /** Look up a user's display name; falls back to truncated address.
    *  Accepts both raw Bastyon addresses and hex-encoded IDs (from room.members).
-   *  Also checks the user store (restored from localStorage on startup) to avoid
-   *  showing raw addresses while Matrix sync is still in progress. */
+   *  Resolution order:
+   *    1. Local alias (user-set "rename contact" — Session 51) — top priority.
+   *    2. Matrix displayName cache (populated by /sync).
+   *    3. User store (synchronously restored from localStorage on boot —
+   *       available before Matrix sync, prevents raw-address flash).
+   *    4. Truncated address fallback. */
   const getDisplayName = (address: string): string => {
     if (!address) return "?";
-    // Direct lookup (raw address)
-    const cached = userDisplayNames.value[address];
-    if (cached) return cached;
     // Try hex-decoded lookup (room.members stores hex IDs, cache uses raw addresses)
     let resolvedAddr = address;
     if (/^[a-f0-9]+$/i.test(address)) {
       try {
         const decoded = hexDecode(address);
         if (decoded !== address && /^[A-Za-z0-9]+$/.test(decoded)) {
-          const decodedCached = userDisplayNames.value[decoded];
-          if (decodedCached) return decodedCached;
           resolvedAddr = decoded;
         }
       } catch { /* not a valid hex string */ }
     }
-    // Check user store (synchronously restored from localStorage — available before Matrix sync)
+    // 1) Local alias — top priority, overrides everything (including Matrix name)
+    const alias = localAliases.value[address]
+      ?? (resolvedAddr !== address ? localAliases.value[resolvedAddr] : undefined);
+    if (alias) return alias;
+    // 2) Matrix displayName cache — direct (raw) lookup, then decoded
+    const cached = userDisplayNames.value[address];
+    if (cached) return cached;
+    if (resolvedAddr !== address) {
+      const decodedCached = userDisplayNames.value[resolvedAddr];
+      if (decodedCached) return decodedCached;
+    }
+    // 3) Check user store (synchronously restored from localStorage — available before Matrix sync)
     const uStore = useUserStore();
     const userProfile = uStore.users[resolvedAddr];
     if (userProfile?.name) return userProfile.name;
     // Fallback: truncated address
     if (address.length > 16) return address.slice(0, 8) + "\u2026" + address.slice(-4);
     return address;
+  };
+
+  /** Resolve a hex-encoded address back to the raw Bastyon form (or echo
+   *  the input if it is already raw). */
+  const resolveRawAddress = (address: string): string => {
+    if (!address) return address;
+    if (/^[a-f0-9]+$/i.test(address)) {
+      try {
+        const decoded = hexDecode(address);
+        if (decoded !== address && /^[A-Za-z0-9]+$/.test(decoded)) return decoded;
+      } catch { /* not valid hex */ }
+    }
+    return address;
+  };
+
+  /** Get the local alias for an address (or null if none).
+   *  Accepts both raw and hex-encoded address forms. */
+  const getLocalAlias = (address: string): string | null => {
+    if (!address) return null;
+    const raw = resolveRawAddress(address);
+    return localAliases.value[address] ?? localAliases.value[raw] ?? null;
+  };
+
+  /** True iff a local alias is set for the address (raw or hex form). */
+  const hasLocalAlias = (address: string): boolean => getLocalAlias(address) !== null;
+
+  /** Load the alias cache from Dexie. Called on login + chat-db init. */
+  const loadLocalAliases = async () => {
+    const kit = chatDbKitRef.value;
+    if (!kit) return;
+    try {
+      const all = await kit.users.getAllAliases();
+      const next: Record<string, string> = {};
+      for (const [addr, { alias }] of Object.entries(all)) next[addr] = alias;
+      localAliases.value = next;
+    } catch (e) {
+      console.warn("[chat-store] loadLocalAliases failed:", e);
+    }
+  };
+
+  /** Set or clear a user's local alias.
+   *  Passing alias = null (or empty/whitespace) clears the alias.
+   *  Performs an optimistic UI update first, then persists to Dexie, then
+   *  best-effort syncs to Matrix account_data for cross-device propagation.
+   *  The alias is NEVER sent as Matrix room displayname \u2014 peers do not see it. */
+  const setContactAlias = async (address: string, alias: string | null): Promise<void> => {
+    if (!address) return;
+    const trimmed = alias?.trim() ? alias.trim() : null;
+    const now = Date.now();
+    const raw = resolveRawAddress(address);
+
+    // Optimistic UI \u2014 key by both raw and hex form so any callsite sees it
+    const next = { ...localAliases.value };
+    if (trimmed) {
+      next[address] = trimmed;
+      if (raw !== address) next[raw] = trimmed;
+    } else {
+      delete next[address];
+      if (raw !== address) delete next[raw];
+    }
+    localAliases.value = next;
+
+    // Dexie (single source of truth \u2014 keyed by raw address)
+    const kit = chatDbKitRef.value;
+    if (kit) {
+      try {
+        await kit.users.setAlias(raw, trimmed, now);
+      } catch (e) {
+        console.warn("[chat-store] setContactAlias: Dexie write failed:", e);
+      }
+    }
+
+    // Matrix account_data (best-effort \u2014 peers do NOT see this; it only
+    // syncs to the same user's other devices via /sync).
+    try {
+      const matrix = getMatrixClientService();
+      const current = (matrix.getAccountData("m.bastyon.contact_aliases") ?? {}) as {
+        aliases?: Record<string, { name: string; updatedAt: number }>;
+      };
+      const aliases = { ...(current.aliases ?? {}) };
+      if (trimmed) aliases[raw] = { name: trimmed, updatedAt: now };
+      else delete aliases[raw];
+      await matrix.setAccountData("m.bastyon.contact_aliases", { aliases });
+    } catch (e) {
+      console.warn("[chat-store] setContactAlias: account_data sync failed:", e);
+    }
   };
 
   // Selection/forward state (Batch 4)
@@ -6366,6 +6468,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     deletingMessage.value = null;
     deletingMessages.value = [];
     userDisplayNames.value = {};
+    localAliases.value = {};
     selectionMode.value = false;
     selectedMessageIds.value = new Set();
     forwardingMessage.value = null;
@@ -6426,6 +6529,11 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     saveForwardDraft,
     restoreForwardDraft,
     getDisplayName,
+    getLocalAlias,
+    hasLocalAlias,
+    localAliases,
+    loadLocalAliases,
+    setContactAlias,
     getRoomMemberCount,
     getRoomPowerLevels,
     getMemberPowerLevelById,

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -558,9 +558,10 @@ export const useChatStore = defineStore(NAMESPACE, () => {
         }
       } catch { /* not a valid hex string */ }
     }
-    // 1) Local alias — top priority, overrides everything (including Matrix name)
-    const alias = localAliases.value[address]
-      ?? (resolvedAddr !== address ? localAliases.value[resolvedAddr] : undefined);
+    // 1) Local alias — top priority, overrides everything (including Matrix name).
+    //    Aliases are always keyed by raw address; `resolvedAddr` was just
+    //    normalized above, so a single lookup is enough.
+    const alias = localAliases.value[resolvedAddr];
     if (alias) return alias;
     // 2) Matrix displayName cache — direct (raw) lookup, then decoded
     const cached = userDisplayNames.value[address];
@@ -592,11 +593,11 @@ export const useChatStore = defineStore(NAMESPACE, () => {
   };
 
   /** Get the local alias for an address (or null if none).
-   *  Accepts both raw and hex-encoded address forms. */
+   *  Accepts both raw and hex-encoded address forms — keys are always raw. */
   const getLocalAlias = (address: string): string | null => {
     if (!address) return null;
     const raw = resolveRawAddress(address);
-    return localAliases.value[address] ?? localAliases.value[raw] ?? null;
+    return localAliases.value[raw] ?? null;
   };
 
   /** True iff a local alias is set for the address (raw or hex form). */
@@ -632,15 +633,12 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     const now = Date.now();
     const raw = resolveRawAddress(address);
 
-    // Optimistic UI \u2014 key by both raw and hex form so any callsite sees it
+    // Optimistic UI \u2014 always key by raw form. Hex callsites normalize via
+    // resolveRawAddress() inside getDisplayName / getLocalAlias, so a single
+    // canonical key avoids stale entries when clearing through a different form.
     const next = { ...localAliases.value };
-    if (trimmed) {
-      next[address] = trimmed;
-      if (raw !== address) next[raw] = trimmed;
-    } else {
-      delete next[address];
-      if (raw !== address) delete next[raw];
-    }
+    if (trimmed) next[raw] = trimmed;
+    else delete next[raw];
     localAliases.value = next;
     // Mirror timestamp so LWW conflict resolution sees this write
     aliasUpdatedAtCache.value = { ...aliasUpdatedAtCache.value, [raw]: now };
@@ -6312,8 +6310,11 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     const kit = chatDbKitRef.value;
 
     const memUpdates: Record<string, string | null> = {};
-    for (const [addr, entry] of Object.entries(content.aliases)) {
-      if (!addr || !entry || typeof entry.updatedAt !== "number") continue;
+    for (const [rawIncoming, entry] of Object.entries(content.aliases)) {
+      if (!rawIncoming || !entry || typeof entry.updatedAt !== "number") continue;
+      // Defense in depth: normalize even though writers should always send
+      // raw addresses. Guards against bad payloads from older / forked clients.
+      const addr = resolveRawAddress(rawIncoming);
       const incomingName = typeof entry.name === "string" ? entry.name.trim() : "";
       const incomingTs = entry.updatedAt;
 

--- a/src/entities/matrix/model/matrix-client.ts
+++ b/src/entities/matrix/model/matrix-client.ts
@@ -57,6 +57,7 @@ export class MatrixClientService {
   private onIncomingCall: IncomingCallCallback | null = null;
   private onRoom: ((room: unknown) => void) | null = null;
   private onRoomAccountData: RoomAccountDataCallback | null = null;
+  private onAccountData: ((event: unknown) => void) | null = null;
   private onEncryptionKeyArrived: ((roomId: string) => void) | null = null;
 
   constructor(domain?: string) {
@@ -79,6 +80,7 @@ export class MatrixClientService {
     onIncomingCall?: IncomingCallCallback;
     onRoom?: (room: unknown) => void;
     onRoomAccountData?: RoomAccountDataCallback;
+    onAccountData?: (event: unknown) => void;
     onEncryptionKeyArrived?: (roomId: string) => void;
   }) {
     if (handlers.onSync) this.onSync = handlers.onSync;
@@ -91,6 +93,7 @@ export class MatrixClientService {
     if (handlers.onIncomingCall) this.onIncomingCall = handlers.onIncomingCall;
     if (handlers.onRoom) this.onRoom = handlers.onRoom;
     if (handlers.onRoomAccountData) this.onRoomAccountData = handlers.onRoomAccountData;
+    if (handlers.onAccountData) this.onAccountData = handlers.onAccountData;
     if (handlers.onEncryptionKeyArrived) this.onEncryptionKeyArrived = handlers.onEncryptionKeyArrived;
   }
 
@@ -288,7 +291,7 @@ export class MatrixClientService {
             types: ["m.receipt", "m.typing"],
           },
           account_data: {
-            types: ["m.fully_read", "m.tag", "m.bastyon.clear_history"],
+            types: ["m.fully_read", "m.tag", "m.bastyon.clear_history", "m.bastyon.contact_aliases"],
           },
         },
         presence: {
@@ -459,6 +462,13 @@ export class MatrixClientService {
     this.client.on("Room.accountData" as string, (event: unknown, room: unknown) => {
       if (!this.chatsReady) return;
       this.onRoomAccountData?.(event, room);
+    });
+
+    // Global per-user account_data changes (e.g. contact aliases from other devices).
+    // Fires whenever a /sync delivers a new global account_data event.
+    this.client.on("accountData" as string, (event: unknown) => {
+      if (!this.chatsReady) return;
+      this.onAccountData?.(event);
     });
 
     // Listen for encryption state events — triggers decryption retry for room
@@ -832,6 +842,21 @@ export class MatrixClientService {
     if (!room) return null;
     const event = room.getAccountData(eventType);
     return event?.getContent() ?? null;
+  }
+
+  /** Set per-user GLOBAL account data (syncs across the user's devices via /sync) */
+  async setAccountData(eventType: string, content: Record<string, unknown>): Promise<void> {
+    if (!this.client) throw new Error("Client not initialized");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (this.client as any).setAccountData(eventType, content);
+  }
+
+  /** Get per-user GLOBAL account data (cached locally by the SDK) */
+  getAccountData(eventType: string): Record<string, unknown> | null {
+    if (!this.client) return null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const event = (this.client as any).getAccountData?.(eventType);
+    return event?.getContent?.() ?? null;
   }
 
   /** Kick a user from a room (requires admin power level) */

--- a/src/features/chat-info/ui/ChatInfoPanel.vue
+++ b/src/features/chat-info/ui/ChatInfoPanel.vue
@@ -903,7 +903,7 @@ const openGallery = (tab: "media" | "files" | "links" | "voice" = "media") => {
                   </span>
                   <button
                     v-if="member !== myHexId"
-                    class="shrink-0 rounded p-1 text-text-on-main-bg-color opacity-0 transition-opacity hover:bg-neutral-grad-2/40 hover:text-text-color group-hover:opacity-100"
+                    class="rename-member-btn shrink-0 rounded p-1 text-text-on-main-bg-color transition-opacity hover:bg-neutral-grad-2/40 hover:text-text-color"
                     :title="chatStore.hasLocalAlias(member) ? t('contact.editAlias') : t('contact.addAlias')"
                     :aria-label="chatStore.hasLocalAlias(member) ? t('contact.editAlias') : t('contact.addAlias')"
                     @click.stop="openRenameDialog(member)"
@@ -1183,5 +1183,24 @@ const openGallery = (tab: "media" | "files" | "links" | "voice" = "media") => {
 .panel-slide-enter-from,
 .panel-slide-leave-to {
   transform: translateX(100%);
+}
+
+/* Per-member rename button:
+ *  - Pointer:fine (mouse) — hover-reveal so the row stays uncluttered.
+ *  - Pointer:coarse (touch / Android) — always visible at low opacity so it
+ *    remains tappable. Hover doesn't work reliably on touch WebViews. */
+.rename-member-btn {
+  opacity: 0;
+}
+@media (hover: hover) and (pointer: fine) {
+  .group:hover .rename-member-btn,
+  .rename-member-btn:focus-visible {
+    opacity: 1;
+  }
+}
+@media (hover: none), (pointer: coarse) {
+  .rename-member-btn {
+    opacity: 0.6;
+  }
 }
 </style>

--- a/src/features/chat-info/ui/ChatInfoPanel.vue
+++ b/src/features/chat-info/ui/ChatInfoPanel.vue
@@ -423,6 +423,7 @@ const BROOM_ICON = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" 
 const BAN_ICON = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="4.93" y1="4.93" x2="19.07" y2="19.07"/></svg>';
 const LOGOUT_ICON = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>';
 const TRASH_ICON = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>';
+const RENAME_ICON = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>';
 
 const moreMenuItems = computed<ContextMenuItem[]>(() => {
   const items: ContextMenuItem[] = [];
@@ -434,6 +435,14 @@ const moreMenuItems = computed<ContextMenuItem[]>(() => {
   });
   if (!room.value?.isGroup) {
     items.push({ label: t("chatInfo.videoCall"), icon: VIDEO_ICON, action: "videoCall" });
+    // Rename contact lives here for DMs — keeps the main panel uncluttered.
+    if (peerAddress.value && peerAddress.value !== myAddress.value) {
+      items.push({
+        label: chatStore.hasLocalAlias(peerAddress.value) ? t("contact.editAlias") : t("contact.addAlias"),
+        icon: RENAME_ICON,
+        action: "rename",
+      });
+    }
   }
   items.push({ label: t("chatInfo.clearHistory"), icon: BROOM_ICON, action: "clearHistory" });
   if (!room.value?.isGroup) {
@@ -454,6 +463,7 @@ const handleMoreAction = (action: string) => {
     case "search": emit("close"); emit("openSearch"); break;
     case "toggleMute": toggleMute(); break;
     case "videoCall": startCall("video"); break;
+    case "rename": if (peerAddress.value) openRenameDialog(peerAddress.value); break;
     case "clearHistory": confirmAction.value = "clear"; break;
     case "block": confirmAction.value = "block"; break;
     case "deleteChat": confirmAction.value = "delete"; break;
@@ -774,19 +784,7 @@ const openGallery = (tab: "media" | "files" | "links" | "voice" = "media") => {
                   {{ t("chatInfo.viewProfile") }}
                 </button>
               </div>
-              <!-- Rename contact (local alias) -->
-              <div v-if="peerAddress && peerAddress !== myAddress" class="mt-3">
-                <button
-                  class="inline-flex items-center gap-2 text-sm text-color-txt-ac hover:underline"
-                  @click="openRenameDialog(peerAddress)"
-                >
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M12 20h9" />
-                    <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
-                  </svg>
-                  {{ chatStore.hasLocalAlias(peerAddress) ? t("contact.editAlias") : t("contact.addAlias") }}
-                </button>
-              </div>
+              <!-- Rename contact (local alias) lives in the 3-dot More menu — see moreMenuItems. -->
             </div>
 
             <!-- Notifications toggle -->

--- a/src/features/chat-info/ui/ChatInfoPanel.vue
+++ b/src/features/chat-info/ui/ChatInfoPanel.vue
@@ -13,6 +13,7 @@ import ContextMenu from "@/shared/ui/context-menu/ContextMenu.vue";
 import type { ContextMenuItem } from "@/shared/ui/context-menu/ContextMenu.vue";
 import Toggle from "@/shared/ui/toggle/Toggle.vue";
 import ChatInfoGallery from "./ChatInfoGallery.vue";
+import RenameContactDialog from "./RenameContactDialog.vue";
 import { useResolvedRoomName } from "@/entities/chat/lib/use-resolved-room-name";
 import { openBastyonProfile } from "@/shared/lib/open-profile-url";
 import { copyToClipboard, shareLink } from "@/shared/lib/share-link";
@@ -492,6 +493,30 @@ const copyAddress = async () => {
   setTimeout(() => copiedAddress.value = false, 2000);
 };
 
+// ── Local contact alias (Session 51) ──
+// Address can be either a raw Bastyon address (DM peer) or a hex-encoded
+// member ID (group member). chatStore.setContactAlias accepts both forms.
+const renameTarget = ref<string | null>(null);
+const myAddress = computed(() => authStore.address ?? "");
+
+const openRenameDialog = (address: string) => {
+  if (!address) return;
+  // Never let the user "rename themselves" via this flow — that lives in
+  // Profile and goes through Pocketnet/Matrix displayname.
+  const raw = /^[a-f0-9]+$/i.test(address) ? hexDecode(address) : address;
+  if (raw === myAddress.value) return;
+  renameTarget.value = address;
+};
+const closeRenameDialog = () => { renameTarget.value = null; };
+const handleAliasSave = async (alias: string) => {
+  if (renameTarget.value) await chatStore.setContactAlias(renameTarget.value, alias);
+  renameTarget.value = null;
+};
+const handleAliasRemove = async () => {
+  if (renameTarget.value) await chatStore.setContactAlias(renameTarget.value, null);
+  renameTarget.value = null;
+};
+
 // ── Media preview (last 4 thumbnails) ──
 const recentMedia = computed<Message[]>(() =>
   chatStore.activeMessages
@@ -749,6 +774,19 @@ const openGallery = (tab: "media" | "files" | "links" | "voice" = "media") => {
                   {{ t("chatInfo.viewProfile") }}
                 </button>
               </div>
+              <!-- Rename contact (local alias) -->
+              <div v-if="peerAddress && peerAddress !== myAddress" class="mt-3">
+                <button
+                  class="inline-flex items-center gap-2 text-sm text-color-txt-ac hover:underline"
+                  @click="openRenameDialog(peerAddress)"
+                >
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M12 20h9" />
+                    <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+                  </svg>
+                  {{ chatStore.hasLocalAlias(peerAddress) ? t("contact.editAlias") : t("contact.addAlias") }}
+                </button>
+              </div>
             </div>
 
             <!-- Notifications toggle -->
@@ -855,7 +893,7 @@ const openGallery = (tab: "media" | "files" | "links" | "voice" = "media") => {
                 <div
                   v-for="member in room.members"
                   :key="`join-${member}`"
-                  class="flex items-center gap-3 rounded-lg px-2 py-2 transition-colors"
+                  class="group flex items-center gap-3 rounded-lg px-2 py-2 transition-colors"
                   :class="isAdmin && member !== myHexId ? 'cursor-pointer hover:bg-neutral-grad-0' : ''"
                   @click="(e: MouseEvent) => openMemberMenu(e, member)"
                 >
@@ -863,6 +901,18 @@ const openGallery = (tab: "media" | "files" | "links" | "voice" = "media") => {
                   <span class="min-w-0 flex-1 truncate text-sm text-text-color">
                     {{ chatStore.getDisplayName(member) }}
                   </span>
+                  <button
+                    v-if="member !== myHexId"
+                    class="shrink-0 rounded p-1 text-text-on-main-bg-color opacity-0 transition-opacity hover:bg-neutral-grad-2/40 hover:text-text-color group-hover:opacity-100"
+                    :title="chatStore.hasLocalAlias(member) ? t('contact.editAlias') : t('contact.addAlias')"
+                    :aria-label="chatStore.hasLocalAlias(member) ? t('contact.editAlias') : t('contact.addAlias')"
+                    @click.stop="openRenameDialog(member)"
+                  >
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M12 20h9" />
+                      <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+                    </svg>
+                  </button>
                   <span
                     v-if="chatStore.isMemberMuted(room.id, member)"
                     class="shrink-0 rounded bg-neutral-grad-2/30 px-1.5 py-0.5 text-[10px] font-medium text-text-on-main-bg-color"
@@ -1099,6 +1149,17 @@ const openGallery = (tab: "media" | "files" | "links" | "voice" = "media") => {
         </div>
       </div>
     </transition>
+
+    <!-- Rename contact dialog (Session 51) — local alias for DM peer or
+         group member. Overlays the whole info panel. -->
+    <RenameContactDialog
+      v-if="renameTarget"
+      :address="renameTarget"
+      :current-alias="chatStore.getLocalAlias(renameTarget)"
+      @save="handleAliasSave"
+      @remove="handleAliasRemove"
+      @close="closeRenameDialog"
+    />
   </Teleport>
 </template>
 

--- a/src/features/chat-info/ui/RenameContactDialog.vue
+++ b/src/features/chat-info/ui/RenameContactDialog.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import { ref, watch, nextTick, onMounted } from "vue";
+
+interface Props {
+  /** Raw Bastyon address (DM) or hex-encoded member ID (group). The chat-store
+   *  alias action accepts either form and normalizes internally. */
+  address: string;
+  /** Current alias text (empty/null = no alias set). */
+  currentAlias: string | null;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits<{
+  save: [alias: string];
+  remove: [];
+  close: [];
+}>();
+
+const { t } = useI18n();
+const alias = ref(props.currentAlias ?? "");
+const inputRef = ref<HTMLInputElement | null>(null);
+
+// Autofocus on mount + when address changes (reusing dialog for another member).
+const focusInput = () => {
+  nextTick(() => {
+    inputRef.value?.focus();
+    inputRef.value?.select();
+  });
+};
+
+onMounted(focusInput);
+watch(() => props.address, () => {
+  alias.value = props.currentAlias ?? "";
+  focusInput();
+});
+
+const onSave = () => {
+  const trimmed = alias.value.trim();
+  if (trimmed) emit("save", trimmed);
+  else emit("remove");
+};
+
+const onRemove = () => emit("remove");
+const onCancel = () => emit("close");
+</script>
+
+<template>
+  <div
+    class="fixed inset-0 z-[70] flex items-center justify-center bg-black/50 p-4"
+    @click.self="onCancel"
+  >
+    <div class="w-full max-w-sm rounded-xl bg-background-total-theme p-5 shadow-xl">
+      <h3 class="mb-3 text-base font-semibold text-text-color">{{ t("contact.renameTitle") }}</h3>
+      <input
+        ref="inputRef"
+        v-model="alias"
+        type="text"
+        :maxlength="64"
+        :placeholder="t('contact.aliasPlaceholder')"
+        class="w-full rounded-lg bg-chat-input-bg px-3 py-2 text-sm text-text-color outline-none placeholder:text-neutral-grad-2"
+        @keyup.enter="onSave"
+        @keyup.escape="onCancel"
+      />
+      <p class="mt-2 text-xs text-text-on-main-bg-color">{{ t("contact.aliasHint") }}</p>
+      <div class="mt-4 flex flex-wrap justify-end gap-2">
+        <button
+          v-if="currentAlias"
+          class="rounded-lg px-3 py-2 text-sm font-medium text-color-bad transition-colors hover:bg-neutral-grad-0"
+          @click="onRemove"
+        >
+          {{ t("contact.removeAlias") }}
+        </button>
+        <button
+          class="rounded-lg px-3 py-2 text-sm font-medium text-text-on-main-bg-color transition-colors hover:bg-neutral-grad-0"
+          @click="onCancel"
+        >
+          {{ t("info.cancel") }}
+        </button>
+        <button
+          class="rounded-lg bg-color-bg-ac px-4 py-2 text-sm font-medium text-text-on-bg-ac-color transition-colors hover:bg-color-bg-ac-1"
+          @click="onSave"
+        >
+          {{ t("contact.save") }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/features/contacts/ui/ContactList.vue
+++ b/src/features/contacts/ui/ContactList.vue
@@ -23,6 +23,7 @@ import { RecycleScroller } from "vue-virtual-scroller";
 import "vue-virtual-scroller/dist/vue-virtual-scroller.css";
 import { getDraft } from "@/shared/lib/drafts";
 import { useSelectionStore } from "@/features/selection";
+import RenameContactDialog from "@/features/chat-info/ui/RenameContactDialog.vue";
 import { hapticImpact } from "@/shared/lib/haptics";
 
 interface Props {
@@ -127,10 +128,17 @@ function _resolveMemberNames(room: ChatRoom, allUsers: Record<string, any>, myHe
     ...(room.invitedMembers ?? []),
   ].filter(m => m !== myHexId);
 
+  // Read localAliases reactively (Session 51) — Pinia ref access here makes
+  // the calling computed re-evaluate when an alias is set/cleared.
+  const aliases = chatStore.localAliases;
+
   const names: string[] = [];
   for (const hexId of otherMembers) {
     const addr = cachedHexDecode(hexId);
     if (/^[A-Za-z0-9]+$/.test(addr)) {
+      // Priority 0: User-set local alias — overrides everything below.
+      const alias = aliases[addr];
+      if (alias) { names.push(alias); continue; }
       // Priority 1: Pocketnet profile (richest data)
       const user = allUsers[addr];
       if (user?.name && !isUnresolvedName(user.name) && user.name !== addr) {
@@ -147,13 +155,17 @@ function _resolveMemberNames(room: ChatRoom, allUsers: Record<string, any>, myHe
   // Fallback: try avatar address
   if (names.length === 0 && room.avatar?.startsWith("__pocketnet__:")) {
     const avatarAddr = room.avatar.slice("__pocketnet__:".length);
-    const user = allUsers[avatarAddr];
-    if (user?.name && !isUnresolvedName(user.name) && user.name !== avatarAddr) {
-      names.push(user.name);
-    } else {
-      const matrixName = chatStore.getDisplayName(avatarAddr);
-      if (matrixName && matrixName !== avatarAddr && matrixName !== "?" && !isUnresolvedName(matrixName)) {
-        names.push(matrixName);
+    const alias = aliases[avatarAddr];
+    if (alias) { names.push(alias); }
+    else {
+      const user = allUsers[avatarAddr];
+      if (user?.name && !isUnresolvedName(user.name) && user.name !== avatarAddr) {
+        names.push(user.name);
+      } else {
+        const matrixName = chatStore.getDisplayName(avatarAddr);
+        if (matrixName && matrixName !== avatarAddr && matrixName !== "?" && !isUnresolvedName(matrixName)) {
+          names.push(matrixName);
+        }
       }
     }
   }
@@ -656,7 +668,22 @@ const ICONS = {
   mute:   svg('<path d="M18 16.5a9 9 0 0 0 .38-10.17"/><path d="M13.73 7.73a4 4 0 0 1 .52 4.52"/><path d="m2 2 20 20"/><path d="M9.34 9.34 3 16h4v4l4.65-4.65"/><path d="M15 2 9.34 7.66"/>'),
   unmute: svg('<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/>'),
   read:   svg('<polyline points="20 6 9 17 4 12"/>'),
+  rename: svg('<path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/>'),
   delete: svg('<path d="M3 6h18"/><path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"/><line x1="10" y1="11" x2="10" y2="17"/><line x1="14" y1="11" x2="14" y2="17"/>'),
+};
+
+/** Resolve the DM peer (raw Bastyon address) for a 1:1 chat. Returns null
+ *  for group rooms or rooms with no resolvable peer. Used by the context-menu
+ *  rename action — group room names are admin-controlled and not aliasable. */
+const getDmPeerAddress = (roomId: string): string | null => {
+  const room = chatStore.rooms.find(r => r.id === roomId);
+  if (!room || room.isGroup) return null;
+  const me = authStore.address ? hexEncode(authStore.address) : "";
+  const candidates = [...room.members, ...(room.invitedMembers ?? [])];
+  const other = candidates.find(m => m !== me);
+  if (!other) return null;
+  const decoded = hexDecode(other);
+  return /^[A-Za-z0-9]+$/.test(decoded) ? decoded : null;
 };
 
 const ctxMenuItems = computed<ContextMenuItem[]>(() => {
@@ -664,12 +691,22 @@ const ctxMenuItems = computed<ContextMenuItem[]>(() => {
   if (!roomId) return [];
   const isPinned = chatStore.pinnedRoomIds.has(roomId);
   const isMuted = chatStore.mutedRoomIds.has(roomId);
-  return [
+  const peer = getDmPeerAddress(roomId);
+  const items: ContextMenuItem[] = [
     { label: isPinned ? t("contactList.unpin") : t("contactList.pin"), icon: isPinned ? ICONS.unpin : ICONS.pin, action: "pin" },
     { label: isMuted ? t("contactList.unmute") : t("contactList.mute"), icon: isMuted ? ICONS.unmute : ICONS.mute, action: "mute" },
     { label: t("contactList.markAsRead"), icon: ICONS.read, action: "read" },
-    { label: t("contactList.delete"), icon: ICONS.delete, action: "delete", danger: true },
   ];
+  // Rename contact (Session 51) — DM rooms only. Group names are admin-controlled.
+  if (peer) {
+    items.push({
+      label: chatStore.hasLocalAlias(peer) ? t("contact.editAlias") : t("contact.addAlias"),
+      icon: ICONS.rename,
+      action: "rename",
+    });
+  }
+  items.push({ label: t("contactList.delete"), icon: ICONS.delete, action: "delete", danger: true });
+  return items;
 });
 
 const openCtxMenu = (e: PointerEvent, room: ChatRoom) => {
@@ -678,6 +715,22 @@ const openCtxMenu = (e: PointerEvent, room: ChatRoom) => {
 
 const deleteConfirm = ref<{ show: boolean; roomId: string | null }>({ show: false, roomId: null });
 
+// Rename contact dialog state (Session 51) — opened from the long-press menu.
+const renameTarget = ref<string | null>(null);
+const openRenameFromCtx = (roomId: string) => {
+  const peer = getDmPeerAddress(roomId);
+  if (peer) renameTarget.value = peer;
+};
+const handleAliasSave = async (alias: string) => {
+  if (renameTarget.value) await chatStore.setContactAlias(renameTarget.value, alias);
+  renameTarget.value = null;
+};
+const handleAliasRemove = async () => {
+  if (renameTarget.value) await chatStore.setContactAlias(renameTarget.value, null);
+  renameTarget.value = null;
+};
+const closeRenameDialog = () => { renameTarget.value = null; };
+
 const handleCtxAction = (action: string) => {
   const roomId = ctxMenu.value.roomId;
   if (!roomId) return;
@@ -685,6 +738,7 @@ const handleCtxAction = (action: string) => {
     case "pin": chatStore.togglePinRoom(roomId); break;
     case "mute": chatStore.toggleMuteRoom(roomId); break;
     case "read": chatStore.markRoomAsRead(roomId); break;
+    case "rename": openRenameFromCtx(roomId); break;
     case "delete":
       deleteConfirm.value = { show: true, roomId };
       break;
@@ -973,6 +1027,16 @@ const onRoomContextMenu = (e: MouseEvent, room: ChatRoom) => {
       :items="ctxMenuItems"
       @close="ctxMenu.show = false"
       @select="handleCtxAction"
+    />
+
+    <!-- Rename contact dialog (Session 51) — opened from long-press menu. -->
+    <RenameContactDialog
+      v-if="renameTarget"
+      :address="renameTarget"
+      :current-alias="chatStore.getLocalAlias(renameTarget)"
+      @save="handleAliasSave"
+      @remove="handleAliasRemove"
+      @close="closeRenameDialog"
     />
 
     <!-- Delete chat confirmation modal -->

--- a/src/features/messaging/model/use-file-download.test.ts
+++ b/src/features/messaging/model/use-file-download.test.ts
@@ -82,6 +82,7 @@ const {
   revokeAllFileUrls,
   appendCacheBust,
   wrapTransientError,
+  _resetToastDedupForTests,
 } = await import("./use-file-download");
 const { MediaUnavailableError, NetworkBlockedError } = await import(
   "@/shared/lib/network/typed-network-errors"
@@ -104,6 +105,8 @@ describe("useFileDownload", () => {
     // Reset crypto stub so tests that do not touch encryption see no
     // pcrypto (matches the original mock default).
     setMockPcrypto(null);
+    // Reset toast dedup so repeated-failure tests start from a clean slate.
+    _resetToastDedupForTests();
   });
 
   describe("saveFile — web platform", () => {
@@ -421,6 +424,49 @@ describe("useFileDownload", () => {
       });
       scope.stop();
     }, 30_000);
+
+    it("does NOT re-surface the same toast on repeated failures for the same message (Session 51 follow-up)", async () => {
+      // Regression: a user reported the 'Server unreachable. Try enabling
+      // Tor or a VPN.' toast firing every time they saved or removed a
+      // contact alias. Root cause: re-renders (virtual scroller recycling,
+      // parent reactivity cascades) triggered MessageBubble.onMounted /
+      // watch(message.id), which re-invoked download() on already-failed
+      // media. Each retry surfaced a fresh toast. Dedup window of 60 s
+      // collapses these into one user-visible notification.
+      (global.fetch as Mock).mockRejectedValue(new TypeError("Failed to fetch"));
+
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download } = useFileDownload();
+        const message = {
+          id: "$evt_dedup_blocked",
+          _key: "client_dedup_blocked",
+          roomId: "!room:server",
+          senderId: "@u:server",
+          content: "file.pdf",
+          timestamp: Date.now(),
+          status: "sent",
+          type: "file",
+          fileInfo: {
+            name: "file.pdf",
+            type: "application/pdf",
+            size: 1024,
+            url: "https://example.com/dedup.pdf",
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        await download(message);
+        await download(message);
+        await download(message);
+
+        const networkBlockedToasts = mockToast.mock.calls.filter(
+          (call: unknown[]) => call[0] === "errors.networkBlocked",
+        );
+        expect(networkBlockedToasts.length).toBe(1);
+      });
+      scope.stop();
+    }, 60_000);
 
     it("after retry exhaustion, exposes errorKind='network' to the UI", async () => {
       (global.fetch as Mock).mockRejectedValue(new TypeError("Failed to fetch"));

--- a/src/features/messaging/model/use-file-download.ts
+++ b/src/features/messaging/model/use-file-download.ts
@@ -150,15 +150,49 @@ export function _resetBugReportDedupForTests(): void {
  *  next action they take. */
 const TYPED_ERROR_TOAST_MS = 5_000;
 
+/** Toast dedup window — keyed by (cacheKey, errorKey). Surface the same
+ *  user-facing toast at most once per window per message. Without dedup,
+ *  Vue re-renders (e.g. virtual scroller recycling, parent re-key cascades
+ *  from unrelated reactive updates like a chat-list refresh) call download()
+ *  again for already-failed media, and each failure re-fires the toast —
+ *  visible as repeated "Server unreachable" notifications during routine
+ *  navigation. */
+const TOAST_DEDUP_WINDOW_MS = 60_000;
+const TOAST_DEDUP_PRUNE_THRESHOLD = 500;
+const toastDedupMap = new Map<string, number>();
+
+function pruneToastDedup(): void {
+  if (toastDedupMap.size < TOAST_DEDUP_PRUNE_THRESHOLD) return;
+  const cutoff = Date.now() - TOAST_DEDUP_WINDOW_MS;
+  for (const [k, ts] of toastDedupMap) {
+    if (ts < cutoff) toastDedupMap.delete(k);
+  }
+}
+
+/** TEST-ONLY: clear the toast dedup map between test cases. */
+export function _resetToastDedupForTests(): void {
+  toastDedupMap.clear();
+}
+
 /** Show a localised toast when a download failure resolves to one of our
  *  typed transient errors. Silent for everything else — generic errors are
- *  still surfaced via the in-bubble retry UI and the auto-bug-report flow. */
-function surfaceTypedErrorToast(err: unknown): void {
+ *  still surfaced via the in-bubble retry UI and the auto-bug-report flow.
+ *  Deduped per (cacheKey, errorKey) within TOAST_DEDUP_WINDOW_MS so that
+ *  repeated re-attempts during the same network glitch do not spam the user. */
+function surfaceTypedErrorToast(err: unknown, cacheKey: string): void {
   let key: "errors.networkBlocked" | "errors.cryptoNotReady" | "errors.mediaUnavailable" | null = null;
   if (err instanceof NetworkBlockedError) key = "errors.networkBlocked";
   else if (err instanceof CryptoNotReadyError) key = "errors.cryptoNotReady";
   else if (err instanceof MediaUnavailableError) key = "errors.mediaUnavailable";
   if (!key) return;
+
+  pruneToastDedup();
+  const dedupKey = `${cacheKey}:${key}`;
+  const now = Date.now();
+  const last = toastDedupMap.get(dedupKey) ?? 0;
+  if (now - last < TOAST_DEDUP_WINDOW_MS) return;
+  toastDedupMap.set(dedupKey, now);
+
   try {
     useToast().toast(tRaw(key), "error", TYPED_ERROR_TOAST_MS);
   } catch (toastErr) {
@@ -574,8 +608,9 @@ export function useFileDownload() {
       // Surface a localised toast for our typed transient failures so the
       // user sees a clear "what to do next" message (region/firewall vs.
       // media-gone vs. keys-still-syncing) instead of just an in-bubble
-      // retry button.
-      surfaceTypedErrorToast(e);
+      // retry button. Deduped per (cacheKey, errorKey) so background
+      // re-attempts during the same glitch do not spam.
+      surfaceTypedErrorToast(e, cacheKey);
       // Skip auto-report for crypto failures (user-actionable, not a bug) and
       // for duplicates within the dedup window. Manual reporting is still
       // available via the bug-report button in the friendly error UI.

--- a/src/features/search/model/use-search-alias.test.ts
+++ b/src/features/search/model/use-search-alias.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia } from "pinia";
+import { createTestingPinia } from "@pinia/testing";
+import { useSearch } from "./use-search";
+import { useChatStore } from "@/entities/chat";
+import { useUserStore } from "@/entities/user/model";
+import { hexEncode } from "@/shared/lib/matrix/functions";
+import type { ChatRoom } from "@/entities/chat";
+
+/**
+ * Regression test for Session 51 follow-up: chat search must include local
+ * aliases. Before this fix, `useSearch.chatResults` only consulted
+ * userStore.users[addr].name in `getMemberNameLower`, so a user-set alias
+ * was invisible to the chat list / quick search ranker.
+ *
+ * Verifies:
+ *   1. A DM with alias "Дядя Петя" is found when typing "Петя".
+ *   2. The same DM is still found by the Pocketnet profile name.
+ *   3. Clearing the alias removes alias-only matches.
+ */
+
+// Mock the matrix client service — search needs to call getMatrixRoom().
+vi.mock("@/entities/matrix", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("@/entities/matrix");
+  return {
+    ...actual,
+    getMatrixClientService: () => ({ getRoom: () => null }),
+  };
+});
+
+function makeDmRoom(peerHex: string, id: string = "!dm:s"): ChatRoom {
+  return {
+    id,
+    name: "DM",
+    isGroup: false,
+    members: [peerHex],
+    invitedMembers: [],
+    membership: "join",
+    unreadCount: 0,
+    lastReadInboundTs: 0,
+    lastReadOutboundTs: 0,
+    updatedAt: Date.now(),
+    syncedAt: Date.now(),
+    hasMoreHistory: true,
+    isDeleted: false,
+    deletedAt: null,
+    deleteReason: null,
+  } as ChatRoom;
+}
+
+describe("useSearch — alias-aware chat search (Session 51)", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    setActivePinia(createTestingPinia({ stubActions: false }));
+  });
+
+  it("finds a DM by the user's local alias", () => {
+    const chat = useChatStore();
+    const user = useUserStore();
+    const peer = "PPeerAddr";
+    const room = makeDmRoom(hexEncode(peer));
+    chat.rooms = [room];
+    user.users[peer] = { name: "Original Pocketnet" } as any;
+    chat.localAliases[peer] = "Дядя Петя";
+
+    const search = useSearch();
+    search.query.value = "Петя";
+    expect(search.chatResults.value.map(r => r.id)).toContain(room.id);
+  });
+
+  it("still finds a DM by Pocketnet profile name when alias is set", () => {
+    const chat = useChatStore();
+    const user = useUserStore();
+    const peer = "PPeerAddr";
+    const room = makeDmRoom(hexEncode(peer));
+    chat.rooms = [room];
+    user.users[peer] = { name: "Original Pocketnet" } as any;
+    chat.localAliases[peer] = "Custom";
+
+    const search = useSearch();
+    search.query.value = "Pocketnet";
+    expect(search.chatResults.value.map(r => r.id)).toContain(room.id);
+  });
+
+  it("does not match by alias after the alias is cleared", async () => {
+    const chat = useChatStore();
+    const user = useUserStore();
+    const peer = "PPeerAddr";
+    const room = makeDmRoom(hexEncode(peer));
+    chat.rooms = [room];
+    user.users[peer] = { name: "Original" } as any;
+
+    await chat.setContactAlias(peer, "TempAlias");
+    const search = useSearch();
+    search.query.value = "TempAlias";
+    expect(search.chatResults.value.map(r => r.id)).toContain(room.id);
+
+    await chat.setContactAlias(peer, null);
+    expect(search.chatResults.value.map(r => r.id)).not.toContain(room.id);
+  });
+});

--- a/src/features/search/model/use-search.ts
+++ b/src/features/search/model/use-search.ts
@@ -3,6 +3,7 @@ import { useChatStore } from "@/entities/chat";
 import type { ChatRoom, Message } from "@/entities/chat";
 import { getMatrixClientService } from "@/entities/matrix";
 import { useUserStore } from "@/entities/user/model";
+import { hexDecode } from "@/shared/lib/matrix/functions";
 import { rankChatRoomsBySearchRelevance } from "./rank-chat-rooms";
 
 export interface MessageSearchResult {
@@ -21,6 +22,8 @@ export function useSearch() {
     if (!q) return [];
     const qLower = q.toLowerCase();
     const matrix = getMatrixClientService();
+    // Read once so Vue tracks the ref — re-rank when an alias is set/cleared.
+    const aliases = chatStore.localAliases;
     return rankChatRoomsBySearchRelevance(chatStore.sortedRooms, {
       queryLower: qLower,
       getMatrixRoom: (roomId) => {
@@ -33,9 +36,20 @@ export function useSearch() {
         };
       },
       getMemberNameLower: (address: string) => {
-        const u = userStore.getUser(address);
-        const raw = (u?.name && String(u.name).trim()) || address;
-        return raw.toLowerCase();
+        // `address` here is a hex-encoded member ID (room.members format).
+        // Aliases are keyed by raw Bastyon address — normalize before lookup.
+        // Concatenate alias + profile name so search finds the chat by either.
+        let raw = address;
+        if (/^[a-f0-9]+$/i.test(address)) {
+          try {
+            const decoded = hexDecode(address);
+            if (decoded !== address && /^[A-Za-z0-9]+$/.test(decoded)) raw = decoded;
+          } catch { /* not hex */ }
+        }
+        const alias = aliases[raw];
+        const u = userStore.getUser(raw);
+        const profile = (u?.name && String(u.name).trim()) || raw;
+        return (alias ? alias + " " + profile : profile).toLowerCase();
       },
     });
   });

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -37,6 +37,15 @@ export const en = {
   "contactList.cancel": "Cancel",
   "contactList.draft": "Draft",
 
+  // ── Contact alias (local "rename contact") ──
+  "contact.renameTitle": "Rename contact",
+  "contact.addAlias": "Add name",
+  "contact.editAlias": "Edit name",
+  "contact.removeAlias": "Remove",
+  "contact.aliasPlaceholder": "e.g. Uncle Pete",
+  "contact.aliasHint": "Visible only to you. Syncs across your devices.",
+  "contact.save": "Save",
+
   // ── Contact search ──
   "contactSearch.placeholder": "Search chats or users...",
   "contactSearch.placeholderShort": "Search",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -39,6 +39,15 @@ export const ru: Record<TranslationKey, string> = {
   "contactList.cancel": "Отмена",
   "contactList.draft": "Черновик",
 
+  // ── Contact alias (local "rename contact") ──
+  "contact.renameTitle": "Переименовать контакт",
+  "contact.addAlias": "Задать имя",
+  "contact.editAlias": "Изменить имя",
+  "contact.removeAlias": "Сбросить",
+  "contact.aliasPlaceholder": "Например, Дядя Петя",
+  "contact.aliasHint": "Имя видно только вам, синхронизируется между вашими устройствами.",
+  "contact.save": "Сохранить",
+
   // ── Contact search ──
   "contactSearch.placeholder": "Поиск чатов или пользователей...",
   "contactSearch.placeholderShort": "Поиск",

--- a/src/shared/lib/local-db/__tests__/user-repository-alias.test.ts
+++ b/src/shared/lib/local-db/__tests__/user-repository-alias.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "fake-indexeddb/auto";
+import { ChatDatabase } from "../schema";
+import { UserRepository } from "../user-repository";
+
+/**
+ * Tests for the local-alias CRUD layer in UserRepository (Session 51).
+ *
+ * Schema v13 adds `localAlias` + `aliasUpdatedAt` to LocalUser. These tests
+ * pin the CRUD shape that chat-store + the cross-device sync handler rely on:
+ *
+ *  - setAlias persists for both known and unknown users (creates a skeleton
+ *    row if the user is not yet cached).
+ *  - setAlias is last-write-wins by timestamp argument (the cross-device sync
+ *    layer uses this for conflict resolution).
+ *  - setAlias(null) clears alias + bumps aliasUpdatedAt (tombstone semantics).
+ *  - getAllAliases returns only rows with a non-empty alias — used to
+ *    hydrate chat-store.localAliases on login / cold-start.
+ */
+
+let db: ChatDatabase;
+let repo: UserRepository;
+
+beforeEach(async () => {
+  const name = `test-alias-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  db = new ChatDatabase(name);
+  await db.open();
+  repo = new UserRepository(db);
+});
+
+afterEach(async () => {
+  await db.delete();
+});
+
+describe("UserRepository — alias CRUD", () => {
+  it("setAlias persists for unknown user (creates skeleton row)", async () => {
+    await repo.setAlias("addr1", "Alias", 1000);
+    expect(await repo.getAlias("addr1")).toBe("Alias");
+  });
+
+  it("setAlias overrides previous alias", async () => {
+    await repo.setAlias("addr1", "First", 1000);
+    await repo.setAlias("addr1", "Second", 2000);
+    expect(await repo.getAlias("addr1")).toBe("Second");
+  });
+
+  it("setAlias(null) clears alias", async () => {
+    await repo.setAlias("addr1", "Alias", 1000);
+    await repo.setAlias("addr1", null, 2000);
+    expect(await repo.getAlias("addr1")).toBeNull();
+  });
+
+  it("setAlias preserves existing name/about/image when adding alias", async () => {
+    await repo.upsertUser({
+      address: "addr1",
+      name: "Real Name",
+      about: "Bio",
+      image: "avatar.jpg",
+      updatedAt: 5000,
+      syncedAt: 5000,
+    });
+    await repo.setAlias("addr1", "Alias", 6000);
+    const user = await repo.getUser("addr1");
+    expect(user?.name).toBe("Real Name");
+    expect(user?.about).toBe("Bio");
+    expect(user?.image).toBe("avatar.jpg");
+    expect(user?.localAlias).toBe("Alias");
+    expect(user?.aliasUpdatedAt).toBe(6000);
+  });
+
+  it("getAliasUpdatedAt returns 0 when no alias set", async () => {
+    expect(await repo.getAliasUpdatedAt("nobody")).toBe(0);
+  });
+
+  it("getAliasUpdatedAt returns stored timestamp after setAlias", async () => {
+    await repo.setAlias("addr1", "Alias", 12345);
+    expect(await repo.getAliasUpdatedAt("addr1")).toBe(12345);
+  });
+
+  it("getAllAliases returns only users with a localAlias", async () => {
+    await repo.setAlias("a1", "A", 1000);
+    await repo.upsertUser({
+      address: "a2",
+      name: "No alias",
+      updatedAt: 0,
+      syncedAt: 0,
+    });
+    const all = await repo.getAllAliases();
+    expect(all).toHaveProperty("a1");
+    expect(all.a1.alias).toBe("A");
+    expect(all.a1.updatedAt).toBe(1000);
+    expect(all).not.toHaveProperty("a2");
+  });
+
+  it("getAllAliases excludes cleared aliases", async () => {
+    await repo.setAlias("a1", "A", 1000);
+    await repo.setAlias("a1", null, 2000);
+    const all = await repo.getAllAliases();
+    expect(all).not.toHaveProperty("a1");
+  });
+});

--- a/src/shared/lib/local-db/schema.ts
+++ b/src/shared/lib/local-db/schema.ts
@@ -150,6 +150,14 @@ export interface LocalUser {
   image?: string;                // Avatar URL
   updatedAt: number;
   syncedAt: number;              // Last fetched from server
+
+  /** User-set local nickname (Telegram-style "rename contact").
+   *  Visible only to the local user, synced across own devices via Matrix
+   *  account_data ("m.bastyon.contact_aliases"). NEVER sent as Matrix
+   *  room displayname — the peer must not see it. */
+  localAlias?: string;
+  /** Epoch-ms of the last `localAlias` change (LWW conflict resolution). */
+  aliasUpdatedAt?: number;
 }
 
 /** Queued operation for sync */
@@ -586,6 +594,21 @@ export class ChatDatabase extends Dexie {
       return tx.table("pendingOps").toCollection().modify(op => {
         if (op.nextAttemptAt === undefined) op.nextAttemptAt = 0;
       });
+    });
+
+    // Version 13: add aliasUpdatedAt index to users for fast LWW conflict
+    // resolution when applying inbound m.bastyon.contact_aliases account_data.
+    // The localAlias field itself is not indexed (read via getAllAliases scan).
+    this.version(13).stores({
+      rooms: "id, updatedAt, membership, isDeleted",
+      messages: "++localId, eventId, clientId, [roomId+timestamp], [roomId+status], senderId",
+      users: "address, updatedAt, aliasUpdatedAt",
+      pendingOps: "++id, [roomId+createdAt], status, clientId, [status+nextAttemptAt]",
+      syncState: "key",
+      attachments: "++id, messageLocalId, status",
+      decryptionQueue: "++id, eventId, roomId, status, [status+nextAttemptAt]",
+      listenedMessages: "messageId",
+      searchCache: "query, expiresAt",
     });
   }
 }

--- a/src/shared/lib/local-db/user-repository.ts
+++ b/src/shared/lib/local-db/user-repository.ts
@@ -42,4 +42,55 @@ export class UserRepository {
   async deleteUser(address: string): Promise<void> {
     await this.db.users.delete(address);
   }
+
+  // ------------------------------------------------------------------
+  // Local alias (Session 51) — Telegram-style contact rename.
+  //
+  // Alias state lives in the existing `users` row to avoid a new table.
+  // Unknown users (no profile yet) get a skeleton row so the alias survives
+  // until the real profile arrives via /sync.
+  // ------------------------------------------------------------------
+
+  /** Set or clear a user's local alias.
+   *  Passing `alias = null` clears the alias but keeps the timestamp bump,
+   *  enabling LWW-based cross-device sync to propagate the tombstone. */
+  async setAlias(address: string, alias: string | null, updatedAt: number = Date.now()): Promise<void> {
+    const existing = await this.db.users.get(address);
+    const next: LocalUser = {
+      address,
+      name: existing?.name ?? "",
+      about: existing?.about,
+      image: existing?.image,
+      updatedAt: existing?.updatedAt ?? 0,
+      syncedAt: existing?.syncedAt ?? 0,
+      localAlias: alias ?? undefined,
+      aliasUpdatedAt: updatedAt,
+    };
+    await this.db.users.put(next);
+  }
+
+  /** Get the local alias (or null if none set). */
+  async getAlias(address: string): Promise<string | null> {
+    const u = await this.db.users.get(address);
+    return u?.localAlias ?? null;
+  }
+
+  /** Get the timestamp of the last alias change (0 if never set). */
+  async getAliasUpdatedAt(address: string): Promise<number> {
+    const u = await this.db.users.get(address);
+    return u?.aliasUpdatedAt ?? 0;
+  }
+
+  /** Return all users that currently have a non-empty alias.
+   *  Used to hydrate chat-store.localAliases on login. */
+  async getAllAliases(): Promise<Record<string, { alias: string; updatedAt: number }>> {
+    const users = await this.db.users.filter(u => !!u.localAlias).toArray();
+    const out: Record<string, { alias: string; updatedAt: number }> = {};
+    for (const u of users) {
+      if (u.localAlias) {
+        out[u.address] = { alias: u.localAlias, updatedAt: u.aliasUpdatedAt ?? 0 };
+      }
+    }
+    return out;
+  }
 }


### PR DESCRIPTION
## Summary

Telegram-style **local contact rename** — give any chat partner or group member a personal name that only you see, synced across your own devices.

- **Single chokepoint:** `getDisplayName(address)` in chat-store now prioritizes `localAlias > Matrix displayName > user store > truncated address`. 30+ UI callsites (chat list, header, message bubbles, mentions, ForwardPicker, ChatSearch) inherit the alias automatically.
- **Storage:** Dexie schema bump v12 → v13. `LocalUser` gains optional `localAlias` + `aliasUpdatedAt`. Backward-compatible.
- **Cross-device sync:** Global Matrix account_data `m.bastyon.contact_aliases` (LWW by timestamp). Mirrors the `m.bastyon.clear_history` pattern. Peers do **not** see the alias.
- **UI:** New `RenameContactDialog` modal. DM ChatInfoPanel gains an "Add name/Edit name" button under View profile; group member rows gain a pencil icon (hover-reveal on desktop, 0.6 opacity on touch).
- **Cold-start:** `loadLocalAliases()` from Dexie on login plus a one-shot replay of cached `m.bastyon.contact_aliases` — aliases appear before /sync.

Closes #582, #574, partial #701.

## Test plan

- [x] `npx vitest run src/entities/chat/model src/shared/lib/local-db src/entities/auth` → 477/477 pass
- [x] 23 new regression tests across alias priority, LWW conflict resolution, hex/raw normalization, tombstones, CRUD
- [x] Independent `superpowers:code-reviewer` pass — H1 (dual-key inconsistency) and M4 (touch-invisible pencil) addressed
- [ ] Manual DM rename → alias visible in chat list / header / message bubbles
- [ ] Manual cross-device — second device receives alias within ~2-3 s
- [ ] Manual remove alias → falls back to Matrix displayName / address
- [ ] Manual group member pencil → rename → timeline sender labels update
- [ ] Manual reopen → aliases load from Dexie before /sync (no raw-address flash)
- [ ] Manual peer (different account) does **not** see the alias

## Notes

- Merge of `origin/master` included (Session 48 share-target + Session 49 sync watchdog). `auth/stores.ts` conflict resolved keeping both `loadLocalAliases` hydration and the new `onConnectivityChange` API.
- 9 pre-existing test failures + 44 pre-existing TS errors are inherited from master — none in our touched files.