### PR TITLE
fix(build): remove duplicate useToast import in MessageInput.vue

### DIFF
--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -25,7 +25,6 @@ import { isSendButtonVisible, isSendButtonDisabled } from "../model/send-button-
 import { isPeerKeysOk } from "../model/peer-keys-ok";
 import { isNative } from "@/shared/lib/platform";
 import { readShareUriAsBlob } from "@/shared/lib/share-target";
-import { useToast } from "@/shared/lib/use-toast";
 
 const PEER_KEYS_GRACE_MS = 2000;
 


### PR DESCRIPTION
## Summary
- Removed duplicate `useToast` import from `src/features/messaging/ui/MessageInput.vue` (it was already imported on line 10 and re-imported on line 28).
- Fixes the CI build failure: `[vite:vue] [vue-compiler-sfc] Identifier 'useToast' has already been declared. (28:9)`.

## Why
A previous edit likely re-added the import alongside the new `share-target` / `platform` imports without noticing the existing one. The Vue SFC compiler rejects duplicate identifiers in `<script setup>`, so the whole build was failing on this file.

## Verification
- `./node_modules/.bin/vite build` — passes (`✓ built in 23.07s`); the duplicate-identifier error from the CI log is gone.

## Test plan
- [ ] CI build succeeds on this branch.
- [ ] Open the chat input and confirm toasts still appear (e.g. send-error toast, peer-keys-not-ready toast).