### PR TITLE
fix(media): pan zoomed photo + filename extension by mime (Session 53)

### DIFF
--- a/src/entities/chat/lib/chat-helpers.test.ts
+++ b/src/entities/chat/lib/chat-helpers.test.ts
@@ -397,6 +397,43 @@ describe("parseFileInfo — filename normalization by mime", () => {
     );
     expect(fi?.name).toBe("Image.png");
   });
+
+  it("treats numeric trailing segment as non-extension (holiday.2024)", () => {
+    // Without alpha-first guard "holiday.2024" looks like it already has an
+    // extension and saves without .jpg. Tighter regex restores .jpg.
+    const fi = parseFileInfo(
+      {
+        body: "holiday.2024",
+        info: { mimetype: "image/jpeg", size: 100, url: "mxc://x", w: 1, h: 1 },
+      },
+      "m.image",
+    );
+    expect(fi?.name).toBe("holiday.2024.jpg");
+  });
+
+  it("strips MIME parameters before mapping to extension", () => {
+    // "image/jpeg; charset=binary" must still resolve to .jpg, not .bin.
+    const fi = parseFileInfo(
+      {
+        body: "Image",
+        info: { mimetype: "image/jpeg; charset=binary", size: 100, url: "mxc://x", w: 1, h: 1 },
+      },
+      "m.image",
+    );
+    expect(fi?.name).toBe("Image.jpg");
+  });
+
+  it("uses default name stem when body is empty string", () => {
+    // "" ?? "image" returned "" — file then saved as ".jpg" with no stem.
+    const fi = parseFileInfo(
+      {
+        body: "",
+        info: { mimetype: "image/jpeg", size: 100, url: "mxc://x", w: 1, h: 1 },
+      },
+      "m.image",
+    );
+    expect(fi?.name).toBe("image.jpg");
+  });
 });
 
 // ─── looksLikeProperName ──────────────────────────────────────────

--- a/src/entities/chat/lib/chat-helpers.test.ts
+++ b/src/entities/chat/lib/chat-helpers.test.ts
@@ -329,6 +329,76 @@ describe("parseFileInfo", () => {
   });
 });
 
+// ─── parseFileInfo — filename normalization (Session 53) ──────────
+
+describe("parseFileInfo — filename normalization by mime", () => {
+  it("adds .jpg when m.image body has no extension", () => {
+    const fi = parseFileInfo(
+      {
+        body: "Image",
+        info: { mimetype: "image/jpeg", size: 100, url: "mxc://x", w: 100, h: 100 },
+      },
+      "m.image",
+    );
+    expect(fi?.name).toBe("Image.jpg");
+  });
+
+  it("keeps existing extension when present", () => {
+    const fi = parseFileInfo(
+      {
+        body: "screenshot.png",
+        info: { mimetype: "image/png", size: 100, url: "mxc://x", w: 100, h: 100 },
+      },
+      "m.image",
+    );
+    expect(fi?.name).toBe("screenshot.png");
+  });
+
+  it("adds .mp4 for m.video without extension", () => {
+    const fi = parseFileInfo(
+      {
+        body: "Video",
+        info: { mimetype: "video/mp4", size: 100, url: "mxc://x" },
+      },
+      "m.video",
+    );
+    expect(fi?.name).toBe("Video.mp4");
+  });
+
+  it("adds .mp3 for m.audio without extension", () => {
+    const fi = parseFileInfo(
+      {
+        body: "Audio",
+        info: { mimetype: "audio/mpeg", size: 100, url: "mxc://x" },
+      },
+      "m.audio",
+    );
+    expect(fi?.name).toBe("Audio.mp3");
+  });
+
+  it("falls back to .bin for unknown mime", () => {
+    const fi = parseFileInfo(
+      {
+        body: "blob",
+        info: { mimetype: "application/x-foo", size: 100, url: "mxc://x", w: 1, h: 1 },
+      },
+      "m.image",
+    );
+    expect(fi?.name).toBe("blob.bin");
+  });
+
+  it("strips encrypted/ prefix from mime when picking extension", () => {
+    const fi = parseFileInfo(
+      {
+        body: "Image",
+        info: { mimetype: "encrypted/image/png", size: 100, url: "mxc://x", w: 1, h: 1 },
+      },
+      "m.image",
+    );
+    expect(fi?.name).toBe("Image.png");
+  });
+});
+
 // ─── looksLikeProperName ──────────────────────────────────────────
 
 describe("looksLikeProperName", () => {

--- a/src/entities/chat/lib/chat-helpers.ts
+++ b/src/entities/chat/lib/chat-helpers.ts
@@ -36,6 +36,36 @@ export function messageTypeFromMime(mime: string): MessageType {
   return MessageType.file;
 }
 
+/** Map MIME → file extension (used when body has no extension). */
+const MIME_EXT: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/jpg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/gif": "gif",
+  "image/heic": "heic",
+  "image/heif": "heif",
+  "video/mp4": "mp4",
+  "video/quicktime": "mov",
+  "video/webm": "webm",
+  "video/3gpp": "3gp",
+  "audio/mpeg": "mp3",
+  "audio/mp3": "mp3",
+  "audio/mp4": "m4a",
+  "audio/ogg": "ogg",
+  "audio/wav": "wav",
+  "audio/webm": "webm",
+  "audio/aac": "aac",
+};
+
+/** Append extension from mime if filename doesn't already have one. */
+function ensureExt(name: string, mime: string): string {
+  if (/\.[a-zA-Z0-9]{2,5}$/.test(name)) return name;
+  const cleanMime = mime.replace(/^encrypted\//, "");
+  const ext = MIME_EXT[cleanMime] ?? "bin";
+  return `${name}.${ext}`;
+}
+
 /** Parse file metadata from raw event content.
  *  m.file events: body is JSON string with {name, type, size, url, secrets}
  *                 matrix-client.ts already parses it into content.pbody
@@ -62,7 +92,7 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
 
   if (msgtype === "m.image" && info) {
     return {
-      name: (content.body as string) ?? "image",
+      name: ensureExt((content.body as string) ?? "image", info.mimetype ?? "image/jpeg"),
       type: info.mimetype ?? "image/jpeg",
       size: info.size ?? 0,
       url: info.url ?? (content.url as string) ?? "",
@@ -86,7 +116,7 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
       : undefined;
 
     return {
-      name: (content.body as string) ?? "Audio",
+      name: ensureExt((content.body as string) ?? "Audio", info.mimetype ?? "audio/mpeg"),
       type: info.mimetype ?? "audio/mpeg",
       size: info.size ?? 0,
       url: info.url ?? (content.url as string) ?? "",
@@ -105,7 +135,7 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
   if (msgtype === "m.video") {
     const url = info?.url ?? (content.url as string) ?? "";
     return {
-      name: (content.body as string) ?? "Video",
+      name: ensureExt((content.body as string) ?? "Video", info?.mimetype ?? "video/mp4"),
       type: info?.mimetype ?? "video/mp4",
       size: info?.size ?? 0,
       url,

--- a/src/entities/chat/lib/chat-helpers.ts
+++ b/src/entities/chat/lib/chat-helpers.ts
@@ -58,10 +58,14 @@ const MIME_EXT: Record<string, string> = {
   "audio/aac": "aac",
 };
 
-/** Append extension from mime if filename doesn't already have one. */
+/** Append extension from mime if filename doesn't already have one.
+ *  - alpha-first regex avoids treating "track.2024" or "v1.0" as already-
+ *    extensioned (saves "holiday.2024" as "holiday.2024.jpg" instead of
+ *    losing the .jpg)
+ *  - strips MIME parameters ("image/jpeg; charset=binary" → "image/jpeg") */
 function ensureExt(name: string, mime: string): string {
-  if (/\.[a-zA-Z0-9]{2,5}$/.test(name)) return name;
-  const cleanMime = mime.replace(/^encrypted\//, "");
+  if (/\.[a-zA-Z][a-zA-Z0-9]{1,4}$/.test(name)) return name;
+  const cleanMime = mime.split(";")[0].trim().toLowerCase().replace(/^encrypted\//, "");
   const ext = MIME_EXT[cleanMime] ?? "bin";
   return `${name}.${ext}`;
 }
@@ -92,7 +96,7 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
 
   if (msgtype === "m.image" && info) {
     return {
-      name: ensureExt((content.body as string) ?? "image", info.mimetype ?? "image/jpeg"),
+      name: ensureExt((content.body as string) || "image", info.mimetype ?? "image/jpeg"),
       type: info.mimetype ?? "image/jpeg",
       size: info.size ?? 0,
       url: info.url ?? (content.url as string) ?? "",
@@ -116,7 +120,7 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
       : undefined;
 
     return {
-      name: ensureExt((content.body as string) ?? "Audio", info.mimetype ?? "audio/mpeg"),
+      name: ensureExt((content.body as string) || "Audio", info.mimetype ?? "audio/mpeg"),
       type: info.mimetype ?? "audio/mpeg",
       size: info.size ?? 0,
       url: info.url ?? (content.url as string) ?? "",
@@ -135,7 +139,7 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
   if (msgtype === "m.video") {
     const url = info?.url ?? (content.url as string) ?? "";
     return {
-      name: ensureExt((content.body as string) ?? "Video", info?.mimetype ?? "video/mp4"),
+      name: ensureExt((content.body as string) || "Video", info?.mimetype ?? "video/mp4"),
       type: info?.mimetype ?? "video/mp4",
       size: info?.size ?? 0,
       url,

--- a/src/features/messaging/ui/MediaViewer.vue
+++ b/src/features/messaging/ui/MediaViewer.vue
@@ -141,6 +141,19 @@ const onTouchend = (e: TouchEvent) => {
   // Reset pinch tracker once one finger lifts so the next two-finger touch
   // starts fresh instead of inheriting the previous distance.
   if (e.touches.length < 2) pinchLastDistance = 0;
+  // 2→1 finger transition: pinch just ended but one finger is still down.
+  // Re-seed both the swipe anchor and the pan anchor so the remaining
+  // finger doesn't drag from stale pre-pinch coordinates.
+  if (e.touches.length === 1) {
+    touchStartX = e.touches[0].clientX;
+    touchStartY = e.touches[0].clientY;
+    touchDeltaX = 0;
+    if (scale.value > 1) {
+      panStartX = translateX.value;
+      panStartY = translateY.value;
+    }
+    return;
+  }
   // Snap back to 1x if a tiny over-pinch left a barely-visible scale change.
   if (scale.value < MIN_SCALE + 0.05 && scale.value !== MIN_SCALE) {
     resetTransform();

--- a/src/features/messaging/ui/MediaViewer.vue
+++ b/src/features/messaging/ui/MediaViewer.vue
@@ -77,13 +77,15 @@ const goPrev = () => {
   }
 };
 
-// Swipe navigation + pinch-to-zoom. Two-finger gestures take priority; one-
-// finger swipes only run when not zoomed so a horizontal pan inside a zoomed
-// image doesn't accidentally jump to the previous/next photo.
+// Swipe navigation + pinch-to-zoom + pan-when-zoomed. Two-finger gestures
+// take priority; one-finger drag is interpreted as pan while zoomed and as
+// swipe (prev/next/dismiss) at 1x.
 let touchStartX = 0;
 let touchStartY = 0;
 let touchDeltaX = 0;
 let pinchLastDistance = 0;
+let panStartX = 0;
+let panStartY = 0;
 
 const onTouchstart = (e: TouchEvent) => {
   if (e.touches.length === 2) {
@@ -94,10 +96,15 @@ const onTouchstart = (e: TouchEvent) => {
     touchDeltaX = 0;
     return;
   }
-  if (scale.value > 1) return; // Don't swipe when zoomed
   touchStartX = e.touches[0].clientX;
   touchStartY = e.touches[0].clientY;
   touchDeltaX = 0;
+  if (scale.value > 1) {
+    // Anchor pan to the current translate so subsequent deltas are relative
+    // to where the finger first touched, not to (0,0) every frame.
+    panStartX = translateX.value;
+    panStartY = translateY.value;
+  }
 };
 
 const onTouchmove = (e: TouchEvent) => {
@@ -110,7 +117,16 @@ const onTouchmove = (e: TouchEvent) => {
     pinchLastDistance = d;
     return;
   }
-  if (scale.value > 1) return;
+  if (scale.value > 1) {
+    // Divide by scale so 1 finger-pixel of drag corresponds to 1 screen-pixel
+    // of movement, regardless of zoom level — without this the photo races
+    // away from the finger at 4x zoom.
+    const dx = e.touches[0].clientX - touchStartX;
+    const dy = e.touches[0].clientY - touchStartY;
+    translateX.value = panStartX + dx / scale.value;
+    translateY.value = panStartY + dy / scale.value;
+    return;
+  }
   touchDeltaX = e.touches[0].clientX - touchStartX;
   const deltaY = e.touches[0].clientY - touchStartY;
 
@@ -215,7 +231,7 @@ const handleSaveCurrent = async () => {
             v-if="currentUrl && currentMessage.type === 'image'"
             :src="currentUrl"
             :alt="currentMessage.fileInfo?.name"
-            class="max-h-full max-w-full object-contain transition-transform duration-200"
+            class="max-h-full max-w-full object-contain"
             :style="{ transform: `scale(${scale}) translate(${translateX}px, ${translateY}px)` }"
             draggable="false"
           />

--- a/src/features/messaging/ui/__tests__/MediaViewer-pan.test.ts
+++ b/src/features/messaging/ui/__tests__/MediaViewer-pan.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression for missing pan when zoomed (issues #712, #693).
+ *
+ * Sessions 33 wired pinch-to-zoom into MediaViewer but the `onTouchmove`
+ * handler still early-returned for `scale.value > 1`, so a one-finger drag
+ * after zoom did nothing. translateX/translateY were initialized and
+ * applied in the template, but never updated — the photo sat frozen under
+ * the user's finger.
+ *
+ * Source-level assertion mirrors the pattern in
+ * MediaViewer-save-button.test.ts: mounting MediaViewer with TouchEvents in
+ * happy-dom requires mocking the chat store, useFileDownload, the Android
+ * back handler and video state preservation, which is brittle relative to
+ * the small wiring we actually want to verify.
+ */
+const getSource = (): string =>
+  readFileSync(resolve(__dirname, "../MediaViewer.vue"), "utf-8");
+
+const extractTouchmove = (source: string): string => {
+  const start = source.indexOf("const onTouchmove");
+  if (start < 0) throw new Error("onTouchmove handler not found");
+  const end = source.indexOf("const onTouchend", start);
+  if (end < 0) throw new Error("end of onTouchmove not found");
+  return source.slice(start, end);
+};
+
+describe("MediaViewer — pan when zoomed (Session 53)", () => {
+  it("updates translateX.value inside onTouchmove (not only in resetTransform)", () => {
+    const body = extractTouchmove(getSource());
+    expect(body).toMatch(/translateX\.value\s*=/);
+    expect(body).toMatch(/translateY\.value\s*=/);
+  });
+
+  it("does not early-return on scale > 1 without applying pan first", () => {
+    const body = extractTouchmove(getSource());
+    const lines = body.split("\n");
+    const guardIdx = lines.findIndex((l) => /scale\.value\s*>\s*1[^a-z]*return/.test(l));
+    if (guardIdx < 0) return; // guard removed entirely — pan path is unconditional, fine
+    // If the guard still exists, translateX/Y assignment must happen before it
+    // so panning still works for the zoomed case.
+    const beforeGuard = lines.slice(0, guardIdx).join("\n");
+    expect(beforeGuard).toMatch(/translateX\.value\s*=/);
+  });
+
+  it("captures pan start on touchstart when already zoomed", () => {
+    const source = getSource();
+    const start = source.indexOf("const onTouchstart");
+    const end = source.indexOf("const onTouchmove", start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const body = source.slice(start, end);
+    // A pan-start anchor must be recorded so the delta in onTouchmove is
+    // relative to the position when the finger first touched the screen,
+    // not to (0,0) every frame.
+    expect(body).toMatch(/panStart[XY]\s*=/);
+  });
+
+  it("removes transition-transform from the runtime gesture img", () => {
+    const source = getSource();
+    const imgStart = source.indexOf("<img");
+    expect(imgStart).toBeGreaterThan(-1);
+    const imgEnd = source.indexOf("/>", imgStart);
+    const imgTag = source.slice(imgStart, imgEnd);
+    // The CSS transition introduced gesture-perceived lag — pan/pinch must
+    // apply transform directly without the 200ms ease.
+    expect(imgTag).not.toMatch(/transition-transform/);
+  });
+});

--- a/src/features/messaging/ui/__tests__/MediaViewer-pan.test.ts
+++ b/src/features/messaging/ui/__tests__/MediaViewer-pan.test.ts
@@ -69,4 +69,30 @@ describe("MediaViewer — pan when zoomed (Session 53)", () => {
     // apply transform directly without the 200ms ease.
     expect(imgTag).not.toMatch(/transition-transform/);
   });
+
+  it("pan formula reads panStartX and divides by scale (finger-pixel parity)", () => {
+    // Guards against two regressions at once:
+    //  1. Forgetting the panStartX anchor: translateX = dx/scale instead of
+    //     panStartX + dx/scale, which makes the image snap back to (0,0) at
+    //     each touchmove.
+    //  2. Forgetting "/ scale": at 4× zoom the photo would race away from
+    //     the finger.
+    const body = extractTouchmove(getSource());
+    expect(body).toMatch(/translateX\.value\s*=\s*panStartX\s*\+/);
+    expect(body).toMatch(/translateY\.value\s*=\s*panStartY\s*\+/);
+    expect(body).toMatch(/\/\s*scale\.value/);
+  });
+
+  it("re-seeds pan anchor on 2→1 finger transition in onTouchend", () => {
+    // After pinch-zoom releases one finger, onTouchstart does NOT fire for
+    // the remaining finger. Without re-seeding, the next touchmove drags
+    // from stale pre-pinch coordinates and the image jumps.
+    const source = getSource();
+    const endStart = source.indexOf("const onTouchend");
+    expect(endStart).toBeGreaterThan(-1);
+    const endBody = source.slice(endStart, source.indexOf("};", endStart));
+    expect(endBody).toMatch(/touches\.length\s*===\s*1/);
+    expect(endBody).toMatch(/touchStartX\s*=\s*e\.touches\[0\]\.clientX/);
+    expect(endBody).toMatch(/panStartX\s*=\s*translateX\.value/);
+  });
 });


### PR DESCRIPTION
## Summary
- restore pan for zoomed images in `MediaViewer` — one-finger drag now updates `translateX/Y` when `scale > 1` (anchored to `panStartX/Y` captured on touchstart; delta divided by scale so finger-pixel = screen-pixel regardless of zoom)
- re-seed pan/swipe anchors on 2→1 finger transition in `onTouchend` (pinch release with one finger still down) so the image doesn't jump from stale pre-pinch coordinates
- remove `transition-transform duration-200` from runtime gesture `<img>` to kill input lag during pinch/pan
- normalize file name in `parseFileInfo` to always have extension by mime — `"Image"` → `"Image.jpg"`, `"Audio"` → `"Audio.mp3"`, `"Video"` → `"Video.mp4"`; preserves existing extension; falls back to `.bin` for unknown mime
- defensive: strip MIME parameters (`image/jpeg; charset=binary`), alpha-first extension regex (so `holiday.2024` doesn't lose `.jpg`), `||` instead of `??` (empty body becomes default stem, not just `.jpg`)

## Closes
- #712 — Нельзя сохранить фото; зуммированное фото нельзя двигать
- #694 — При сохранении картинки название (Image) не имеет ".jpg"
- #693 — Pinch-zoom: чувствительность низковата, нельзя смещать

## Test plan
- [x] unit: `parseFileInfo` adds extension for image/audio/video; preserves existing; strips encrypted/ and MIME params; handles empty body; handles `holiday.2024`-style names
- [x] unit: `MediaViewer.vue` source contains pan formula `translateX = panStartX + dx/scale`, captures pan anchor on touchstart when zoomed, re-seeds on 2→1 finger transition, no `transition-transform` on runtime img
- [x] full suite: 1829/1838 PASS (the 9 fails are pre-existing in \`isUnresolvedName\`/\`video-embed\`/\`open-profile-url\` and unrelated to this PR)
- [ ] manual on Android: zoom → pan works in both axes; pinch → release one finger → drag continues smoothly; save photo from MediaViewer lands in gallery with .jpg

## Out of scope (next sessions)
- Native MediaStore write path (M3 in research) for direct gallery save
- Pan bounds clamping (currently unbounded — fine while inside frame, cosmetic if dragged far off)