### PR TITLE
fix(audio): native idle watchdog restores MODE_NORMAL on orphaned call (Session 54)

### DIFF
--- a/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
@@ -39,6 +39,16 @@ class AudioRouter private constructor(private val context: Context) {
         private const val TAG = "AudioRouter"
         private const val LIFECYCLE_TAG = "AudioLifecycle"
 
+        /**
+         * Maximum lifetime of a single audio-routing session before the
+         * watchdog forces a reset. Picked at 5 minutes because a real call
+         * cycle is rarely longer than a few minutes for our user base; if
+         * we have not seen a stop()/forceStop() by then, the JS finalize
+         * path almost certainly never ran (process killed by OEM, Doze,
+         * or battery-saver between hangup and stopAudioRouting).
+         */
+        private const val AUDIO_MAX_LIFETIME_MS = 5L * 60_000L
+
         @Volatile
         private var INSTANCE: AudioRouter? = null
 
@@ -70,6 +80,24 @@ class AudioRouter private constructor(private val context: Context) {
                 INSTANCE = null
             }
         }
+
+        /**
+         * Pure predicate used by the orphan-watchdog (Session 54).
+         *
+         * Returns true when the watchdog should brute-force restore
+         * MODE_NORMAL: the router still thinks audio routing is active,
+         * but the call infrastructure (WebRTC manager + foreground
+         * service) is gone — meaning the JS-side stopAudioRouting never
+         * reached us (OEM killed the process).
+         *
+         * Exposed at companion-object scope so it can be unit-tested
+         * without spinning up a real AudioManager / Looper.
+         */
+        @androidx.annotation.VisibleForTesting
+        internal fun shouldForceStopForWatchdog(
+            callAlive: Boolean,
+            isRouterActive: Boolean,
+        ): Boolean = isRouterActive && !callAlive
     }
 
     enum class Device(val label: String) {
@@ -107,6 +135,15 @@ class AudioRouter private constructor(private val context: Context) {
     private var isActive = false
     private var callType = "voice"
     private var bluetoothDeviceName: String? = null
+
+    // Session 54: cancellable Runnables. The 500ms re-apply runnable used to
+    // be an anonymous lambda we could never cancel — on ultra-fast hangups
+    // (stop() within 500ms of start()) it would fire after stop() and put
+    // the device back into MODE_IN_COMMUNICATION. The orphan watchdog needs
+    // the same cancel guarantee: stop()/forceStop() must remove it so a
+    // healthy hangup does not later trigger a redundant forceStop.
+    private var reapplyRunnable: Runnable? = null
+    private var stopWatchdog: Runnable? = null
 
     private val deviceCallback = object : AudioDeviceCallback() {
         override fun onAudioDevicesAdded(addedDevices: Array<out AudioDeviceInfo>) {
@@ -159,12 +196,47 @@ class AudioRouter private constructor(private val context: Context) {
 
         // OEM fix: Some Chinese ROMs (MIUI, RealmeUI, XOS) reset audio mode
         // asynchronously after init. Re-apply after a short delay to catch resets.
-        mainHandler.postDelayed({
+        // Stored as a field so stop() / forceStop() can cancel it on fast hangups.
+        reapplyRunnable?.let { mainHandler.removeCallbacks(it) }
+        val reapply = Runnable {
             if (isActive && audioManager.mode != AudioManager.MODE_IN_COMMUNICATION) {
                 Log.w(LIFECYCLE_TAG, "Audio mode was reset by system — re-applying MODE_IN_COMMUNICATION")
                 audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
             }
-        }, 500)
+        }
+        reapplyRunnable = reapply
+        mainHandler.postDelayed(reapply, 500)
+
+        // Session 54: orphan-call watchdog. If the JS finalize never runs
+        // (process killed by OEM Doze / battery-saver between hangup and
+        // stopAudioRouting), AudioRouter stays in MODE_IN_COMMUNICATION
+        // forever and the phone's media volume is broken until reboot.
+        // Every AUDIO_MAX_LIFETIME_MS we check whether the call foreground
+        // service is still running; if not, we forceStop() ourselves.
+        // (WebRTCPlugin.manager is plugin-lifetime, not call-lifetime, so
+        // including it in the predicate would never trip — the call
+        // foreground service is the actual call-liveness signal.)
+        stopWatchdog?.let { mainHandler.removeCallbacks(it) }
+        val watchdog = object : Runnable {
+            override fun run() {
+                val callAlive = CallForegroundService.isRunning
+                if (shouldForceStopForWatchdog(callAlive = callAlive, isRouterActive = isActive)) {
+                    Log.w(
+                        LIFECYCLE_TAG,
+                        "Audio watchdog: no active call after ${AUDIO_MAX_LIFETIME_MS}ms — forceStop",
+                    )
+                    forceStop()
+                } else if (isActive) {
+                    // Call still alive (or router was already stopped) —
+                    // rearm for another window. Only rearm while we still
+                    // believe routing is active; if isActive is false we
+                    // are already torn down and rescheduling would be a leak.
+                    mainHandler.postDelayed(this, AUDIO_MAX_LIFETIME_MS)
+                }
+            }
+        }
+        stopWatchdog = watchdog
+        mainHandler.postDelayed(watchdog, AUDIO_MAX_LIFETIME_MS)
 
         audioManager.registerAudioDeviceCallback(deviceCallback, mainHandler)
 
@@ -195,6 +267,16 @@ class AudioRouter private constructor(private val context: Context) {
         }
 
         isActive = false
+
+        // Session 54: cancel the orphan watchdog and the OEM re-apply
+        // runnable before tearing down. Without these removeCallbacks,
+        // a healthy hangup followed by an immediate new call would see
+        // the previous call's watchdog still scheduled, and a 500ms
+        // re-apply could fire after the new start() had set the mode.
+        stopWatchdog?.let { mainHandler.removeCallbacks(it) }
+        stopWatchdog = null
+        reapplyRunnable?.let { mainHandler.removeCallbacks(it) }
+        reapplyRunnable = null
 
         // Session 23: previously a single call chain. If
         // unregisterAudioDeviceCallback or BT SCO teardown threw, the
@@ -282,6 +364,15 @@ class AudioRouter private constructor(private val context: Context) {
     fun forceStop() = synchronized(lifecycleLock) {
         Log.w(LIFECYCLE_TAG, "forceStop() — bypassing guards, brute reset")
         isActive = false
+
+        // Session 54: same cancellation as stop() — the watchdog itself
+        // may have triggered this forceStop, but a no-op removeCallbacks
+        // on the currently-executing Runnable is safe and prevents the
+        // (cancelled) reapply runnable from outliving us.
+        stopWatchdog?.let { mainHandler.removeCallbacks(it) }
+        stopWatchdog = null
+        reapplyRunnable?.let { mainHandler.removeCallbacks(it) }
+        reapplyRunnable = null
 
         try { audioManager.unregisterAudioDeviceCallback(deviceCallback) } catch (_: Exception) {}
 

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallActivity.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallActivity.kt
@@ -295,8 +295,14 @@ class CallActivity : Activity(), SensorEventListener {
             }
         }
 
-        // D-10: Restore audio context when returning to active call
-        val hasActiveCall = WebRTCPlugin.manager != null
+        // D-10 / Session 54: Restore audio context only if the call is
+        // really still alive. Previously we keyed off WebRTCPlugin.manager
+        // alone, which can outlive the call lifecycle (e.g. when the
+        // foreground service was killed by the OEM but the JS-side manager
+        // reference was never cleared). In that case onResume was happily
+        // re-applying MODE_IN_COMMUNICATION on a corpse call, leaving the
+        // device's volume controls stuck on VoIP-only until reboot (#708).
+        val hasActiveCall = WebRTCPlugin.manager != null && CallForegroundService.isRunning
         if (hasActiveCall) {
             val am = getSystemService(Context.AUDIO_SERVICE) as AudioManager
             am.mode = AudioManager.MODE_IN_COMMUNICATION

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallForegroundService.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallForegroundService.kt
@@ -77,8 +77,27 @@ class CallForegroundService : Service() {
             context.startService(intent)
         }
 
-        // D-10: Re-request audio focus from CallActivity.onResume
+        // D-10: Re-request audio focus from CallActivity.onResume.
+        // Session 54: @Volatile so the isRunning getter can be read safely
+        // from non-main threads if a future caller does so. Today all
+        // readers are on the main thread (watchdog + CallActivity.onResume),
+        // but the cost of @Volatile is a single memory barrier so the
+        // safety win is free.
+        @Volatile
         private var instance: CallForegroundService? = null
+
+        /**
+         * Session 54: exposed read-only liveness flag. Other call surfaces
+         * (AudioRouter orphan watchdog, CallActivity.onResume) need to know
+         * whether the foreground service is actually running before
+         * restoring MODE_IN_COMMUNICATION — assuming the service is up just
+         * because we have a saved Activity reference is what produced the
+         * orphan VoIP-mode bug (#708 / #462). Kept as a property getter so
+         * the underlying `instance` reference can stay private.
+         */
+        @JvmStatic
+        val isRunning: Boolean
+            get() = instance != null
 
         fun reRequestAudioFocus(context: Context) {
             instance?.requestAudioFocus()

--- a/android/app/src/test/java/com/forta/chat/plugins/calls/AudioRouterWatchdogTest.kt
+++ b/android/app/src/test/java/com/forta/chat/plugins/calls/AudioRouterWatchdogTest.kt
@@ -1,0 +1,47 @@
+package com.forta.chat.plugins.calls
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for Session 54 — AudioManager mode orphan watchdog.
+ *
+ * The watchdog must restore MODE_NORMAL when the call is dead (process killed
+ * by OEM between hangup and `stopAudioRouting`) but AudioRouter still thinks
+ * it owns audio. Logic is exposed as a pure predicate so it can be covered
+ * in a JVM unit test without Robolectric / mockk.
+ */
+class AudioRouterWatchdogTest {
+
+    @Test
+    fun deadCall_andActiveRouter_triggersForceStop() {
+        assertTrue(
+            "router active + call dead → must force stop",
+            AudioRouter.shouldForceStopForWatchdog(callAlive = false, isRouterActive = true),
+        )
+    }
+
+    @Test
+    fun aliveCall_doesNotTriggerForceStop() {
+        assertFalse(
+            "call still alive → watchdog should rearm, not stop",
+            AudioRouter.shouldForceStopForWatchdog(callAlive = true, isRouterActive = true),
+        )
+    }
+
+    @Test
+    fun inactiveRouter_isNoOp_evenIfCallDead() {
+        assertFalse(
+            "router already stopped → watchdog is a no-op",
+            AudioRouter.shouldForceStopForWatchdog(callAlive = false, isRouterActive = false),
+        )
+    }
+
+    @Test
+    fun inactiveRouter_aliveCall_isNoOp() {
+        assertFalse(
+            AudioRouter.shouldForceStopForWatchdog(callAlive = true, isRouterActive = false),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- **AudioRouter native watchdog** — каждые 5 мин проверяет `CallForegroundService.isRunning`. Если сервис мёртв, а router всё ещё думает, что audio routing активен → `forceStop()` восстанавливает `MODE_NORMAL`. Защищает от OEM-килла процесса между `peerConnection.close` и JS `stopAudioRouting` (MIUI / Xiaomi / OnePlus / Doze / battery-saver).
- **Cancellable Runnables** — 500ms re-apply runnable теперь хранится как поле и отменяется в `stop()` / `forceStop()` (раньше анонимная лямбда продолжала жить после быстрого hangup).
- **`CallForegroundService.isRunning`** — `@JvmStatic` property getter поверх приватного `instance` (с `@Volatile`).
- **`CallActivity.onResume`** теперь требует И `WebRTCPlugin.manager != null` И `CallForegroundService.isRunning` перед восстановлением `MODE_IN_COMMUNICATION` — иначе onResume на трупе вызова успевал откатить watchdog.

Закрывает #708 (вероятно также #462, #466, #482).

## Why this works
Логика watchdog — pure predicate `shouldForceStopForWatchdog(callAlive, isRouterActive)` в companion object. Это позволяет полностью покрыть truth table unit-тестами без Robolectric / mockk (4 случая в `AudioRouterWatchdogTest`).

## Test plan
- [x] `./gradlew app:testDebugUnitTest --tests AudioRouterWatchdogTest` — 4/4 pass
- [x] `./gradlew app:testDebugUnitTest` (вся test-сюита проекта) — pass
- [x] `./gradlew app:assembleDebug` — pass
- [x] `vitest run` — pass (unhandled rejections в чужих тестах существовали и до Session 54)
- [x] code review (superpowers:code-reviewer) — no critical/high. MEDIUM-замечания (\`@Volatile\` на \`instance\`, упрощение predicate от dead-code manager-check) учтены.
- [ ] **manual on-device (Xiaomi/MIUI):**
  1. Начать audio call.
  2. \`adb shell dumpsys audio | grep \"mode=\"\` → \`MODE_IN_COMMUNICATION\` ✓
  3. \`adb shell am kill com.forta.chat\`
  4. Подождать 5+ мин.
  5. \`adb shell dumpsys audio | grep \"mode=\"\` → \`MODE_NORMAL\` ✓
- [ ] **manual:** обычный hangup сразу же возвращает \`MODE_NORMAL\` (не сломали happy path).

## Out of scope
- Рефакторинг AudioRouter на AudioFocus-listener pattern — отдельная задача.
- iOS — там mode управляется AVAudioSession, эта сессия его не касается.