### PR TITLE
fix(i18n): localize 'Today'/'Yesterday' in chat list (Session 56)

### DIFF
--- a/src/shared/lib/format.test.ts
+++ b/src/shared/lib/format.test.ts
@@ -1,10 +1,19 @@
 /**
  * Tests for date/time formatting utilities.
  */
-import { describe, it, expect } from "vitest";
-import { formatDate, formatDuration } from "./format";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { formatDate, formatDuration, formatRelativeTime } from "./format";
+
+const LOCALE_KEY = "forta-chat:locale";
 
 describe("formatDate", () => {
+  beforeEach(() => {
+    localStorage.removeItem(LOCALE_KEY);
+  });
+  afterEach(() => {
+    localStorage.removeItem(LOCALE_KEY);
+  });
+
   it("returns 'Today' for today's date", () => {
     expect(formatDate(new Date())).toBe("Today");
   });
@@ -22,6 +31,40 @@ describe("formatDate", () => {
     expect(result).not.toBe("Today");
     expect(result).not.toBe("Yesterday");
     expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("returns 'Сегодня' in russian locale for today", () => {
+    localStorage.setItem(LOCALE_KEY, JSON.stringify("ru"));
+    expect(formatDate(new Date())).toBe("Сегодня");
+  });
+
+  it("returns 'Вчера' in russian locale for yesterday", () => {
+    localStorage.setItem(LOCALE_KEY, JSON.stringify("ru"));
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    expect(formatDate(yesterday)).toBe("Вчера");
+  });
+});
+
+describe("formatRelativeTime", () => {
+  beforeEach(() => {
+    localStorage.removeItem(LOCALE_KEY);
+  });
+  afterEach(() => {
+    localStorage.removeItem(LOCALE_KEY);
+  });
+
+  it("returns 'Yesterday' in english for yesterday", () => {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    expect(formatRelativeTime(yesterday)).toBe("Yesterday");
+  });
+
+  it("returns 'Вчера' in russian locale for yesterday", () => {
+    localStorage.setItem(LOCALE_KEY, JSON.stringify("ru"));
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    expect(formatRelativeTime(yesterday)).toBe("Вчера");
   });
 });
 

--- a/src/shared/lib/format.ts
+++ b/src/shared/lib/format.ts
@@ -1,3 +1,5 @@
+import { tRaw } from "@/shared/lib/i18n";
+
 export function formatTime(date: Date): string {
   return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
@@ -7,8 +9,8 @@ export function formatDate(date: Date): string {
   const yesterday = new Date(today);
   yesterday.setDate(yesterday.getDate() - 1);
 
-  if (isSameDay(date, today)) return "Today";
-  if (isSameDay(date, yesterday)) return "Yesterday";
+  if (isSameDay(date, today)) return tRaw("date.today");
+  if (isSameDay(date, yesterday)) return tRaw("date.yesterday");
 
   return date.toLocaleDateString([], {
     day: "numeric",
@@ -40,7 +42,7 @@ export function formatRelativeTime(date: Date): string {
 
   const yesterday = new Date(now);
   yesterday.setDate(yesterday.getDate() - 1);
-  if (isSameDay(date, yesterday)) return "Yesterday";
+  if (isSameDay(date, yesterday)) return tRaw("date.yesterday");
 
   // Within same week: day name
   const diffMs = now.getTime() - date.getTime();

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -736,6 +736,10 @@ export const en = {
   "push.unknownSender": "Unknown",
   "push.file": "📎 File",
 
+  // ── Relative date labels (sidebar / chat list) ──
+  "date.today": "Today",
+  "date.yesterday": "Yesterday",
+
   // ── Notification channels ──
   "channel.messages": "Messages",
   "channel.messagesDesc": "Chat message notifications",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -738,6 +738,10 @@ export const ru: Record<TranslationKey, string> = {
   "push.unknownSender": "Неизвестный",
   "push.file": "📎 Файл",
 
+  // ── Relative date labels (sidebar / chat list) ──
+  "date.today": "Сегодня",
+  "date.yesterday": "Вчера",
+
   // ── Notification channels ──
   "channel.messages": "Сообщения",
   "channel.messagesDesc": "Уведомления о сообщениях",


### PR DESCRIPTION
## Summary
- New i18n keys `date.today` / `date.yesterday` added to `en.ts` and `ru.ts`
- `formatDate` and `formatRelativeTime` in `src/shared/lib/format.ts` now read labels through `tRaw()` (standalone translator that works in non-Vue contexts)
- 4 regression tests in `format.test.ts` covering both English and Russian locales

## Why
Issue #704: chat sidebar showed hardcoded English "Today"/"Yesterday" even when the user picked Russian — labels are visible next to every chat in `ContactList`, `ChannelList`, and `ChatSearch`.

## Root Cause
`src/shared/lib/format.ts` had three hardcoded English literals (`return "Today"`, `return "Yesterday"` in two places) instead of going through i18n.

## Approach
Used `tRaw()` instead of `useI18n()` because `format.ts` is a pure utility imported into multiple Vue components — using a Vue-only translator would force every call site into a Vue setup scope. `tRaw()` is the documented standalone translator (`src/shared/lib/i18n/index.ts:33-47`) already used by `push-service.ts` for the same reason.

## Test plan
- [x] vitest: `format.test.ts` — 12 scenarios pass (4 new for ru locale)
- [x] full suite: 1841 passing, 9 pre-existing fails on master (no regressions)
- [x] `vue-tsc`: 47 errors (identical baseline as master, no new ones)
- [x] code review: APPROVE (`superpowers:code-reviewer`)
- [ ] manual: switch app language to Russian → sidebar shows "Сегодня" / "Вчера"
- [ ] manual: switch back to English → "Today" / "Yesterday"

Closes part of #704 (the "Yesterday" labels). The "New message" part of #704 belongs to push notifications and is tracked separately in Session 40.

## Out of scope
- Localization of weekday/month names in `formatDate`/`formatRelativeTime` else-branches (`toLocaleDateString([])` uses system locale, not app locale) — pre-existing, separate audit.
- `ChannelPostBubble.vue` reactivity (computed without `useI18n` subscription) — pre-existing in unused component.