### PR TITLE
fix(media-download): encrypted attachment fallback to content.file.url (Session 57)

### DIFF
--- a/src/entities/chat/lib/chat-helpers.test.ts
+++ b/src/entities/chat/lib/chat-helpers.test.ts
@@ -329,6 +329,102 @@ describe("parseFileInfo", () => {
   });
 });
 
+// ─── parseFileInfo — encrypted attachment via content.file.url (Session 57) ───
+// Canonical Matrix encrypted attachments carry url under `content.file.url`
+// alongside { iv, key }. Some non-Bastyon clients (Element, Cinny, FluffyChat)
+// emit m.image/m.audio/m.video/m.file without copying that url to
+// `content.url` / `content.info.url`. Forta must read content.file.url as a
+// fallback or tap «Download» throws "No file URL" and opens a bug-report.
+
+describe("parseFileInfo — encrypted attachment (content.file.url fallback)", () => {
+  it("reads url from content.file.url when content.url and info.url are missing (m.file)", () => {
+    const content = {
+      msgtype: "m.file",
+      body: "report.pdf",
+      file: {
+        url: "mxc://matrix.bastyon.com/abc123",
+        mimetype: "application/pdf",
+        key: { kty: "oct", k: "..." },
+        iv: "...",
+      },
+      info: { mimetype: "application/pdf", size: 12345 },
+    };
+    const fi = parseFileInfo(content, "m.file");
+    expect(fi).toBeDefined();
+    expect(fi!.url).toBe("mxc://matrix.bastyon.com/abc123");
+  });
+
+  it("reads url from content.file.url for m.image", () => {
+    const content = {
+      body: "photo.jpg",
+      file: { url: "mxc://server/img1", mimetype: "image/jpeg" },
+      info: { mimetype: "image/jpeg", w: 100, h: 200 },
+    };
+    const fi = parseFileInfo(content, "m.image");
+    expect(fi).toBeDefined();
+    expect(fi!.url).toBe("mxc://server/img1");
+  });
+
+  it("reads url from content.file.url for m.audio", () => {
+    const content = {
+      body: "voice.opus",
+      file: { url: "mxc://server/aud1", mimetype: "audio/opus" },
+      info: { mimetype: "audio/opus", duration: 5000 },
+    };
+    const fi = parseFileInfo(content, "m.audio");
+    expect(fi).toBeDefined();
+    expect(fi!.url).toBe("mxc://server/aud1");
+  });
+
+  it("reads url from content.file.url for m.video", () => {
+    const content = {
+      body: "video.mp4",
+      file: { url: "mxc://server/vid1", mimetype: "video/mp4" },
+      info: { mimetype: "video/mp4", w: 1920, h: 1080 },
+    };
+    const fi = parseFileInfo(content, "m.video");
+    expect(fi).toBeDefined();
+    expect(fi!.url).toBe("mxc://server/vid1");
+  });
+
+  it("prefers info.url over content.file.url when both present (m.image)", () => {
+    const content = {
+      body: "x.jpg",
+      file: { url: "mxc://server/from-file" },
+      info: { mimetype: "image/jpeg", url: "mxc://server/from-info", w: 1, h: 1 },
+    };
+    const fi = parseFileInfo(content, "m.image");
+    expect(fi!.url).toBe("mxc://server/from-info");
+  });
+
+  it("prefers pbody.url over content.file.url when both present (m.file)", () => {
+    const content = {
+      pbody: { name: "x.pdf", type: "application/pdf", size: 0, url: "mxc://server/from-pbody" },
+      file: { url: "mxc://server/from-file" },
+    };
+    const fi = parseFileInfo(content, "m.file");
+    expect(fi!.url).toBe("mxc://server/from-pbody");
+  });
+
+  it("m.file without pbody but with content.file.url returns valid FileInfo", () => {
+    // No pbody → first branch skipped; second branch (body-as-JSON) also fails.
+    // Need a third branch that handles raw m.file with content.file.url.
+    const content = {
+      body: "report.pdf",
+      file: {
+        url: "mxc://matrix.bastyon.com/abc123",
+        mimetype: "application/pdf",
+        key: { kty: "oct", k: "..." },
+        iv: "...",
+      },
+      info: { mimetype: "application/pdf", size: 12345 },
+    };
+    const fi = parseFileInfo(content, "m.file");
+    expect(fi).toBeDefined();
+    expect(fi!.url).toBe("mxc://matrix.bastyon.com/abc123");
+  });
+});
+
 // ─── parseFileInfo — filename normalization (Session 53) ──────────
 
 describe("parseFileInfo — filename normalization by mime", () => {

--- a/src/entities/chat/lib/chat-helpers.ts
+++ b/src/entities/chat/lib/chat-helpers.ts
@@ -79,13 +79,22 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
   const pbody = content.pbody as any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const info = content.info as any;
+  // Canonical Matrix encrypted attachments (Element, Cinny, FluffyChat, …)
+  // carry `mxc://` url under `content.file.url` alongside { iv, key, hashes }.
+  // Bastyon's own pipeline duplicates the url into pbody/info/content.url,
+  // but messages forwarded from other clients omit those copies — without a
+  // fallback the download path throws "No file URL" (Session 57, bugs #740,
+  // #739, #719, #567).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const encryptedFile = content.file as any;
+  const encryptedUrl: string | undefined = typeof encryptedFile?.url === "string" ? encryptedFile.url : undefined;
 
   if (msgtype === "m.file" && pbody) {
     return {
       name: pbody.name ?? "file",
       type: (pbody.type ?? "").replace("encrypted/", ""),
       size: pbody.size ?? 0,
-      url: pbody.url ?? "",
+      url: pbody.url ?? encryptedUrl ?? "",
       secrets: pbody.secrets ? {
         block: pbody.secrets.block,
         keys: pbody.secrets.keys,
@@ -99,7 +108,7 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
       name: ensureExt((content.body as string) || "image", info.mimetype ?? "image/jpeg"),
       type: info.mimetype ?? "image/jpeg",
       size: info.size ?? 0,
-      url: info.url ?? (content.url as string) ?? "",
+      url: info.url ?? encryptedUrl ?? (content.url as string) ?? "",
       w: info.w,
       h: info.h,
       caption: info.caption ?? undefined,
@@ -123,7 +132,7 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
       name: ensureExt((content.body as string) || "Audio", info.mimetype ?? "audio/mpeg"),
       type: info.mimetype ?? "audio/mpeg",
       size: info.size ?? 0,
-      url: info.url ?? (content.url as string) ?? "",
+      url: info.url ?? encryptedUrl ?? (content.url as string) ?? "",
       duration: typeof info.duration === "number" && info.duration > 0
         ? Math.round(info.duration / 1000)
         : undefined,
@@ -137,7 +146,7 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
   }
 
   if (msgtype === "m.video") {
-    const url = info?.url ?? (content.url as string) ?? "";
+    const url = info?.url ?? encryptedUrl ?? (content.url as string) ?? "";
     return {
       name: ensureExt((content.body as string) || "Video", info?.mimetype ?? "video/mp4"),
       type: info?.mimetype ?? "video/mp4",
@@ -174,6 +183,23 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
         };
       }
     } catch { /* not JSON, ignore */ }
+  }
+
+  // Canonical Matrix encrypted m.file from non-Bastyon clients: no pbody,
+  // body is a plain filename string. Construct FileInfo directly from
+  // content.file.url + info{mimetype,size}.
+  if (msgtype === "m.file" && encryptedUrl) {
+    const mime = (info?.mimetype as string | undefined) ?? "application/octet-stream";
+    return {
+      name: ensureExt((content.body as string) || "file", mime),
+      type: mime.replace("encrypted/", ""),
+      size: info?.size ?? 0,
+      url: encryptedUrl,
+      // Secrets follow Matrix EncryptedFile shape: { url, key, iv, hashes, v }.
+      // We do not surface them here because the bastyon-chat crypto pipeline
+      // reads its own pbody.secrets shape; canonical-Matrix decryption is
+      // handled by matrix-js-sdk before parseFileInfo runs.
+    };
   }
 
   return undefined;

--- a/src/features/messaging/model/use-file-download-bug-report.test.ts
+++ b/src/features/messaging/model/use-file-download-bug-report.test.ts
@@ -225,6 +225,63 @@ describe("useFileDownload — auto bug-report blacklist & dedup", () => {
     expect(bugReportOpen).toHaveBeenCalledTimes(1);
   });
 
+  // ── MissingUrlError (Session 57) ─────────────────────────────────────
+  // Encrypted attachments without a usable mxc url used to throw a generic
+  // `Error("No file URL")` that auto-opened the bug-report modal — overwhelming
+  // signal in bugs #740 #739 #719 #567. Now: typed MissingUrlError → silent
+  // toast, no auto-report, no retry waste.
+
+  it("does NOT auto-open bug-report when fileInfo.url is empty (MissingUrlError)", async () => {
+    const scope = effectScope();
+    await scope.run(async () => {
+      const { download } = useFileDownload();
+      const msg = makeMessage({
+        id: "$evt-no-url",
+        _key: "client-no-url",
+        fileInfo: {
+          name: "report.pdf",
+          type: "application/pdf",
+          size: 12345,
+          url: "", // No url — simulates parse failure on legacy DB row
+          secrets: { keys: "k", block: 1, v: 1 },
+        },
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await runWithFakeTimers(() => download(msg as any));
+    });
+    scope.stop();
+
+    expect(bugReportOpen).not.toHaveBeenCalled();
+  });
+
+  it("does NOT issue a network fetch when fileInfo.url is empty", async () => {
+    // The empty-url guard must short-circuit before fetch so callers never
+    // burn a network roundtrip on an obviously-broken message.
+    const fetchSpy = vi.fn() as unknown as Mock;
+    global.fetch = fetchSpy;
+
+    const scope = effectScope();
+    await scope.run(async () => {
+      const { download } = useFileDownload();
+      const msg = makeMessage({
+        id: "$evt-no-url-fetch",
+        _key: "client-no-url-fetch",
+        fileInfo: {
+          name: "x.bin",
+          type: "application/octet-stream",
+          size: 1,
+          url: "",
+          secrets: { keys: "k", block: 1, v: 1 },
+        },
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await runWithFakeTimers(() => download(msg as any));
+    });
+    scope.stop();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("emits a SECOND bug-report after the dedup window (5 minutes) elapses", async () => {
     vi.setSystemTime(new Date("2026-04-29T10:00:00Z"));
 

--- a/src/features/messaging/model/use-file-download.ts
+++ b/src/features/messaging/model/use-file-download.ts
@@ -11,6 +11,7 @@ import {
   CryptoNotReadyError,
   isNetworkBlocked,
   MediaUnavailableError,
+  MissingUrlError,
   NetworkBlockedError,
 } from "@/shared/lib/network/typed-network-errors";
 import { waitForRoomCrypto } from "@/entities/matrix/model/wait-for-crypto";
@@ -127,7 +128,8 @@ function shouldAutoReport(messageKey: string, err: unknown): boolean {
   if (
     err instanceof CryptoNotReadyError ||
     err instanceof NetworkBlockedError ||
-    err instanceof MediaUnavailableError
+    err instanceof MediaUnavailableError ||
+    err instanceof MissingUrlError
   ) {
     return false;
   }
@@ -180,10 +182,16 @@ export function _resetToastDedupForTests(): void {
  *  Deduped per (cacheKey, errorKey) within TOAST_DEDUP_WINDOW_MS so that
  *  repeated re-attempts during the same network glitch do not spam the user. */
 function surfaceTypedErrorToast(err: unknown, cacheKey: string): void {
-  let key: "errors.networkBlocked" | "errors.cryptoNotReady" | "errors.mediaUnavailable" | null = null;
+  let key:
+    | "errors.networkBlocked"
+    | "errors.cryptoNotReady"
+    | "errors.mediaUnavailable"
+    | "errors.missingUrl"
+    | null = null;
   if (err instanceof NetworkBlockedError) key = "errors.networkBlocked";
   else if (err instanceof CryptoNotReadyError) key = "errors.cryptoNotReady";
   else if (err instanceof MediaUnavailableError) key = "errors.mediaUnavailable";
+  else if (err instanceof MissingUrlError) key = "errors.missingUrl";
   if (!key) return;
 
   pruneToastDedup();
@@ -325,7 +333,7 @@ async function downloadAndDecrypt(
   timestamp: number,
   signal?: AbortSignal,
 ): Promise<Blob> {
-  if (!fileInfo.url) throw new Error("No file URL");
+  if (!fileInfo.url) throw new MissingUrlError();
   if (signal?.aborted) throw new DOMException("Download cancelled", "AbortError");
 
   let lastError: unknown;
@@ -409,8 +417,8 @@ async function downloadAndDecrypt(
       // the toast tells them what's going on.
       if (e instanceof CryptoNotReadyError) throw e;
       // Don't retry on permanent errors (missing URL, 4xx client errors)
+      if (e instanceof MissingUrlError) throw e;
       if (e instanceof Error) {
-        if (e.message === "No file URL") throw e;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const status = (e as any).status as number | undefined;
         if (status !== undefined && NON_RETRIABLE_STATUSES.has(status)) throw e;

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -860,6 +860,7 @@ export const en = {
   "errors.mediaUnavailable": "Media unavailable. Please try again later.",
   "errors.networkBlocked": "Server unreachable. Try enabling Tor or a VPN.",
   "errors.cryptoNotReady": "Encryption keys are still loading. Please wait.",
+  "errors.missingUrl": "File is corrupted or never arrived. Ask the sender to resend.",
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -862,4 +862,5 @@ export const ru: Record<TranslationKey, string> = {
   "errors.mediaUnavailable": "Медиа недоступно. Попробуйте позже.",
   "errors.networkBlocked": "Сервер недоступен. Попробуйте включить Tor или VPN.",
   "errors.cryptoNotReady": "Ключи шифрования ещё загружаются. Подождите.",
+  "errors.missingUrl": "Файл повреждён или не пришёл с источника. Попросите отправителя прислать ещё раз.",
 };

--- a/src/shared/lib/network/typed-network-errors.ts
+++ b/src/shared/lib/network/typed-network-errors.ts
@@ -16,6 +16,12 @@
  *  - `CryptoNotReadyError`  — `authStore.pcrypto.rooms[roomId]` wasn't ready
  *    when we tried to decrypt. Caller should wait briefly and retry; this is
  *    a startup race, not a permanent failure.
+ *  - `MissingUrlError`      — the message event has no usable mxc URL at all
+ *    (neither pbody.url, info.url, content.url, nor content.file.url). This
+ *    is a data-shape problem: corrupted DB row, redacted event, or a
+ *    non-Bastyon client emitting a shape we don't yet parse. Surface a
+ *    friendly toast — never an auto-bug-report, since there's nothing the
+ *    user can debug.
  */
 
 /** Heuristic patterns that indicate the request never reached the server.
@@ -67,6 +73,13 @@ export class CryptoNotReadyError extends Error {
     );
     this.name = "CryptoNotReadyError";
     this.roomId = roomId;
+  }
+}
+
+export class MissingUrlError extends Error {
+  constructor() {
+    super("Message has no usable file URL");
+    this.name = "MissingUrlError";
   }
 }
 


### PR DESCRIPTION
## Summary

- `parseFileInfo` теперь читает `content.file.url` для canonical Matrix encrypted attachments (m.file / m.image / m.audio / m.video). Без этого fallback'а сообщения, пришедшие от не-Bastyon Matrix-клиентов (Element, Cinny, FluffyChat) или forwarded media приходили в Dexie с `url = ""` и при попытке скачать падали с `Error("No file URL")`.
- Добавлена terminal-ветка для canonical `m.file` без `pbody`: парсит FileInfo прямо из `content.file.url` + `content.info.mimetype/size`.
- Новый typed error `MissingUrlError`. При реально пустом url пользователь видит **toast** `errors.missingUrl` («Файл повреждён или не пришёл с источника...»), а не auto-bug-report modal. Skip retry-loop + skip `shouldAutoReport`.
- i18n ключ `errors.missingUrl` для ru + en.

## Closes

- forta-bugs#740 — Error: no file url. Ошибка при попытке скачать файл из сообщения
- forta-bugs#739 — Нет возможности скачать полученный файл pdf
- forta-bugs#719 — Failed to download file. Ошибка: Error: No file URL
- forta-bugs#567 — Failed to download file. Ошибка: Error: No file URL

## Test plan

- [x] **Unit**: 7 новых regression-тестов в \`chat-helpers.test.ts\` (4 media-типа + edge cases: prefers info.url/pbody.url, m.file без pbody)
- [x] **Unit**: 2 регресс-теста в \`use-file-download-bug-report.test.ts\` (MissingUrlError не открывает bug-report, не делает fetch)
- [x] Build / TS / test baseline: 0 новых ошибок относительно master (47 TS errors + 9 test failures одинаковы на master и branch — все pre-existing)
- [ ] **Manual** (после мержа): отправить из Element/Cinny encrypted PDF в Bastyon-чат → tap «Скачать» → файл сохраняется
- [ ] **Manual**: симулировать \`fileInfo.url = ""\` (изменить Dexie row) → tap «Скачать» → toast вместо bug-report

## Out of scope

- Re-parse legacy Dexie-сообщений с \`url = ""\` (нужна отдельная DB-миграция; новые сообщения после мержа парсятся корректно)
- Forwarded media local blob URL revocation (отдельная задача)
- Pre-existing TS-ошибки и pre-existing test failures (есть на master до этого PR)