### PR TITLE
fix(voice-recorder): enable autoGainControl для нормальной громкости (Session 65)

### DIFF
--- a/src/features/messaging/model/use-voice-recorder.test.ts
+++ b/src/features/messaging/model/use-voice-recorder.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useVoiceRecorder } from "./use-voice-recorder";
+
+describe("useVoiceRecorder — getUserMedia constraints", () => {
+  let gumSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    gumSpy = vi.fn(async () => ({
+      getAudioTracks: () => [{ enabled: true, stop: () => {} }],
+      getTracks: () => [{ stop: () => {} }],
+    }));
+    Object.defineProperty(global.navigator, "mediaDevices", {
+      writable: true,
+      configurable: true,
+      value: { getUserMedia: gumSpy },
+    });
+    global.MediaRecorder = vi.fn(() => ({
+      addEventListener: vi.fn(),
+      start: vi.fn(),
+      state: "recording",
+      stop: vi.fn(),
+    })) as unknown as typeof MediaRecorder;
+    (global.MediaRecorder as unknown as { isTypeSupported: () => boolean }).isTypeSupported = vi.fn(() => true);
+  });
+
+  it("requests audio with autoGainControl: true", async () => {
+    const recorder = useVoiceRecorder();
+    await recorder.startRecording();
+    expect(gumSpy).toHaveBeenCalled();
+    const constraints = gumSpy.mock.calls[0][0] as { audio: { autoGainControl: boolean } };
+    expect(constraints.audio.autoGainControl).toBe(true);
+  });
+
+  it("requests audio with echoCancellation: true", async () => {
+    const recorder = useVoiceRecorder();
+    await recorder.startRecording();
+    const constraints = gumSpy.mock.calls[0][0] as { audio: { echoCancellation: boolean } };
+    expect(constraints.audio.echoCancellation).toBe(true);
+  });
+
+  it("requests audio with noiseSuppression: true", async () => {
+    const recorder = useVoiceRecorder();
+    await recorder.startRecording();
+    const constraints = gumSpy.mock.calls[0][0] as { audio: { noiseSuppression: boolean } };
+    expect(constraints.audio.noiseSuppression).toBe(true);
+  });
+});

--- a/src/features/messaging/model/use-voice-recorder.ts
+++ b/src/features/messaging/model/use-voice-recorder.ts
@@ -41,9 +41,9 @@ export function useVoiceRecorder() {
       const gum = (isNative && getRealGetUserMedia()) || navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
       audioStream = await gum({
         audio: {
-          echoCancellation: false,
-          noiseSuppression: false,
-          autoGainControl: false,
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
         },
       });
 


### PR DESCRIPTION
## Summary
- В `use-voice-recorder.ts` constraints flipped: `autoGainControl: false` → `true` (плюс echoCancellation, noiseSuppression)
- Это стандартные voice constraints — AGC нормализует тихую речь, EC давит локальное эхо, NS чистит фон

## Closes
- forta-bugs#735 — Voice messages очень тихие

## Test plan
- [ ] Unit: 3 теста — getUserMedia called with AGC/EC/NS = true
- [ ] Manual: voice message нормально слышен на same device
- [ ] Manual: воспроизведение получателем — комфортный уровень

## Out of scope
- Live call audio constraints (отдельный pipeline в call-service.ts)
- Settings toggle для opt-out из NS (если будут жалобы на артефакты — отдельная сессия)