### PR TITLE
feat(android-back): Settings/Contacts → Chats on first Back tap (Session 63)

### DIFF
--- a/src/pages/chat/ChatPage.vue
+++ b/src/pages/chat/ChatPage.vue
@@ -15,7 +15,7 @@ const chatStore = useChatStore();
 const authStore = useAuthStore();
 const channelStore = useChannelStore();
 const { t } = useI18n();
-const { settingsSubView, closeSettingsContent, setTab } = useSidebarTab();
+const { activeTab, settingsSubView, closeSettingsContent, setTab } = useSidebarTab();
 
 const isMobile = ref(window.innerWidth < 768);
 
@@ -123,6 +123,18 @@ useAndroidBackHandler("chat-settings-content", 70, () => {
 useAndroidBackHandler("chat-back-to-sidebar", 60, () => {
   if (!isMobile.value || showSidebar.value) return false;
   onBackToSidebar();
+  return true;
+});
+
+// Telegram-like UX: first Back from Settings/Contacts returns to Chats
+// instead of minimizing the app. Lower priority than subview handler (70)
+// so subview close still wins. Only fires when no chat is open (priority 60
+// handler already returned false because showSidebar is true).
+useAndroidBackHandler("chat-tab-to-chats", 55, () => {
+  if (!isMobile.value) return false;
+  if (activeTab.value === "chats") return false;
+  if (settingsSubView.value) return false;
+  setTab("chats");
   return true;
 });
 </script>

--- a/src/pages/chat/__tests__/ChatPage.test.ts
+++ b/src/pages/chat/__tests__/ChatPage.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
 import { computed, ref } from "vue";
+import type { SidebarTab } from "@/widgets/sidebar/model/use-sidebar-tab";
 
 // ── Force mobile viewport before Vue mounts ──────────────────────
 beforeEach(() => {
@@ -83,13 +84,14 @@ vi.mock("@/shared/lib/i18n", () => ({
 const closeSettingsContentSpy = vi.fn();
 const setTabSpy = vi.fn();
 const settingsSubViewRef = ref<string | null>(null);
+const activeTabRef = ref<SidebarTab>("chats");
 
 vi.mock("@/widgets/sidebar/model/use-sidebar-tab", () => ({
   useSidebarTab: () => ({
     settingsSubView: settingsSubViewRef,
     closeSettingsContent: closeSettingsContentSpy,
     setTab: setTabSpy,
-    activeTab: ref("chats"),
+    activeTab: activeTabRef,
     openSettingsContent: vi.fn(),
   }),
 }));
@@ -97,6 +99,8 @@ vi.mock("@/widgets/sidebar/model/use-sidebar-tab", () => ({
 vi.mock("@/shared/lib/composables/use-android-back-handler", () => ({
   useAndroidBackHandler: vi.fn(),
 }));
+
+import { useAndroidBackHandler } from "@/shared/lib/composables/use-android-back-handler";
 
 vi.mock("@/features/messaging/model/use-audio-playback", () => ({
   useAudioPlayback: () => ({
@@ -150,10 +154,12 @@ beforeEach(() => {
   fakeRoomsInitialized.value = false;
   fakeActiveChannelAddress.value = null;
   settingsSubViewRef.value = null;
+  activeTabRef.value = "chats";
   setActiveRoomSpy.mockClear();
   closeSettingsContentSpy.mockClear();
   setTabSpy.mockClear();
   clearActiveChannelSpy.mockClear();
+  vi.mocked(useAndroidBackHandler).mockClear();
 });
 
 afterEach(() => {
@@ -390,6 +396,123 @@ describe("ChatPage — reactive showSidebar", () => {
     expect(isVisible(sidebar.element as HTMLElement)).toBe(false);
     const cw = wrapper.find('[data-testid="chat-window"]');
     expect(isVisible(cw.element as HTMLElement)).toBe(true);
+
+    wrapper.unmount();
+  });
+});
+
+// ── Regression: Back from Settings/Contacts must return to Chats ──
+//
+// Telegram-like UX (issue #729, continuation of #276): the very first
+// tap of Android Back when the user is on Settings or Contacts tab
+// (without an open subview) should switch the sidebar to "chats" instead
+// of minimizing the app. Only the second tap minimizes.
+//
+// The handler is registered with priority 55 — below the existing
+// settings-subview handler (70) so a tap inside settings still closes
+// the subview first, and above the fallback minimize.
+describe("ChatPage Android back handler — chat-tab-to-chats", () => {
+  const getTabToChatsHandler = (): (() => boolean) => {
+    const mocked = vi.mocked(useAndroidBackHandler);
+    const call = mocked.mock.calls.find((c) => c[0] === "chat-tab-to-chats");
+    if (!call) throw new Error("handler 'chat-tab-to-chats' was not registered");
+    return call[2] as () => boolean;
+  };
+
+  it("registers handler with id 'chat-tab-to-chats' and priority 55", async () => {
+    const wrapper = mount(ChatPage, mountOpts);
+    await flushPromises();
+
+    const mocked = vi.mocked(useAndroidBackHandler);
+    const call = mocked.mock.calls.find((c) => c[0] === "chat-tab-to-chats");
+
+    expect(call).toBeDefined();
+    expect(call![1]).toBe(55);
+    expect(typeof call![2]).toBe("function");
+
+    wrapper.unmount();
+  });
+
+  it("returns true and calls setTab('chats') when activeTab='settings' and no subview", async () => {
+    activeTabRef.value = "settings";
+    settingsSubViewRef.value = null;
+
+    const wrapper = mount(ChatPage, mountOpts);
+    await flushPromises();
+
+    const handler = getTabToChatsHandler();
+    const consumed = handler();
+
+    expect(consumed).toBe(true);
+    expect(setTabSpy).toHaveBeenCalledWith("chats");
+
+    wrapper.unmount();
+  });
+
+  it("returns true and calls setTab('chats') when activeTab='contacts'", async () => {
+    activeTabRef.value = "contacts";
+    settingsSubViewRef.value = null;
+
+    const wrapper = mount(ChatPage, mountOpts);
+    await flushPromises();
+
+    const handler = getTabToChatsHandler();
+    const consumed = handler();
+
+    expect(consumed).toBe(true);
+    expect(setTabSpy).toHaveBeenCalledWith("chats");
+
+    wrapper.unmount();
+  });
+
+  it("returns false (passes through) when activeTab='chats' — fallback minimize", async () => {
+    activeTabRef.value = "chats";
+
+    const wrapper = mount(ChatPage, mountOpts);
+    await flushPromises();
+
+    const handler = getTabToChatsHandler();
+    const consumed = handler();
+
+    expect(consumed).toBe(false);
+    expect(setTabSpy).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
+
+  it("returns false when settingsSubView is set — defer to higher-priority handler", async () => {
+    activeTabRef.value = "settings";
+    settingsSubViewRef.value = "appearance";
+
+    const wrapper = mount(ChatPage, mountOpts);
+    await flushPromises();
+
+    const handler = getTabToChatsHandler();
+    const consumed = handler();
+
+    expect(consumed).toBe(false);
+    expect(setTabSpy).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+  });
+
+  it("returns false on desktop (isMobile=false)", async () => {
+    // Desktop layout always shows the sidebar — Back has no meaning here.
+    Object.defineProperty(window, "innerWidth", {
+      value: 1200,
+      configurable: true,
+      writable: true,
+    });
+    activeTabRef.value = "settings";
+
+    const wrapper = mount(ChatPage, mountOpts);
+    await flushPromises();
+
+    const handler = getTabToChatsHandler();
+    const consumed = handler();
+
+    expect(consumed).toBe(false);
+    expect(setTabSpy).not.toHaveBeenCalled();
 
     wrapper.unmount();
   });

--- a/src/shared/lib/composables/use-android-back-handler.ts
+++ b/src/shared/lib/composables/use-android-back-handler.ts
@@ -17,6 +17,7 @@ const handlers: { id: string; priority: number; handler: BackHandler }[] = [];
  *    80 — side panels (info panel, search)
  *    70 — sub-views (settings content, group creation)
  *    60 — chat view (back to sidebar on mobile)
+ *    55 — tab fallback (Settings/Contacts → Chats on mobile)
  *    50 — router-level pages (settings, profile)
  *    --   (fallback) App.minimizeApp()
  */


### PR DESCRIPTION
## Summary

Telegram-like UX: на mobile первый тап Android Back из вкладок **Settings** или **Contacts** (без открытого subview) переключает на вкладку **Chats** вместо сворачивания приложения. Второй Back уже сворачивает app.

- Новый `useAndroidBackHandler("chat-tab-to-chats", 55, ...)` в `ChatPage.vue`
- Priority **55** — ниже `chat-settings-content`/`chat-group-creation` (70) и `chat-back-to-sidebar` (60), выше fallback minimize
- Документация priority guide в `use-android-back-handler.ts` обновлена

## Closes

- forta-bugs#729 — В продолжение #276: первый Back должен возвращать на список чатов, а не сворачивать приложение

## Implementation

**Files:**
- `src/pages/chat/ChatPage.vue` — добавлен priority-55 handler, `activeTab` в деструктуризации `useSidebarTab()`
- `src/shared/lib/composables/use-android-back-handler.ts` — добавлен slot 55 в priority guide
- `src/pages/chat/__tests__/ChatPage.test.ts` — 6 регрессионных тестов

**Logic:**
\`\`\`ts
useAndroidBackHandler("chat-tab-to-chats", 55, () => {
  if (!isMobile.value) return false;
  if (activeTab.value === "chats") return false;
  if (settingsSubView.value) return false; // defer to higher-priority handler
  setTab("chats");
  return true;
});
\`\`\`

## Test plan

Unit (✅ 14/14 pass):
- [x] Handler регистрируется с id=\"chat-tab-to-chats\" и priority=55
- [x] activeTab=\"settings\" + no subview → setTab(\"chats\"), returns true
- [x] activeTab=\"contacts\" → setTab(\"chats\"), returns true
- [x] activeTab=\"chats\" → pass-through (returns false) для fallback minimize
- [x] settingsSubView set → pass-through (defer to priority-70 handler)
- [x] Desktop (window.innerWidth >= 768) → pass-through

Manual (Android device — нужно проверить):
- [ ] App → tap «Настройки» → tap Back → переключается на «Чаты», app не свернулся
- [ ] Tap Back ещё раз → app свернулся (fallback)
- [ ] Settings → Профиль → tap Back → закрылся Профиль, остался в Settings (existing priority-70 handler)
- [ ] Open chat on mobile → tap Back → вернулся на sidebar (existing priority-60 handler)
- [ ] Chats tab → tap Back → app свернулся (fallback)

## Out of scope

- /channels tab (если когда-либо появится)
- Поведение в open chat — без изменений
- Desktop UX — early return