### PR TITLE
fix(emoji-picker): push messages above picker via --emoji-picker-height (Session 59)

### DIFF
--- a/src/features/messaging/ui/EmojiPicker.vue
+++ b/src/features/messaging/ui/EmojiPicker.vue
@@ -73,8 +73,11 @@ const panelStyle = computed(() =>
 
 // Publish the picker's height as a CSS var so MessageList can pad its bottom
 // and keep the latest messages visible above the docked picker (Telegram-like).
-// Only relevant in input mode — reaction mode is a floating popover near the
-// tapped message and doesn't obscure the bottom of the chat scrolу.
+// Only the input-mode instance owns this var. Reaction-mode is a floating
+// popover anchored to a long-pressed message and must NOT touch the var —
+// otherwise the two pickers stomp each other when both are momentarily live.
+// Scope is documentElement on purpose: ChatWindow is the only consumer in
+// this app, and a global var avoids threading a provide/inject down the tree.
 const panelRef = ref<HTMLElement | null>(null);
 let panelObserver: ResizeObserver | null = null;
 
@@ -89,11 +92,15 @@ const publishPickerHeight = (h: number) => {
 watch(
   [() => props.show, panelRef, () => props.mode],
   ([show, el, mode]) => {
+    // Reaction-mode is hands-off: never read, never write — let the input
+    // instance (if any) keep ownership of the var.
+    if (mode !== "input") return;
+
     if (panelObserver) {
       panelObserver.disconnect();
       panelObserver = null;
     }
-    if (!show || !el || mode !== "input") {
+    if (!show || !el) {
       publishPickerHeight(0);
       return;
     }
@@ -111,7 +118,8 @@ watch(
 onScopeDispose(() => {
   panelObserver?.disconnect();
   panelObserver = null;
-  publishPickerHeight(0);
+  // Only the owning instance resets — same gate as the watcher above.
+  if (props.mode === "input") publishPickerHeight(0);
 });
 
 const filteredEmojis = computed(() => {

--- a/src/features/messaging/ui/EmojiPicker.vue
+++ b/src/features/messaging/ui/EmojiPicker.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, nextTick } from "vue";
+import { ref, computed, watch, nextTick, onScopeDispose } from "vue";
 import { useThemeStore } from "@/entities/theme";
 import { EMOJI_CATEGORIES, searchEmojis } from "@/shared/lib/emoji-data";
 import { useMobile } from "@/shared/lib/composables/use-media-query";
@@ -70,6 +70,49 @@ const panelStyle = computed(() =>
     vh: typeof window !== "undefined" ? window.innerHeight : 600,
   }),
 );
+
+// Publish the picker's height as a CSS var so MessageList can pad its bottom
+// and keep the latest messages visible above the docked picker (Telegram-like).
+// Only relevant in input mode — reaction mode is a floating popover near the
+// tapped message and doesn't obscure the bottom of the chat scrolу.
+const panelRef = ref<HTMLElement | null>(null);
+let panelObserver: ResizeObserver | null = null;
+
+const publishPickerHeight = (h: number) => {
+  if (typeof document === "undefined") return;
+  document.documentElement.style.setProperty(
+    "--emoji-picker-height",
+    `${Math.max(0, Math.round(h))}px`,
+  );
+};
+
+watch(
+  [() => props.show, panelRef, () => props.mode],
+  ([show, el, mode]) => {
+    if (panelObserver) {
+      panelObserver.disconnect();
+      panelObserver = null;
+    }
+    if (!show || !el || mode !== "input") {
+      publishPickerHeight(0);
+      return;
+    }
+    publishPickerHeight(el.getBoundingClientRect().height);
+    if (typeof ResizeObserver === "undefined") return;
+    panelObserver = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) publishPickerHeight(entry.contentRect.height);
+    });
+    panelObserver.observe(el);
+  },
+  { immediate: true, flush: "post" },
+);
+
+onScopeDispose(() => {
+  panelObserver?.disconnect();
+  panelObserver = null;
+  publishPickerHeight(0);
+});
 
 const filteredEmojis = computed(() => {
   if (!search.value) return null;
@@ -149,6 +192,7 @@ useAndroidBackHandler(`emoji-picker-${props.mode}`, 90, () => {
     <transition name="emoji-popup">
       <div v-if="props.show" class="fixed inset-0 z-50" @click.self="emit('close')">
         <div
+          ref="panelRef"
           class="emoji-panel flex flex-col overflow-hidden border border-neutral-grad-0 bg-background-total-theme shadow-2xl"
           :class="isMobile ? 'fixed' : 'absolute rounded-2xl'"
           :style="panelStyle"

--- a/src/features/messaging/ui/MessageList.vue
+++ b/src/features/messaging/ui/MessageList.vue
@@ -26,6 +26,7 @@ import { useUnreadBanner } from "../model/use-unread-banner";
 import { useReadTracker } from "../model/use-read-tracker";
 import { decideFabAction, shouldAutoDismissBanner } from "../model/fab-decision";
 import UnreadBanner from "./UnreadBanner.vue";
+import { computeChatListStyle } from "./chat-list-style";
 
 const chatStore = useChatStore();
 const authStore = useAuthStore();
@@ -1199,11 +1200,15 @@ const setSearchQuery = (q: string) => {
   searchQuery.value = q;
 };
 
+// Reserve room at the bottom of the chat scrolу for the docked EmojiPicker
+// (input mode). See `chat-list-style.ts` for rationale.
+const listStyle = computed(() => computeChatListStyle(themeStore.chatWallpaper));
+
 defineExpose({ scrollToMessage, setSearchQuery });
 </script>
 
 <template>
-  <div ref="listRef" class="relative min-h-0 flex-1" :style="themeStore.chatWallpaper ? { background: themeStore.chatWallpaper } : {}">
+  <div ref="listRef" class="relative min-h-0 flex-1" :style="listStyle">
     <!-- Floating date header (single, non-stacking) -->
     <div
       v-if="currentDateLabel && !loading"

--- a/src/features/messaging/ui/__tests__/EmojiPicker-height-var.test.ts
+++ b/src/features/messaging/ui/__tests__/EmojiPicker-height-var.test.ts
@@ -136,4 +136,40 @@ describe("EmojiPicker — publishes --emoji-picker-height", () => {
 
     wrapper.unmount();
   });
+
+  // Two EmojiPicker instances coexist in the chat tree — one bound to the
+  // input panel ("input" mode), one anchored to the long-pressed message
+  // ("reaction" mode). Reaction-mode lifecycle must NOT stomp the height
+  // published by the input panel, otherwise the chat list collapses while
+  // the docked picker is still visible.
+  it("reaction-mode lifecycle never overwrites the height published by an open input picker", async () => {
+    const input = mount(EmojiPicker, {
+      props: { show: true, mode: "input", x: 0, y: 0 },
+      attachTo: document.body,
+    });
+    await nextTick();
+    await nextTick();
+    expect(getVar()).toBe(`${FAKE_PICKER_HEIGHT}px`);
+
+    // User long-presses a message — reaction picker mounts on top.
+    const reaction = mount(EmojiPicker, {
+      props: { show: true, mode: "reaction", x: 100, y: 200 },
+      attachTo: document.body,
+    });
+    await nextTick();
+    await nextTick();
+    expect(getVar()).toBe(`${FAKE_PICKER_HEIGHT}px`);
+
+    // Reaction picker closes — input picker is still docked.
+    await reaction.setProps({ show: false });
+    await nextTick();
+    await nextTick();
+    expect(getVar()).toBe(`${FAKE_PICKER_HEIGHT}px`);
+
+    reaction.unmount();
+    await nextTick();
+    expect(getVar()).toBe(`${FAKE_PICKER_HEIGHT}px`);
+
+    input.unmount();
+  });
 });

--- a/src/features/messaging/ui/__tests__/EmojiPicker-height-var.test.ts
+++ b/src/features/messaging/ui/__tests__/EmojiPicker-height-var.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick, ref } from "vue";
+
+vi.mock("@/shared/lib/i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k, locale: { value: "en" } }),
+}));
+
+vi.mock("@/entities/theme", () => ({
+  useThemeStore: () => ({
+    recentEmojis: [],
+    quickReactions: [],
+    animationsEnabled: true,
+    chatWallpaper: null,
+  }),
+}));
+
+vi.mock("@/shared/lib/composables/use-android-back-handler", () => ({
+  useAndroidBackHandler: vi.fn(),
+}));
+
+// Force mobile so the input-mode branch (which docks the picker and publishes
+// height) is exercised.
+vi.mock("@/shared/lib/composables/use-media-query", () => ({
+  useMobile: () => ref(true),
+}));
+
+// Local ResizeObserver mock — happy-dom doesn't deliver observe callbacks.
+// The picker only relies on the initial publish via getBoundingClientRect(),
+// so an empty stub is enough to keep the watcher from throwing.
+class ResizeObserverStub {
+  observe = vi.fn();
+  disconnect = vi.fn();
+  unobserve = vi.fn();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(_cb: ResizeObserverCallback) {}
+}
+
+// happy-dom's getBoundingClientRect returns all-zero for un-laid-out elements,
+// so the picker would publish "0px" without this override. We patch the
+// prototype to report a stable 320px height for any element queried during
+// the test.
+const FAKE_PICKER_HEIGHT = 320;
+const originalRect = Element.prototype.getBoundingClientRect;
+
+import EmojiPicker from "../EmojiPicker.vue";
+
+const CSS_VAR = "--emoji-picker-height";
+
+const getVar = () => document.documentElement.style.getPropertyValue(CSS_VAR);
+
+const setRectHeight = (h: number) => {
+  Element.prototype.getBoundingClientRect = function () {
+    return {
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      bottom: h,
+      right: 0,
+      width: 0,
+      height: h,
+      toJSON() {
+        return {};
+      },
+    } as DOMRect;
+  };
+};
+
+describe("EmojiPicker — publishes --emoji-picker-height", () => {
+  beforeEach(() => {
+    vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+    document.documentElement.style.setProperty(CSS_VAR, "0px");
+    setRectHeight(FAKE_PICKER_HEIGHT);
+  });
+
+  afterEach(() => {
+    document.documentElement.style.setProperty(CSS_VAR, "0px");
+    Element.prototype.getBoundingClientRect = originalRect;
+    vi.unstubAllGlobals();
+  });
+
+  it("publishes a non-zero height when shown in input mode on mobile", async () => {
+    const wrapper = mount(EmojiPicker, {
+      props: { show: true, mode: "input", x: 0, y: 0 },
+      attachTo: document.body,
+    });
+    await nextTick();
+    await nextTick();
+
+    expect(getVar()).toBe(`${FAKE_PICKER_HEIGHT}px`);
+
+    wrapper.unmount();
+  });
+
+  it("resets --emoji-picker-height to 0px on unmount", async () => {
+    const wrapper = mount(EmojiPicker, {
+      props: { show: true, mode: "input", x: 0, y: 0 },
+      attachTo: document.body,
+    });
+    await nextTick();
+    await nextTick();
+    expect(getVar()).toBe(`${FAKE_PICKER_HEIGHT}px`);
+
+    wrapper.unmount();
+    await nextTick();
+    expect(getVar()).toBe("0px");
+  });
+
+  it("does not publish height for reaction mode (popover near button)", async () => {
+    const wrapper = mount(EmojiPicker, {
+      props: { show: true, mode: "reaction", x: 100, y: 200 },
+      attachTo: document.body,
+    });
+    await nextTick();
+    await nextTick();
+
+    expect(getVar()).toBe("0px");
+
+    wrapper.unmount();
+  });
+
+  it("clears the var when `show` flips false (closed by user)", async () => {
+    const wrapper = mount(EmojiPicker, {
+      props: { show: true, mode: "input", x: 0, y: 0 },
+      attachTo: document.body,
+    });
+    await nextTick();
+    await nextTick();
+    expect(getVar()).toBe(`${FAKE_PICKER_HEIGHT}px`);
+
+    await wrapper.setProps({ show: false });
+    await nextTick();
+    await nextTick();
+    expect(getVar()).toBe("0px");
+
+    wrapper.unmount();
+  });
+});

--- a/src/features/messaging/ui/__tests__/chat-list-style.test.ts
+++ b/src/features/messaging/ui/__tests__/chat-list-style.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { computeChatListStyle } from "../chat-list-style";
+
+describe("computeChatListStyle", () => {
+  it("reserves bottom space for the docked EmojiPicker via CSS var", () => {
+    const style = computeChatListStyle(null);
+    expect(style.paddingBottom).toBe("var(--emoji-picker-height, 0px)");
+  });
+
+  it("animates padding-bottom so the layout shift is not abrupt", () => {
+    const style = computeChatListStyle(null);
+    expect(style.transition).toContain("padding-bottom");
+  });
+
+  it("preserves chat wallpaper background when set", () => {
+    const wallpaper = "url('/wallpapers/forest.jpg') center/cover";
+    const style = computeChatListStyle(wallpaper);
+    expect(style.background).toBe(wallpaper);
+    expect(style.paddingBottom).toBe("var(--emoji-picker-height, 0px)");
+  });
+
+  it("omits background when no wallpaper is configured", () => {
+    const style = computeChatListStyle(null);
+    expect("background" in style).toBe(false);
+  });
+
+  it("omits background when wallpaper is an empty string (treat as falsy)", () => {
+    const style = computeChatListStyle("");
+    expect("background" in style).toBe(false);
+  });
+});

--- a/src/features/messaging/ui/chat-list-style.ts
+++ b/src/features/messaging/ui/chat-list-style.ts
@@ -1,0 +1,23 @@
+/**
+ * Inline style for the chat MessageList root.
+ *
+ * Extracted as a pure function so the layout contract can be unit-tested
+ * without mounting the heavyweight `MessageList.vue` (Pinia + virtual scroller
+ * + dozens of sub-components).
+ *
+ * `--emoji-picker-height` is published by `EmojiPicker.vue` in input mode and
+ * reserves room at the bottom of the chat scrolу so the latest messages stay
+ * visible above the docked picker (Telegram-like behavior).
+ */
+
+import type { CSSProperties } from "vue";
+
+export function computeChatListStyle(
+  chatWallpaper: string | null | undefined,
+): CSSProperties {
+  return {
+    paddingBottom: "var(--emoji-picker-height, 0px)",
+    transition: "padding-bottom 200ms ease",
+    ...(chatWallpaper ? { background: chatWallpaper } : {}),
+  };
+}


### PR DESCRIPTION
## Summary
- `EmojiPicker.vue` (input mode) теперь публикует `--emoji-picker-height` через `ResizeObserver` — MessageList применяет `padding-bottom: var(--emoji-picker-height, 0px)` и последние сообщения смещаются выше picker'а (Telegram-like).
- Reaction-mode picker (long-press на сообщение) НЕ публикует и НЕ читает эту переменную — input-инстанс единственный владелец.
- Style root MessageList вынесен в pure helper `chat-list-style.ts` для юнит-тестирования без mount всего SFC.

## Root cause
`EmojiPicker.vue` рендерится через `<Teleport to="body">` как `position: fixed; bottom: var(--message-input-height, 0px)`. Layout не «знал» про picker, MessageList сохранял полную высоту, и нижние ~360px scrollу перекрывались — скрывая 3–5 последних сообщений. Сейчас picker публикует свою фактическую высоту → MessageList резервирует место → ChatVirtualScroller (column-reverse) автоматически удерживает последнее сообщение в видимой зоне над picker'ом.

## Closes
- [auto-bug-reports#728](../forta-bugs/issues/728) — «в чате при нажатии кнопки выбора эмотиконов шторка закрывает последние сообщения» (продолжение #685).

## Test plan
- [x] Unit: 5 тестов в `EmojiPicker-height-var.test.ts` — publish in input mode, reset on unmount, skip reaction mode, clear on `show=false`, **dual-instance race regression** (reaction lifecycle не стирает height входного picker'а).
- [x] Unit: 5 тестов в `chat-list-style.test.ts` — padding-bottom var, transition, wallpaper merge, no wallpaper, empty wallpaper.
- [x] `npx vitest run src/features/messaging/` → 282 passed, 0 failed.
- [x] `vite build` → ✓ built без новых ошибок.
- [x] `vue-tsc --noEmit` → 49 errors (== master, в моих файлах 0).
- [x] `superpowers:code-reviewer` → HIGH cross-instance race выявлен и пофикшен в `ded5fc8`.
- [ ] Manual Android smoke: open picker → последние 2–3 сообщения видны над picker'ом; reaction picker (long-press) НЕ двигает chat list.