### PR TITLE
feat(media): HEIC/HEIF auto-conversion to JPEG before upload (Session 60)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "dexie": "^4.3.0",
         "emoji-kitchen-mart": "^6.0.5",
         "file-saver": "^2.0.5",
+        "heic2any": "^0.0.4",
         "matrix-js-sdk-bastyon": "^23.2.5",
         "miscreant": "^0.3.2",
         "node-fetch": "^2.7.0",
@@ -5965,6 +5966,12 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/heic2any": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz",
+      "integrity": "sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==",
+      "license": "MIT"
     },
     "node_modules/hookable": {
       "version": "5.5.3",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "dexie": "^4.3.0",
     "emoji-kitchen-mart": "^6.0.5",
     "file-saver": "^2.0.5",
+    "heic2any": "^0.0.4",
     "matrix-js-sdk-bastyon": "^23.2.5",
     "miscreant": "^0.3.2",
     "node-fetch": "^2.7.0",

--- a/src/features/messaging/model/use-messages.test.ts
+++ b/src/features/messaging/model/use-messages.test.ts
@@ -529,3 +529,44 @@ describe("useMessages", () => {
     });
   });
 });
+
+// ─── convertHeicToJpeg ────────────────────────────────────────────
+// Mock heic2any at top level — vi.mock is hoisted, so importing it before
+// the describe block lets us use vi.mocked() for per-test overrides.
+vi.mock("heic2any", () => ({
+  default: vi.fn(async () => new Blob(["jpegBytes"], { type: "image/jpeg" })),
+}));
+
+describe("convertHeicToJpeg", () => {
+  it("returns input file unchanged for non-HEIC MIME", async () => {
+    const { convertHeicToJpeg } = await import("./use-messages");
+    const file = new File(["abc"], "photo.jpg", { type: "image/jpeg" });
+    const out = await convertHeicToJpeg(file);
+    expect(out).toBe(file);
+  });
+
+  it("renames .heic file extension to .jpg", async () => {
+    const { convertHeicToJpeg } = await import("./use-messages");
+    const file = new File(["heicData"], "IMG_1234.heic", { type: "image/heic" });
+    const out = await convertHeicToJpeg(file);
+    expect(out.name).toBe("IMG_1234.jpg");
+    expect(out.type).toBe("image/jpeg");
+  });
+
+  it("renames .heif extension to .jpg, MIME image/jpeg", async () => {
+    const { convertHeicToJpeg } = await import("./use-messages");
+    const file = new File(["heifData"], "photo.HEIF", { type: "image/heif" });
+    const out = await convertHeicToJpeg(file);
+    expect(out.name).toBe("photo.jpg");
+    expect(out.type).toBe("image/jpeg");
+  });
+
+  it("falls back to original file if heic2any throws", async () => {
+    const heic2anyMod = await import("heic2any");
+    vi.mocked(heic2anyMod.default).mockRejectedValueOnce(new Error("unsupported"));
+    const { convertHeicToJpeg } = await import("./use-messages");
+    const file = new File(["heicData"], "broken.heic", { type: "image/heic" });
+    const out = await convertHeicToJpeg(file);
+    expect(out).toBe(file); // fail-open
+  });
+});

--- a/src/features/messaging/model/use-messages.test.ts
+++ b/src/features/messaging/model/use-messages.test.ts
@@ -29,6 +29,12 @@ vi.mock("@/shared/lib/connectivity", () => ({
   useConnectivity: vi.fn(() => ({ isOnline: { value: true } })),
 }));
 
+// Mock heic2any — happy path returns a JPEG blob; per-test overrides via
+// vi.mocked(heic2anyDefault).mockRejectedValueOnce(...) when needed.
+vi.mock("heic2any", () => ({
+  default: vi.fn(async () => new Blob(["jpegBytes"], { type: "image/jpeg" })),
+}));
+
 // Mock MatrixClientService with all needed methods
 const mockRedactEvent = vi.fn();
 const mockSendReaction = vi.fn(() => "$reaction_event_1");
@@ -531,11 +537,6 @@ describe("useMessages", () => {
 });
 
 // ─── convertHeicToJpeg ────────────────────────────────────────────
-// Mock heic2any at top level — vi.mock is hoisted, so importing it before
-// the describe block lets us use vi.mocked() for per-test overrides.
-vi.mock("heic2any", () => ({
-  default: vi.fn(async () => new Blob(["jpegBytes"], { type: "image/jpeg" })),
-}));
 
 describe("convertHeicToJpeg", () => {
   it("returns input file unchanged for non-HEIC MIME", async () => {

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -79,6 +79,34 @@ function resolveMime(file: File): string {
   return MIME_EXT_FALLBACK[ext] ?? "application/octet-stream";
 }
 
+/** Convert HEIC/HEIF File to JPEG so Android WebView (Chromium) can render it.
+ *  iPhone cameras default to HEIC; Chromium does not support HEIC in <img>,
+ *  resulting in a broken image on the receiver side. heic2any is loaded
+ *  dynamically (~250KB gzipped) only on the first HEIC encounter.
+ *  Returns the original file when the input is not HEIC/HEIF, or when
+ *  conversion fails (fail-open: better to send the original than nothing). */
+export async function convertHeicToJpeg(file: File): Promise<File> {
+  const isHeic =
+    /image\/(heic|heif)/i.test(file.type) ||
+    /\.(heic|heif)$/i.test(file.name);
+  if (!isHeic) return file;
+
+  try {
+    const heic2any = (await import("heic2any")).default;
+    const result = await heic2any({
+      blob: file,
+      toType: "image/jpeg",
+      quality: 0.85,
+    });
+    const jpegBlob = Array.isArray(result) ? result[0] : (result as Blob);
+    const newName = file.name.replace(/\.(heic|heif)$/i, ".jpg");
+    return new File([jpegBlob], newName, { type: "image/jpeg" });
+  } catch (e) {
+    console.warn("[convertHeicToJpeg] conversion failed, sending original:", e);
+    return file; // fail-open
+  }
+}
+
 /** Track which clientIds are already being cancelled (prevent double invocation) */
 const cancellingSet = new Set<string>();
 
@@ -329,6 +357,12 @@ export function useMessages() {
     const roomId = chatStore.activeRoomId;
     if (!roomId || !file) return false;
 
+    // Android WebView cannot render HEIC; convert image-typed input before
+    // size check so the (typically smaller) JPEG payload is what we measure.
+    if (file.type.startsWith("image/") || /\.(heic|heif)$/i.test(file.name)) {
+      file = await convertHeicToJpeg(file);
+    }
+
     if (file.size > MAX_UPLOAD_SIZE) {
       console.warn(`[use-messages] File too large: ${file.name} (${(file.size / 1024 / 1024).toFixed(1)} MB)`);
       return false;
@@ -405,6 +439,11 @@ export function useMessages() {
   ): Promise<boolean> => {
     const roomId = chatStore.activeRoomId;
     if (!roomId || !file) return false;
+
+    // HEIC must be converted before getImageDimensions — Chromium <img> cannot
+    // decode HEIC at all, so reading naturalWidth/Height on the original blob
+    // would produce zeros and corrupt the m.image event payload.
+    file = await convertHeicToJpeg(file);
 
     const matrixService = getMatrixClientService();
     if (!matrixService.isReady()) return false;

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -82,7 +82,7 @@ function resolveMime(file: File): string {
 /** Convert HEIC/HEIF File to JPEG so Android WebView (Chromium) can render it.
  *  iPhone cameras default to HEIC; Chromium does not support HEIC in <img>,
  *  resulting in a broken image on the receiver side. heic2any is loaded
- *  dynamically (~250KB gzipped) only on the first HEIC encounter.
+ *  dynamically (~340 KB gzipped chunk) only on the first HEIC encounter.
  *  Returns the original file when the input is not HEIC/HEIF, or when
  *  conversion fails (fail-open: better to send the original than nothing). */
 export async function convertHeicToJpeg(file: File): Promise<File> {
@@ -357,25 +357,24 @@ export function useMessages() {
     const roomId = chatStore.activeRoomId;
     if (!roomId || !file) return false;
 
-    // Android WebView cannot render HEIC; convert image-typed input before
-    // size check so the (typically smaller) JPEG payload is what we measure.
-    if (file.type.startsWith("image/") || /\.(heic|heif)$/i.test(file.name)) {
-      file = await convertHeicToJpeg(file);
-    }
-
     if (file.size > MAX_UPLOAD_SIZE) {
       console.warn(`[use-messages] File too large: ${file.name} (${(file.size / 1024 / 1024).toFixed(1)} MB)`);
       return false;
     }
 
+    // Android WebView cannot render HEIC; convertHeicToJpeg short-circuits
+    // for non-HEIC inputs, so calling it unconditionally is safe and keeps
+    // the two send paths symmetric.
+    const processedFile = await convertHeicToJpeg(file);
+
     const matrixService = getMatrixClientService();
     if (!matrixService.isReady()) return false;
 
     // Determine message type from MIME (with fallback for HEIC/extension-only files)
-    const mime = normalizeMime(resolveMime(file));
+    const mime = normalizeMime(resolveMime(processedFile));
     const msgType = messageTypeFromMime(mime);
 
-    const localBlobUrl = URL.createObjectURL(file);
+    const localBlobUrl = URL.createObjectURL(processedFile);
 
     if (!isChatDbReady()) {
       // Without Dexie we have no crash-safe queue — dropping the send is
@@ -389,12 +388,12 @@ export function useMessages() {
     const localMsg = await dbKit.messages.createLocal({
       roomId,
       senderId: authStore.address ?? "",
-      content: file.name,
+      content: processedFile.name,
       type: msgType,
       fileInfo: {
-        name: file.name,
+        name: processedFile.name,
         type: mime,
-        size: file.size,
+        size: processedFile.size,
         url: localBlobUrl,
       },
       forwardedFrom: options.forwardedFrom,
@@ -405,10 +404,10 @@ export function useMessages() {
     // Persist blob so SyncEngine.syncSendFile can resume after a crash.
     const attachmentId = await dbKit.db.attachments.add({
       messageLocalId: localMsg.localId!,
-      fileName: file.name,
+      fileName: processedFile.name,
       mimeType: mime,
-      size: file.size,
-      localBlob: file,
+      size: processedFile.size,
+      localBlob: processedFile,
       status: "local",
     });
 
@@ -416,7 +415,7 @@ export function useMessages() {
       "send_file",
       roomId,
       {
-        fileName: file.name,
+        fileName: processedFile.name,
         mimeType: mime,
         msgtype: "m.file",
         attachmentId,
@@ -440,17 +439,22 @@ export function useMessages() {
     const roomId = chatStore.activeRoomId;
     if (!roomId || !file) return false;
 
+    if (file.size > MAX_UPLOAD_SIZE) {
+      console.warn(`[use-messages] Image too large: ${file.name} (${(file.size / 1024 / 1024).toFixed(1)} MB)`);
+      return false;
+    }
+
     // HEIC must be converted before getImageDimensions — Chromium <img> cannot
     // decode HEIC at all, so reading naturalWidth/Height on the original blob
     // would produce zeros and corrupt the m.image event payload.
-    file = await convertHeicToJpeg(file);
+    const processedFile = await convertHeicToJpeg(file);
 
     const matrixService = getMatrixClientService();
     if (!matrixService.isReady()) return false;
 
-    const dimensions = await getImageDimensions(file);
-    const imageMime = resolveMime(file);
-    const localBlobUrl = URL.createObjectURL(file);
+    const dimensions = await getImageDimensions(processedFile);
+    const imageMime = resolveMime(processedFile);
+    const localBlobUrl = URL.createObjectURL(processedFile);
 
     if (!isChatDbReady()) {
       console.error("[use-messages] sendImage: chat DB not ready");
@@ -462,12 +466,12 @@ export function useMessages() {
     const localMsg = await dbKit.messages.createLocal({
       roomId,
       senderId: authStore.address ?? "",
-      content: options.caption || file.name,
+      content: options.caption || processedFile.name,
       type: MessageType.image,
       fileInfo: {
-        name: file.name,
+        name: processedFile.name,
         type: imageMime,
-        size: file.size,
+        size: processedFile.size,
         url: localBlobUrl,
         w: dimensions.w,
         h: dimensions.h,
@@ -481,10 +485,10 @@ export function useMessages() {
 
     const attachmentId = await dbKit.db.attachments.add({
       messageLocalId: localMsg.localId!,
-      fileName: file.name,
+      fileName: processedFile.name,
       mimeType: imageMime,
-      size: file.size,
-      localBlob: file,
+      size: processedFile.size,
+      localBlob: processedFile,
       status: "local",
     });
 
@@ -492,7 +496,7 @@ export function useMessages() {
       "send_file",
       roomId,
       {
-        fileName: file.name,
+        fileName: processedFile.name,
         mimeType: imageMime,
         msgtype: "m.image",
         attachmentId,
@@ -501,7 +505,7 @@ export function useMessages() {
           w: dimensions.w,
           h: dimensions.h,
           mimetype: imageMime,
-          size: file.size,
+          size: processedFile.size,
           ...(options.caption ? { caption: options.caption } : {}),
           ...(options.captionAbove != null ? { captionAbove: options.captionAbove } : {}),
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2584,6 +2584,11 @@ he@^1.2.0:
   resolved "https://registry.npmjs.org/he/-/he-1.2.0.tgz"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+heic2any@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.npmjs.org/heic2any/-/heic2any-0.0.4.tgz"
+  integrity sha512-3lLnZiDELfabVH87htnRolZ2iehX9zwpRyGNz22GKXIu0fznlblf0/ftppXKNqS26dqFSeqfIBhAmAj/uSp0cA==
+
 hookable@^5.5.3:
   version "5.5.3"
   resolved "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz"


### PR DESCRIPTION
## Summary
- Добавлен `heic2any@0.0.4` (~340 KB gzipped chunk, dynamic import — загружается только при первом HEIC)
- `convertHeicToJpeg(file)` — pure function, конвертирует HEIC/HEIF → JPEG (quality 0.85), fail-open
- Integration: `sendImage` и `sendFile` вызывают конвертер до upload (после size-check для OOM-защиты)
- Все Matrix-метаданные (`fileInfo`, `eventInfo.w/h`, mimeType) собираются по уже сконвертированному JPEG

## Closes
- forta-bugs#730 — HEIC фото с iPhone не отображаются у Android-получателей

## Why
iPhone camera saves photos as HEIC by default. Android WebView (Chromium) cannot decode HEIC in `<img>` — receiver sees a broken image placeholder. Client-side conversion перед отправкой решает проблему без серверного дописывания.

## Test plan
- [x] Unit: 4 теста — non-HEIC pass-through, .heic → .jpg, .HEIF → .jpg (case-insensitive), fail-open при exception
- [x] Existing 38 use-messages tests PASS (no regressions)
- [x] `vite build` — heic2any в отдельном чанке (340 KB gzip)
- [ ] Manual: iPhone HEIC → отправка через Android → получатель видит JPEG

## Out of scope
- JPEG XL (.jxl) support
- iOS-native HEIC rendering (and already works)
- Forwarded HEIC — проходит через тот же `sendImage`, поэтому конвертация работает автоматически

## Review notes addressed
- HIGH: `sendImage` теперь имеет `MAX_UPLOAD_SIZE` guard перед HEIC decoding (OOM защита на low-end Android)
- MEDIUM: параметр-reassignment заменён на `const processedFile`
- MEDIUM: убран redundant image-type guard в `sendFile` — `convertHeicToJpeg` уже short-circuits для non-HEIC
- LOW: `vi.mock("heic2any")` поднят наверх test-файла