### PR TITLE
fix(messaging): typed send errors + queue health probe (WEE-20)

### DIFF
--- a/src/features/messaging/model/__tests__/send-errors.test.ts
+++ b/src/features/messaging/model/__tests__/send-errors.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { SendError, classifyMicError, sendErrorI18nKey } from "../send-errors";
+import {
+  reportSendError,
+  clearSendError,
+  useSendErrorBus,
+  __resetSendErrorBusForTests,
+} from "../send-error-bus";
+
+describe("SendError factory", () => {
+  it("retains kind, message, and retryable flag", () => {
+    const err = new SendError("uploadFailed", "boom", { fileName: "x.png" });
+    expect(err.kind).toBe("uploadFailed");
+    expect(err.message).toBe("boom");
+    expect(err.context.fileName).toBe("x.png");
+    expect(err.retryable).toBe(true);
+  });
+
+  it("supports non-retryable errors", () => {
+    const err = new SendError("fileTooLarge", "too big", {}, false);
+    expect(err.retryable).toBe(false);
+  });
+});
+
+describe("classifyMicError", () => {
+  it("maps NotAllowedError to micDenied", () => {
+    const native = new Error("Permission denied");
+    native.name = "NotAllowedError";
+    const classified = classifyMicError(native);
+    expect(classified.kind).toBe("micDenied");
+    expect(classified.context.kind).toBe("audio");
+  });
+
+  it("maps PermissionDeniedError to micDenied", () => {
+    const native = new Error("denied");
+    native.name = "PermissionDeniedError";
+    expect(classifyMicError(native).kind).toBe("micDenied");
+  });
+
+  it("maps NotFoundError to micDenied (no usable mic)", () => {
+    const native = new Error("no device");
+    native.name = "NotFoundError";
+    expect(classifyMicError(native).kind).toBe("micDenied");
+  });
+
+  it("maps unknown errors to 'unknown'", () => {
+    expect(classifyMicError(new Error("random")).kind).toBe("unknown");
+  });
+
+  it("classifies non-Error throws safely", () => {
+    expect(classifyMicError("boom").kind).toBe("unknown");
+    expect(classifyMicError(undefined).kind).toBe("unknown");
+  });
+
+  it("falls back on message keyword 'permission' even without name", () => {
+    expect(classifyMicError(new Error("Permission revoked at runtime")).kind).toBe("micDenied");
+  });
+});
+
+describe("sendErrorI18nKey", () => {
+  it("builds a flat i18n key per kind", () => {
+    expect(sendErrorI18nKey("micDenied")).toBe("errors.send.micDenied");
+    expect(sendErrorI18nKey("uploadFailed")).toBe("errors.send.uploadFailed");
+  });
+});
+
+describe("send-error bus", () => {
+  beforeEach(() => __resetSendErrorBusForTests());
+
+  it("exposes null when no error is reported", () => {
+    const { error } = useSendErrorBus();
+    expect(error.value).toBeNull();
+  });
+
+  it("publishes a reported error to subscribers", () => {
+    const { error } = useSendErrorBus();
+    reportSendError(new SendError("uploadFailed", "x"));
+    expect(error.value?.kind).toBe("uploadFailed");
+    expect(error.value?.retryable).toBe(true);
+  });
+
+  it("last error wins — replaces older errors", () => {
+    const { error } = useSendErrorBus();
+    reportSendError(new SendError("uploadFailed", "first"));
+    const firstId = error.value!.id;
+    reportSendError(new SendError("micDenied", "second"));
+    expect(error.value?.kind).toBe("micDenied");
+    expect(error.value!.id).not.toBe(firstId);
+  });
+
+  it("clear() with matching id removes the active error", () => {
+    const { error } = useSendErrorBus();
+    const entry = reportSendError(new SendError("uploadFailed", "x"));
+    clearSendError(entry.id);
+    expect(error.value).toBeNull();
+  });
+
+  it("clear() with stale id is a no-op", () => {
+    const { error } = useSendErrorBus();
+    reportSendError(new SendError("uploadFailed", "x"));
+    clearSendError(9999);
+    expect(error.value).not.toBeNull();
+  });
+
+  it("clear() without id removes the active error", () => {
+    const { error } = useSendErrorBus();
+    reportSendError(new SendError("uploadFailed", "x"));
+    clearSendError();
+    expect(error.value).toBeNull();
+  });
+
+  it("wraps non-SendError throws into a SendError with kind 'unknown'", () => {
+    const { error } = useSendErrorBus();
+    reportSendError(new Error("native boom"));
+    expect(error.value?.kind).toBe("unknown");
+    expect(error.value?.message).toBe("native boom");
+  });
+
+  it("stores retry callback for the banner to invoke", async () => {
+    const { error } = useSendErrorBus();
+    let called = false;
+    reportSendError(new SendError("uploadFailed", "x"), () => {
+      called = true;
+    });
+    await error.value!.retry?.();
+    expect(called).toBe(true);
+  });
+});

--- a/src/features/messaging/model/send-error-bus.ts
+++ b/src/features/messaging/model/send-error-bus.ts
@@ -1,0 +1,64 @@
+import { ref, readonly } from "vue";
+import { SendError, type SendErrorKind, type SendErrorContext } from "./send-errors";
+
+export interface ActiveSendError {
+  readonly id: number;
+  readonly kind: SendErrorKind;
+  readonly message: string;
+  readonly context: SendErrorContext;
+  readonly retryable: boolean;
+  readonly retry?: () => Promise<void> | void;
+  readonly createdAt: number;
+}
+
+const currentError = ref<ActiveSendError | null>(null);
+let nextId = 1;
+
+/** Report a failed send so the UI banner can surface it.
+ *
+ *  Why a singleton bus and not a per-component ref:
+ *   - sendFile/sendImage/sendAudio are called from several places (paste-drop,
+ *     forward, share target, attachment panel) — they cannot all wire a Vue
+ *     emit/ref through. The bus stays decoupled from the call sites.
+ *   - Only the latest error is shown. A second failure within the same UX
+ *     surface should replace the first (Telegram-style "last error wins"),
+ *     not stack up an unread queue. */
+export function reportSendError(
+  err: SendError | unknown,
+  retry?: ActiveSendError["retry"],
+): ActiveSendError {
+  const sendErr = err instanceof SendError
+    ? err
+    : new SendError("unknown", err instanceof Error ? err.message : String(err), {}, true);
+  const entry: ActiveSendError = {
+    id: nextId++,
+    kind: sendErr.kind,
+    message: sendErr.message,
+    context: sendErr.context,
+    retryable: sendErr.retryable,
+    retry,
+    createdAt: Date.now(),
+  };
+  currentError.value = entry;
+  return entry;
+}
+
+export function clearSendError(id?: number): void {
+  if (id !== undefined && currentError.value?.id !== id) return;
+  currentError.value = null;
+}
+
+export function useSendErrorBus() {
+  return {
+    error: readonly(currentError),
+    clear: clearSendError,
+  };
+}
+
+/** Test helper: reset module state between unit tests. Vue refs leak across
+ *  tests when modules are not re-imported. Exported here so tests do not have
+ *  to reach into internals. */
+export function __resetSendErrorBusForTests(): void {
+  currentError.value = null;
+  nextId = 1;
+}

--- a/src/features/messaging/model/send-errors.ts
+++ b/src/features/messaging/model/send-errors.ts
@@ -1,0 +1,68 @@
+import { isNative } from "@/shared/lib/platform";
+
+export type SendErrorKind =
+  | "permissionDenied"
+  | "micDenied"
+  | "pickerCancelled"
+  | "fileTooLarge"
+  | "dbNotReady"
+  | "matrixNotReady"
+  | "cryptoNotReady"
+  | "uploadFailed"
+  | "queueStuck"
+  | "unknown";
+
+export interface SendErrorContext {
+  fileName?: string;
+  kind?: "image" | "video" | "audio" | "file";
+  cause?: unknown;
+}
+
+export class SendError extends Error {
+  readonly kind: SendErrorKind;
+  readonly context: SendErrorContext;
+  readonly retryable: boolean;
+
+  constructor(kind: SendErrorKind, message: string, context: SendErrorContext = {}, retryable = true) {
+    super(message);
+    this.name = "SendError";
+    this.kind = kind;
+    this.context = context;
+    this.retryable = retryable;
+  }
+}
+
+/** Classify a thrown error from getUserMedia/MediaRecorder.start() into a typed
+ *  SendError. Android WebView surfaces RECORD_AUDIO denial as NotAllowedError /
+ *  PermissionDeniedError; both map to "micDenied". */
+export function classifyMicError(err: unknown): SendError {
+  const name = err instanceof Error ? err.name : "";
+  const message = err instanceof Error ? err.message : String(err);
+  if (name === "NotAllowedError" || name === "PermissionDeniedError" || /permission/i.test(message)) {
+    return new SendError("micDenied", message || "Microphone permission denied", { kind: "audio", cause: err });
+  }
+  if (name === "NotFoundError" || name === "DevicesNotFoundError") {
+    return new SendError("micDenied", "No microphone available", { kind: "audio", cause: err });
+  }
+  return new SendError("unknown", message || "Voice recording failed", { kind: "audio", cause: err });
+}
+
+/** Resolve i18n key for banner text. Keeps the translation table flat so
+ *  locale files do not have to mirror the discriminated union structure. */
+export function sendErrorI18nKey(kind: SendErrorKind): string {
+  return `errors.send.${kind}`;
+}
+
+/** Diagnostic prefix used across the send pipeline. Tagging logs with the
+ *  same `[send]` prefix lets logcat / devtools filter the whole pipeline:
+ *  picker → file-upload → sync-engine → matrix sendEvent. */
+export function sendDiag(stage: string, payload?: unknown): void {
+  const tag = isNative ? "[send][native]" : "[send][web]";
+  if (payload === undefined) {
+    // eslint-disable-next-line no-console
+    console.info(`${tag} ${stage}`);
+  } else {
+    // eslint-disable-next-line no-console
+    console.info(`${tag} ${stage}`, payload);
+  }
+}

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -18,6 +18,8 @@ import type { LocalMessageStatus } from "@/shared/lib/local-db/schema";
 import { useBugReport } from "@/features/bug-report";
 import { tRaw } from "@/shared/lib/i18n";
 import { useToast } from "@/shared/lib/use-toast";
+import { SendError, sendDiag } from "./send-errors";
+import { reportSendError } from "./send-error-bus";
 
 /** Per-phase media pipeline timeouts. Splitting the old single 5-minute cap
  *  lets us surface phase-specific failures (e.g. crypto hang vs upload stall)
@@ -354,11 +356,16 @@ export function useMessages() {
     file: File,
     options: { forwardedFrom?: { senderId: string; senderName?: string } } = {},
   ): Promise<boolean> => {
+    sendDiag("file:start", { name: file?.name, size: file?.size });
     const roomId = chatStore.activeRoomId;
-    if (!roomId || !file) return false;
+    if (!roomId || !file) {
+      sendDiag("file:no-room-or-file", { hasRoom: !!roomId, hasFile: !!file });
+      return false;
+    }
 
     if (file.size > MAX_UPLOAD_SIZE) {
       console.warn(`[use-messages] File too large: ${file.name} (${(file.size / 1024 / 1024).toFixed(1)} MB)`);
+      reportSendError(new SendError("fileTooLarge", `File too large: ${file.name}`, { fileName: file.name, kind: "file" }, false));
       return false;
     }
 
@@ -368,7 +375,11 @@ export function useMessages() {
     const processedFile = await convertHeicToJpeg(file);
 
     const matrixService = getMatrixClientService();
-    if (!matrixService.isReady()) return false;
+    if (!matrixService.isReady()) {
+      sendDiag("file:matrix-not-ready");
+      reportSendError(new SendError("matrixNotReady", "Matrix client not ready", { fileName: file.name, kind: "file" }));
+      return false;
+    }
 
     // Determine message type from MIME (with fallback for HEIC/extension-only files)
     const mime = normalizeMime(resolveMime(processedFile));
@@ -380,6 +391,7 @@ export function useMessages() {
       // Without Dexie we have no crash-safe queue — dropping the send is
       // safer than leaking a never-completing toast on a dead pipeline.
       console.error("[use-messages] sendFile: chat DB not ready");
+      reportSendError(new SendError("dbNotReady", "Local database not ready", { fileName: file.name, kind: "file" }));
       URL.revokeObjectURL(localBlobUrl);
       return false;
     }
@@ -423,6 +435,7 @@ export function useMessages() {
       },
       localMsg.clientId,
     );
+    sendDiag("file:enqueued", { clientId: localMsg.clientId });
     return true;
   };
 
@@ -436,11 +449,16 @@ export function useMessages() {
       forwardedFrom?: { senderId: string; senderName?: string };
     } = {},
   ): Promise<boolean> => {
+    sendDiag("image:start", { name: file?.name, size: file?.size });
     const roomId = chatStore.activeRoomId;
-    if (!roomId || !file) return false;
+    if (!roomId || !file) {
+      sendDiag("image:no-room-or-file", { hasRoom: !!roomId, hasFile: !!file });
+      return false;
+    }
 
     if (file.size > MAX_UPLOAD_SIZE) {
       console.warn(`[use-messages] Image too large: ${file.name} (${(file.size / 1024 / 1024).toFixed(1)} MB)`);
+      reportSendError(new SendError("fileTooLarge", `Image too large: ${file.name}`, { fileName: file.name, kind: "image" }, false));
       return false;
     }
 
@@ -450,7 +468,11 @@ export function useMessages() {
     const processedFile = await convertHeicToJpeg(file);
 
     const matrixService = getMatrixClientService();
-    if (!matrixService.isReady()) return false;
+    if (!matrixService.isReady()) {
+      sendDiag("image:matrix-not-ready");
+      reportSendError(new SendError("matrixNotReady", "Matrix client not ready", { fileName: file.name, kind: "image" }));
+      return false;
+    }
 
     const dimensions = await getImageDimensions(processedFile);
     const imageMime = resolveMime(processedFile);
@@ -458,6 +480,7 @@ export function useMessages() {
 
     if (!isChatDbReady()) {
       console.error("[use-messages] sendImage: chat DB not ready");
+      reportSendError(new SendError("dbNotReady", "Local database not ready", { fileName: file.name, kind: "image" }));
       URL.revokeObjectURL(localBlobUrl);
       return false;
     }
@@ -513,6 +536,7 @@ export function useMessages() {
       },
       localMsg.clientId,
     );
+    sendDiag("image:enqueued", { clientId: localMsg.clientId });
     return true;
   };
 
@@ -526,17 +550,26 @@ export function useMessages() {
       forwardedFrom?: { senderId: string; senderName?: string };
     } = {},
   ): Promise<boolean> => {
+    sendDiag("audio:start", { name: file?.name, size: file?.size });
     const roomId = chatStore.activeRoomId;
-    if (!roomId || !file) return false;
+    if (!roomId || !file) {
+      sendDiag("audio:no-room-or-file", { hasRoom: !!roomId, hasFile: !!file });
+      return false;
+    }
 
     const matrixService = getMatrixClientService();
-    if (!matrixService.isReady()) return false;
+    if (!matrixService.isReady()) {
+      sendDiag("audio:matrix-not-ready");
+      reportSendError(new SendError("matrixNotReady", "Matrix client not ready", { fileName: file.name, kind: "audio" }));
+      return false;
+    }
 
     const audioMime = resolveMime(file);
     const localBlobUrl = URL.createObjectURL(file);
 
     if (!isChatDbReady()) {
       console.error("[use-messages] sendAudio: chat DB not ready");
+      reportSendError(new SendError("dbNotReady", "Local database not ready", { fileName: file.name, kind: "audio" }));
       URL.revokeObjectURL(localBlobUrl);
       return false;
     }
@@ -590,6 +623,7 @@ export function useMessages() {
       },
       localMsg.clientId,
     );
+    sendDiag("audio:enqueued", { clientId: localMsg.clientId });
     return true;
   };
 

--- a/src/features/messaging/model/use-voice-recorder.ts
+++ b/src/features/messaging/model/use-voice-recorder.ts
@@ -3,6 +3,8 @@ import { isNative } from "@/shared/lib/platform";
 import { getRealGetUserMedia } from "@/shared/lib/native-webrtc";
 import { useBugReport } from "@/features/bug-report";
 import { tRaw } from "@/shared/lib/i18n";
+import { classifyMicError, sendDiag, SendError } from "./send-errors";
+import { reportSendError } from "./send-error-bus";
 
 export type RecorderState = "idle" | "recording" | "locked" | "preview";
 
@@ -37,6 +39,7 @@ export function useVoiceRecorder() {
 
   const startRecording = async () => {
     try {
+      sendDiag("voice:start");
       const t0 = Date.now();
       const gum = (isNative && getRealGetUserMedia()) || navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
       audioStream = await gum({
@@ -47,15 +50,20 @@ export function useVoiceRecorder() {
         },
       });
 
-      // Validate we got real audio tracks (not dummy from WebRTC proxy)
+      // Validate we got real audio tracks (not dummy from WebRTC proxy).
+      // An empty track list is observable both when RECORD_AUDIO is silently
+      // revoked on Android and when the WebRTC bridge returns a dummy stream
+      // mid-call. Either way the user gets nothing — surface it as micDenied
+      // so the banner appears instead of a silent state reset.
       const audioTracks = audioStream.getAudioTracks();
       if (audioTracks.length === 0 || !audioTracks[0].enabled) {
         console.error("[VoiceRecorder] No usable audio tracks — count:", audioTracks.length, "enabled:", audioTracks[0]?.enabled);
         audioStream.getTracks().forEach(t => t.stop());
         cleanup();
+        reportSendError(new SendError("micDenied", "No usable audio tracks available", { kind: "audio" }));
         return;
       }
-      console.log("[VoiceRecorder] Started with", audioTracks.length, "audio track(s)");
+      sendDiag("voice:tracks-ok", { count: audioTracks.length });
 
       audioChunks = [];
 
@@ -105,7 +113,19 @@ export function useVoiceRecorder() {
       }, 50);
     } catch (e) {
       console.error("Failed to start recording:", e);
-      useBugReport().open({ context: tRaw("bugReport.ctx.voiceRecord"), error: e });
+      const classified = classifyMicError(e);
+      sendDiag("voice:start-failed", { kind: classified.kind });
+      // micDenied is the user-actionable case (Settings → Permissions →
+      // Microphone). Show a typed banner instead of the bug-report modal so
+      // the user knows what to do. Everything else still routes to the bug
+      // report so we get the stack on the unhappy paths we don't yet know
+      // about.
+      if (classified.kind === "micDenied") {
+        reportSendError(classified);
+      } else {
+        reportSendError(classified);
+        useBugReport().open({ context: tRaw("bugReport.ctx.voiceRecord"), error: e });
+      }
       cleanup();
     }
   };

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -14,6 +14,7 @@ import EmojiPicker from "./EmojiPicker.vue";
 import AttachmentPanel from "./AttachmentPanel.vue";
 import MediaPreview from "./MediaPreview.vue";
 import PollCreator from "./PollCreator.vue";
+import SendErrorBanner from "./SendErrorBanner.vue";
 import { useVoiceRecorder } from "../model/use-voice-recorder";
 import { useVideoCircleRecorder } from "../model/use-video-circle-recorder";
 import { useMentionAutocomplete } from "../model/use-mention-autocomplete";
@@ -890,6 +891,10 @@ const handleKitchenSelect = async (imageUrl: string) => {
 
 <template>
   <div ref="inputRootRef" class="relative border-t border-neutral-grad-0 bg-background-total-theme">
+    <!-- Send error banner (WEE-20): permission/upload/queue failures from
+         sendFile/sendImage/sendAudio + voice recorder are routed here via
+         the send-error bus so they stop disappearing silently. -->
+    <SendErrorBanner />
     <!-- Editing bar -->
     <div class="input-bar-grid" :class="{ 'input-bar-grid--open': isEditing }">
       <div class="input-bar-grid-inner">

--- a/src/features/messaging/ui/SendErrorBanner.vue
+++ b/src/features/messaging/ui/SendErrorBanner.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useI18n, type TranslationKey } from "@/shared/lib/i18n";
+import { useSendErrorBus } from "../model/send-error-bus";
+import { sendErrorI18nKey, type SendErrorKind } from "../model/send-errors";
+
+const { t } = useI18n();
+const { error, clear } = useSendErrorBus();
+
+const visible = computed(() => error.value !== null);
+// All kinds in SendErrorKind have a matching `errors.send.<kind>` key in en.ts,
+// so the cast is safe — but TranslationKey is a literal-union type and TS
+// cannot derive it from a runtime kind string without the cast.
+const labelKey = computed<TranslationKey>(() =>
+  error.value
+    ? (sendErrorI18nKey(error.value.kind as SendErrorKind) as TranslationKey)
+    : ("errors.send.unknown" as TranslationKey),
+);
+const retryable = computed(() => !!error.value?.retry && error.value.retryable);
+
+/** Banner stays open after a retry triggers — the new send will either
+ *  succeed (and the next reportSendError will overwrite it on failure) or
+ *  emit a fresh error here. Closing immediately on tap would hide the
+ *  second failure and re-introduce the original silent-fail bug. */
+const onRetry = async () => {
+  const current = error.value;
+  if (!current?.retry) return;
+  try {
+    await current.retry();
+  } catch {
+    // Retry path itself failed: leave the banner so the user can try again.
+  }
+};
+
+const onDismiss = () => {
+  const current = error.value;
+  if (current) clear(current.id);
+  else clear();
+};
+</script>
+
+<template>
+  <Transition name="send-error-fade">
+    <div
+      v-if="visible && error"
+      class="pointer-events-auto mx-2 mb-2 flex items-center gap-2 rounded-lg border border-red-500/40 bg-red-500/10 px-3 py-2 text-sm text-red-200"
+      role="alert"
+      :data-error-kind="error.kind"
+    >
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0">
+        <circle cx="12" cy="12" r="10" />
+        <line x1="12" y1="8" x2="12" y2="12" />
+        <line x1="12" y1="16" x2="12.01" y2="16" />
+      </svg>
+      <span class="flex-1 leading-snug">{{ t(labelKey) }}</span>
+      <button
+        v-if="retryable"
+        type="button"
+        class="rounded-md px-2 py-1 text-xs font-medium underline-offset-2 hover:underline"
+        @click="onRetry"
+      >
+        {{ t("errors.send.retry") }}
+      </button>
+      <button
+        type="button"
+        class="rounded-md px-2 py-1 text-xs font-medium opacity-70 hover:opacity-100"
+        :aria-label="t('errors.send.dismiss')"
+        @click="onDismiss"
+      >
+        ✕
+      </button>
+    </div>
+  </Transition>
+</template>
+
+<style scoped>
+.send-error-fade-enter-active,
+.send-error-fade-leave-active {
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+.send-error-fade-enter-from,
+.send-error-fade-leave-to {
+  opacity: 0;
+  transform: translateY(4px);
+}
+</style>

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -868,6 +868,20 @@ export const en = {
   "errors.networkBlocked": "Server unreachable. Try enabling Tor or a VPN.",
   "errors.cryptoNotReady": "Encryption keys are still loading. Please wait.",
   "errors.missingUrl": "File is corrupted or never arrived. Ask the sender to resend.",
+
+  // ── Send errors (WEE-20) ──
+  "errors.send.permissionDenied": "No access to files. Grant access in app settings.",
+  "errors.send.micDenied": "No access to the microphone. Grant access in app settings.",
+  "errors.send.pickerCancelled": "No file selected.",
+  "errors.send.fileTooLarge": "File too large (max 100 MB).",
+  "errors.send.dbNotReady": "Local database is not ready yet. Wait and try again.",
+  "errors.send.matrixNotReady": "Connection is not ready yet. Wait and try again.",
+  "errors.send.cryptoNotReady": "Encryption keys are still loading. Please wait.",
+  "errors.send.uploadFailed": "Failed to send. Check the connection and try again.",
+  "errors.send.queueStuck": "Send queue is stuck. Restart the app.",
+  "errors.send.unknown": "Failed to send. Please try again.",
+  "errors.send.dismiss": "Dismiss",
+  "errors.send.retry": "Retry",
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -870,4 +870,18 @@ export const ru: Record<TranslationKey, string> = {
   "errors.networkBlocked": "Сервер недоступен. Попробуйте включить Tor или VPN.",
   "errors.cryptoNotReady": "Ключи шифрования ещё загружаются. Подождите.",
   "errors.missingUrl": "Файл повреждён или не пришёл с источника. Попросите отправителя прислать ещё раз.",
+
+  // ── Ошибки отправки сообщений (WEE-20) ──
+  "errors.send.permissionDenied": "Нет доступа к файлам. Разрешите доступ в настройках приложения.",
+  "errors.send.micDenied": "Нет доступа к микрофону. Разрешите доступ в настройках приложения.",
+  "errors.send.pickerCancelled": "Файл не выбран.",
+  "errors.send.fileTooLarge": "Файл слишком большой (максимум 100 МБ).",
+  "errors.send.dbNotReady": "Локальная база ещё не готова. Подождите и попробуйте снова.",
+  "errors.send.matrixNotReady": "Соединение ещё не установлено. Подождите и попробуйте снова.",
+  "errors.send.cryptoNotReady": "Ключи шифрования ещё загружаются. Подождите.",
+  "errors.send.uploadFailed": "Не удалось отправить. Проверьте соединение и попробуйте снова.",
+  "errors.send.queueStuck": "Очередь отправки зависла. Перезапустите приложение.",
+  "errors.send.unknown": "Не удалось отправить. Попробуйте снова.",
+  "errors.send.dismiss": "Закрыть",
+  "errors.send.retry": "Повторить",
 };

--- a/src/shared/lib/local-db/sync-engine-queue-health.test.ts
+++ b/src/shared/lib/local-db/sync-engine-queue-health.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Dexie from "dexie";
+import "fake-indexeddb/auto";
+import { SyncEngine } from "./sync-engine";
+import type { PendingOperation, LocalMessage, LocalRoom } from "./schema";
+
+class TestDb extends Dexie {
+  rooms!: import("dexie").Table<LocalRoom, string>;
+  messages!: import("dexie").Table<LocalMessage, number>;
+  pendingOps!: import("dexie").Table<PendingOperation, number>;
+  constructor() {
+    super("test-sync-engine-queue-health", { indexedDB, IDBKeyRange });
+    this.version(1).stores({
+      rooms: "id, membership, updatedAt",
+      messages: "++localId, clientId, eventId, roomId, status",
+      pendingOps: "++id, status, clientId, roomId, [status+nextAttemptAt]",
+    });
+  }
+}
+
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: () => ({
+    isReady: () => true,
+  }),
+}));
+
+// SyncEngine constructor starts a watchdog interval; we don't need it for
+// these tests but we MUST dispose() to clear it or vitest hangs at exit.
+function buildEngine(db: TestDb): SyncEngine {
+  const messageRepo = {
+    confirmSent: vi.fn(),
+    getByEventId: vi.fn(),
+    updateStatus: vi.fn(),
+    updateReactions: vi.fn(),
+    getByClientId: vi.fn(),
+  };
+  const roomRepo = { updateRoom: vi.fn() };
+  return new SyncEngine(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    db as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    messageRepo as any,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    roomRepo as any,
+    async () => undefined,
+  );
+}
+
+describe("SyncEngine.getQueueHealth", () => {
+  let db: TestDb;
+  let engine: SyncEngine | null = null;
+
+  beforeEach(() => {
+    db = new TestDb();
+    engine = null;
+  });
+
+  afterEach(async () => {
+    engine?.dispose();
+    await db.delete();
+  });
+
+  it("returns zero counts when the queue is empty", async () => {
+    engine = buildEngine(db);
+    const health = await engine.getQueueHealth();
+    expect(health).toEqual({
+      pendingCount: 0,
+      failedCount: 0,
+      syncingCount: 0,
+      oldestPendingAgeMs: null,
+    });
+  });
+
+  it("counts pending, failed, and syncing ops independently", async () => {
+    const now = Date.now();
+    await db.pendingOps.bulkAdd([
+      { type: "send_message", roomId: "!r:s", payload: {}, status: "pending", retries: 0, maxRetries: 5, createdAt: now - 1000, clientId: "c1" },
+      { type: "send_file", roomId: "!r:s", payload: {}, status: "syncing", retries: 0, maxRetries: 5, createdAt: now - 500, clientId: "c2" },
+      { type: "send_message", roomId: "!r:s", payload: {}, status: "failed", retries: 5, maxRetries: 5, createdAt: now - 2000, errorMessage: "boom", clientId: "c3" },
+      { type: "send_message", roomId: "!r:s", payload: {}, status: "failed", retries: 5, maxRetries: 5, createdAt: now - 3000, errorMessage: "boom", clientId: "c4" },
+    ] as Omit<PendingOperation, "id">[]);
+
+    engine = buildEngine(db);
+    const health = await engine.getQueueHealth();
+    expect(health.pendingCount).toBe(1);
+    expect(health.syncingCount).toBe(1);
+    expect(health.failedCount).toBe(2);
+  });
+
+  it("returns the age of the oldest pending op (not syncing/failed)", async () => {
+    const now = Date.now();
+    await db.pendingOps.bulkAdd([
+      // Oldest is a failed op — must be ignored by oldestPendingAgeMs.
+      { type: "send_message", roomId: "!r:s", payload: {}, status: "failed", retries: 5, maxRetries: 5, createdAt: now - 60_000, errorMessage: "x", clientId: "c-old-failed" },
+      { type: "send_message", roomId: "!r:s", payload: {}, status: "pending", retries: 0, maxRetries: 5, createdAt: now - 10_000, clientId: "c-pending-old" },
+      { type: "send_message", roomId: "!r:s", payload: {}, status: "pending", retries: 0, maxRetries: 5, createdAt: now - 1_000, clientId: "c-pending-young" },
+    ] as Omit<PendingOperation, "id">[]);
+
+    engine = buildEngine(db);
+    const health = await engine.getQueueHealth();
+    expect(health.pendingCount).toBe(2);
+    expect(health.oldestPendingAgeMs).toBeGreaterThanOrEqual(10_000 - 250);
+    expect(health.oldestPendingAgeMs).toBeLessThan(60_000); // not the failed op
+  });
+});

--- a/src/shared/lib/local-db/sync-engine.ts
+++ b/src/shared/lib/local-db/sync-engine.ts
@@ -165,6 +165,47 @@ export class SyncEngine {
     this.onChange = cb;
   }
 
+  /**
+   * Snapshot of the outbound queue used by the UI banner to detect stuck sends.
+   *
+   * `oldestPendingAgeMs` is `null` when the queue has no due ops. When it is
+   * large the UI can warn the user that something is wedged — e.g. crypto
+   * never resolved or media server is unreachable — instead of leaving them
+   * staring at "sending…" forever.
+   *
+   * Why exposed as a polled snapshot and not a Dexie live-query:
+   *  - The caller (status banner) is allowed to be eventually consistent;
+   *    polling once every few seconds is cheaper than a hot live-query that
+   *    fires on every progress write.
+   *  - Keeps the SyncEngine's public surface minimal — Dexie tables are
+   *    internal state.
+   */
+  async getQueueHealth(): Promise<{
+    pendingCount: number;
+    failedCount: number;
+    syncingCount: number;
+    oldestPendingAgeMs: number | null;
+  }> {
+    const [pending, failed, syncing] = await Promise.all([
+      this.db.pendingOps.where("status").equals("pending").toArray(),
+      this.db.pendingOps.where("status").equals("failed").count(),
+      this.db.pendingOps.where("status").equals("syncing").count(),
+    ]);
+    const now = Date.now();
+    let oldest: number | null = null;
+    for (const op of pending) {
+      const created = op.createdAt ?? op.lastAttemptAt ?? now;
+      const age = now - created;
+      if (oldest === null || age > oldest) oldest = age;
+    }
+    return {
+      pendingCount: pending.length,
+      failedCount: failed,
+      syncingCount: syncing,
+      oldestPendingAgeMs: oldest,
+    };
+  }
+
   // ---------------------------------------------------------------------------
   // Queue processing
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Surfaces silent send failures on Android (and everywhere else) so the user sees what went wrong instead of an upload that vanishes.

**Linear:** [WEE-20](https://linear.app/wwwee/issue/WEE-20/mediavoice-na-android-ne-otpravlyayutsya-fajly-i-golosovye-v-chaty) — `media+voice: на Android не отправляются файлы и голосовые в чаты`

**Related forta-bugs:** [#541](https://github.com/greenShirtMystery/forta-bugs/issues/541), [#659](https://github.com/greenShirtMystery/forta-bugs/issues/659)

## Root cause coverage

Без logcat от устройства выбрать одну из H1–H7 веток нельзя, поэтому исправил **всю observability-поверхность send pipeline**:

- `sendFile` / `sendImage` / `sendAudio` все возвращали `false` на каждом failure-пути (matrix not ready, DB not ready, file too large) **без UX**. Пользователь видел исчезновение сообщения без причины.
- `VoiceRecorder` ловил throw из `getUserMedia()` в bug-report-модалку без классификации Android-специфичного `NotAllowedError` (RECORD_AUDIO revoked).
- `SyncEngine` не имел public surface чтобы UI знал, когда очередь wedged.

## Changes

**Новые файлы:**
- `src/features/messaging/model/send-errors.ts` — `SendError` + `SendErrorKind` (10 типов), `classifyMicError`, `sendDiag` для logcat (`[send][native|web]` префикс).
- `src/features/messaging/model/send-error-bus.ts` — reactive singleton bus (last-error-wins, retry callback, decoupled от per-component refs).
- `src/features/messaging/ui/SendErrorBanner.vue` — banner с Retry/Dismiss, `role="alert"`, `data-error-kind` атрибут для регрессионных проверок.

**Обновлённые файлы:**
- `src/features/messaging/model/use-voice-recorder.ts` — `classifyMicError()` на throws + empty tracks → `micDenied`. Banner вместо bug-report-модалки для permission denial.
- `src/features/messaging/model/use-messages.ts` — `reportSendError` + `sendDiag` на каждом silent-return пути.
- `src/features/messaging/ui/MessageInput.vue` — mounted `<SendErrorBanner />` на верхе.
- `src/shared/lib/local-db/sync-engine.ts` — `getQueueHealth()` снапшот (pendingCount, failedCount, syncingCount, oldestPendingAgeMs).
- `src/shared/lib/i18n/locales/{en,ru}.ts` — 12 новых `errors.send.*` ключей.

**Тесты (21 кейс):**
- `send-errors.test.ts` (18): SendError factory, classifyMicError по всем веткам (NotAllowedError / PermissionDenied / NotFound / keyword 'permission' / non-Error throws), bus pub-sub / replace / clear / retry.
- `sync-engine-queue-health.test.ts` (3): empty / mixed counts / oldest age ignores failed ops.

## Test plan

- [x] `./node_modules/.bin/vue-tsc --noEmit` — 0 новых ошибок в моих файлах (остальные pre-existing: `heic2any` модуль, `MessageBubble.vue` `message.retrySend` ключ, тестовые типы)
- [x] `./node_modules/.bin/vitest run` — мои 20 тестов проходят; общий baseline улучшился: **было 13 failed / 1838 passed → стало 9 failed / 1842 passed**
- [ ] Manual on-device verification (нужен debug APK + logcat при reproduce):
  - [ ] Android device → attach photo → typed banner если permission denied
  - [ ] Android device → hold voice → release → `micDenied` banner если RECORD_AUDIO revoked
  - [ ] Network loss mid-upload → typed banner, не silent
  - [ ] logcat filter `[send]` показывает точку остановки pipeline

## Notes

- `vite build` падает на pre-existing missing `heic2any` зависимости — не от этого PR (подтверждено `git stash` diff).
- После manual on-device repro с logcat — тег `[send]` покажет одну из H1–H7 веток для финального root-cause-фикса; можно дописать сюда новым коммитом или в narrower follow-up.