### PR TITLE
fix(media-download): resolve mxc:// to http before fetch (WEE-17)

### DIFF
--- a/src/features/messaging/model/use-file-download.test.ts
+++ b/src/features/messaging/model/use-file-download.test.ts
@@ -62,6 +62,18 @@ vi.mock("@/shared/lib/matrix/functions", () => ({
   hexEncode: vi.fn((s: string) => s),
 }));
 
+// --- Matrix client service mock ---
+// `getMatrixClientService().mxcToHttp(mxc)` resolves an mxc:// URI to an HTTP
+// download URL. Tests can override the implementation per case via
+// `mockMxcToHttp.mockImplementation(...)` to simulate baseUrl changes between
+// retry attempts (the fresh-resolve regression for WEE-17).
+const mockMxcToHttp: Mock = vi.fn((mxc: string) =>
+  mxc.startsWith("mxc://") ? `https://homeserver.example/_matrix/media/r0/download/${mxc.slice(6)}` : null,
+);
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: vi.fn(() => ({ mxcToHttp: mockMxcToHttp })),
+}));
+
 // --- Bug report & i18n mocks (called on download errors) ---
 vi.mock("@/features/bug-report", () => ({
   useBugReport: vi.fn(() => ({ open: vi.fn() })),
@@ -122,6 +134,11 @@ describe("useFileDownload", () => {
     setMockPcrypto(null);
     // Reset toast dedup so repeated-failure tests start from a clean slate.
     _resetToastDedupForTests();
+    // Restore the default mxc → http resolver so per-test overrides do not
+    // leak into subsequent cases.
+    mockMxcToHttp.mockImplementation((mxc: string) =>
+      mxc.startsWith("mxc://") ? `https://homeserver.example/_matrix/media/r0/download/${mxc.slice(6)}` : null,
+    );
   });
 
   describe("saveFile — web platform", () => {
@@ -454,6 +471,18 @@ describe("useFileDownload", () => {
       expect(withQuery).toMatch(/^https:\/\/example\.com\/file\.pdf\?token=abc&cb=/);
     });
 
+    it("does NOT mangle blob:/data: URLs with cache-bust (those schemes do not accept query strings)", () => {
+      // Regression safety net for WEE-17 review: appending `?cb=` to a blob:
+      // URL breaks the URL grammar and the next fetch would fail spuriously.
+      // blob: / data: have no HTTP cache layer to bust anyway.
+      expect(appendCacheBust("blob:http://localhost/abc-123", 1)).toBe(
+        "blob:http://localhost/abc-123",
+      );
+      expect(appendCacheBust("data:image/png;base64,iVBORw0KGgo=", 2)).toBe(
+        "data:image/png;base64,iVBORw0KGgo=",
+      );
+    });
+
     it("retry attempts produce distinct cache-bust values", () => {
       const a = appendCacheBust("https://example.com/file.pdf", 1);
       const b = appendCacheBust("https://example.com/file.pdf", 2);
@@ -739,6 +768,223 @@ describe("useFileDownload", () => {
       });
       scope.stop();
     }, 30_000);
+
+    // ─────────────────────────────────────────────────────────────────────
+    // WEE-17: mxc:// → http resolve before fetch
+    //
+    // Matrix encrypted attachments arrive with `fileInfo.url = "mxc://..."`
+    // (parseFileInfo preserves the canonical Matrix URI). `fetch("mxc://...")`
+    // throws `TypeError: Failed to fetch` immediately in Capacitor's WebView
+    // shim, and cache-bust alone cannot rescue it — every retry attempt would
+    // fetch the same un-resolvable scheme.
+    //
+    // Closes forta-bugs#776 #763 #648 #513 #475 #441 #373 — the largest media
+    // failure cluster on the bug board.
+    // ─────────────────────────────────────────────────────────────────────
+    it("resolves mxc:// URLs to http via matrixService.mxcToHttp before fetch (WEE-17)", async () => {
+      (global.fetch as Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        blob: () => Promise.resolve(new Blob([new Uint8Array([1, 2, 3])])),
+      });
+
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download } = useFileDownload();
+        const message = {
+          id: "$evt_mxc",
+          _key: "client_mxc",
+          roomId: "!room:server",
+          senderId: "@u:server",
+          content: "photo.jpg",
+          timestamp: Date.now(),
+          status: "sent",
+          type: "image",
+          fileInfo: {
+            name: "photo.jpg",
+            type: "image/jpeg",
+            size: 1024,
+            url: "mxc://matrix.bastyon.com/abc123",
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        await download(message);
+
+        // The Matrix client must have been consulted to translate mxc → http.
+        expect(mockMxcToHttp).toHaveBeenCalledWith("mxc://matrix.bastyon.com/abc123");
+        // fetch must NOT have been called with the raw mxc:// URI (that would
+        // throw TypeError: Failed to fetch on every retry).
+        const [firstUrl] = (global.fetch as Mock).mock.calls[0];
+        expect(firstUrl).not.toMatch(/^mxc:\/\//);
+        expect(firstUrl).toBe("https://homeserver.example/_matrix/media/r0/download/matrix.bastyon.com/abc123");
+      });
+      scope.stop();
+    });
+
+    it("does NOT call mxcToHttp for http/https URLs (already resolved)", async () => {
+      (global.fetch as Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        blob: () => Promise.resolve(new Blob([new Uint8Array([1, 2, 3])])),
+      });
+
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download } = useFileDownload();
+        const message = {
+          id: "$evt_http",
+          _key: "client_http",
+          roomId: "!room:server",
+          senderId: "@u:server",
+          content: "file.pdf",
+          timestamp: Date.now(),
+          status: "sent",
+          type: "file",
+          fileInfo: {
+            name: "file.pdf",
+            type: "application/pdf",
+            size: 1024,
+            url: "https://example.com/file.pdf",
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        await download(message);
+
+        expect(mockMxcToHttp).not.toHaveBeenCalled();
+      });
+      scope.stop();
+    });
+
+    it("re-resolves mxc:// on every retry attempt — picks up homeserver baseUrl changes (WEE-17 H2)", async () => {
+      // First attempt fails with Failed-to-fetch (region block / stale CDN);
+      // before the second attempt, the Matrix client has reconfigured its
+      // baseUrl (e.g. failover from one media server to another). A fresh
+      // resolve must happen so the second fetch goes to the new homeserver
+      // instead of replaying the same stale URL.
+      (global.fetch as Mock)
+        .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          blob: () => Promise.resolve(new Blob([new Uint8Array([1, 2, 3])])),
+        });
+
+      // Different homeserver URLs on each resolve.
+      mockMxcToHttp
+        .mockReturnValueOnce("https://old.example/_matrix/media/r0/download/server/file")
+        .mockReturnValueOnce("https://new.example/_matrix/media/r0/download/server/file");
+
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download } = useFileDownload();
+        const message = {
+          id: "$evt_refresh",
+          _key: "client_refresh",
+          roomId: "!room:server",
+          senderId: "@u:server",
+          content: "file.pdf",
+          timestamp: Date.now(),
+          status: "sent",
+          type: "file",
+          fileInfo: {
+            name: "file.pdf",
+            type: "application/pdf",
+            size: 1024,
+            url: "mxc://server/file",
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        await download(message);
+
+        // mxcToHttp must have been consulted twice — once per attempt — so a
+        // baseUrl change between retries is picked up.
+        expect(mockMxcToHttp).toHaveBeenCalledTimes(2);
+        const calls = (global.fetch as Mock).mock.calls;
+        expect(calls[0][0]).toMatch(/^https:\/\/old\.example\//);
+        // Second attempt uses the new baseUrl (with cache-bust appended).
+        expect(calls[1][0]).toMatch(/^https:\/\/new\.example\/.+\?cb=/);
+      });
+      scope.stop();
+    }, 15_000);
+
+    it("treats mxcToHttp throwing the same as returning null (cold-start Matrix client)", async () => {
+      mockMxcToHttp.mockImplementation(() => {
+        throw new Error("Client not initialized");
+      });
+
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download, getState } = useFileDownload();
+        const message = {
+          id: "$evt_throw",
+          _key: "client_throw",
+          roomId: "!room:server",
+          senderId: "@u:server",
+          content: "file.pdf",
+          timestamp: Date.now(),
+          status: "sent",
+          type: "file",
+          fileInfo: {
+            name: "file.pdf",
+            type: "application/pdf",
+            size: 1024,
+            url: "mxc://server/file",
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        await download(message);
+
+        // Throw collapses to the same MediaUnavailableError fast-fail path —
+        // a throwing Matrix client should not cause an unhandled rejection.
+        expect((global.fetch as Mock).mock.calls.length).toBe(0);
+        expect(getState("client_throw").errorKind).toBe("network");
+      });
+      scope.stop();
+    });
+
+    it("throws MediaUnavailableError when mxcToHttp returns null (no Matrix client)", async () => {
+      mockMxcToHttp.mockReturnValue(null);
+
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download, getState } = useFileDownload();
+        const message = {
+          id: "$evt_unresolved",
+          _key: "client_unresolved",
+          roomId: "!room:server",
+          senderId: "@u:server",
+          content: "file.pdf",
+          timestamp: Date.now(),
+          status: "sent",
+          type: "file",
+          fileInfo: {
+            name: "file.pdf",
+            type: "application/pdf",
+            size: 1024,
+            url: "mxc://server/file",
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        await download(message);
+
+        // Resolve failure is terminal — do NOT burn the retry budget on
+        // something that cannot be retried.
+        expect((global.fetch as Mock).mock.calls.length).toBe(0);
+        expect(getState("client_unresolved").errorKind).toBe("network");
+        // User sees the typed "media unavailable" toast, not a generic error.
+        expect(mockToast).toHaveBeenCalledWith(
+          "errors.mediaUnavailable",
+          "error",
+          expect.any(Number),
+        );
+      });
+      scope.stop();
+    });
 
     it("does not retry on 404 (fast-fail)", async () => {
       (global.fetch as Mock).mockResolvedValue({

--- a/src/features/messaging/model/use-file-download.ts
+++ b/src/features/messaging/model/use-file-download.ts
@@ -1,6 +1,7 @@
 import { ref, onScopeDispose, type Ref } from "vue";
 import { useAuthStore } from "@/entities/auth";
 import type { FileInfo, Message } from "@/entities/chat";
+import { getMatrixClientService } from "@/entities/matrix";
 import type { PcryptoRoomInstance } from "@/entities/matrix/model/matrix-crypto";
 import { hexEncode } from "@/shared/lib/matrix/functions";
 import { isNative, isElectron, isAndroid } from "@/shared/lib/platform";
@@ -252,11 +253,44 @@ let cacheBustCounter = 0;
  *  we've already seen a confirmed miss, and polluting the canonical URL
  *  hurts CDN hit rates. Retries (`attempt >= 1`) get a unique `cb=` so
  *  Service Workers, browser HTTP cache, and intermediate proxies all
- *  re-resolve instead of replaying the prior failure. */
+ *  re-resolve instead of replaying the prior failure.
+ *
+ *  `blob:` and `data:` URIs are left untouched: query strings are not part of
+ *  their grammar, so appending `?cb=...` would mangle the URL and break the
+ *  fetch. Those schemes also bypass HTTP caches by construction — there is
+ *  nothing to bust. */
 export function appendCacheBust(url: string, attempt: number): string {
   if (attempt <= 0) return url;
+  if (url.startsWith("blob:") || url.startsWith("data:")) return url;
   const sep = url.includes("?") ? "&" : "?";
   return `${url}${sep}cb=${Date.now()}_${++cacheBustCounter}`;
+}
+
+/** Resolve a Matrix `mxc://` URI to an HTTP download URL via the active
+ *  Matrix client. Non-mxc inputs (`https://`, `blob:`, `data:`) pass through
+ *  unchanged — those are already directly fetchable.
+ *
+ *  Returns `null` only when the input is `mxc://` and the Matrix client
+ *  cannot resolve it (no client / no baseUrl). Callers treat null as a
+ *  terminal media-unavailable failure: nothing the retry loop can do.
+ *
+ *  Called fresh on every retry attempt so transient client state changes
+ *  (homeserver baseUrl rotation, access-token refresh) take effect between
+ *  attempts. Historically the download path passed `fileInfo.url` straight
+ *  to `fetch`, and for encrypted attachments from non-Bastyon clients
+ *  (Element / Cinny / forwarded messages) that URL is `mxc://...`, which
+ *  Capacitor's WebView shim rejects with `TypeError: Failed to fetch`. That
+ *  one missing translation accounts for the largest media-failure cluster
+ *  on the bug board (forta-bugs #776 #763 #648 #513 #475 #441 #373). */
+export function resolveMediaUrl(url: string): string | null {
+  if (!url.startsWith("mxc://")) return url;
+  try {
+    return getMatrixClientService().mxcToHttp(url);
+  } catch {
+    // Matrix service not yet initialised (cold start race) — treat as a
+    // resolve miss; the outer error path surfaces MediaUnavailableError.
+    return null;
+  }
 }
 
 /** True for failures that look like a network/server issue we should label
@@ -347,9 +381,20 @@ async function downloadAndDecrypt(
 
     try {
       // Download the file (with hard timeout to avoid indefinite MIUI/Tor stalls).
+      // Resolve mxc:// → http on every attempt so a fresh homeserver baseUrl /
+      // access-token rotation takes effect between retries. Without this,
+      // encrypted attachments from non-Bastyon clients (forta-bugs #776 #763
+      // #648 #513 #475 #441 #373) carry raw mxc:// URIs that fetch() rejects
+      // with TypeError: Failed to fetch on every attempt.
       // On retry attempts, append a cache-bust so Service Workers / CDN edges
       // don't replay the prior failure response (issues #648, #641, #637).
-      const fetchUrl = appendCacheBust(fileInfo.url, attempt);
+      const resolvedUrl = resolveMediaUrl(fileInfo.url);
+      if (resolvedUrl === null) {
+        // Cannot translate mxc:// — Matrix client missing or unknown baseUrl.
+        // This is terminal: the retry budget will hit the same null every time.
+        throw new MediaUnavailableError(fileInfo.url);
+      }
+      const fetchUrl = appendCacheBust(resolvedUrl, attempt);
       const response = await fetchWithTimeout(fetchUrl, signal);
       if (!response.ok) {
         const err = new Error(`Download failed: ${response.status}`);
@@ -419,6 +464,9 @@ async function downloadAndDecrypt(
       if (e instanceof CryptoNotReadyError) throw e;
       // Don't retry on permanent errors (missing URL, 4xx client errors)
       if (e instanceof MissingUrlError) throw e;
+      // mxc:// could not be resolved to an http URL (no Matrix client, no
+      // baseUrl). Every retry will hit the same null — fast-fail.
+      if (e instanceof MediaUnavailableError) throw e;
       if (e instanceof Error) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const status = (e as any).status as number | undefined;


### PR DESCRIPTION
## Summary

- Adds `resolveMediaUrl()` that translates `mxc://` URIs to HTTP via `matrixService.mxcToHttp()` before every fetch attempt. Pre-existing `appendCacheBust` retry path was useless for raw `mxc://` URIs — every retry fetched the same un-resolvable scheme and got `TypeError: Failed to fetch`.
- Fresh resolve on each retry attempt picks up homeserver baseUrl rotation / access-token refresh without a separate trigger.
- `mxcToHttp` returning null or throwing → `MediaUnavailableError` fast-fail (no point burning 1+3+6 s on a guaranteed-null resolve).
- `appendCacheBust` skips `blob:` / `data:` URIs so it doesn't mangle them on retry.

## Why it matters

`parseFileInfo` stores the canonical Matrix URI (`mxc://...`) verbatim, and Capacitor's WebView shim rejects that scheme in `fetch()`. This is the largest media-failure cluster on the bug board.

## Linear

- Resolves [WEE-17](https://linear.app/wwwee/issue/WEE-17/media-download-failure-typeerror-failed-to-fetch-retry-fresh-mxc-url)

## Closes

- Closes greenShirtMystery/forta-bugs#776
- Closes greenShirtMystery/forta-bugs#763
- Closes greenShirtMystery/forta-bugs#648
- Closes greenShirtMystery/forta-bugs#513
- Closes greenShirtMystery/forta-bugs#475
- Closes greenShirtMystery/forta-bugs#441
- Closes greenShirtMystery/forta-bugs#373

## Test plan

- [x] 6 new tests added in `use-file-download.test.ts` (35/35 ✅):
  - mxc:// is resolved via `mxcToHttp` before fetch
  - http:// URLs do NOT consult `mxcToHttp`
  - fresh resolve on each retry attempt (baseUrl rotation between retries)
  - `mxcToHttp` returns null → terminal `MediaUnavailableError` + no fetch
  - `mxcToHttp` throws → same fast-fail as null
  - `appendCacheBust` leaves `blob:` and `data:` URIs untouched
- [x] Full suite: 1826/1835 passing (9 failures are pre-existing on master — verified by stash diff)
- [x] vue-tsc: 51 errors (baseline 51 — no regressions)
- [x] Code review: 1 HIGH addressed inline (blob: cache-bust mangling), MEDIUM/LOW logged for follow-up
- [ ] Manual QA on Android: receive image from Element / Cinny user, verify it downloads
- [ ] Manual QA: simulate matrix service `mxcToHttp` returning null (e.g. logout race) — should show "Файл недоступен" toast, not crash

## Risk

- Low. The change is additive: only mxc:// URIs go through the new resolve path; http/https/blob/data URLs preserve current behavior. Existing 29 download tests pass unchanged.