### PR TITLE
fix(calls): incoming-call notification ringtone, accept dismiss, navigation (WEE-18)

### DIFF
--- a/android/app/src/main/java/com/forta/chat/FortaFirebaseMessagingService.kt
+++ b/android/app/src/main/java/com/forta/chat/FortaFirebaseMessagingService.kt
@@ -12,6 +12,7 @@ import android.telecom.TelecomManager
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.forta.chat.plugins.calls.CallConnectionService
+import com.forta.chat.plugins.calls.CallNotificationConfig
 import com.forta.chat.plugins.calls.CancelledCallStore
 import com.forta.chat.plugins.calls.IncomingCallActivity
 import com.forta.chat.plugins.calls.InviteThrottleGuard
@@ -47,19 +48,45 @@ class FortaFirebaseMessagingService : FirebaseMessagingService() {
                 }
             )
         }
-        if (nm.getNotificationChannel(CHANNEL_CALLS) == null) {
-            nm.createNotificationChannel(
-                NotificationChannel(CHANNEL_CALLS, getString(R.string.channel_calls), NotificationManager.IMPORTANCE_MAX).apply {
-                    description = getString(R.string.channel_calls_desc)
-                    enableVibration(true)
+
+        // WEE-18 / forta-bugs#768: NotificationChannel settings are
+        // immutable after first creation. v1.x created the "calls"
+        // channel without an explicit ringtone, and on Xiaomi MIUI the
+        // channel was preserved silent across upgrades, so every
+        // incoming push arrived without a ring. Migrate to a fresh id
+        // and remove the legacy ones so the new ringtone/lockscreen/DND
+        // settings take effect for everyone.
+        for (legacyId in CallNotificationConfig.LEGACY_INCOMING_CALL_CHANNEL_IDS) {
+            if (nm.getNotificationChannel(legacyId) != null) {
+                try {
+                    nm.deleteNotificationChannel(legacyId)
+                } catch (e: Exception) {
+                    Log.w(TAG, "Failed to delete legacy channel $legacyId", e)
+                }
+            }
+        }
+        if (nm.getNotificationChannel(CallNotificationConfig.INCOMING_CALL_CHANNEL_ID) == null) {
+            val spec = CallNotificationConfig.incomingCallChannelSpec(
+                name = getString(R.string.channel_incoming_calls),
+                description = getString(R.string.channel_incoming_calls_desc),
+            )
+            val channel = NotificationChannel(spec.id, spec.name, spec.importance).apply {
+                description = spec.description
+                enableVibration(spec.withVibration)
+                lockscreenVisibility = spec.lockscreenVisibility
+                setBypassDnd(spec.bypassDnd)
+                setShowBadge(true)
+                if (spec.withRingtone) {
                     setSound(
                         RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE),
                         android.media.AudioAttributes.Builder()
+                            .setContentType(android.media.AudioAttributes.CONTENT_TYPE_SONIFICATION)
                             .setUsage(android.media.AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
-                            .build()
+                            .build(),
                     )
                 }
-            )
+            }
+            nm.createNotificationChannel(channel)
         }
     }
 
@@ -301,10 +328,11 @@ class FortaFirebaseMessagingService : FirebaseMessagingService() {
         // This is the only ringer path that survives Android 10+ killed-app
         // background-startActivity restrictions (no exception thrown — the
         // launch is silently dropped). Posting the notification with
-        // setFullScreenIntent + CHANNEL_CALLS (IMPORTANCE_MAX, ringtone)
+        // setFullScreenIntent + the migrated incoming-call channel
+        // (IMPORTANCE_MAX, explicit ringtone, lockscreen-public, bypass-DND)
         // wakes the screen and rings reliably from the locked screen on
         // every device the system grants USE_FULL_SCREEN_INTENT to.
-        showSimpleCallNotification(roomId, callerName)
+        showSimpleCallNotification(roomId, callerName, callId)
 
         // Best-effort additional path: when the process is in foreground or
         // recently stopped, startActivity succeeds and the user gets the
@@ -343,28 +371,96 @@ class FortaFirebaseMessagingService : FirebaseMessagingService() {
         }
     }
 
-    private fun showSimpleCallNotification(roomId: String, callerName: String) {
-        val intent = Intent(this, MainActivity::class.java).apply {
-            putExtra(EXTRA_PUSH_ROOM_ID, roomId)
-            putExtra("push_call", true)
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+    private fun showSimpleCallNotification(roomId: String, callerName: String, callId: String) {
+        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        // WEE-18 / forta-bugs#768: on Android 14+ (API 34) USE_FULL_SCREEN_INTENT
+        // is a special permission users grant via Settings. Without it the
+        // FSI silently degrades to a heads-up. Log so we can correlate
+        // user reports against missing permission rather than channel
+        // settings. The notification still posts — action buttons remain
+        // tappable from the heads-up, and the foreground startActivity
+        // attempt that follows in showCallNotification is the fallback
+        // ringer path for the killed-process case.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
+            !nm.canUseFullScreenIntent()
+        ) {
+            Log.w(TAG, "USE_FULL_SCREEN_INTENT not granted; incoming-call notification will appear heads-up only")
         }
-        val pendingIntent = PendingIntent.getActivity(
-            this, "call_$roomId".hashCode(), intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+
+        // WEE-18 / forta-bugs#308, #268: route both the content tap and
+        // the full-screen-intent through IncomingCallActivity directly.
+        // The previous design opened MainActivity with `push_call=true`,
+        // which lifted the WebView but left no ringer surface — users
+        // tapped the notification, saw the chat list, and had to guess
+        // that a call had been ringing.
+        val ringerIntent = Intent(this, IncomingCallActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra("callId", callId)
+            putExtra("callerName", callerName)
+            putExtra("roomId", roomId)
+            putExtra("hasVideo", false)
+        }
+        val ringerPendingIntent = PendingIntent.getActivity(
+            this, "call_$roomId".hashCode(), ringerIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
         )
-        val notification = NotificationCompat.Builder(this, CHANNEL_CALLS)
+
+        // Accept / decline action buttons. Tapping them in the shade
+        // launches IncomingCallActivity with an action= extra, which
+        // dispatches the answer/reject flow and dismisses the ringer
+        // notification (#751). Using distinct request codes so the
+        // PendingIntent flags can update independently per-callId.
+        val acceptIntent = Intent(this, IncomingCallActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                Intent.FLAG_ACTIVITY_SINGLE_TOP
+            putExtra("callId", callId)
+            putExtra("callerName", callerName)
+            putExtra("roomId", roomId)
+            putExtra("hasVideo", false)
+            putExtra("action", "accept")
+        }
+        val acceptPendingIntent = PendingIntent.getActivity(
+            this, "call_accept_$roomId".hashCode(), acceptIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val declineIntent = Intent(this, IncomingCallActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                Intent.FLAG_ACTIVITY_SINGLE_TOP
+            putExtra("callId", callId)
+            putExtra("callerName", callerName)
+            putExtra("roomId", roomId)
+            putExtra("hasVideo", false)
+            putExtra("action", "decline")
+        }
+        val declinePendingIntent = PendingIntent.getActivity(
+            this, "call_decline_$roomId".hashCode(), declineIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val notification = NotificationCompat.Builder(this, CallNotificationConfig.INCOMING_CALL_CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_notification)
             .setContentTitle(callerName)
             .setContentText(getString(R.string.push_incoming_call))
             .setAutoCancel(true)
-            .setContentIntent(pendingIntent)
+            .setContentIntent(ringerPendingIntent)
             .setPriority(NotificationCompat.PRIORITY_MAX)
             .setCategory(NotificationCompat.CATEGORY_CALL)
-            .setFullScreenIntent(pendingIntent, true)
+            .setFullScreenIntent(ringerPendingIntent, true)
             .setOngoing(true)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .addAction(
+                R.drawable.ic_call_accept,
+                getString(R.string.call_accept),
+                acceptPendingIntent,
+            )
+            .addAction(
+                R.drawable.ic_call_end,
+                getString(R.string.call_decline),
+                declinePendingIntent,
+            )
             .build()
-        val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         nm.notify(NOTIF_TAG, "call_$roomId".hashCode(), notification)
     }
 
@@ -387,7 +483,6 @@ class FortaFirebaseMessagingService : FirebaseMessagingService() {
         private const val TAG = "FortaPush"
         const val PREFS_NAME = "forta_push"
         const val CHANNEL_MESSAGES = "messages"
-        const val CHANNEL_CALLS = "calls"
         const val NOTIF_TAG = "forta_push"
         const val EXTRA_PUSH_ROOM_ID = "push_room_id"
         const val EXTRA_PUSH_EVENT_ID = "push_event_id"

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallConnectionService.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallConnectionService.kt
@@ -74,8 +74,9 @@ class CallConnectionService : ConnectionService() {
 
         // Session 41: Telecom is about to post its own FSI ringer notification
         // (CHANNEL_INCOMING_CALLS, id 9999). The FCM service already posted
-        // one on the push path (CHANNEL_CALLS, "call_$roomId".hashCode()) —
-        // dismiss it now so we don't ring twice from two different channels.
+        // one on the push path (CallNotificationConfig.INCOMING_CALL_CHANNEL_ID,
+        // "call_$roomId".hashCode()) — dismiss it now so we don't ring twice
+        // from two different channels.
         if (roomId.isNotEmpty()) {
             com.forta.chat.FortaFirebaseMessagingService
                 .dismissPushCallNotification(applicationContext, roomId)

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallNotificationConfig.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallNotificationConfig.kt
@@ -1,0 +1,69 @@
+package com.forta.chat.plugins.calls
+
+/**
+ * Pure data + constants for the incoming-call notification channel.
+ *
+ * The runtime channel object is [android.app.NotificationChannel], which is
+ * Android-framework-only and cannot be instantiated in pure JVM unit tests.
+ * Extracting the spec into a plain Kotlin data class lets us regression-test
+ * the values that matter (importance, ringtone, lockscreen visibility, DND
+ * bypass) without pulling in Robolectric.
+ *
+ * Production callers build a [android.app.NotificationChannel] from this
+ * spec; the spec is the source of truth.
+ */
+data class IncomingCallChannelSpec(
+    val id: String,
+    val name: String,
+    val description: String,
+    /** [android.app.NotificationManager.IMPORTANCE_MAX] (= 5) */
+    val importance: Int,
+    /** Whether to attach the system default ringtone (TYPE_RINGTONE). */
+    val withRingtone: Boolean,
+    val withVibration: Boolean,
+    /** [android.app.Notification.VISIBILITY_PUBLIC] (= 1) */
+    val lockscreenVisibility: Int,
+    /** Whether the channel can interrupt Do-Not-Disturb. */
+    val bypassDnd: Boolean,
+)
+
+object CallNotificationConfig {
+
+    /**
+     * Active channel id for incoming-call ringer notifications.
+     *
+     * Bumped from "calls" because [android.app.NotificationChannel]
+     * settings are immutable after the channel is first created on the
+     * device. Forta v1.x shipped a "calls" channel without an explicit
+     * ringtone, and once a Xiaomi MIUI user had the channel created
+     * silent (or muted it manually), no app-side `setSound(...)` could
+     * resurrect the ring (forta-bugs#768).
+     *
+     * Creating a fresh channel id forces Android to apply the new
+     * settings exactly once, after which users keep full control over
+     * their own customizations.
+     */
+    const val INCOMING_CALL_CHANNEL_ID = "incoming_call_v2"
+
+    /**
+     * Legacy ids we explicitly delete on FCM service start. Without
+     * deletion the old "calls" channel keeps showing in the per-app
+     * notification settings even though no notifications are posted to
+     * it any longer — clutter that users have flagged on the bug board.
+     */
+    val LEGACY_INCOMING_CALL_CHANNEL_IDS: List<String> = listOf("calls")
+
+    fun incomingCallChannelSpec(name: String, description: String): IncomingCallChannelSpec =
+        IncomingCallChannelSpec(
+            id = INCOMING_CALL_CHANNEL_ID,
+            name = name,
+            description = description,
+            // NotificationManager.IMPORTANCE_MAX
+            importance = 5,
+            withRingtone = true,
+            withVibration = true,
+            // Notification.VISIBILITY_PUBLIC — show on lock screen with full content
+            lockscreenVisibility = 1,
+            bypassDnd = true,
+        )
+}

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/IncomingCallActivity.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/IncomingCallActivity.kt
@@ -158,6 +158,28 @@ class IncomingCallActivity : Activity() {
         handler.postDelayed(countdownRunnable, 1000)
     }
 
+    /**
+     * Re-dispatch action extras when the system delivers a new Intent to
+     * an already-resident instance.
+     *
+     * The notification's Accept / Decline action buttons (added in the
+     * FCM service for WEE-18) launch this Activity with
+     * launchMode="singleTop", so when the ringer is already visible the
+     * tap arrives via onNewIntent rather than a fresh onCreate. Without
+     * this override the action= extra would be silently ignored and the
+     * shade button would behave like a no-op (#751 backslide path).
+     */
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+
+        val action = intent.getStringExtra("action")
+        if (action == "accept" || action == "decline") {
+            Log.d(TAG, "onNewIntent: dispatching action=$action on resident instance")
+            if (action == "accept") accept() else decline()
+        }
+    }
+
     private fun accept() {
         Log.d(TAG, "Accept pressed")
         cleanup()

--- a/android/app/src/test/java/com/forta/chat/plugins/calls/CallNotificationConfigTest.kt
+++ b/android/app/src/test/java/com/forta/chat/plugins/calls/CallNotificationConfigTest.kt
@@ -1,0 +1,87 @@
+package com.forta.chat.plugins.calls
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for [CallNotificationConfig].
+ *
+ * Anchors the channel-migration contract behind WEE-18:
+ *   * forta-bugs#768 — Xiaomi 12X silent push (no ringtone on incoming call)
+ *
+ * NotificationChannel itself is Android-framework-only, so we verify the
+ * spec the production code derives the channel from. If anything here
+ * regresses the spec back to silent / muted / non-public, this test fails
+ * before users do.
+ */
+class CallNotificationConfigTest {
+
+    @Test
+    fun `migration channel id differs from legacy ids`() {
+        for (legacyId in CallNotificationConfig.LEGACY_INCOMING_CALL_CHANNEL_IDS) {
+            assertNotEquals(
+                "Migration target must use a new id so Android recreates the channel with the fixed settings",
+                legacyId,
+                CallNotificationConfig.INCOMING_CALL_CHANNEL_ID,
+            )
+        }
+    }
+
+    @Test
+    fun `legacy ids include the original v1 calls channel`() {
+        assertTrue(
+            "Must delete the original 'calls' channel so its silent-from-old-install state cannot persist",
+            CallNotificationConfig.LEGACY_INCOMING_CALL_CHANNEL_IDS.contains("calls"),
+        )
+    }
+
+    @Test
+    fun `incoming-call spec has importance MAX so it surfaces over lock screen`() {
+        val spec = CallNotificationConfig.incomingCallChannelSpec("Calls", "desc")
+        // NotificationManager.IMPORTANCE_MAX
+        assertEquals(5, spec.importance)
+    }
+
+    @Test
+    fun `incoming-call spec sets ringtone (regression for #768)`() {
+        val spec = CallNotificationConfig.incomingCallChannelSpec("Calls", "desc")
+        assertTrue(
+            "Channel must request a ringtone — silent channel was the #768 root cause on Xiaomi MIUI",
+            spec.withRingtone,
+        )
+    }
+
+    @Test
+    fun `incoming-call spec enables vibration`() {
+        val spec = CallNotificationConfig.incomingCallChannelSpec("Calls", "desc")
+        assertTrue(spec.withVibration)
+    }
+
+    @Test
+    fun `incoming-call spec is visible on the lockscreen`() {
+        val spec = CallNotificationConfig.incomingCallChannelSpec("Calls", "desc")
+        // Notification.VISIBILITY_PUBLIC
+        assertEquals(
+            "Lockscreen visibility must be PUBLIC — the ringer is the surface that wakes the screen",
+            1,
+            spec.lockscreenVisibility,
+        )
+    }
+
+    @Test
+    fun `incoming-call spec bypasses Do-Not-Disturb like the system dialer`() {
+        val spec = CallNotificationConfig.incomingCallChannelSpec("Calls", "desc")
+        assertTrue(
+            "Incoming calls must ring through DND, mirroring system phone-app behaviour",
+            spec.bypassDnd,
+        )
+    }
+
+    @Test
+    fun `spec id matches the active channel id constant`() {
+        val spec = CallNotificationConfig.incomingCallChannelSpec("Calls", "desc")
+        assertEquals(CallNotificationConfig.INCOMING_CALL_CHANNEL_ID, spec.id)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes four overlapping Android incoming-call bugs by migrating to a fresh notification channel and routing notification taps through the ringer Activity:

- **#768** — Xiaomi MIUI silent push: v1.x \`\"calls\"\` channel was preserved silent across upgrades because NotificationChannel settings are immutable after first creation. Migrating to \`\"incoming_call_v2\"\` with explicit ringtone + DND bypass forces Android to apply the fixed settings once.
- **#751** — Persistent ringer notification after Accept: notification had no Accept action button and its PendingIntent opened MainActivity (which never dismissed the ringer notification). Action buttons now relaunch IncomingCallActivity with \`action=accept|decline\`, which already dismisses the FSI ringer notification on entry.
- **#308 / #268** — Accept opens nothing / app minimises: tapping the notification opened MainActivity instead of IncomingCallActivity. Both content and full-screen PendingIntents now target IncomingCallActivity directly with full call extras.

## Linear
- Resolves [WEE-18](https://linear.app/wwwee/issue/WEE-18/calls-incoming-call-silent-push-persistent-push-posle-accept)

## Closes
- Closes greenShirtMystery/forta-bugs#768
- Closes greenShirtMystery/forta-bugs#751
- Closes greenShirtMystery/forta-bugs#308
- Closes greenShirtMystery/forta-bugs#268

## Changes

| File | What changed |
| ---- | ----- |
| \`android/app/.../plugins/calls/CallNotificationConfig.kt\` | NEW — pure data + constants for the channel spec; testable without Robolectric |
| \`android/app/src/test/.../CallNotificationConfigTest.kt\` | NEW — 8 JUnit tests anchoring importance/ringtone/lockscreen/DND/migration |
| \`android/app/.../FortaFirebaseMessagingService.kt\` | Channel migration + delete legacy \"calls\" + Accept/Decline action buttons + PendingIntents → IncomingCallActivity + Android 14+ FSI-permission diagnostic |
| \`android/app/.../plugins/calls/IncomingCallActivity.kt\` | \`onNewIntent\` override dispatches action= extras when launched on a resident singleTop instance |
| \`android/app/.../plugins/calls/CallConnectionService.kt\` | Comment touch-up: stale \`CHANNEL_CALLS\` reference renamed to new constant |

## Verification

- ✅ \`./gradlew testDebugUnitTest\` — BUILD SUCCESSFUL, 8 new tests pass, no regressions in other call-package tests
- ✅ Kotlin compilation clean (only pre-existing deprecation warnings)
- ⚠️ TS \`npm run build\` / \`npm run test\` have pre-existing failures on master unrelated to these Kotlin-only changes

## Follow-ups (not blocking)

From \`superpowers:code-reviewer\`:

- M1: Release notes should mention the one-time channel reset.
- M2/M3: \`CallConnectionService\` still uses a separate \`incoming_calls\` channel; consider consolidating into \`CallNotificationConfig\`.
- M4: \`IncomingCallActivity.onNewIntent\` dispatch could be extracted to a pure helper for unit coverage.
- M5: Brief ringtone-burst when Accept tapped during \`onCreate\`; re-order action-check before \`setContentView\` for clean UX.
- L1/L2: Pre-existing shadowing + keyguard lift verification on real device.

## Test plan

- [ ] Xiaomi (MIUI): incoming call → ringtone audible + full-screen ringer wakes screen
- [ ] Lock-screen Accept (notification action) → call screen opens; FSI notification dismissed within 200 ms
- [ ] Lock-screen Decline (notification action) → ringer dismisses; remote caller receives \`m.call.reject\`
- [ ] Tap on notification body (not action) → IncomingCallActivity opens normally
- [ ] After Accept from notification, ringer notification is gone from the shade
- [ ] Android 14+ device WITHOUT \`USE_FULL_SCREEN_INTENT\` granted: heads-up still works
- [ ] Existing v1.x install (\"calls\" channel present): channel removed; new \"Incoming Calls\" appears