### PR TITLE
fix(calls): extend OEM mode-reapply window + retry startAudioRouting (WEE-16)

### DIFF
--- a/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
@@ -98,6 +98,42 @@ class AudioRouter private constructor(private val context: Context) {
             callAlive: Boolean,
             isRouterActive: Boolean,
         ): Boolean = isRouterActive && !callAlive
+
+        /**
+         * Pure predicate for the WEE-16 extended OEM mode-reapply window.
+         *
+         * Returns true when the periodic watchdog should re-apply
+         * MODE_IN_COMMUNICATION:
+         *   - The router still thinks routing is active.
+         *   - The OS reports a mode other than MODE_IN_COMMUNICATION,
+         *     which means something (typically an aggressive OEM ROM)
+         *     reset it after `start()` already applied the correct mode.
+         *
+         * Exposed at companion-object scope so it can be covered by a
+         * JVM-only JUnit test without Robolectric / mockk.
+         */
+        @androidx.annotation.VisibleForTesting
+        internal fun shouldReapplyMode(
+            currentMode: Int,
+            isActive: Boolean,
+        ): Boolean = isActive && currentMode != AudioManager.MODE_IN_COMMUNICATION
+
+        /**
+         * WEE-16: schedule of re-apply ticks (in ms after `start()`).
+         *
+         * The original single 500 ms re-apply caught fast OEM resets
+         * (MIUI/RealmeUI/XOS) but missed slower resets observed on
+         * Huawei P70 / Xiaomi 12X — those reset MODE_IN_COMMUNICATION
+         * 1–5 s after acceptCall, leaving the user with one-way or
+         * fully silent audio. The schedule below covers that window
+         * without burning CPU on long-running calls (re-apply stops
+         * after the last tick because OEM resets are start-of-call
+         * behaviour — once the call survives the first ~8 s, audio
+         * mode stays stable for the rest of the session).
+         */
+        @androidx.annotation.VisibleForTesting
+        internal fun modeReapplyScheduleMs(): List<Long> =
+            listOf(500L, 1_500L, 3_500L, 7_500L)
     }
 
     enum class Device(val label: String) {
@@ -132,7 +168,17 @@ class AudioRouter private constructor(private val context: Context) {
     @Volatile private var coreListener: Listener? = null
     @Volatile private var uiListener: Listener? = null
     private var activeDevice: Device = Device.EARPIECE
-    private var isActive = false
+    // WEE-16: @Volatile so the periodic re-apply runnables observe a
+    // stop()/forceStop()-side write across threads. start()/stop()/
+    // forceStop() are invoked from arbitrary Capacitor plugin threads
+    // while the runnables run on the main handler. Without this barrier
+    // a runnable could see isActive=true after stop() set it to false
+    // and re-apply MODE_IN_COMMUNICATION on top of stop()'s MODE_NORMAL
+    // restore — exactly the regression the OEM-reset window is trying
+    // to prevent. The lifecycleLock around start/stop/forceStop gives
+    // mutual exclusion among themselves but does not synchronize with
+    // the lock-free runnables.
+    @Volatile private var isActive = false
     private var callType = "voice"
     private var bluetoothDeviceName: String? = null
 
@@ -142,7 +188,13 @@ class AudioRouter private constructor(private val context: Context) {
     // the device back into MODE_IN_COMMUNICATION. The orphan watchdog needs
     // the same cancel guarantee: stop()/forceStop() must remove it so a
     // healthy hangup does not later trigger a redundant forceStop.
-    private var reapplyRunnable: Runnable? = null
+    //
+    // WEE-16: a single 500ms re-apply only catches fast OEM resets (MIUI /
+    // RealmeUI / XOS). Slower resets observed on Huawei P70 / Xiaomi 12X
+    // (1–5 s after start) slipped through and left peers hearing silence.
+    // We now schedule the whole [modeReapplyScheduleMs] list and track
+    // every runnable here so stop()/forceStop() can cancel each one.
+    private val reapplyRunnables = mutableListOf<Runnable>()
     private var stopWatchdog: Runnable? = null
 
     private val deviceCallback = object : AudioDeviceCallback() {
@@ -194,18 +246,36 @@ class AudioRouter private constructor(private val context: Context) {
         audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
         Log.d(LIFECYCLE_TAG, "start($callType): set mode=MODE_IN_COMMUNICATION, initial active=$activeDevice")
 
-        // OEM fix: Some Chinese ROMs (MIUI, RealmeUI, XOS) reset audio mode
-        // asynchronously after init. Re-apply after a short delay to catch resets.
-        // Stored as a field so stop() / forceStop() can cancel it on fast hangups.
-        reapplyRunnable?.let { mainHandler.removeCallbacks(it) }
-        val reapply = Runnable {
-            if (isActive && audioManager.mode != AudioManager.MODE_IN_COMMUNICATION) {
-                Log.w(LIFECYCLE_TAG, "Audio mode was reset by system — re-applying MODE_IN_COMMUNICATION")
-                audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+        // OEM fix: Some Chinese ROMs (MIUI, RealmeUI, XOS, HyperOS, EMUI,
+        // HarmonyOS) reset audio mode asynchronously after init. WEE-16:
+        // a single 500ms re-apply caught fast OEMs but missed slower resets
+        // on Huawei P70 / Xiaomi 12X (1–5s after start), leaving the peer
+        // with one-way or fully silent audio. We schedule the whole
+        // [modeReapplyScheduleMs] list; each runnable is stored so stop()
+        // / forceStop() can cancel any that haven't fired yet on hangup.
+        cancelReapplyRunnables()
+        for (delayMs in modeReapplyScheduleMs()) {
+            val reapply = Runnable {
+                // Wrap the WHOLE body — `audioManager.mode` getter is
+                // documented to throw SecurityException on the exact
+                // OEM ROMs we're trying to recover (MIUI privacy shield,
+                // Huawei AudioRecord guard). Letting that escape into
+                // the main handler crashes the process.
+                try {
+                    if (shouldReapplyMode(audioManager.mode, isActive)) {
+                        Log.w(
+                            LIFECYCLE_TAG,
+                            "Audio mode reset detected at +${delayMs}ms — re-applying MODE_IN_COMMUNICATION",
+                        )
+                        audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+                    }
+                } catch (e: Exception) {
+                    Log.w(LIFECYCLE_TAG, "Re-apply tick at +${delayMs}ms threw", e)
+                }
             }
+            reapplyRunnables.add(reapply)
+            mainHandler.postDelayed(reapply, delayMs)
         }
-        reapplyRunnable = reapply
-        mainHandler.postDelayed(reapply, 500)
 
         // Session 54: orphan-call watchdog. If the JS finalize never runs
         // (process killed by OEM Doze / battery-saver between hangup and
@@ -269,14 +339,14 @@ class AudioRouter private constructor(private val context: Context) {
         isActive = false
 
         // Session 54: cancel the orphan watchdog and the OEM re-apply
-        // runnable before tearing down. Without these removeCallbacks,
+        // runnables before tearing down. Without these removeCallbacks,
         // a healthy hangup followed by an immediate new call would see
-        // the previous call's watchdog still scheduled, and a 500ms
-        // re-apply could fire after the new start() had set the mode.
+        // the previous call's watchdog still scheduled, and any pending
+        // re-apply tick could fire after the new start() had set the mode.
+        // WEE-16: the single runnable is now a list (modeReapplyScheduleMs).
         stopWatchdog?.let { mainHandler.removeCallbacks(it) }
         stopWatchdog = null
-        reapplyRunnable?.let { mainHandler.removeCallbacks(it) }
-        reapplyRunnable = null
+        cancelReapplyRunnables()
 
         // Session 23: previously a single call chain. If
         // unregisterAudioDeviceCallback or BT SCO teardown threw, the
@@ -320,6 +390,18 @@ class AudioRouter private constructor(private val context: Context) {
 
             Log.d(LIFECYCLE_TAG, "stop(): set mode=MODE_NORMAL, cleared comm device")
         }
+    }
+
+    /**
+     * WEE-16: remove every pending OEM-mode re-apply runnable from the
+     * main handler and clear the tracking list. Idempotent — calling
+     * twice (start() → start() before stop()) is a no-op on the second
+     * call because the list is empty.
+     */
+    private fun cancelReapplyRunnables() {
+        if (reapplyRunnables.isEmpty()) return
+        for (r in reapplyRunnables) mainHandler.removeCallbacks(r)
+        reapplyRunnables.clear()
     }
 
     /**
@@ -368,11 +450,11 @@ class AudioRouter private constructor(private val context: Context) {
         // Session 54: same cancellation as stop() — the watchdog itself
         // may have triggered this forceStop, but a no-op removeCallbacks
         // on the currently-executing Runnable is safe and prevents the
-        // (cancelled) reapply runnable from outliving us.
+        // (cancelled) reapply runnables from outliving us. WEE-16: the
+        // single runnable is now a list (modeReapplyScheduleMs).
         stopWatchdog?.let { mainHandler.removeCallbacks(it) }
         stopWatchdog = null
-        reapplyRunnable?.let { mainHandler.removeCallbacks(it) }
-        reapplyRunnable = null
+        cancelReapplyRunnables()
 
         try { audioManager.unregisterAudioDeviceCallback(deviceCallback) } catch (_: Exception) {}
 

--- a/android/app/src/test/java/com/forta/chat/plugins/calls/AudioRouterModeReapplyTest.kt
+++ b/android/app/src/test/java/com/forta/chat/plugins/calls/AudioRouterModeReapplyTest.kt
@@ -1,0 +1,99 @@
+package com.forta.chat.plugins.calls
+
+import android.media.AudioManager
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Regression tests for WEE-16 — extended OEM mode re-apply window.
+ *
+ * Forta runs on aggressive Chinese OEM ROMs (MIUI / HyperOS / EMUI / HarmonyOS
+ * / RealmeUI / XOS) that reset `AudioManager.mode` from `MODE_IN_COMMUNICATION`
+ * back to `MODE_NORMAL` asynchronously after call accept. The original AudioRouter
+ * only re-applied once after 500 ms, which catches the fast reset window but
+ * misses slower OEM resets observed on Huawei P70 / Xiaomi 12X (reset at 1–5 s)
+ * — peer hears silence because audio capture lands in media stream context
+ * instead of voice-call context.
+ *
+ * Logic is exposed as pure predicates so they can be covered in a JVM unit
+ * test without Robolectric / mockk.
+ */
+class AudioRouterModeReapplyTest {
+
+    @Test
+    fun activeRouter_withWrongMode_triggersReapply() {
+        assertTrue(
+            "active + MODE_NORMAL → must re-apply MODE_IN_COMMUNICATION",
+            AudioRouter.shouldReapplyMode(
+                currentMode = AudioManager.MODE_NORMAL,
+                isActive = true,
+            ),
+        )
+    }
+
+    @Test
+    fun activeRouter_withCorrectMode_doesNotReapply() {
+        assertFalse(
+            "active + MODE_IN_COMMUNICATION → must NOT re-apply (no-op)",
+            AudioRouter.shouldReapplyMode(
+                currentMode = AudioManager.MODE_IN_COMMUNICATION,
+                isActive = true,
+            ),
+        )
+    }
+
+    @Test
+    fun inactiveRouter_doesNotReapply_evenWithWrongMode() {
+        assertFalse(
+            "router stopped → must NOT re-apply (would clobber a fresh call)",
+            AudioRouter.shouldReapplyMode(
+                currentMode = AudioManager.MODE_NORMAL,
+                isActive = false,
+            ),
+        )
+    }
+
+    @Test
+    fun inactiveRouter_doesNotReapply_evenWithCorrectMode() {
+        assertFalse(
+            AudioRouter.shouldReapplyMode(
+                currentMode = AudioManager.MODE_IN_COMMUNICATION,
+                isActive = false,
+            ),
+        )
+    }
+
+    @Test
+    fun activeRouter_inCallScreening_triggersReapply() {
+        // MODE_IN_CALL (cellular) is also wrong context for VoIP — re-apply.
+        assertTrue(
+            AudioRouter.shouldReapplyMode(
+                currentMode = AudioManager.MODE_IN_CALL,
+                isActive = true,
+            ),
+        )
+    }
+
+    @Test
+    fun reapplySchedule_coversExpectedOemResetWindows() {
+        // The schedule must include the original 500 ms catch (fast OEMs) and
+        // extend to ≥ 5 s to cover slow OEM resets observed on Huawei P70 /
+        // Xiaomi 12X. Each delay must be strictly increasing so cancellation
+        // semantics stay simple.
+        val schedule = AudioRouter.modeReapplyScheduleMs()
+        assertTrue("schedule must include the original 500ms tick", schedule.contains(500L))
+        assertTrue(
+            "schedule must extend to >= 5000ms to cover slow OEM resets",
+            schedule.last() >= 5_000L,
+        )
+        assertTrue(
+            "schedule must be strictly increasing — duplicates would post duplicate handler callbacks",
+            schedule.zipWithNext().all { (a, b) -> a < b },
+        )
+        assertTrue(
+            "schedule must have at least 3 ticks to span the OEM reset window",
+            schedule.size >= 3,
+        )
+    }
+}

--- a/src/features/video-calls/model/call-service.ts
+++ b/src/features/video-calls/model/call-service.ts
@@ -847,10 +847,12 @@ export function useCallService() {
       // setCommunicationDevice, BT hot-swap, OEM delayed re-apply.
       // Must come AFTER placeCall so the call exists; graceful degradation
       // on failure (no reason to drop the call if routing fails).
+      // WEE-16: the bridge now retries with a backoff and never rejects
+      // — failures are logged inside the bridge with full attempt count.
+      // We do not await it: starting audio routing is non-blocking for
+      // the dial-tone UX.
       if (isNative) {
-        nativeCallBridge.startAudioRouting({ callType: type }).catch((e) => {
-          console.warn("[call-service] startAudioRouting failed:", e);
-        });
+        void nativeCallBridge.startAudioRouting({ callType: type });
       }
     } catch (e) {
       console.error("[call-service] Failed to place call:", e);
@@ -1196,11 +1198,11 @@ export function useCallService() {
 
       // Activate native VoIP audio routing after answering. Graceful
       // degradation on failure — never drop the call for a routing hiccup.
+      // WEE-16: the bridge now retries with a backoff and never rejects;
+      // failures are logged inside the bridge.
       if (isNative) {
         const callType = isVideo ? "video" : "voice";
-        nativeCallBridge.startAudioRouting({ callType }).catch((e) => {
-          console.warn("[call-service] startAudioRouting failed:", e);
-        });
+        void nativeCallBridge.startAudioRouting({ callType });
       }
     } catch (e) {
       console.error("[call-service] Failed to answer call:", e);

--- a/src/shared/lib/native-calls/__tests__/with-retry.test.ts
+++ b/src/shared/lib/native-calls/__tests__/with-retry.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi } from "vitest";
+import { withRetry } from "../with-retry";
+
+describe("withRetry", () => {
+  it("returns on first success without delay", async () => {
+    const op = vi.fn().mockResolvedValueOnce("ok");
+
+    const result = await withRetry(op, { delaysMs: [50, 150], label: "test" });
+
+    expect(result).toEqual({ outcome: "success", value: "ok", attempts: 1 });
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on transient failure and resolves on second attempt", async () => {
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce("ok");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const result = await withRetry(op, {
+      delaysMs: [50, 150],
+      label: "test",
+      sleep,
+    });
+
+    expect(result.outcome).toBe("success");
+    if (result.outcome === "success") {
+      expect(result.value).toBe("ok");
+      expect(result.attempts).toBe(2);
+    }
+    expect(op).toHaveBeenCalledTimes(2);
+    // Sleep called once between attempt 1 and attempt 2, with the FIRST delay.
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(50);
+  });
+
+  it("walks the delays array in order across multiple retries", async () => {
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("e1"))
+      .mockRejectedValueOnce(new Error("e2"))
+      .mockResolvedValueOnce("ok");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const result = await withRetry(op, {
+      delaysMs: [50, 150, 400],
+      label: "test",
+      sleep,
+    });
+
+    expect(result.outcome).toBe("success");
+    expect(op).toHaveBeenCalledTimes(3);
+    expect(sleep.mock.calls.map((c) => c[0])).toEqual([50, 150]);
+  });
+
+  it("gives up after exhausting all attempts and reports the last error", async () => {
+    const finalError = new Error("final");
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("e1"))
+      .mockRejectedValueOnce(new Error("e2"))
+      .mockRejectedValue(finalError);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const result = await withRetry(op, {
+      delaysMs: [10, 20],
+      label: "test",
+      sleep,
+    });
+
+    // delaysMs.length=2 → total attempts = 3 (initial + 2 retries).
+    expect(result).toEqual({
+      outcome: "failure",
+      error: finalError,
+      attempts: 3,
+    });
+    expect(op).toHaveBeenCalledTimes(3);
+    // Two sleeps between the three attempts.
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry when delaysMs is empty (single-shot)", async () => {
+    const err = new Error("nope");
+    const op = vi.fn().mockRejectedValue(err);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const result = await withRetry(op, {
+      delaysMs: [],
+      label: "test",
+      sleep,
+    });
+
+    expect(result).toEqual({ outcome: "failure", error: err, attempts: 1 });
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("captures non-Error rejections without crashing", async () => {
+    const op = vi.fn().mockRejectedValue("string error");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const result = await withRetry(op, {
+      delaysMs: [5],
+      label: "test",
+      sleep,
+      onAttemptFailed: () => {
+        /* quiet stderr in test */
+      },
+    });
+
+    expect(result.outcome).toBe("failure");
+    if (result.outcome === "failure") {
+      // Non-Error rejections are wrapped so the consumer always gets a real Error.
+      expect(result.error).toBeInstanceOf(Error);
+      expect(result.error.message).toContain("string error");
+    }
+  });
+
+  it("wraps undefined and null rejections in informative Errors", async () => {
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const undefRes = await withRetry(
+      () => Promise.reject(undefined),
+      {
+        delaysMs: [],
+        label: "test",
+        sleep,
+        onAttemptFailed: () => {
+          /* quiet stderr */
+        },
+      },
+    );
+    expect(undefRes.outcome).toBe("failure");
+    if (undefRes.outcome === "failure") {
+      expect(undefRes.error.message).toMatch(/undefined/);
+    }
+
+    const nullRes = await withRetry(
+      () => Promise.reject(null),
+      {
+        delaysMs: [],
+        label: "test",
+        sleep,
+        onAttemptFailed: () => {
+          /* quiet stderr */
+        },
+      },
+    );
+    expect(nullRes.outcome).toBe("failure");
+    if (nullRes.outcome === "failure") {
+      expect(nullRes.error.message).toMatch(/null/);
+    }
+  });
+
+  it("aborts before retrying when signal is already aborted in backoff", async () => {
+    const controller = new AbortController();
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValueOnce("ok");
+    const sleep = vi.fn().mockImplementation(async () => {
+      // Simulate a hangup happening DURING the backoff sleep.
+      controller.abort();
+    });
+
+    const result = await withRetry(op, {
+      delaysMs: [50, 150],
+      label: "test",
+      sleep,
+      signal: controller.signal,
+      onAttemptFailed: () => {
+        /* quiet stderr */
+      },
+    });
+
+    // After the first failure we sleep, signal aborts during sleep, the
+    // loop must NOT call op() again.
+    expect(result.outcome).toBe("aborted");
+    if (result.outcome === "aborted") {
+      expect(result.attempts).toBe(1);
+    }
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts before the first attempt when signal is pre-aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const op = vi.fn();
+
+    const result = await withRetry(op, {
+      delaysMs: [50],
+      label: "test",
+      signal: controller.signal,
+    });
+
+    expect(result).toEqual({ outcome: "aborted", attempts: 0 });
+    expect(op).not.toHaveBeenCalled();
+  });
+
+  it("calls the injected onAttemptFailed hook with structured payload", async () => {
+    const onAttemptFailed = vi.fn();
+    const err = new Error("nope");
+    const op = vi.fn().mockRejectedValue(err);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await withRetry(op, {
+      delaysMs: [50, 150],
+      label: "structured",
+      sleep,
+      onAttemptFailed,
+    });
+
+    expect(onAttemptFailed).toHaveBeenCalledTimes(3);
+    expect(onAttemptFailed.mock.calls[0][0]).toMatchObject({
+      attempt: 1,
+      error: err,
+      nextDelayMs: 50,
+      label: "structured",
+    });
+    expect(onAttemptFailed.mock.calls[2][0]).toMatchObject({
+      attempt: 3,
+      nextDelayMs: null,
+    });
+  });
+});

--- a/src/shared/lib/native-calls/native-call-bridge.ts
+++ b/src/shared/lib/native-calls/native-call-bridge.ts
@@ -2,6 +2,7 @@ import { registerPlugin } from '@capacitor/core';
 import { isNative } from '@/shared/lib/platform';
 import { NativeWebRTC } from '@/shared/lib/native-webrtc/native-webrtc-bridge';
 import { isInviteEventExpired } from './invite-ttl';
+import { withRetry } from './with-retry';
 
 /**
  * Shape returned by `NativeCall.probeAudioAvailability`. See
@@ -221,6 +222,16 @@ export async function consumePendingRejectCallId(
 
 class NativeCallBridge {
   private callService: any = null;
+  /**
+   * WEE-16: signal aborted by stop/forceStop so any in-flight
+   * `startAudioRouting` retry bails immediately. Without this, a user
+   * who hangs up during the retry backoff would see the retry resume
+   * after AudioRouter.stop() ran — leaving the device stuck in
+   * MODE_IN_COMMUNICATION until the Session 54 orphan watchdog (~5 min).
+   * Recreated on each `startAudioRouting` call so each call cycle has
+   * its own cancellation token.
+   */
+  private audioRoutingAbort: AbortController | null = null;
 
   async wire(callService: { answerCall: () => void; rejectCall: () => void; hangup: () => void }): Promise<void> {
     if (!isNative) return;
@@ -589,13 +600,50 @@ class NativeCallBridge {
    * Wires MODE_IN_COMMUNICATION, setCommunicationDevice (API 31+),
    * AudioDeviceCallback for BT hot-swap, and OEM delayed re-apply
    * (Xiaomi/Realme/XOS reset audio mode ~500 ms after init).
+   *
+   * WEE-16: the bridge used to swallow transient failures with a single
+   * `console.warn`. On Android the underlying `audioManager.mode` setter
+   * can throw a transient `SecurityException` / `IllegalStateException`
+   * immediately after `call.answer()` if the call foreground service
+   * has not yet bound — leaving the device in MODE_NORMAL for the rest
+   * of the conversation and the peer hearing silence. We now retry on
+   * a short backoff so a single transient hiccup does not silently kill
+   * audio for the whole call.
    */
   async startAudioRouting(options: { callType: string }): Promise<void> {
     if (!isNative) return;
-    try {
-      await NativeCall.startAudioRouting(options);
-    } catch (e) {
-      console.warn('[NativeCallBridge] startAudioRouting failed:', e);
+    // Abort any in-flight retry from a previous call cycle so we don't
+    // double-arm AudioRouter. Then create a fresh controller scoped to
+    // this call cycle; `stopAudioRouting`/`forceStopAudio` will abort it.
+    this.audioRoutingAbort?.abort();
+    const controller = new AbortController();
+    this.audioRoutingAbort = controller;
+    const result = await withRetry(
+      () => NativeCall.startAudioRouting(options),
+      {
+        delaysMs: [150, 400, 800],
+        label: 'startAudioRouting',
+        signal: controller.signal,
+      },
+    );
+    if (result.outcome === 'failure') {
+      console.warn(
+        '[NativeCallBridge] startAudioRouting failed after',
+        result.attempts,
+        'attempts:',
+        result.error,
+      );
+    } else if (result.outcome === 'aborted') {
+      console.warn(
+        '[NativeCallBridge] startAudioRouting aborted after',
+        result.attempts,
+        'attempts (hangup during backoff)',
+      );
+    } else if (result.attempts > 1) {
+      console.warn(
+        '[NativeCallBridge] startAudioRouting recovered on attempt',
+        result.attempts,
+      );
     }
   }
 
@@ -607,6 +655,11 @@ class NativeCallBridge {
    */
   async stopAudioRouting(): Promise<void> {
     if (!isNative) return;
+    // WEE-16: abort any pending startAudioRouting retry before tearing
+    // down. Otherwise a retry scheduled during a transient failure can
+    // fire AudioRouter.start() right after we stopped it.
+    this.audioRoutingAbort?.abort();
+    this.audioRoutingAbort = null;
     try {
       await NativeCall.stopAudioRouting();
     } catch (e) {
@@ -625,6 +678,10 @@ class NativeCallBridge {
    */
   async forceStopAudio(): Promise<void> {
     if (!isNative) return;
+    // WEE-16: same abort wiring as stopAudioRouting — the brute reset
+    // path must also kill in-flight retries.
+    this.audioRoutingAbort?.abort();
+    this.audioRoutingAbort = null;
     try {
       await NativeCall.forceStopAudio();
     } catch (e) {

--- a/src/shared/lib/native-calls/with-retry.ts
+++ b/src/shared/lib/native-calls/with-retry.ts
@@ -1,0 +1,128 @@
+/**
+ * Generic async-operation retry helper used by the native-call bridge to
+ * survive transient failures from Capacitor plugins.
+ *
+ * Motivation (WEE-16): `nativeCallBridge.startAudioRouting` used to be
+ * fire-and-forget with a `.catch` that only logged a warning. On Android,
+ * `AudioManager.setMode` (called inside `AudioRouter.start`) can throw a
+ * transient `SecurityException` or `IllegalStateException` immediately
+ * after `call.answer()` if the JVM is still parking the call foreground
+ * service. A single failed call would leave the device in MODE_NORMAL
+ * for the whole conversation — peer hears silence.
+ *
+ * The helper is deliberately tiny: pure logic, no module-level state,
+ * no platform imports. Pass an injected `sleep` to make tests deterministic.
+ */
+
+export interface WithRetryOptions {
+  /**
+   * Delays between attempts. `delaysMs.length + 1` attempts are made in
+   * total — i.e. `[]` is a single-shot, `[100, 200]` is 3 attempts.
+   * Use an empty array to disable retry without changing the call site.
+   */
+  delaysMs: readonly number[];
+  /** Free-form tag used only for log messages so logs stay greppable. */
+  label: string;
+  /**
+   * Sleep primitive. Defaults to `setTimeout`-based sleep. Tests inject
+   * a synchronous mock so the suite does not actually wait.
+   */
+  sleep?: (ms: number) => Promise<void>;
+  /** Override for production logging — defaults to `console.warn`. */
+  onAttemptFailed?: (info: {
+    attempt: number;
+    error: Error;
+    nextDelayMs: number | null;
+    label: string;
+  }) => void;
+  /**
+   * Optional cancellation signal. When the signal fires while a retry is
+   * pending (between attempts), the helper aborts and returns
+   * `outcome: "aborted"` immediately. This is critical for WEE-16: if
+   * the user hangs up during the retry backoff, a stale retry would
+   * otherwise re-arm AudioRouter after stopAudioRouting() already tore
+   * it down — leaving the device stuck in MODE_IN_COMMUNICATION until
+   * the orphan watchdog fires (up to 5 minutes later).
+   */
+  signal?: AbortSignal;
+}
+
+export type WithRetryResult<T> =
+  | { outcome: "success"; value: T; attempts: number }
+  | { outcome: "failure"; error: Error; attempts: number }
+  | { outcome: "aborted"; attempts: number };
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const defaultOnFailed: NonNullable<WithRetryOptions["onAttemptFailed"]> = ({
+  attempt,
+  error,
+  nextDelayMs,
+  label,
+}) => {
+  const next = nextDelayMs === null ? "no retry left" : `retry in ${nextDelayMs}ms`;
+  console.warn(
+    `[withRetry/${label}] attempt ${attempt} failed: ${error.message} (${next})`,
+  );
+};
+
+function toError(value: unknown): Error {
+  if (value instanceof Error) return value;
+  if (typeof value === "string") return new Error(value);
+  if (value === undefined) return new Error("undefined rejection");
+  if (value === null) return new Error("null rejection");
+  try {
+    return new Error(JSON.stringify(value));
+  } catch {
+    return new Error(String(value));
+  }
+}
+
+/**
+ * Run `op`, retrying on rejection according to `delaysMs`.
+ *
+ * Returns a discriminated-union result so the caller can branch on
+ * outcome without try/catch noise at every call site. Always resolves —
+ * never throws.
+ */
+export async function withRetry<T>(
+  op: () => Promise<T>,
+  options: WithRetryOptions,
+): Promise<WithRetryResult<T>> {
+  const delays = options.delaysMs;
+  const totalAttempts = delays.length + 1;
+  const sleep = options.sleep ?? defaultSleep;
+  const onFailed = options.onAttemptFailed ?? defaultOnFailed;
+  const signal = options.signal;
+
+  let lastError: Error | null = null;
+  for (let attempt = 1; attempt <= totalAttempts; attempt++) {
+    if (signal?.aborted) {
+      return { outcome: "aborted", attempts: attempt - 1 };
+    }
+    try {
+      const value = await op();
+      return { outcome: "success", value, attempts: attempt };
+    } catch (e: unknown) {
+      const error = toError(e);
+      lastError = error;
+      const nextDelay = attempt < totalAttempts ? delays[attempt - 1] : null;
+      onFailed({ attempt, error, nextDelayMs: nextDelay, label: options.label });
+      if (nextDelay !== null) {
+        await sleep(nextDelay);
+        if (signal?.aborted) {
+          return { outcome: "aborted", attempts: attempt };
+        }
+      }
+    }
+  }
+
+  // Loop invariant: lastError is set when totalAttempts >= 1 and all
+  // attempts rejected. `totalAttempts` is always >= 1 (delays.length + 1).
+  return {
+    outcome: "failure",
+    error: lastError ?? new Error("withRetry: no error captured"),
+    attempts: totalAttempts,
+  };
+}


### PR DESCRIPTION
## Summary

- **AudioRouter** now re-applies `MODE_IN_COMMUNICATION` at `[500, 1500, 3500, 7500]ms` instead of a single 500ms tick — covers slow OEM resets on Huawei P70 / Xiaomi 12X (the original 500ms window only caught fast MIUI/XOS resets).
- `nativeCallBridge.startAudioRouting` retries with `[150, 400, 800]ms` backoff through a new `withRetry` helper that supports `AbortSignal`; `stopAudioRouting` / `forceStopAudio` abort any in-flight retry so a fast hangup cannot resurrect AudioRouter post-stop.
- `AudioRouter.isActive` marked `@Volatile`; the re-apply tick body wraps `audioManager.mode` getter (can throw `SecurityException` on MIUI/Huawei).

## Linear

- Resolves [WEE-16](https://linear.app/wwwee/issue/WEE-16/calls-net-zvuka-v-audiovideozvonke-one-way-ili-both-ways) — P0 "нет звука в аудио/видеозвонке"

## Closes

- Closes greenShirtMystery/forta-bugs#775 — Собеседники не слышат друг друга. А видео есть
- Closes greenShirtMystery/forta-bugs#774 — Нет звука при разговоре. А видео проходит
- Closes greenShirtMystery/forta-bugs#755 — Xiaomi 12X/14T видим, но не слышим
- Closes greenShirtMystery/forta-bugs#750 — Видео есть, звука нет
- Closes greenShirtMystery/forta-bugs#720 — Huawei pura 70 pro/70 нет голоса
- Closes greenShirtMystery/forta-bugs#557 — Невозможно установить звонок app→app/browser
- Closes greenShirtMystery/forta-bugs#332 — После ответа нет звука

## Files

- `android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt` — periodic re-apply schedule, pure-logic predicates (`shouldReapplyMode`, `modeReapplyScheduleMs`), `cancelReapplyRunnables`, defensive try/catch around mode getter, `@Volatile isActive`.
- `android/app/src/test/java/com/forta/chat/plugins/calls/AudioRouterModeReapplyTest.kt` — 6 JUnit tests (matches the `AudioRouterWatchdogTest` pattern, no Robolectric).
- `src/shared/lib/native-calls/with-retry.ts` — pure async retry helper with discriminated-union result and `AbortSignal` support.
- `src/shared/lib/native-calls/__tests__/with-retry.test.ts` — 10 vitest cases (single success, retry-then-success, exhaustion, abort during sleep, pre-aborted signal, undefined/null rejections, `onAttemptFailed` payload).
- `src/shared/lib/native-calls/native-call-bridge.ts` — `startAudioRouting` wires `withRetry`; `stopAudioRouting`/`forceStopAudio` abort the in-flight retry.
- `src/features/video-calls/model/call-service.ts` — cleaned up two now-dead `.catch` blocks on `startAudioRouting` (the bridge never rejects).

## Test plan

- [x] `npm test` for call-service + native-calls: **132 PASS / 0 FAIL**
- [x] `./gradlew :app:testDebugUnitTest --tests "AudioRouter*"`: **6/6 PASS**
- [x] `vue-tsc --noEmit`: no new TS errors (baseline 49 → 49)
- [ ] Manual QA on Android 14 (Pixel 8): accept call → audio works, no crash, MODE_IN_COMMUNICATION survives 10s call
- [ ] Manual QA on Xiaomi MIUI / Huawei EMUI: accept call → bidirectional audio holds
- [ ] Manual QA: hangup during call ringing → no stale MODE_IN_COMMUNICATION