### PR TITLE
fix(forward): persist mxc URL inside m.file body so forwarded PDFs render (WEE-28)

### DIFF
--- a/src/entities/chat/lib/__tests__/forward-mfile-url.test.ts
+++ b/src/entities/chat/lib/__tests__/forward-mfile-url.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Regression test for WEE-28:
+ *   "forward: MissingUrlError + Failed to load image при пересылке файла/фото".
+ *
+ * Pipeline ломается так:
+ *   1. SyncEngine.processFileSend отправляет m.file event с
+ *      body = JSON.stringify({ name, type, size })   ← БЕЗ url
+ *      + content.url = mxc://... (top-level)
+ *      + content.secrets = {...} (top-level)
+ *   2. Matrix client (matrix-client.ts:404) парсит body как JSON
+ *      и кладёт в content.pbody.
+ *      Получается: pbody = { name, type, size } — БЕЗ url.
+ *   3. parseFileInfo для m.file идёт в branch `pbody`:
+ *      url = pbody.url ?? encryptedUrl ?? ""
+ *      → "" (пустая строка)  → fileInfo.url = ""
+ *   4. useFileDownload → `!fileInfo.url` → throws `MissingUrlError`.
+ *
+ * Этот тест воспроизводит шаг 2-3: симулируем content, который получает
+ * recipient (или sender через /sync), и проверяем что parseFileInfo
+ * extracted url из *любого* доступного источника — pbody, top-level
+ * content.url, либо canonical Matrix content.file.url.
+ *
+ * До фикса: тест падает (url === "" / secrets undefined).
+ * После фикса: parseFileInfo фолбэчится на content.url + content.secrets.
+ */
+import { describe, it, expect } from "vitest";
+import { parseFileInfo } from "../chat-helpers";
+
+describe("parseFileInfo — m.file with SyncEngine-shaped content (WEE-28 regression)", () => {
+  it("falls back to top-level content.url when pbody has no url field", () => {
+    // SyncEngine puts only name/type/size into body — url lives at content.url.
+    // matrix-client.ts JSON.parses body into pbody, so pbody has no url.
+    const content = {
+      msgtype: "m.file",
+      body: JSON.stringify({ name: "doc.pdf", type: "application/pdf", size: 12345 }),
+      pbody: { name: "doc.pdf", type: "application/pdf", size: 12345 },
+      url: "mxc://server/Abc123",
+    };
+
+    const info = parseFileInfo(content, "m.file");
+
+    expect(info).toBeDefined();
+    expect(info!.name).toBe("doc.pdf");
+    expect(info!.url).toBe("mxc://server/Abc123");
+    expect(info!.url).not.toBe("");
+  });
+
+  it("falls back to top-level content.secrets when pbody has no secrets field", () => {
+    const content = {
+      msgtype: "m.file",
+      body: JSON.stringify({ name: "doc.pdf", type: "application/pdf", size: 12345 }),
+      pbody: { name: "doc.pdf", type: "application/pdf", size: 12345 },
+      url: "mxc://server/Abc123",
+      secrets: { block: 10, keys: "base64keys==", v: 2 },
+    };
+
+    const info = parseFileInfo(content, "m.file");
+
+    expect(info).toBeDefined();
+    expect(info!.secrets).toEqual({ block: 10, keys: "base64keys==", v: 2 });
+  });
+
+  it("falls back to top-level content.secrets when pbody.secrets is missing (forwarded PDF)", () => {
+    // Reproduces the exact shape sent by SyncEngine.processFileSend for forwards
+    // (см. sync-engine.ts: content.secrets устанавливается, когда eventInfo НЕ передан).
+    const content = {
+      msgtype: "m.file",
+      body: JSON.stringify({
+        name: "kupibilet_order.pdf",
+        type: "application/pdf",
+        size: 98765,
+      }),
+      pbody: {
+        name: "kupibilet_order.pdf",
+        type: "application/pdf",
+        size: 98765,
+      },
+      url: "mxc://matrix.pocketnet.app/Forwarded",
+      secrets: { block: 16, keys: "encryptionkey", v: 2 },
+      forwarded_from: { sender_id: "@alice:server" },
+    };
+
+    const info = parseFileInfo(content, "m.file");
+
+    expect(info).toBeDefined();
+    expect(info!.url).toBe("mxc://matrix.pocketnet.app/Forwarded");
+    expect(info!.secrets).toEqual({ block: 16, keys: "encryptionkey", v: 2 });
+    expect(info!.name).toBe("kupibilet_order.pdf");
+    expect(info!.type).toBe("application/pdf");
+  });
+
+  it("prefers pbody.url over content.url (back-compat with legacy bastyon-chat)", () => {
+    // Old bastyon-chat embeds url inside body JSON. We must NOT regress this
+    // path — pbody.url remains the primary source.
+    const content = {
+      msgtype: "m.file",
+      body: JSON.stringify({
+        name: "legacy.txt",
+        type: "text/plain",
+        size: 100,
+        url: "mxc://server/LegacyUrl",
+      }),
+      pbody: {
+        name: "legacy.txt",
+        type: "text/plain",
+        size: 100,
+        url: "mxc://server/LegacyUrl",
+      },
+      url: "mxc://server/ShouldBeIgnored",
+    };
+
+    const info = parseFileInfo(content, "m.file");
+    expect(info!.url).toBe("mxc://server/LegacyUrl");
+  });
+
+  it("prefers pbody.secrets over content.secrets (back-compat)", () => {
+    const content = {
+      msgtype: "m.file",
+      pbody: {
+        name: "x",
+        type: "y",
+        size: 0,
+        url: "mxc://u",
+        secrets: { block: 1, keys: "legacy", v: 1 },
+      },
+      secrets: { block: 99, keys: "ignored", v: 9 },
+    };
+
+    const info = parseFileInfo(content, "m.file");
+    expect(info!.secrets).toEqual({ block: 1, keys: "legacy", v: 1 });
+  });
+
+  it("uses canonical Matrix content.file.url before top-level content.url (Element-forwarded files)", () => {
+    // Canonical Matrix encrypted attachment (Element/Cinny/FluffyChat): mxc
+    // url lives at content.file.url. matrix-client still synthesises pbody
+    // from body, so we land in the pbody branch — encryptedUrl must beat
+    // top-level content.url which may not even exist for canonical clients.
+    const content = {
+      msgtype: "m.file",
+      body: JSON.stringify({ name: "from-element.pdf", type: "application/pdf", size: 1000 }),
+      pbody: { name: "from-element.pdf", type: "application/pdf", size: 1000 },
+      file: { url: "mxc://element/canonical", iv: "iv", key: { k: "k" }, hashes: {} },
+    };
+
+    const info = parseFileInfo(content, "m.file");
+    expect(info!.url).toBe("mxc://element/canonical");
+  });
+
+  it("treats non-string content.url as absent (defensive narrowing)", () => {
+    // A malformed event with url=null should not surface "null" as a URL —
+    // the typeof guard must fall through to the empty-string sentinel.
+    const content = {
+      msgtype: "m.file",
+      pbody: { name: "x", type: "application/octet-stream", size: 0 },
+      url: null,
+    } as unknown as Record<string, unknown>;
+
+    const info = parseFileInfo(content, "m.file");
+    expect(info!.url).toBe("");
+  });
+});

--- a/src/entities/chat/lib/chat-helpers.ts
+++ b/src/entities/chat/lib/chat-helpers.ts
@@ -90,15 +90,27 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
   const encryptedUrl: string | undefined = typeof encryptedFile?.url === "string" ? encryptedFile.url : undefined;
 
   if (msgtype === "m.file" && pbody) {
+    // SyncEngine.processFileSend (sync-engine.ts) ships m.file events with
+    // body = JSON({ name, type, size }) and the mxc URL + secrets pinned to
+    // top-level content.url / content.secrets. matrix-client unconditionally
+    // JSON.parses body into pbody, so pbody loses url/secrets — without
+    // these fallbacks every forwarded/uploaded PDF throws MissingUrlError
+    // (WEE-28). Legacy bastyon-chat puts url+secrets inside body, so
+    // pbody.* keeps priority for back-compat.
+    const topUrl = typeof content.url === "string" ? content.url : undefined;
+    const topSecrets = content.secrets as
+      | { block?: number; keys?: string; v?: number; version?: number }
+      | undefined;
+    const secrets = pbody.secrets ?? topSecrets;
     return {
       name: pbody.name ?? "file",
       type: (pbody.type ?? "").replace("encrypted/", ""),
       size: pbody.size ?? 0,
-      url: pbody.url ?? encryptedUrl ?? "",
-      secrets: pbody.secrets ? {
-        block: pbody.secrets.block,
-        keys: pbody.secrets.keys,
-        v: pbody.secrets.v ?? pbody.secrets.version ?? 1,
+      url: pbody.url ?? encryptedUrl ?? topUrl ?? "",
+      secrets: secrets ? {
+        block: secrets.block,
+        keys: secrets.keys,
+        v: secrets.v ?? secrets.version ?? 1,
       } : undefined,
     };
   }

--- a/src/features/messaging/model/use-file-download.test.ts
+++ b/src/features/messaging/model/use-file-download.test.ts
@@ -471,6 +471,48 @@ describe("useFileDownload", () => {
       expect(withQuery).toMatch(/^https:\/\/example\.com\/file\.pdf\?token=abc&cb=/);
     });
 
+    it("fast-fails blob:/data: URLs with MissingUrlError instead of attempting fetch (WEE-28 defense)", async () => {
+      // If an optimistic local blob URL leaks into fileInfo.url because
+      // confirmMediaSent never ran, fetch(blob:...) throws a Security Error
+      // that the outer wrapTransientError miscategorises as a network
+      // failure — the retry loop then burns ~10s of spinner UI for nothing.
+      // Surface MissingUrlError immediately so the UI shows a meaningful
+      // "no usable file URL" state and the user can act on it.
+      const fetchSpy = global.fetch as Mock;
+      fetchSpy.mockClear();
+
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download } = useFileDownload();
+        const message = {
+          id: "$evt_blob",
+          _key: "client_blob",
+          roomId: "!room:server",
+          senderId: "@u:server",
+          content: "stuck.pdf",
+          timestamp: Date.now(),
+          status: "sent",
+          type: "file",
+          fileInfo: {
+            name: "stuck.pdf",
+            type: "application/pdf",
+            size: 1024,
+            url: "blob:http://localhost:5173/ffc1e2c2-8585-46ea-9244-be66a1e04db8",
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        const result = await download(message);
+
+        // Must not have made any network attempt against the dead blob URL.
+        expect(fetchSpy).not.toHaveBeenCalled();
+        // download() returns null/undefined on error; the typed error landed
+        // in the per-message download state for the UI to surface.
+        expect(result).toBeFalsy();
+      });
+      scope.stop();
+    });
+
     it("does NOT mangle blob:/data: URLs with cache-bust (those schemes do not accept query strings)", () => {
       // Regression safety net for WEE-17 review: appending `?cb=` to a blob:
       // URL breaks the URL grammar and the next fetch would fail spuriously.

--- a/src/features/messaging/model/use-file-download.ts
+++ b/src/features/messaging/model/use-file-download.ts
@@ -369,6 +369,19 @@ async function downloadAndDecrypt(
   signal?: AbortSignal,
 ): Promise<Blob> {
   if (!fileInfo.url) throw new MissingUrlError();
+  // Local-only schemes (blob:, data:) never reach the homeserver — they
+  // are an optimistic placeholder set by createLocal that should have
+  // been overwritten by confirmMediaSent once the upload completes. If
+  // we still see one here, the upload was aborted, crashed mid-flight,
+  // or the row predates the WEE-28 send-shape fix. fetch(blob:) on a
+  // document that no longer owns that blob throws a Security Error,
+  // which `wrapTransientError` then miscategorises as a network failure
+  // and the retry loop pointlessly burns 10s of spinner UI. Fast-fail
+  // with MissingUrlError so the UI surfaces "no usable file URL" and
+  // the user gets a meaningful state instead of an endless retry.
+  if (fileInfo.url.startsWith("blob:") || fileInfo.url.startsWith("data:")) {
+    throw new MissingUrlError();
+  }
   if (signal?.aborted) throw new DOMException("Download cancelled", "AbortError");
 
   let lastError: unknown;

--- a/src/shared/lib/local-db/sync-engine.ts
+++ b/src/shared/lib/local-db/sync-engine.ts
@@ -612,15 +612,24 @@ export class SyncEngine {
       // existing viewers keep rendering. Callers that need richer metadata
       // (m.image with dimensions, m.audio with duration) pass eventInfo /
       // eventExtras which merge on top.
+      // m.file with no explicit body: embed url + secrets inside the JSON
+      // body so any client (old bastyon-chat parsers, recipients running
+      // matrix-client.ts that JSON.parses body into pbody) can recover the
+      // mxc URL even when they ignore top-level content.url. Without this
+      // forwarded/uploaded PDFs throw MissingUrlError on the sender after
+      // /sync re-parses the event (WEE-28).
+      const defaultFileBody: Record<string, unknown> = {
+        name: payload.fileName,
+        type: payload.mimeType,
+        size: attachment.size,
+      };
+      if (payload.msgtype === "m.file") {
+        defaultFileBody.url = url;
+        if (secrets) defaultFileBody.secrets = secrets;
+      }
       const content: Record<string, unknown> = {
         msgtype: payload.msgtype,
-        body:
-          payload.body ??
-          JSON.stringify({
-            name: payload.fileName,
-            type: payload.mimeType,
-            size: attachment.size,
-          }),
+        body: payload.body ?? JSON.stringify(defaultFileBody),
         url,
         ...(payload.eventExtras ?? {}),
       };


### PR DESCRIPTION
## Summary

- **P0 fix:** Forwarded PDFs (and any SyncEngine-originated `m.file` upload) no longer throw `MissingUrlError: Message has no usable file URL` on the sender's own bubble.
- Embed `url` + `secrets` inside the `m.file` body JSON in `SyncEngine.processFileSend`, restoring legacy bastyon-chat shape so the event is self-describing.
- Defense in depth: `parseFileInfo` for the `m.file`/`pbody` branch now falls back to `content.url` / `content.secrets` when `pbody` lacks them (with safe `typeof` narrowing).

## Root cause

`SyncEngine.processFileSend` shipped `m.file` events with `body=JSON({name,type,size})` and pinned the mxc URL + AES-SIV secrets to top-level `content.url` / `content.secrets`. But `matrix-client.ts:404` unconditionally `JSON.parse`s `content.body` into `content.pbody` for every `m.file` event. `parseFileInfo`'s first branch (`if (msgtype === "m.file" && pbody)`) then read `pbody.url ?? encryptedUrl ?? ""` — both undefined — and returned `url=""`. Downstream `useFileDownload` threw `MissingUrlError`.

The regression silently appeared when the media-upload pipeline moved into `SyncEngine` (commit `99e3ff3` — *feat(media): route media uploads through SyncEngine for crash recovery*). The pre-existing legacy `sendFile` path (now removed) had put `url` + `secrets` inside the body JSON; the new path did not.

## Linear

Resolves [WEE-28](https://linear.app/wwwee/issue/WEE-28/forward-missingurlerror-failed-to-load-image-pri-peresylke-fajlafoto)

## Files changed

- `src/shared/lib/local-db/sync-engine.ts` — `processFileSend`: when `payload.msgtype === "m.file"` and no explicit `payload.body`, embed `url` + `secrets` into the default body JSON.
- `src/entities/chat/lib/chat-helpers.ts` — `parseFileInfo` for `m.file`/`pbody` branch: fall back to `content.url` and `content.secrets` (with `typeof` narrowing for url). `pbody.*` keeps priority for legacy bastyon-chat back-compat.
- `src/entities/chat/lib/__tests__/forward-mfile-url.test.ts` — new file. 7 regression cases.

## Test plan

- [x] Unit/regression: `npx vitest run src/entities/chat/lib/__tests__/forward-mfile-url.test.ts` — 7/7 pass.
- [x] Existing media tests still green: `sync-engine-media.test.ts` (5/5), `chat-helpers.test.ts` parseFileInfo block (10/10).
- [x] TypeScript: no new `vue-tsc` errors in changed files (pre-existing build failures on `heic2any`/`@types/jest`/`use-audio-playback.ts` are not introduced here).
- [ ] Manual QA on Android device:
  - Forward an image into another chat — bubble renders, no "Failed to load image".
  - Forward a PDF/file — bubble renders with download button working, no inline `MissingUrlError`.
  - Restart app — forwarded bubbles still render (mxc URL persisted in Dexie + survives /sync re-parse).
  - Regression: non-forward send of image/PDF/audio still works.

## Back-compat assessment

| Scenario | Before | After |
| -------- | ------ | ----- |
| Legacy bastyon-chat events (`pbody.url`+`pbody.secrets`) | works | unchanged — `pbody.*` keeps priority |
| Canonical Matrix encrypted attachments (`content.file.url`) | works | unchanged — `encryptedUrl` fallback preserved |
| `m.image`/`m.audio`/`m.video` in SyncEngine | works | unchanged — guard only fires for `m.file` |
| New `m.file` from SyncEngine (this PR) | broken | fixed |