### PR TITLE
fix(auth-profile): persist self profile so stale Pocketnet response can't revert the name (WEE-26)

### DIFF
--- a/src/entities/auth/lib/__tests__/self-profile-cache.test.ts
+++ b/src/entities/auth/lib/__tests__/self-profile-cache.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import {
+  readSelfProfile,
+  writeSelfProfile,
+  clearSelfProfile,
+  mergeSelfProfileWithRemote,
+  SELF_PROFILE_GRACE_MS,
+  type SelfProfileSnapshot,
+} from "../self-profile-cache";
+import type { UserData } from "@/app/providers/initializers/types";
+
+const ADDR = "PSelfProfileTestAddrXXXXXXXXXXXXXXXX";
+
+function makeSnapshot(overrides: Partial<SelfProfileSnapshot> = {}): SelfProfileSnapshot {
+  return {
+    address: ADDR,
+    name: "Alice",
+    about: "hi",
+    image: "https://cdn.example/alice.png",
+    site: "https://alice.dev",
+    language: "en",
+    localEditedAt: 0,
+    syncedAt: 0,
+    ...overrides,
+  };
+}
+
+function makeRemote(overrides: Partial<UserData> = {}): UserData {
+  return {
+    name: "RemoteName",
+    about: "remote about",
+    image: "https://remote.example/img.png",
+    site: "https://remote.example",
+    language: "ru",
+    addresses: [],
+    ref: null,
+    keys: [],
+    ...overrides,
+  } as UserData;
+}
+
+describe("self-profile-cache (WEE-26)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe("read/write/clear", () => {
+    it("returns null when no snapshot is stored", () => {
+      expect(readSelfProfile(ADDR)).toBeNull();
+    });
+
+    it("round-trips a snapshot through localStorage", () => {
+      const snap = makeSnapshot({ localEditedAt: 1_000, syncedAt: 2_000 });
+      writeSelfProfile(snap);
+      const restored = readSelfProfile(ADDR);
+      expect(restored).toEqual(snap);
+    });
+
+    it("ignores snapshots whose stored address does not match the lookup key", () => {
+      writeSelfProfile(makeSnapshot({ address: ADDR }));
+      // Forge a tampered entry under the same key but with a different address.
+      const key = `forta-chat-self-profile:${ADDR}`;
+      localStorage.setItem(
+        key,
+        JSON.stringify({ ...makeSnapshot(), address: "PDifferentAddr" }),
+      );
+      expect(readSelfProfile(ADDR)).toBeNull();
+    });
+
+    it("returns null when the stored JSON is corrupt", () => {
+      localStorage.setItem(`forta-chat-self-profile:${ADDR}`, "{not-json");
+      expect(readSelfProfile(ADDR)).toBeNull();
+    });
+
+    it("coerces missing optional fields to empty strings / zero timestamps", () => {
+      localStorage.setItem(
+        `forta-chat-self-profile:${ADDR}`,
+        JSON.stringify({ address: ADDR }),
+      );
+      const restored = readSelfProfile(ADDR);
+      expect(restored).toEqual({
+        address: ADDR,
+        name: "",
+        about: "",
+        image: "",
+        site: "",
+        language: "",
+        localEditedAt: 0,
+        syncedAt: 0,
+      });
+    });
+
+    it("clearSelfProfile removes the snapshot", () => {
+      writeSelfProfile(makeSnapshot());
+      clearSelfProfile(ADDR);
+      expect(readSelfProfile(ADDR)).toBeNull();
+    });
+
+    it("no-ops on empty address rather than touching storage", () => {
+      writeSelfProfile(makeSnapshot({ address: "" }));
+      // Nothing got written under any key
+      expect(localStorage.length).toBe(0);
+      expect(readSelfProfile("")).toBeNull();
+      // clear is also safe
+      clearSelfProfile("");
+    });
+  });
+
+  describe("mergeSelfProfileWithRemote", () => {
+    it("returns the remote unchanged when no cache exists", () => {
+      const remote = makeRemote();
+      expect(mergeSelfProfileWithRemote(null, remote)).toEqual(remote);
+    });
+
+    it("prefers cached non-empty fields when remote returns empty", () => {
+      const cached = makeSnapshot({ localEditedAt: Date.now() });
+      const remote = makeRemote({ name: "", image: "", about: "" });
+      const merged = mergeSelfProfileWithRemote(cached, remote);
+      expect(merged.name).toBe("Alice");
+      expect(merged.image).toBe("https://cdn.example/alice.png");
+      expect(merged.about).toBe("hi");
+      // Authoritative remote fields untouched
+      expect(merged.addresses).toEqual(remote.addresses);
+      expect(merged.keys).toEqual(remote.keys);
+    });
+
+    it("prefers cached values when local edit is within grace window and remote disagrees", () => {
+      const now = 1_000_000_000;
+      const cached = makeSnapshot({
+        name: "Alice",
+        localEditedAt: now - 60_000, // 1 minute ago — well within grace
+      });
+      const remote = makeRemote({ name: "OldPocketnetName" });
+      const merged = mergeSelfProfileWithRemote(cached, remote, now);
+      expect(merged.name).toBe("Alice");
+    });
+
+    it("accepts the remote value once the propagation grace window elapses", () => {
+      const now = 1_000_000_000;
+      const cached = makeSnapshot({
+        name: "Alice",
+        localEditedAt: now - SELF_PROFILE_GRACE_MS - 1,
+      });
+      const remote = makeRemote({ name: "NewBlockchainName" });
+      const merged = mergeSelfProfileWithRemote(cached, remote, now);
+      expect(merged.name).toBe("NewBlockchainName");
+    });
+
+    it("treats localEditedAt=0 as 'never edited locally' so remote always wins on conflict", () => {
+      const cached = makeSnapshot({ name: "InheritedFromSync", localEditedAt: 0 });
+      const remote = makeRemote({ name: "BlockchainName" });
+      const merged = mergeSelfProfileWithRemote(cached, remote);
+      expect(merged.name).toBe("BlockchainName");
+    });
+
+    it("falls back to cached value even with localEditedAt=0 if remote field is empty", () => {
+      const cached = makeSnapshot({ name: "Alice", localEditedAt: 0 });
+      const remote = makeRemote({ name: "" });
+      const merged = mergeSelfProfileWithRemote(cached, remote);
+      expect(merged.name).toBe("Alice");
+    });
+
+    it("does not back-fill an empty cached field with a remote empty value", () => {
+      const cached = makeSnapshot({ about: "", localEditedAt: Date.now() });
+      const remote = makeRemote({ about: "" });
+      expect(mergeSelfProfileWithRemote(cached, remote).about).toBe("");
+    });
+
+    it("merges field-by-field — different fields can take different sources", () => {
+      const now = 1_000_000_000;
+      const cached = makeSnapshot({
+        name: "Alice",
+        about: "hi",
+        image: "https://cdn/alice.png",
+        site: "",
+        language: "",
+        localEditedAt: now - 60_000,
+      });
+      const remote = makeRemote({
+        name: "OldName",
+        about: "",
+        image: "",
+        site: "https://remote.site",
+        language: "ru",
+      });
+      const merged = mergeSelfProfileWithRemote(cached, remote, now);
+      expect(merged.name).toBe("Alice");
+      expect(merged.about).toBe("hi");
+      expect(merged.image).toBe("https://cdn/alice.png");
+      expect(merged.site).toBe("https://remote.site");
+      expect(merged.language).toBe("ru");
+    });
+  });
+});

--- a/src/entities/auth/lib/index.ts
+++ b/src/entities/auth/lib/index.ts
@@ -3,3 +3,4 @@ export * from "./proxy-rotator";
 export * from "./poll-timer";
 export * from "./mnemonic-storage";
 export * from "./sync-profile-to-matrix";
+export * from "./self-profile-cache";

--- a/src/entities/auth/lib/self-profile-cache.ts
+++ b/src/entities/auth/lib/self-profile-cache.ts
@@ -1,0 +1,166 @@
+/**
+ * Self-profile persistence + merge helpers (WEE-26, forta-bugs#596, #580).
+ *
+ * Forta identity is two-layered: Pocketnet blockchain (authoritative) +
+ * Matrix room state (peer-visible). The blockchain `updateProfile` commit
+ * is asynchronous — for some minutes/hours after a save, the proxied
+ * `getuserprofile` RPC can still return the *pre-edit* name. Before this
+ * module existed, that stale RPC value overwrote the local in-memory
+ * `userInfo` and the `useUserStore` cache, so users opened the app after
+ * an update and saw their name reverted to a previous value.
+ *
+ * Strategy: persist a small self-profile snapshot to localStorage with a
+ * `localEditedAt` timestamp. While that timestamp is within the propagation
+ * grace window, prefer the cached values for the user-facing display
+ * fields (name/about/image/site/language) when the remote disagrees. Once
+ * the window elapses, the remote wins — so cross-device edits propagate.
+ *
+ * localStorage rather than Dexie: this snapshot must be available *before*
+ * Dexie is initialized (Dexie init happens inside `initMatrix`, which runs
+ * after `fetchUserInfo`).
+ */
+import type { UserData } from "@/app/providers/initializers/types";
+
+/** localStorage key prefix; final key is `${PREFIX}${address}`. */
+const KEY_PREFIX = "forta-chat-self-profile:";
+
+/** How long after a local edit we keep preferring the cached value over a
+ *  conflicting remote response. Pocketnet propagation is normally minutes,
+ *  but proxy/CDN caches and offline nodes can drag this out — 7d is the
+ *  observed worst case in forta-bugs#596 reports. */
+export const SELF_PROFILE_GRACE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface SelfProfileSnapshot {
+  address: string;
+  name: string;
+  about: string;
+  image: string;
+  site: string;
+  language: string;
+  /** Epoch-ms of the last user-initiated save. 0 means "never edited locally". */
+  localEditedAt: number;
+  /** Epoch-ms of the last successful Pocketnet refresh. 0 means "never synced". */
+  syncedAt: number;
+}
+
+function keyFor(address: string): string {
+  return `${KEY_PREFIX}${address}`;
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function isNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function safeStorage(): Storage | null {
+  try {
+    return typeof localStorage !== "undefined" ? localStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Read the cached snapshot for an address, or null if absent / corrupt. */
+export function readSelfProfile(address: string): SelfProfileSnapshot | null {
+  if (!address) return null;
+  const storage = safeStorage();
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(keyFor(address));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const p = parsed as Record<string, unknown>;
+    if (!isString(p.address) || p.address !== address) return null;
+    return {
+      address: p.address,
+      name: isString(p.name) ? p.name : "",
+      about: isString(p.about) ? p.about : "",
+      image: isString(p.image) ? p.image : "",
+      site: isString(p.site) ? p.site : "",
+      language: isString(p.language) ? p.language : "",
+      localEditedAt: isNumber(p.localEditedAt) ? p.localEditedAt : 0,
+      syncedAt: isNumber(p.syncedAt) ? p.syncedAt : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Persist (overwrite) the self-profile snapshot. */
+export function writeSelfProfile(snapshot: SelfProfileSnapshot): void {
+  if (!snapshot.address) return;
+  const storage = safeStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(keyFor(snapshot.address), JSON.stringify(snapshot));
+  } catch {
+    // Quota / private-mode etc. — non-fatal; cache will simply not survive
+    // this restart, falling back to remote-wins behaviour.
+  }
+}
+
+/** Drop the cached snapshot — typically on logout for the leaving account. */
+export function clearSelfProfile(address: string): void {
+  if (!address) return;
+  const storage = safeStorage();
+  if (!storage) return;
+  try {
+    storage.removeItem(keyFor(address));
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Pick the field value to display.
+ *
+ *  Two protections layered together:
+ *
+ *  1. Empty-remote fallback (always on, mirrors `entities/user mergeUserUpdate`):
+ *     a non-empty cached value is never blanked out by an empty remote
+ *     response. Pocketnet routinely returns empty rows on transient RPC
+ *     errors, so the project consistently treats those as "no update" rather
+ *     than a deliberate clear. Trade-off: a genuine cross-device *clear*
+ *     would not propagate to a device that already has a cached value —
+ *     accepted because users effectively never blank their own fields
+ *     (they replace one value with another).
+ *
+ *  2. Grace-window conflict resolution (only when a recent local edit
+ *     exists): when remote disagrees with the cached non-empty value, prefer
+ *     cached. This is the WEE-26 fix — a stale `getuserprofile` response
+ *     after a recent save would otherwise revert the name.
+ */
+function pickField(
+  remote: string | undefined,
+  cached: string,
+  isRecentLocalEdit: boolean,
+): string {
+  const remoteStr = remote ?? "";
+  if (!remoteStr && cached) return cached;
+  if (isRecentLocalEdit && remoteStr !== cached && cached) return cached;
+  return remoteStr;
+}
+
+/** Merge a remote UserData against the cached snapshot. The result preserves
+ *  every authoritative field from `remote` (addresses, keys, ref, etc.) and
+ *  only overrides the user-facing fields where the cache should win. */
+export function mergeSelfProfileWithRemote(
+  cached: SelfProfileSnapshot | null,
+  remote: UserData,
+  now: number = Date.now(),
+): UserData {
+  if (!cached) return remote;
+  const isRecentLocalEdit =
+    cached.localEditedAt > 0 && now - cached.localEditedAt < SELF_PROFILE_GRACE_MS;
+  return {
+    ...remote,
+    name: pickField(remote.name, cached.name, isRecentLocalEdit),
+    about: pickField(remote.about, cached.about, isRecentLocalEdit),
+    image: pickField(remote.image, cached.image, isRecentLocalEdit),
+    site: pickField(remote.site, cached.site, isRecentLocalEdit),
+    language: pickField(remote.language, cached.language, isRecentLocalEdit),
+  };
+}

--- a/src/entities/auth/model/__tests__/profile-matrix-sync.test.ts
+++ b/src/entities/auth/model/__tests__/profile-matrix-sync.test.ts
@@ -23,21 +23,21 @@ describe("auth store editUserData triggers Matrix profile sync (Session 45)", ()
     const src = getStoresSource();
     const start = src.indexOf("const { execute: editUserData");
     expect(start).toBeGreaterThan(-1);
-    const block = src.slice(start, start + 1500);
+    const block = src.slice(start, start + 3000);
     expect(block).toMatch(/syncProfileToMatrix\(/);
   });
 
   it("guards Matrix sync behind matrixReady so we don't sync before login completes", () => {
     const src = getStoresSource();
     const start = src.indexOf("const { execute: editUserData");
-    const block = src.slice(start, start + 1500);
+    const block = src.slice(start, start + 3000);
     expect(block).toMatch(/matrixReady/);
   });
 
   it("only syncs when blockchain edit succeeded", () => {
     const src = getStoresSource();
     const start = src.indexOf("const { execute: editUserData");
-    const block = src.slice(start, start + 1500);
+    const block = src.slice(start, start + 3000);
     // Either explicit success === true check, or success !== false guard
     expect(block).toMatch(/success\s*===\s*true|success\s*!==\s*false/);
   });
@@ -45,7 +45,7 @@ describe("auth store editUserData triggers Matrix profile sync (Session 45)", ()
   it("fires Matrix sync without blocking the save (no await on syncProfileToMatrix)", () => {
     const src = getStoresSource();
     const start = src.indexOf("const { execute: editUserData");
-    const block = src.slice(start, start + 1500);
+    const block = src.slice(start, start + 3000);
     // Look for a `void syncProfileToMatrix(...)` fire-and-forget pattern.
     // Plain `await syncProfileToMatrix` would re-introduce H3 (UI hang).
     expect(block).toMatch(/void\s+syncProfileToMatrix\s*\(/);

--- a/src/entities/auth/model/__tests__/profile-persistence.test.ts
+++ b/src/entities/auth/model/__tests__/profile-persistence.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Source-level regression: ensures the WEE-26 self-profile cache stays wired
+ * into the auth store. These guards exist because the previous behaviour —
+ * unconditionally accepting a Pocketnet response — silently re-introduced
+ * forta-bugs#596 / #580 whenever someone refactored fetchUserInfo.
+ *
+ * Behaviour of the cache helpers themselves lives in
+ * src/entities/auth/lib/__tests__/self-profile-cache.test.ts.
+ */
+const getStoresSource = () =>
+  readFileSync(resolve(__dirname, "../stores.ts"), "utf-8");
+
+describe("auth store wires the self-profile cache (WEE-26)", () => {
+  it("imports the cache helpers from ../lib", () => {
+    const src = getStoresSource();
+    expect(src).toMatch(/readSelfProfile\b/);
+    expect(src).toMatch(/writeSelfProfile\b/);
+    expect(src).toMatch(/mergeSelfProfileWithRemote\b/);
+  });
+
+  it("persists the snapshot inside the editUserData success path", () => {
+    const src = getStoresSource();
+    const start = src.indexOf("const { execute: editUserData");
+    expect(start).toBeGreaterThan(-1);
+    const block = src.slice(start, start + 3000);
+    expect(block).toMatch(/result\?\.success\s*===\s*true/);
+    expect(block).toMatch(/writeSelfProfile\(/);
+    expect(block).toMatch(/localEditedAt:\s*Date\.now\(\)/);
+  });
+
+  it("updates in-memory userInfo right after a successful save", () => {
+    const src = getStoresSource();
+    const start = src.indexOf("const { execute: editUserData");
+    const block = src.slice(start, start + 3000);
+    // Must call setUserInfo with the merged payload so the form reflects
+    // the save without waiting for another fetchUserInfo.
+    expect(block).toMatch(/setUserInfo\(merged\)/);
+  });
+
+  it("fetchUserInfo merges the cached snapshot into the Pocketnet response", () => {
+    const src = getStoresSource();
+    const start = src.indexOf("const fetchUserInfo = async () =>");
+    expect(start).toBeGreaterThan(-1);
+    const block = src.slice(start, start + 3000);
+    expect(block).toMatch(/readSelfProfile\(/);
+    expect(block).toMatch(/mergeSelfProfileWithRemote\(/);
+    // Must call setUserInfo with the merged result — not the raw userData.
+    expect(block).toMatch(/setUserInfo\(merged\)/);
+    // And persist the merged snapshot with a fresh syncedAt
+    expect(block).toMatch(/writeSelfProfile\(/);
+    expect(block).toMatch(/syncedAt:\s*Date\.now\(\)/);
+  });
+
+  it("does not set userInfo from the raw Pocketnet userData any more", () => {
+    const src = getStoresSource();
+    const start = src.indexOf("const fetchUserInfo = async () =>");
+    const block = src.slice(start, start + 3000);
+    // Old buggy behaviour: setUserInfo(userData) — directly trusting RPC.
+    expect(block).not.toMatch(/setUserInfo\(userData\)/);
+  });
+
+  it("onRegistrationConfirmed merges instead of replacing", () => {
+    const src = getStoresSource();
+    const start = src.indexOf("async function onRegistrationConfirmed");
+    expect(start).toBeGreaterThan(-1);
+    const block = src.slice(start, start + 3000);
+    expect(block).toMatch(/mergeSelfProfileWithRemote\(/);
+    expect(block).toMatch(/setUserInfo\(merged\)/);
+    expect(block).toMatch(/writeSelfProfile\(/);
+  });
+
+  it("logout invokes clearSelfProfile to drop the per-address snapshot", () => {
+    const src = getStoresSource();
+    const start = src.indexOf("const logout = async () =>");
+    expect(start).toBeGreaterThan(-1);
+    const block = src.slice(start, start + 4000);
+    expect(block).toMatch(/clearSelfProfile\(/);
+  });
+
+  it("fetchUserInfo snapshots the active address before awaiting the RPC", () => {
+    const src = getStoresSource();
+    const start = src.indexOf("const fetchUserInfo = async () =>");
+    const block = src.slice(start, start + 3000);
+    // Captured snapshot prevents a logout-mid-fetch race from leaking
+    // profile state across accounts.
+    expect(block).toMatch(/const\s+requestAddress\s*=\s*address\.value/);
+    expect(block).toMatch(/if\s*\(\s*address\.value\s*!==\s*requestAddress\s*\)/);
+  });
+
+  it("editUserData snapshots the active address before broadcasting", () => {
+    const src = getStoresSource();
+    const start = src.indexOf("const { execute: editUserData");
+    const block = src.slice(start, start + 3000);
+    expect(block).toMatch(/const\s+editAddress\s*=\s*address\.value/);
+    expect(block).toMatch(/address\.value\s*===\s*editAddress/);
+  });
+});

--- a/src/entities/auth/model/__tests__/registration-poll.test.ts
+++ b/src/entities/auth/model/__tests__/registration-poll.test.ts
@@ -46,7 +46,13 @@ describe("registration poll", () => {
     const fnStart = source.indexOf("async function onRegistrationConfirmed");
     expect(fnStart).toBeGreaterThan(-1);
     const fnSection = source.slice(fnStart, fnStart + 1200);
-    const loadIdx = fnSection.indexOf("loadUsersInfo([address.value!], { update: true })");
+    // Address may be passed either as `address.value!` directly or as a
+    // snapshot variable (`confirmedAddress`) — both are valid; the only
+    // ordering invariant is that loadUsersInfo runs before initializeAndFetchUserData.
+    const loadMatch = fnSection.match(
+      /loadUsersInfo\(\s*\[\s*(?:address\.value!|confirmedAddress)\s*\]\s*,\s*\{\s*update:\s*true\s*\}\s*\)/,
+    );
+    const loadIdx = loadMatch?.index ?? -1;
     const initIdx = fnSection.indexOf("initializeAndFetchUserData");
     expect(loadIdx).toBeGreaterThan(-1);
     expect(initIdx).toBeGreaterThan(loadIdx);

--- a/src/entities/auth/model/stores.ts
+++ b/src/entities/auth/model/stores.ts
@@ -44,6 +44,10 @@ import {
   loadMnemonic,
   clearMnemonic,
   syncProfileToMatrix,
+  readSelfProfile,
+  writeSelfProfile,
+  clearSelfProfile,
+  mergeSelfProfileWithRemote,
 } from "../lib";
 import { createKeyPair } from "./key-pair";
 
@@ -260,10 +264,36 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
 
   const { execute: editUserData, isLoading: isEditingUserData } =
     useAsyncOperation(async (userData: UserData) => {
+      // Snapshot the active address before the RPC so a logout that happens
+      // during the broadcast cannot misroute the cache write into another
+      // account.
+      const editAddress = address.value!;
+      const merged = mergeObjects(userInfo.value!, userData);
       const result = await appInitializer.editUserData({
-        address: address.value!,
-        userData: mergeObjects(userInfo.value!, userData)
+        address: editAddress,
+        userData: merged
       });
+
+      if (result?.success === true && address.value === editAddress) {
+        // Persist the just-saved profile so it survives Pocketnet RPC
+        // returning the *pre-edit* name on the next boot — root cause of
+        // WEE-26 / forta-bugs#596, #580.
+        const prev = readSelfProfile(editAddress);
+        writeSelfProfile({
+          address: editAddress,
+          name: merged.name ?? "",
+          about: merged.about ?? "",
+          image: merged.image ?? "",
+          site: merged.site ?? "",
+          language: merged.language ?? "",
+          localEditedAt: Date.now(),
+          syncedAt: prev?.syncedAt ?? 0,
+        });
+        // Reflect the new values in in-memory userInfo immediately so the
+        // form (and any other consumer) shows the saved name without
+        // waiting for a fresh fetchUserInfo to settle.
+        setUserInfo(merged);
+      }
 
       // Best-effort Matrix profile sync — ensures peers see the user's chosen
       // nickname + avatar instead of a truncated wallet address. Pocketnet
@@ -777,8 +807,14 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
       return;
     }
 
+    // Snapshot the active address so a logout + re-login that races with the
+    // RPC cannot cause us to write the first account's profile into the
+    // second account's cache slot.
+    const requestAddress = address.value;
+    const requestPrivateKey = privateKey.value;
+
     await appInitializer.initializeAndFetchUserData(
-      address.value,
+      requestAddress,
       (userData: UserData) => {
         // Defensive: app-initializer guards against undefined userData, but
         // this callback is reached from three flows (login, onConfirmed,
@@ -787,20 +823,45 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
         // login()'s catch and surface as "Invalid private key or mnemonic"
         // on the register page after a successful registration.
         if (!userData) return;
-        setUserInfo(userData);
-        PocketnetInstanceConfigurator.setUserAddress(address.value!);
+
+        // Bail if the active account changed mid-flight — the response
+        // belongs to a logged-out session and must not touch the new one.
+        if (address.value !== requestAddress) return;
+
+        // Merge cached self-profile (last user save) into the remote snapshot
+        // so a stale Pocketnet `getuserprofile` response cannot revert the
+        // user's name within the propagation window — WEE-26 / forta-bugs#596,
+        // #580. When no cache exists or the local edit is older than the grace
+        // window, remote wins unchanged.
+        const cached = readSelfProfile(requestAddress);
+        const merged = mergeSelfProfileWithRemote(cached, userData);
+
+        setUserInfo(merged);
+        PocketnetInstanceConfigurator.setUserAddress(requestAddress);
         PocketnetInstanceConfigurator.setUserGetKeyPairFc(() =>
-          createKeyPair(privateKey.value!)
+          createKeyPair(requestPrivateKey)
         );
+
+        writeSelfProfile({
+          address: requestAddress,
+          name: merged.name ?? "",
+          about: merged.about ?? "",
+          image: merged.image ?? "",
+          site: merged.site ?? "",
+          language: merged.language ?? "",
+          localEditedAt: cached?.localEditedAt ?? 0,
+          syncedAt: Date.now(),
+        });
+
         // Sync own profile to userStore so Avatar components show correct name/initial
-        if (userData && userData.name) {
-          useUserStore().setUser(address.value!, {
-            address: address.value!,
-            name: userData.name ?? "",
-            about: userData.about ?? "",
-            image: userData.image ?? "",
-            site: userData.site ?? "",
-            language: userData.language ?? "",
+        if (merged.name) {
+          useUserStore().setUser(requestAddress, {
+            address: requestAddress,
+            name: merged.name ?? "",
+            about: merged.about ?? "",
+            image: merged.image ?? "",
+            site: merged.site ?? "",
+            language: merged.language ?? "",
           });
         }
       }
@@ -1036,6 +1097,9 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
     clearAllDrafts();
     clearQueue();
     clearAccountLocalStorage(logoutAddress ?? undefined);
+    // Drop self-profile snapshot (WEE-26). Routed through the cache helper
+    // so the key prefix stays a single source of truth.
+    if (logoutAddress) clearSelfProfile(logoutAddress);
 
     // ── 5. Delete Dexie local-first database (await to prevent race with re-login) ──
     await deleteChatDb().catch(() => {});
@@ -1359,24 +1423,44 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
 
 
       try {
-        await appInitializer.loadUsersInfo([address.value!], { update: true });
+        // Snapshot — see fetchUserInfo. Prevents a logout race from writing
+        // this account's confirmed profile into a different account's slot.
+        const confirmedAddress = address.value!;
+        await appInitializer.loadUsersInfo([confirmedAddress], { update: true });
         await appInitializer.initializeAndFetchUserData(
-          address.value!,
+          confirmedAddress,
           (data: UserData) => {
             // Defensive guard — see fetchUserInfo for rationale. Without
             // this, a timing quirk in psdk.userInfo.get() (cache miss right
             // after blockchain confirmation) would crash the callback and
             // abort the post-registration flow.
             if (!data) return;
-            setUserInfo(data);
+            if (address.value !== confirmedAddress) return;
+            // Same merge logic as fetchUserInfo — preserves any cached
+            // self-profile (e.g. from pendingRegProfile or a prior session)
+            // when Pocketnet returns an empty/stale row right after the
+            // confirmation tx propagates (WEE-26).
+            const cached = readSelfProfile(confirmedAddress);
+            const merged = mergeSelfProfileWithRemote(cached, data);
+            setUserInfo(merged);
+            writeSelfProfile({
+              address: confirmedAddress,
+              name: merged.name ?? "",
+              about: merged.about ?? "",
+              image: merged.image ?? "",
+              site: merged.site ?? "",
+              language: merged.language ?? "",
+              localEditedAt: cached?.localEditedAt ?? 0,
+              syncedAt: Date.now(),
+            });
             // Sync confirmed profile to userStore so Avatar/BottomTabBar update immediately
-            useUserStore().setUser(address.value!, {
-              address: address.value!,
-              name: data.name ?? "",
-              about: data.about ?? "",
-              image: data.image ?? "",
-              site: data.site ?? "",
-              language: data.language ?? "",
+            useUserStore().setUser(confirmedAddress, {
+              address: confirmedAddress,
+              name: merged.name ?? "",
+              about: merged.about ?? "",
+              image: merged.image ?? "",
+              site: merged.site ?? "",
+              language: merged.language ?? "",
             });
           }
         );


### PR DESCRIPTION
## Summary

- Persist user's own profile (name/about/image/site/language + `localEditedAt` / `syncedAt`) to localStorage on every save.
- On `fetchUserInfo` / `onRegistrationConfirmed`, merge the cached snapshot into the Pocketnet response so a stale `getuserprofile` row can't revert the user's name within the propagation window.
- Snapshot the active address before each async RPC to prevent a fast logout/login race from leaking profile state across accounts.
- Drop the snapshot on logout via a dedicated `clearSelfProfile` helper so the key prefix stays single-sourced inside the cache module.

## Root cause

`appInitializer.editUserData` -> Pocketnet `updateProfile` resolves before the on-chain commit propagates. The next `getuserprofile` RPC can return the *pre-edit* name for minutes/hours afterwards (proxy/CDN caching exacerbates this). `fetchUserInfo` accepted that stale value as authoritative and overwrote in-memory `userInfo` plus the `useUserStore` cache — so users opening the app after a Forta update saw their previous name re-appear.

## Fix

New `entities/auth/lib/self-profile-cache.ts`:

- `read/write/clearSelfProfile` — localStorage-backed snapshot, keyed by address.
- `mergeSelfProfileWithRemote(cached, remote)` — for `name`/`about`/`image`/`site`/`language`:
  - Non-empty cached field beats an empty remote response (mirrors existing `entities/user mergeUserUpdate`).
  - Within a 7-day propagation grace window, cached beats a *different* non-empty remote (defends against stale `getuserprofile`).
  - After the grace window, remote wins so cross-device edits eventually propagate.
- Address-snapshot guards in `editUserData`, `fetchUserInfo`, and `onRegistrationConfirmed` so a logout-mid-RPC race can't write the wrong account's data.

## Linear

- Resolves [WEE-26](https://linear.app/wwwee/issue/WEE-26/auth-profile-imya-sbrasyvaetsya-posle-obnovleniya-prilozheniya)

## Closes

Closes greenShirtMystery/forta-bugs#596
Closes greenShirtMystery/forta-bugs#580

## Test plan

- [x] `npm run test` for `src/entities/auth/`, `src/features/user-management/`, `src/shared/lib/clear-account-storage` — **148/148 passing** (16 new unit tests for the cache + merge, 9 new source-level regression tests, no other auth/user tests regressed).
- [x] `vue-tsc --noEmit` — no new diagnostics in any touched file (pre-existing tsc errors in unrelated files mirror `master`).
- [ ] Manual QA (Android): edit display name -> kill app -> reopen -> name persists. Repeat after Forta app update.
- [ ] Manual QA: edit name on device A -> wait ~10s -> open on device B -> peer-visible name (Matrix `displayname`) reflects the new value.
- [ ] Logout / re-login on the same device -> name shows from current Pocketnet state (cache cleared via `clearSelfProfile`).