### PR TITLE
fix(media-save): toast feedback + in-flight guards (WEE-25)

### DIFF
--- a/src/features/messaging/ui/MediaViewer.vue
+++ b/src/features/messaging/ui/MediaViewer.vue
@@ -32,6 +32,11 @@ const currentIndex = ref(0);
 const scale = ref(1);
 const translateX = ref(0);
 const translateY = ref(0);
+// In-flight guard: while a save is running, ignore further taps on the same
+// button. Without this, a fast multi-tap on Android (where the toast is
+// delayed by base64 + native MediaStore.insert) creates one duplicate per
+// extra tap — forta-bugs#758, WEE-25.
+const saving = ref(false);
 
 const mediaMessages = computed(() => chatStore.activeMediaMessages);
 
@@ -195,17 +200,21 @@ watch(currentMessage, async (msg) => {
 });
 
 const handleSaveCurrent = async () => {
+  if (saving.value) return;
   const msg = currentMessage.value;
   const url = currentUrl.value;
   if (!msg || !msg.fileInfo || !url) return;
   const mime = msg.fileInfo.type || "";
   const isMedia = mime.startsWith("image/") || mime.startsWith("video/");
+  saving.value = true;
   try {
     await saveFile(url, msg.fileInfo.name, mime);
     toast(t(isMedia ? "media.savedToGallery" : "media.savedToDownloads"), "success");
   } catch (e) {
     console.error("[MediaViewer] save failed:", e);
     toast(t("media.saveFailed"), "error");
+  } finally {
+    saving.value = false;
   }
 };
 </script>
@@ -235,7 +244,7 @@ const handleSaveCurrent = async () => {
           <button
             data-testid="media-save"
             class="text-white/80 transition-colors hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
-            :disabled="!currentUrl"
+            :disabled="!currentUrl || saving"
             :title="t('media.save')"
             :aria-label="t('media.save')"
             @click="handleSaveCurrent"

--- a/src/features/messaging/ui/MessageBubble.vue
+++ b/src/features/messaging/ui/MessageBubble.vue
@@ -6,6 +6,7 @@ import { stripMentionAddresses, stripBastyonLinks } from "@/shared/lib/message-f
 import { useFileDownload } from "../model/use-file-download";
 import { useBugReport } from "@/features/bug-report";
 import { tRaw } from "@/shared/lib/i18n";
+import { useToast } from "@/shared/lib/use-toast";
 import { useVideoStatePreservation } from "@/shared/lib/composables/use-video-state-preservation";
 import MessageContent from "./MessageContent.vue";
 import MessageStatusIcon from "./MessageStatusIcon.vue";
@@ -176,6 +177,12 @@ const handleBubbleClick = () => {
   }
 };
 const { getState, download, saveFile, formatSize } = useFileDownload();
+// Toast cached at setup time so the async `handleFileDownload` doesn't re-enter
+// the composable after an `await`. useToast() is module-state today and safe
+// to re-enter, but keeping the call site at setup matches MediaViewer /
+// MessageList / UserEditForm and avoids the "composable after await" Vue
+// pitfall if useToast ever starts using inject() / getCurrentInstance.
+const { toast: showToast } = useToast();
 
 const time = computed(() => formatTime(new Date(props.message.timestamp)));
 
@@ -235,10 +242,29 @@ const handleMediaClick = () => {
   }
 };
 
+// In-flight guard for the file/audio bubble save button: prevents 5 rapid
+// taps from creating 5 duplicate downloads (forta-bugs#758, WEE-25).
+const isSavingFile = ref(false);
+
 const handleFileDownload = async () => {
+  if (isSavingFile.value) return;
   if (!props.message.fileInfo) return;
-  const url = fileState.value.objectUrl ?? await download(props.message);
-  if (url) await saveFile(url, props.message.fileInfo.name, props.message.fileInfo.type);
+  isSavingFile.value = true;
+  try {
+    const url = fileState.value.objectUrl ?? await download(props.message);
+    if (!url) return;
+    const mime = props.message.fileInfo.type || "";
+    const isMedia = mime.startsWith("image/") || mime.startsWith("video/");
+    try {
+      await saveFile(url, props.message.fileInfo.name, mime);
+      showToast(t(isMedia ? "media.savedToGallery" : "media.savedToDownloads"), "success");
+    } catch (e) {
+      console.error("[MessageBubble] save failed:", e);
+      showToast(t("media.saveFailed"), "error");
+    }
+  } finally {
+    isSavingFile.value = false;
+  }
 };
 
 const retryDownload = () => {
@@ -729,7 +755,11 @@ const replyPreviewSender = computed(() => {
             <div class="truncate text-[11px] opacity-70">{{ replyPreviewText }}</div>
           </div>
         </div>
-        <button class="flex w-full items-center gap-3 text-left" @click="handleFileDownload">
+        <button
+          class="flex w-full items-center gap-3 text-left disabled:opacity-60"
+          :disabled="isSavingFile"
+          @click="handleFileDownload"
+        >
           <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg" :class="props.isOwn ? 'bg-white/20' : 'bg-color-bg-ac/10'">
             <svg v-if="fileState.loading" class="contain-strict h-5 w-5 animate-spin" :class="props.isOwn ? 'text-white' : 'text-color-bg-ac'" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" stroke-dasharray="31.4 31.4" /></svg>
             <svg v-else width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" :class="props.isOwn ? 'text-white' : 'text-color-bg-ac'">

--- a/src/features/messaging/ui/MessageList.vue
+++ b/src/features/messaging/ui/MessageList.vue
@@ -159,22 +159,34 @@ const handleContextAction = (action: string, message: import("@/entities/chat").
   closeContextMenu();
 };
 
+// In-flight guard for the context-menu save path: a long-press → Save while
+// the previous Save is still streaming would otherwise create a duplicate
+// MediaStore entry (forta-bugs#758, WEE-25). Keyed by cacheKey so different
+// messages remain independently savable while one is in progress.
+const savingInFlight = new Set<string>();
+
 const handleSaveMedia = async (message: import("@/entities/chat").Message) => {
   if (!message.fileInfo) return;
   // Match the cache key used by MessageBubble + MediaViewer: stable clientId
   // when available so an in-flight upload's blob URL is reused instead of
   // re-decrypting the just-rendered file.
   const cacheKey = message._key || message.id;
-  const url = getFileState(cacheKey).objectUrl ?? (await downloadFile(message));
-  if (!url) return;
-  const mime = message.fileInfo.type || "";
-  const isMedia = mime.startsWith("image/") || mime.startsWith("video/");
+  if (savingInFlight.has(cacheKey)) return;
+  savingInFlight.add(cacheKey);
   try {
-    await saveFile(url, message.fileInfo.name, mime);
-    toast(t(isMedia ? "media.savedToGallery" : "media.savedToDownloads"), "success");
-  } catch (e) {
-    console.error("[MessageList] save failed:", e);
-    toast(t("media.saveFailed"), "error");
+    const url = getFileState(cacheKey).objectUrl ?? (await downloadFile(message));
+    if (!url) return;
+    const mime = message.fileInfo.type || "";
+    const isMedia = mime.startsWith("image/") || mime.startsWith("video/");
+    try {
+      await saveFile(url, message.fileInfo.name, mime);
+      toast(t(isMedia ? "media.savedToGallery" : "media.savedToDownloads"), "success");
+    } catch (e) {
+      console.error("[MessageList] save failed:", e);
+      toast(t("media.saveFailed"), "error");
+    }
+  } finally {
+    savingInFlight.delete(cacheKey);
   }
 };
 

--- a/src/features/messaging/ui/__tests__/MediaViewer-save-button.test.ts
+++ b/src/features/messaging/ui/__tests__/MediaViewer-save-button.test.ts
@@ -34,7 +34,10 @@ describe("MediaViewer — save-to-gallery button", () => {
     const start = source.indexOf('data-testid="media-save"');
     expect(start).toBeGreaterThan(-1);
     const fragment = source.slice(start, start + 500);
-    expect(fragment).toMatch(/:disabled="!currentUrl"/);
+    // The button must guard against `!currentUrl`. After WEE-25 it also
+    // disables while a save is in flight (`|| saving`) — the assertion is
+    // loosened to match either form so the guarded variant stays valid.
+    expect(fragment).toMatch(/:disabled="!currentUrl(\s*\|\|\s*\w+)?"/);
   });
 
   it("wires the save button click to a handler that calls saveFile", () => {

--- a/src/features/messaging/ui/__tests__/save-to-gallery-guards.test.ts
+++ b/src/features/messaging/ui/__tests__/save-to-gallery-guards.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * WEE-25 regression suite — confirmation toast + in-flight guard across all
+ * three save-to-gallery entry points.
+ *
+ * Source: forta-bugs#780 (no toast), #758 (5 taps = 5 dupes), #753 (audio),
+ * #281 (profile save without feedback).
+ *
+ * Source-level asserts keep this test trivial to run in CI without mounting
+ * the full Vue + Pinia + native plugin tree. Mirrors the pattern used by
+ * MediaViewer-save-button.test.ts and MessageContextMenu-save-action.test.ts.
+ */
+const read = (rel: string): string =>
+  readFileSync(resolve(__dirname, rel), "utf-8");
+
+describe("WEE-25 / MediaViewer — in-flight guard", () => {
+  const source = read("../MediaViewer.vue");
+
+  it("declares a saving ref next to currentIndex", () => {
+    expect(source).toMatch(/const\s+saving\s*=\s*ref\(false\)/);
+  });
+
+  it("early-returns from handleSaveCurrent when a save is already running", () => {
+    const fnStart = source.indexOf("const handleSaveCurrent");
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf("\n};", fnStart);
+    const fn = source.slice(fnStart, fnEnd);
+    expect(fn).toMatch(/if\s*\(\s*saving\.value\s*\)\s*return/);
+    expect(fn).toMatch(/saving\.value\s*=\s*true/);
+    expect(fn).toMatch(/saving\.value\s*=\s*false/);
+  });
+
+  it("disables the save button while saving is true", () => {
+    const start = source.indexOf('data-testid="media-save"');
+    expect(start).toBeGreaterThan(-1);
+    const fragment = source.slice(start, start + 500);
+    expect(fragment).toMatch(/:disabled="!currentUrl \|\| saving"/);
+  });
+});
+
+describe("WEE-25 / MessageBubble — file/audio save toast + guard", () => {
+  const source = read("../MessageBubble.vue");
+
+  it("imports useToast", () => {
+    expect(source).toMatch(/import\s*\{\s*useToast\s*\}\s*from\s*"@\/shared\/lib\/use-toast"/);
+  });
+
+  it("caches toast at setup top-level (not after await inside handler)", () => {
+    // The Vue "composables must run during setup, not after await" invariant
+    // is enforced at the call site — handleFileDownload uses the cached
+    // reference instead of re-entering useToast() post-await.
+    expect(source).toMatch(/const\s*\{\s*toast(\s*:\s*\w+)?\s*\}\s*=\s*useToast\(\)/);
+  });
+
+  it("declares an isSavingFile ref", () => {
+    expect(source).toMatch(/const\s+isSavingFile\s*=\s*ref\(false\)/);
+  });
+
+  it("handleFileDownload wires toast on success and error and is guarded", () => {
+    const fnStart = source.indexOf("const handleFileDownload");
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf("\n};", fnStart);
+    const fn = source.slice(fnStart, fnEnd);
+    expect(fn).toMatch(/if\s*\(\s*isSavingFile\.value\s*\)\s*return/);
+    expect(fn).toMatch(/isSavingFile\.value\s*=\s*true/);
+    expect(fn).toMatch(/isSavingFile\.value\s*=\s*false/);
+    // Success branch: must call the cached toast reference (alias `showToast`
+    // or destructured `toast`) with the savedToGallery/Downloads key.
+    expect(fn).toMatch(/\b(showToast|toast)\(.*media\.savedTo(Gallery|Downloads)/);
+    expect(fn).toMatch(/\b(showToast|toast)\(.*media\.saveFailed.*"error"/);
+    // Audio messages travel through the same file/audio download path —
+    // not branching on mime here means audio files now save through the
+    // same flow as PDFs, archives, etc. (forta-bugs#753).
+    expect(fn).toContain("saveFile");
+  });
+
+  it("disables the file save button while isSavingFile is true", () => {
+    expect(source).toMatch(/:disabled="isSavingFile"/);
+  });
+});
+
+describe("WEE-25 / MessageList — context-menu save guard", () => {
+  const source = read("../MessageList.vue");
+
+  it("uses a per-cacheKey in-flight Set to dedupe long-press → Save", () => {
+    expect(source).toMatch(/savingInFlight\s*=\s*new\s+Set<string>\(\)/);
+  });
+
+  it("handleSaveMedia early-returns when the same cacheKey is in flight", () => {
+    const fnStart = source.indexOf("const handleSaveMedia");
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf("\n};", fnStart);
+    const fn = source.slice(fnStart, fnEnd);
+    expect(fn).toMatch(/savingInFlight\.has\(cacheKey\)/);
+    expect(fn).toMatch(/savingInFlight\.add\(cacheKey\)/);
+    expect(fn).toMatch(/savingInFlight\.delete\(cacheKey\)/);
+  });
+});
+
+describe("WEE-25 / SaveMediaPlugin — audio mime support (Android)", () => {
+  // Kotlin source is checked into the JS tree under android/. Reading it
+  // here keeps audio-mime routing in the regression net so a future
+  // refactor of the native plugin can't silently strip Music/* routing
+  // (forta-bugs#753).
+  const source = readFileSync(
+    resolve(__dirname, "../../../../../android/app/src/main/java/com/forta/chat/plugins/savemedia/SaveMediaPlugin.kt"),
+    "utf-8",
+  );
+
+  it("routes audio/* mime to the Music collection on API 29+", () => {
+    expect(source).toMatch(/mime\.startsWith\("audio\/"\)\s*->\s*\n?\s*MediaStore\.Audio\.Media\.getContentUri/);
+  });
+
+  it("routes audio/* mime to DIRECTORY_MUSIC on legacy storage", () => {
+    expect(source).toMatch(/mime[Tt]ype\.startsWith\("audio\/"\)\s*->\s*Environment\.DIRECTORY_MUSIC/);
+  });
+
+  it("maps audio/* to a Music/Forta Chat relative path", () => {
+    expect(source).toMatch(/"audio\/".*->\s*"Music\/Forta Chat"/s);
+  });
+});

--- a/src/features/user-management/ui/UserEditForm.vue
+++ b/src/features/user-management/ui/UserEditForm.vue
@@ -5,11 +5,13 @@ import { useLocaleStore } from "@/entities/locale";
 import type { Locale } from "@/entities/locale";
 import Avatar from "@/shared/ui/avatar/Avatar.vue";
 import { fileToBase64, uploadImage } from "@/shared/lib/upload-image";
+import { useToast } from "@/shared/lib/use-toast";
 
 const authStore = useAuthStore();
 const userStore = useUserStore();
 const localeStore = useLocaleStore();
 const { t } = useI18n();
+const { toast } = useToast();
 
 // Start empty — we sync from userInfo via watch below. Initializing from
 // authStore.userInfo at mount captures a snapshot that never updates when
@@ -128,6 +130,9 @@ const handleSave = async () => {
       (result as { success: boolean }).success === false
     ) {
       saveError.value = t("profile.saveFailed");
+      // The inline error text is easy to miss on long forms (forta-bugs#281,
+      // WEE-25) — surface a toast as well so the user gets immediate feedback.
+      toast(t("profile.saveFailed"), "error");
       return;
     }
 
@@ -144,10 +149,17 @@ const handleSave = async () => {
     }
     saveSuccess.value = true;
     setTimeout(() => (saveSuccess.value = false), 2000);
+    // Toast in addition to the inline button state: profile save can run
+    // for several seconds (long-running RPC, forta-bugs#281), and the user
+    // may have scrolled away or switched apps — toast lands feedback even
+    // when the button is off-screen.
+    toast(t("profile.saved"), "success");
   } catch (err) {
     console.error("[UserEditForm] handleSave failed:", err);
-    saveError.value =
+    const message =
       err instanceof Error ? err.message : t("profile.saveFailed");
+    saveError.value = message;
+    toast(t("profile.saveFailed"), "error");
   }
 };
 

--- a/src/features/user-management/ui/__tests__/user-edit-form-source.test.ts
+++ b/src/features/user-management/ui/__tests__/user-edit-form-source.test.ts
@@ -34,7 +34,7 @@ describe("UserEditForm — source-level invariants (session 05)", () => {
     // then capture the entire function body up to its closing brace.
     const handleSaveStart = src.indexOf("handleSave = async");
     expect(handleSaveStart).toBeGreaterThan(-1);
-    const saveFn = src.slice(handleSaveStart, handleSaveStart + 2000);
+    const saveFn = src.slice(handleSaveStart, handleSaveStart + 3000);
     expect(saveFn).toMatch(/try\s*\{/);
     expect(saveFn).toMatch(/catch\s*\(/);
     // On failure, must set a user-visible error signal

--- a/src/features/user-management/ui/__tests__/user-edit-form-toast.test.ts
+++ b/src/features/user-management/ui/__tests__/user-edit-form-toast.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * WEE-25 / forta-bugs#281 — profile Save must produce user-visible feedback.
+ *
+ * The inline `saveSuccess` button-state toggle is easy to miss on long forms
+ * or when the user has scrolled away. This test pins the toast wiring so a
+ * future refactor cannot silently drop it.
+ *
+ * Source-level assertion mirrors user-edit-form-source.test.ts so we don't
+ * have to mount the full auth + locale + user store tree for one branch.
+ */
+const getSource = () =>
+  readFileSync(resolve(__dirname, "../UserEditForm.vue"), "utf-8");
+
+describe("UserEditForm — toast feedback on save (WEE-25)", () => {
+  it("imports useToast from shared/lib", () => {
+    const src = getSource();
+    expect(src).toMatch(/import\s*\{\s*useToast\s*\}\s*from\s*"@\/shared\/lib\/use-toast"/);
+  });
+
+  it("destructures toast from useToast at component setup", () => {
+    const src = getSource();
+    expect(src).toMatch(/const\s*\{\s*toast\s*\}\s*=\s*useToast\(\)/);
+  });
+
+  it("handleSave surfaces a success toast after editUserData succeeds", () => {
+    const src = getSource();
+    const start = src.indexOf("handleSave = async");
+    expect(start).toBeGreaterThan(-1);
+    const fn = src.slice(start, start + 3000);
+    // Success branch must call toast(t('profile.saved'), 'success').
+    expect(fn).toMatch(/toast\(\s*t\(\s*["']profile\.saved["']\s*\)\s*,\s*["']success["']\s*\)/);
+  });
+
+  it("handleSave surfaces an error toast on failure (catch + structured envelope)", () => {
+    const src = getSource();
+    const start = src.indexOf("handleSave = async");
+    expect(start).toBeGreaterThan(-1);
+    const fn = src.slice(start, start + 3000);
+    // At least one error-path toast for the surfaced failure mode.
+    expect(fn).toMatch(/toast\(\s*t\(\s*["']profile\.saveFailed["']\s*\)\s*,\s*["']error["']\s*\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- Wire `useToast()` into all three save-to-gallery entry points (MediaViewer, MessageList context menu, MessageBubble file/audio bubble) so the user gets confirmation on success/error
- Add in-flight guards (`saving` ref / `isSavingFile` ref / `savingInFlight` Set keyed by cacheKey) so 5 rapid taps no longer produce 5 duplicate files in the gallery (forta-bugs#758)
- Add toast feedback to profile Save (`UserEditForm`) alongside the existing inline `saveSuccess` state so a long-running `editUserData` produces visible feedback even when the user scrolled away (forta-bugs#281)
- Lock down `audio/*` mime routing in the native `SaveMediaPlugin.kt` with a regression test — the Kotlin side already supported it, but it wasn't pinned (forta-bugs#753)

## Linear
- Resolves [WEE-25](https://linear.app/wwwee/issue/WEE-25)

## Closes
Closes greenShirtMystery/forta-bugs#780
Closes greenShirtMystery/forta-bugs#758
Closes greenShirtMystery/forta-bugs#753
Closes greenShirtMystery/forta-bugs#281

## Test plan
- [x] `npm run test` — full suite: 174 passed | 10 failed (10 failures are pre-existing flake, identical to baseline)
- [x] 17 new source-level regression tests covering all four files + Kotlin plugin audio routing
- [x] `vue-tsc --noEmit` — 0 new TypeScript errors introduced (51-line baseline unchanged)
- [x] Code review by `code-reviewer` agent — only one HIGH finding (useToast called after await in MessageBubble), addressed by caching toast at setup top-level
- [ ] Manual QA on Android: tap Save once → toast appears; tap-tap-tap quickly → only one file saved; save audio message → arrives in Music/Forta Chat; profile Save → toast appears