### PR TITLE
fix(emoji-picker): full-opacity sticky section headers (WEE-9)

### DIFF
--- a/src/features/messaging/ui/EmojiPicker.vue
+++ b/src/features/messaging/ui/EmojiPicker.vue
@@ -304,7 +304,7 @@ useAndroidBackHandler(`emoji-picker-${props.mode}`, 90, () => {
                 :key="section.key"
                 :ref="(el) => setSectionRef(el, i)"
               >
-                <div class="sticky top-0 z-10 bg-background-total-theme/90 px-1 py-1 text-[11px] font-medium uppercase tracking-wider text-text-on-main-bg-color/60 backdrop-blur-sm">
+                <div class="sticky top-0 z-10 bg-background-total-theme px-1 py-1 text-[11px] font-medium uppercase tracking-wider text-text-on-main-bg-color/60">
                   {{ section.name }}
                 </div>
                 <div class="grid grid-cols-8 gap-0.5 pb-2">

--- a/src/features/messaging/ui/__tests__/EmojiPicker-section-header-opacity.test.ts
+++ b/src/features/messaging/ui/__tests__/EmojiPicker-section-header-opacity.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { nextTick, ref } from "vue";
+
+// Regression for WEE-9 / forta-bugs#696:
+// Sticky section headers in EmojiPicker must be fully opaque — emoji rows
+// scrolling under a header must not bleed through (no /opacity suffix on the
+// background, no backdrop-blur).
+
+vi.mock("@/shared/lib/i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k, locale: { value: "en" } }),
+}));
+
+vi.mock("@/entities/theme", () => ({
+  useThemeStore: () => ({
+    recentEmojis: [],
+    quickReactions: [],
+    animationsEnabled: true,
+    chatWallpaper: null,
+  }),
+}));
+
+vi.mock("@/shared/lib/composables/use-android-back-handler", () => ({
+  useAndroidBackHandler: vi.fn(),
+}));
+
+vi.mock("@/shared/lib/composables/use-media-query", () => ({
+  useMobile: () => ref(true),
+}));
+
+class ResizeObserverStub {
+  observe = vi.fn();
+  disconnect = vi.fn();
+  unobserve = vi.fn();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(_cb: ResizeObserverCallback) {}
+}
+
+import EmojiPicker from "../EmojiPicker.vue";
+
+describe("EmojiPicker — sticky section headers are fully opaque", () => {
+  beforeEach(() => {
+    vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders sticky section headers without /opacity suffix and without backdrop-blur", async () => {
+    const wrapper = mount(EmojiPicker, {
+      props: { show: true, mode: "input", x: 0, y: 0 },
+      attachTo: document.body,
+    });
+    // First tick mounts the Teleport target; the second flushes the watcher
+    // that publishes the panel size and reveals the category sections.
+    await nextTick();
+    await nextTick();
+
+    // Picker uses `<Teleport to="body">` so its DOM lives outside wrapper.vm.
+    // Scope the query via `.emoji-panel` (the picker root class) so other
+    // unrelated sticky elements that might appear in body never feed into
+    // this assertion.
+    const stickyHeaders = document.querySelectorAll(
+      ".emoji-panel .sticky.top-0",
+    );
+    expect(stickyHeaders.length).toBeGreaterThan(0);
+
+    stickyHeaders.forEach((header) => {
+      const cls = header.getAttribute("class") ?? "";
+      expect(cls).toContain("bg-background-total-theme");
+      // No Tailwind /opacity suffix on the background — would bleed through.
+      expect(cls).not.toMatch(/bg-background-total-theme\/\d+/);
+      // No backdrop-blur — same root cause (glass effect leaks emoji below).
+      expect(cls).not.toMatch(/backdrop-blur/);
+    });
+
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- Sticky category headers in `EmojiPicker.vue` used `bg-background-total-theme/90` + `backdrop-blur-sm`; on mobile WebView the 10% transparency let emoji rows visibly bleed through the header during scroll.
- Drop both classes so the header is fully opaque (no glass effect, no scrim).
- Add a regression test that mounts the picker and asserts every sticky section header keeps `bg-background-total-theme` without any `/digits` opacity suffix and without `backdrop-blur`.

## Linear
- Resolves [WEE-9](https://linear.app/wwwee/issue/WEE-9/emoji-keyboard-section-headers-prosvechivayut-pri-skrolle)

## Closes
- Closes greenShirtMystery/forta-bugs#696

## Test plan
- [x] New unit test added: src/features/messaging/ui/__tests__/EmojiPicker-section-header-opacity.test.ts
- [x] vitest run on new test — GREEN; verified RED before the fix
- [x] vue-tsc --noEmit reports zero new errors for EmojiPicker.vue or the new test file
- [ ] Manual QA on Android: open emoji picker → scroll Smileys → Animals & Nature, header pins to top, emoji underneath are not visible through it
- [ ] Manual QA: behavior identical in light and dark themes

## Out of scope
- Sticky positioning, virtualization, header sizing — untouched
- Other Tailwind opacity-suffix usages elsewhere in the codebase