### PR TITLE
fix(channels): persist Bastyon channels + optimistic group write to Dexie (WEE-24)

### DIFF
--- a/src/entities/channel/model/__tests__/channel-store-persistence.test.ts
+++ b/src/entities/channel/model/__tests__/channel-store-persistence.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+
+import { useChannelStore } from "../channel-store";
+import { useAuthStore } from "@/entities/auth";
+import { getChatDb, isChatDbReady } from "@/shared/lib/local-db";
+import type { LocalChannel } from "@/shared/lib/local-db";
+
+vi.mock("@/entities/auth", () => ({
+  useAuthStore: vi.fn(),
+}));
+
+vi.mock("@/shared/lib/local-db", () => ({
+  getChatDb: vi.fn(),
+  isChatDbReady: vi.fn(),
+}));
+
+interface FakeChannelRepo {
+  getAll: ReturnType<typeof vi.fn>;
+  replaceAll: ReturnType<typeof vi.fn>;
+  bulkUpsert: ReturnType<typeof vi.fn>;
+  clear: ReturnType<typeof vi.fn>;
+}
+
+function makeRepo(stored: LocalChannel[] = []): FakeChannelRepo {
+  const state = [...stored];
+  return {
+    getAll: vi.fn(async () => [...state]),
+    replaceAll: vi.fn(async (channels: LocalChannel[]) => {
+      state.splice(0, state.length, ...channels);
+    }),
+    bulkUpsert: vi.fn(async (channels: LocalChannel[]) => {
+      for (const c of channels) {
+        const idx = state.findIndex((s) => s.address === c.address);
+        if (idx >= 0) state[idx] = c;
+        else state.push(c);
+      }
+    }),
+    clear: vi.fn(async () => {
+      state.length = 0;
+    }),
+  };
+}
+
+describe("channel-store — Dexie hydration + persistence (WEE-24)", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.mocked(useAuthStore).mockReset();
+    vi.mocked(getChatDb).mockReset();
+    vi.mocked(isChatDbReady).mockReset();
+  });
+
+  // --- A1: cold-start render from Dexie before Pocketnet RPC ---
+  it("hydrates the channel list from Dexie before Matrix/RPC fetch returns", async () => {
+    const repo = makeRepo([
+      {
+        address: "addr_1",
+        name: "Persisted One",
+        avatar: "av1",
+        lastContent: null,
+        syncOrder: 0,
+        updatedAt: 100,
+      },
+      {
+        address: "addr_2",
+        name: "Persisted Two",
+        avatar: "av2",
+        lastContent: null,
+        syncOrder: 1,
+        updatedAt: 100,
+      },
+    ]);
+
+    vi.mocked(isChatDbReady).mockReturnValue(true);
+    vi.mocked(getChatDb).mockReturnValue({ channels: repo } as never);
+
+    const store = useChannelStore();
+    expect(store.channels).toEqual([]);
+
+    await store.hydrateFromDexie();
+
+    expect(repo.getAll).toHaveBeenCalledTimes(1);
+    expect(store.channels.map((c) => c.address)).toEqual(["addr_1", "addr_2"]);
+    expect(store.channels[0].name).toBe("Persisted One");
+    expect(store.isHydrated).toBe(true);
+  });
+
+  it("hydrateFromDexie is a no-op when the chat DB is not ready (logged out / tests)", async () => {
+    vi.mocked(isChatDbReady).mockReturnValue(false);
+
+    const store = useChannelStore();
+    await store.hydrateFromDexie();
+
+    expect(getChatDb).not.toHaveBeenCalled();
+    expect(store.channels).toEqual([]);
+    expect(store.isHydrated).toBe(false);
+  });
+
+  it("does not overwrite an already-populated in-memory list", async () => {
+    const repo = makeRepo([
+      {
+        address: "stale",
+        name: "Stale",
+        avatar: "",
+        lastContent: null,
+        syncOrder: 0,
+        updatedAt: 0,
+      },
+    ]);
+    vi.mocked(isChatDbReady).mockReturnValue(true);
+    vi.mocked(getChatDb).mockReturnValue({ channels: repo } as never);
+
+    const store = useChannelStore();
+    store.channels = [
+      { address: "fresh", name: "Fresh", avatar: "", lastContent: null },
+    ];
+
+    await store.hydrateFromDexie();
+
+    expect(store.channels.map((c) => c.address)).toEqual(["fresh"]);
+  });
+
+  it("hydrateFromDexie is idempotent within a session", async () => {
+    const repo = makeRepo([
+      {
+        address: "a",
+        name: "A",
+        avatar: "",
+        lastContent: null,
+        syncOrder: 0,
+        updatedAt: 0,
+      },
+    ]);
+    vi.mocked(isChatDbReady).mockReturnValue(true);
+    vi.mocked(getChatDb).mockReturnValue({ channels: repo } as never);
+
+    const store = useChannelStore();
+    await store.hydrateFromDexie();
+    await store.hydrateFromDexie();
+
+    expect(repo.getAll).toHaveBeenCalledTimes(1);
+  });
+
+  // --- A2: fetchChannels writes to Dexie so the next cold-start is non-empty ---
+  it("persists the full set to Dexie after a reset fetch", async () => {
+    const repo = makeRepo();
+    vi.mocked(isChatDbReady).mockReturnValue(true);
+    vi.mocked(getChatDb).mockReturnValue({ channels: repo } as never);
+
+    const fetched = Array.from({ length: 20 }, (_, i) => ({
+      address: `addr_${i}`,
+      name: `Ch${i}`,
+    }));
+    vi.mocked(useAuthStore).mockReturnValue({
+      address: "me",
+      getSubscribesChannels: vi.fn().mockResolvedValueOnce({
+        channels: fetched,
+        height: 1000,
+      }),
+    } as unknown as ReturnType<typeof useAuthStore>);
+
+    const store = useChannelStore();
+    await store.fetchChannels(true);
+
+    expect(repo.replaceAll).toHaveBeenCalledTimes(1);
+    const persisted = repo.replaceAll.mock.calls[0][0] as LocalChannel[];
+    expect(persisted).toHaveLength(20);
+    expect(persisted[0].address).toBe("addr_0");
+    expect(persisted[0].syncOrder).toBe(0);
+    expect(persisted[5].syncOrder).toBe(5);
+    expect(store.isHydrated).toBe(true);
+  });
+
+  it("upserts only the newly appended page on non-reset fetches", async () => {
+    const repo = makeRepo();
+    vi.mocked(isChatDbReady).mockReturnValue(true);
+    vi.mocked(getChatDb).mockReturnValue({ channels: repo } as never);
+
+    const page0 = Array.from({ length: 20 }, (_, i) => ({
+      address: `p0_${i}`,
+      name: `Ch${i}`,
+    }));
+    const page1 = Array.from({ length: 20 }, (_, i) => ({
+      address: `p1_${i}`,
+      name: `Ch${20 + i}`,
+    }));
+    vi.mocked(useAuthStore).mockReturnValue({
+      address: "me",
+      getSubscribesChannels: vi
+        .fn()
+        .mockResolvedValueOnce({ channels: page0, height: 1000 })
+        .mockResolvedValueOnce({ channels: page1, height: 1000 }),
+    } as unknown as ReturnType<typeof useAuthStore>);
+
+    const store = useChannelStore();
+    await store.fetchChannels(true);
+    await store.fetchChannels(false);
+
+    expect(repo.replaceAll).toHaveBeenCalledTimes(1);
+    expect(repo.bulkUpsert).toHaveBeenCalledTimes(1);
+    const appended = repo.bulkUpsert.mock.calls[0][0] as LocalChannel[];
+    expect(appended).toHaveLength(20);
+    expect(appended[0].address).toBe("p1_0");
+    // syncOrder continues from the previous page tail
+    expect(appended[0].syncOrder).toBe(20);
+    expect(appended[19].syncOrder).toBe(39);
+  });
+
+  it("reset fetch does NOT clear the visible list until the RPC response arrives", async () => {
+    const repo = makeRepo();
+    vi.mocked(isChatDbReady).mockReturnValue(true);
+    vi.mocked(getChatDb).mockReturnValue({ channels: repo } as never);
+
+    let resolveRpc: (v: unknown) => void = () => {};
+    const rpcPromise = new Promise((resolve) => {
+      resolveRpc = resolve;
+    });
+    vi.mocked(useAuthStore).mockReturnValue({
+      address: "me",
+      getSubscribesChannels: vi.fn().mockReturnValue(rpcPromise),
+    } as unknown as ReturnType<typeof useAuthStore>);
+
+    const store = useChannelStore();
+    store.channels = [
+      { address: "persisted", name: "Persisted", avatar: "", lastContent: null },
+    ];
+
+    const inFlight = store.fetchChannels(true);
+    // Still showing the Dexie-hydrated list while RPC is in-flight
+    expect(store.channels.map((c) => c.address)).toEqual(["persisted"]);
+
+    resolveRpc({ channels: [{ address: "fresh", name: "Fresh" }], height: 1 });
+    await inFlight;
+
+    // Only after RPC resolves the list is replaced by the server view
+    expect(store.channels.map((c) => c.address)).toEqual(["fresh"]);
+  });
+
+  it("Dexie persistence failure does not break fetchChannels (warn-and-continue)", async () => {
+    const repo = makeRepo();
+    repo.replaceAll.mockRejectedValueOnce(new Error("db kaput"));
+    vi.mocked(isChatDbReady).mockReturnValue(true);
+    vi.mocked(getChatDb).mockReturnValue({ channels: repo } as never);
+
+    vi.mocked(useAuthStore).mockReturnValue({
+      address: "me",
+      getSubscribesChannels: vi.fn().mockResolvedValueOnce({
+        channels: [{ address: "a", name: "A" }],
+        height: 1,
+      }),
+    } as unknown as ReturnType<typeof useAuthStore>);
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const store = useChannelStore();
+    await expect(store.fetchChannels(true)).resolves.toBeUndefined();
+    expect(store.channels.map((c) => c.address)).toEqual(["a"]);
+    warn.mockRestore();
+  });
+
+  // --- concurrent-fetch dedup (sidebar + child both kick off RPC) ---
+  it("dedupes overlapping fetchChannels calls (only one RPC per cold-start)", async () => {
+    const repo = makeRepo();
+    vi.mocked(isChatDbReady).mockReturnValue(true);
+    vi.mocked(getChatDb).mockReturnValue({ channels: repo } as never);
+
+    let resolveRpc: (v: unknown) => void = () => {};
+    const rpcPromise = new Promise((resolve) => {
+      resolveRpc = resolve;
+    });
+    const getSubsSpy = vi.fn().mockReturnValue(rpcPromise);
+    vi.mocked(useAuthStore).mockReturnValue({
+      address: "me",
+      getSubscribesChannels: getSubsSpy,
+    } as unknown as ReturnType<typeof useAuthStore>);
+
+    const store = useChannelStore();
+    // Two parallel kick-offs — one from ChatSidebar.onMounted, one from
+    // ChannelList.onMounted that races right behind it.
+    const a = store.fetchChannels(true);
+    const b = store.fetchChannels(true);
+
+    resolveRpc({ channels: [{ address: "x", name: "X" }], height: 1 });
+    await Promise.all([a, b]);
+
+    expect(getSubsSpy).toHaveBeenCalledTimes(1);
+    expect(repo.replaceAll).toHaveBeenCalledTimes(1);
+  });
+
+  // --- cleanup ---
+  it("cleanup resets isHydrated so a fresh login starts clean", async () => {
+    const repo = makeRepo([
+      {
+        address: "a",
+        name: "A",
+        avatar: "",
+        lastContent: null,
+        syncOrder: 0,
+        updatedAt: 0,
+      },
+    ]);
+    vi.mocked(isChatDbReady).mockReturnValue(true);
+    vi.mocked(getChatDb).mockReturnValue({ channels: repo } as never);
+
+    const store = useChannelStore();
+    await store.hydrateFromDexie();
+    expect(store.isHydrated).toBe(true);
+
+    store.cleanup();
+    expect(store.isHydrated).toBe(false);
+    expect(store.channels).toEqual([]);
+  });
+});

--- a/src/entities/channel/model/channel-store.ts
+++ b/src/entities/channel/model/channel-store.ts
@@ -2,6 +2,8 @@ import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 
 import { useAuthStore } from "@/entities/auth";
+import { getChatDb, isChatDbReady } from "@/shared/lib/local-db";
+import type { ChannelLastContent, LocalChannel } from "@/shared/lib/local-db";
 
 import type { Channel, ChannelPost } from "./types";
 
@@ -48,6 +50,62 @@ function parseChannel(raw: Record<string, unknown>): Channel {
   };
 }
 
+function channelLastContentToPost(c: ChannelLastContent): ChannelPost {
+  return {
+    txid: c.txid,
+    type: c.type,
+    caption: c.caption,
+    message: c.message,
+    time: c.time,
+    height: c.height,
+    scoreSum: c.scoreSum,
+    scoreCnt: c.scoreCnt,
+    comments: c.comments,
+    images: c.images,
+    url: c.url,
+    tags: c.tags,
+    settings: c.settings,
+  };
+}
+
+function postToChannelLastContent(p: ChannelPost): ChannelLastContent {
+  return {
+    txid: p.txid,
+    type: p.type,
+    caption: p.caption,
+    message: p.message,
+    time: p.time,
+    height: p.height,
+    scoreSum: p.scoreSum,
+    scoreCnt: p.scoreCnt,
+    comments: p.comments,
+    images: p.images,
+    url: p.url,
+    tags: p.tags,
+    settings: p.settings,
+  };
+}
+
+function localToChannel(lc: LocalChannel): Channel {
+  return {
+    address: lc.address,
+    name: lc.name,
+    avatar: lc.avatar,
+    lastContent: lc.lastContent ? channelLastContentToPost(lc.lastContent) : null,
+  };
+}
+
+function channelToLocal(c: Channel, syncOrder: number, now: number): LocalChannel {
+  return {
+    address: c.address,
+    name: c.name,
+    avatar: c.avatar,
+    lastContent: c.lastContent ? postToChannelLastContent(c.lastContent) : null,
+    syncOrder,
+    updatedAt: now,
+  };
+}
+
 export const useChannelStore = defineStore("channel", () => {
   const channels = ref<Channel[]>([]);
   const activeChannelAddress = ref<string | null>(null);
@@ -61,6 +119,10 @@ export const useChannelStore = defineStore("channel", () => {
   const blockHeight = ref(0);
   const channelError = ref<string | null>(null);
   const postsError = ref<string | null>(null);
+  /** True once a successful Dexie hydration completed in this session.
+   *  Prevents `fetchChannels(reset=true)` from clearing the visible list
+   *  before the RPC response arrives — Dexie data stays as first-paint. */
+  const isHydrated = ref(false);
 
   const activeChannel = computed(() =>
     channels.value.find((c) => c.address === activeChannelAddress.value) ?? null
@@ -78,15 +140,74 @@ export const useChannelStore = defineStore("channel", () => {
       : false
   );
 
+  /** Cold-start render: load the persisted channel set from Dexie before the
+   *  Pocketnet RPC response arrives. Tor + slow networks can delay
+   *  `fetchChannels` by 10–20s, during which the sidebar would otherwise be
+   *  empty — users perceive that as "groups/channels disappeared" (WEE-24). */
+  async function hydrateFromDexie(): Promise<void> {
+    if (isHydrated.value) return;
+    if (!isChatDbReady()) return;
+    try {
+      const stored = await getChatDb().channels.getAll();
+      if (stored.length > 0 && channels.value.length === 0) {
+        channels.value = stored.map(localToChannel);
+      }
+      isHydrated.value = true;
+    } catch (e) {
+      console.warn("[channel-store] hydrateFromDexie failed:", e);
+    }
+  }
+
+  /** Persist the currently visible list to Dexie. `reset=true` rewrites the
+   *  full set so unsubscribed channels disappear locally too; otherwise the
+   *  newly appended page is upserted on top of existing rows. */
+  async function persistChannels(reset: boolean, freshlyAdded: Channel[]): Promise<void> {
+    if (!isChatDbReady()) return;
+    const now = Date.now();
+    try {
+      const repo = getChatDb().channels;
+      if (reset) {
+        // Mirror the in-memory list one-for-one so order is preserved.
+        await repo.replaceAll(
+          channels.value.map((c, idx) => channelToLocal(c, idx, now)),
+        );
+      } else if (freshlyAdded.length > 0) {
+        // syncOrder follows the in-memory tail; cheaper than recomputing
+        // every existing row.
+        const startIdx = channels.value.length - freshlyAdded.length;
+        await repo.bulkUpsert(
+          freshlyAdded.map((c, i) => channelToLocal(c, startIdx + i, now)),
+        );
+      }
+    } catch (e) {
+      console.warn("[channel-store] persistChannels failed:", e);
+    }
+  }
+
   async function fetchChannels(reset = false) {
     const authStore = useAuthStore();
     const addr = authStore.address;
     if (!addr) return;
 
+    // Dedupe concurrent fetches. With Dexie hydration in place, both
+    // ChatSidebar and ChannelList kick off `fetchChannels(true)` on cold-start
+    // (sidebar fires first, then the child once its `onMounted` runs) —
+    // without this guard each cold-start would burn two Pocketnet RPC calls
+    // and race two `replaceAll` Dexie writes. The `isLoadingChannels` flag is
+    // flipped back to `false` in the `finally` block, so sequential
+    // pagination still works as before.
+    if (isLoadingChannels.value) return;
+
     if (reset) {
       channelsPage.value = 0;
       hasMoreChannels.value = true;
-      channels.value = [];
+      // Do NOT clear `channels.value` here — keep the Dexie-hydrated list as
+      // the first-paint until the RPC response replaces it. Otherwise a slow
+      // network would flash an empty sidebar on every restart (WEE-24).
+      // Accepted trade-off: a channel the user unsubscribed from on another
+      // device stays visible for the in-flight window. We accept that over
+      // flashing an empty sidebar; `replaceAll` in `persistChannels` drops
+      // unsubscribed entries the moment the RPC response lands.
       blockHeight.value = 4675546;
     }
 
@@ -142,6 +263,13 @@ export const useChannelStore = defineStore("channel", () => {
 
       hasMoreChannels.value = pageHadFullCount;
       channelsPage.value += 1;
+
+      // Persist fresh server data so the next cold-start renders immediately.
+      // `reset` mirrors the full list (drops unsubscribed channels); pages
+      // upsert only the newly appended slice. Mark hydrated since post-fetch
+      // Dexie state is now authoritative.
+      await persistChannels(reset, fresh);
+      isHydrated.value = true;
     } catch (e) {
       console.error("[channel-store] fetchChannels error:", e);
       channelError.value = String(e);
@@ -228,6 +356,7 @@ export const useChannelStore = defineStore("channel", () => {
     blockHeight.value = 0;
     channelError.value = null;
     postsError.value = null;
+    isHydrated.value = false;
   };
 
   return {
@@ -243,11 +372,13 @@ export const useChannelStore = defineStore("channel", () => {
     blockHeight,
     channelError,
     postsError,
+    isHydrated,
     activeChannel,
     activePosts,
     activeHasMorePosts,
     fetchChannels,
     fetchPosts,
+    hydrateFromDexie,
     setActiveChannel,
     clearActiveChannel,
     cleanup,

--- a/src/entities/chat/model/__tests__/chat-store-add-room-persist.test.ts
+++ b/src/entities/chat/model/__tests__/chat-store-add-room-persist.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia } from "pinia";
+import { createTestingPinia } from "@pinia/testing";
+import { makeRoom } from "@/test-utils";
+
+const mockMatrixService = {
+  getUserId: vi.fn(() => "@me:server"),
+  getRoom: vi.fn(() => ({ selfMembership: "join" })),
+  sendReadReceipt: vi.fn(async () => true),
+  isReady: vi.fn(() => false),
+  kit: {
+    client: { getUserId: () => "@me:server" },
+    isTetatetChat: vi.fn(() => true),
+    getRoomMembers: vi.fn(() => []),
+  },
+};
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: vi.fn(() => mockMatrixService),
+}));
+
+import { useChatStore } from "../chat-store";
+
+function makeKit() {
+  const bulkSyncRooms = vi.fn(async () => {});
+  const kit = {
+    rooms: {
+      bulkSyncRooms,
+      // Stubs for `setChatDbKit` side-effects: chat-store kicks off
+      // `initDexieRooms` and `observeRoomChanges` when the kit is wired.
+      getAllRooms: vi.fn(async () => []),
+      observeRoomChanges: vi.fn(() => () => {}),
+    },
+    eventWriter: { enableBatching: vi.fn() },
+  };
+  return { kit, bulkSyncRooms };
+}
+
+describe("chat-store — addRoom optimistic Dexie write (WEE-24)", () => {
+  let store: ReturnType<typeof useChatStore>;
+
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }));
+    store = useChatStore();
+    vi.clearAllMocks();
+  });
+
+  it("does not throw when no chat DB kit is wired (logged out / tests)", () => {
+    // No setChatDbKit call — bulkSyncRooms must be skipped silently.
+    expect(() => store.addRoom(makeRoom({ id: "!r:s" }))).not.toThrow();
+    expect(store.rooms.find((r) => r.id === "!r:s")).toBeDefined();
+  });
+
+  it("mirrors a freshly created group to Dexie so it survives a restart", () => {
+    const { kit, bulkSyncRooms } = makeKit();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store.setChatDbKit(kit as any);
+
+    const newGroup = makeRoom({
+      id: "!new-group:s",
+      name: "Project Alpha",
+      isGroup: true,
+      members: ["me", "alice", "bob"],
+      avatar: "mxc://x",
+      unreadCount: 0,
+      updatedAt: 12345,
+    });
+    store.addRoom(newGroup);
+
+    expect(bulkSyncRooms).toHaveBeenCalledTimes(1);
+    const payload = bulkSyncRooms.mock.calls[0]?.[0];
+    expect(Array.isArray(payload)).toBe(true);
+    expect(payload).toHaveLength(1);
+    expect(payload?.[0]).toMatchObject({
+      id: "!new-group:s",
+      name: "Project Alpha",
+      isGroup: true,
+      members: ["me", "alice", "bob"],
+      membership: "join",
+      isDeleted: false,
+      hasMoreHistory: true,
+      lastReadInboundTs: 0,
+      lastReadOutboundTs: 0,
+    });
+  });
+
+  it("re-issues the Dexie write when the same room is added again (acts as update)", () => {
+    const { kit, bulkSyncRooms } = makeKit();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store.setChatDbKit(kit as any);
+
+    store.addRoom(makeRoom({ id: "!r:s", name: "Old name", updatedAt: 1 }));
+    store.addRoom(makeRoom({ id: "!r:s", name: "New name", updatedAt: 2 }));
+
+    expect(bulkSyncRooms).toHaveBeenCalledTimes(2);
+    expect(bulkSyncRooms.mock.calls[1]?.[0]?.[0]).toMatchObject({
+      id: "!r:s",
+      name: "New name",
+      updatedAt: 2,
+    });
+  });
+
+  it("does not crash when the Dexie write rejects (warn-and-continue)", async () => {
+    const bulkSyncRooms = vi.fn(async () => {
+      throw new Error("db down");
+    });
+    const kit = {
+      rooms: {
+        bulkSyncRooms,
+        getAllRooms: vi.fn(async () => []),
+        observeRoomChanges: vi.fn(() => () => {}),
+      },
+      eventWriter: { enableBatching: vi.fn() },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store.setChatDbKit(kit as any);
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    store.addRoom(makeRoom({ id: "!r:s" }));
+    // Pinia/runtime should let the rejection settle without throwing
+    await new Promise((r) => setImmediate(r));
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -3400,6 +3400,43 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       rooms.value.push(room);
     }
     roomsMap.set(room.id, existing ?? room);
+
+    // Optimistic Dexie write: rooms produced by `createGroup` (and other
+    // explicit "I just created/joined this" code paths) used to live only in
+    // the in-memory Pinia state until the next Matrix /sync arrived and
+    // `fullRoomRefresh` mirrored everything to Dexie. If the user closed the
+    // app in that window, the newly created group was lost on cold-start —
+    // see WEE-24 / forta-bugs#553. `bulkSyncRooms` handles both new-insert
+    // (full defaults) and merge-with-existing semantics, so it is safe to
+    // call unconditionally here. Fire-and-forget — UI already updated.
+    if (chatDbKitRef.value) {
+      chatDbKitRef.value.rooms
+        .bulkSyncRooms([
+          {
+            id: room.id,
+            name: room.name,
+            avatar: room.avatar,
+            isGroup: room.isGroup,
+            members: room.members,
+            membership: room.membership ?? "join",
+            topic: room.topic,
+            syncedAt: Date.now(),
+            updatedAt: room.updatedAt,
+            lastMessageTimestamp: room.lastMessage?.timestamp,
+            serverUnreadCount: room.unreadCount,
+            unreadCount: room.unreadCount,
+            hasMoreHistory: true,
+            lastReadInboundTs: 0,
+            lastReadOutboundTs: 0,
+            isDeleted: false,
+            deletedAt: null,
+            deleteReason: null,
+          },
+        ])
+        .catch((e: unknown) => {
+          console.warn("[chat-store] addRoom: optimistic Dexie write failed:", e);
+        });
+    }
   };
 
   /** Helper: optimistically remove a room from runtime UI state */

--- a/src/features/channels/ui/ChannelList.vue
+++ b/src/features/channels/ui/ChannelList.vue
@@ -16,11 +16,21 @@ const emit = defineEmits<{ selectChannel: [address: string] }>();
 
 const scrollerRef = ref<InstanceType<typeof RecycleScroller>>();
 
-onMounted(() => {
+onMounted(async () => {
+  // Hydrate from Dexie first so the sidebar shows the persisted list
+  // immediately on cold-start — without waiting for the (potentially slow,
+  // Tor-routed) Pocketnet RPC `getsubscribeschannels` response. WEE-24.
+  if (channelStore.channels.length === 0) {
+    await channelStore.hydrateFromDexie();
+  }
+
   if (channelStore.channels.length === 0) {
     channelStore.fetchChannels(true).then(() => nextTick(prefetchVisiblePosts));
   } else {
     nextTick(prefetchVisiblePosts);
+    // Refresh in the background so newly subscribed channels appear and stale
+    // previews update — Dexie data is the first-paint, RPC the second.
+    channelStore.fetchChannels(true);
   }
   attachScrollListener();
 });

--- a/src/shared/lib/local-db/channel-repository.test.ts
+++ b/src/shared/lib/local-db/channel-repository.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Dexie from "dexie";
+import "fake-indexeddb/auto";
+import { ChannelRepository } from "./channel-repository";
+import type { LocalChannel } from "./schema";
+
+class TestDb extends Dexie {
+  channels!: import("dexie").Table<LocalChannel, string>;
+  constructor() {
+    super("test-channel-repo", { indexedDB, IDBKeyRange });
+    this.version(1).stores({
+      channels: "address, syncOrder, updatedAt",
+    });
+  }
+}
+
+function makeChannel(over: Partial<LocalChannel> = {}): LocalChannel {
+  return {
+    address: over.address ?? "addr_default",
+    name: over.name ?? "Default",
+    avatar: over.avatar ?? "",
+    lastContent: over.lastContent ?? null,
+    syncOrder: over.syncOrder ?? 0,
+    updatedAt: over.updatedAt ?? Date.now(),
+  };
+}
+
+describe("ChannelRepository", () => {
+  let db: TestDb;
+  let repo: ChannelRepository;
+
+  beforeEach(() => {
+    db = new TestDb();
+    repo = new ChannelRepository(db as never);
+  });
+
+  afterEach(async () => {
+    await db.delete();
+  });
+
+  it("returns persisted channels in syncOrder", async () => {
+    await db.channels.bulkPut([
+      makeChannel({ address: "c", name: "C", syncOrder: 2 }),
+      makeChannel({ address: "a", name: "A", syncOrder: 0 }),
+      makeChannel({ address: "b", name: "B", syncOrder: 1 }),
+    ]);
+
+    const result = await repo.getAll();
+
+    expect(result.map((c) => c.address)).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns an empty array when no channels are persisted", async () => {
+    const result = await repo.getAll();
+    expect(result).toEqual([]);
+  });
+
+  it("replaceAll wipes the previous set before inserting (drops unsubscribed)", async () => {
+    await db.channels.bulkPut([
+      makeChannel({ address: "old1", name: "Old1", syncOrder: 0 }),
+      makeChannel({ address: "old2", name: "Old2", syncOrder: 1 }),
+    ]);
+
+    await repo.replaceAll([
+      makeChannel({ address: "new1", name: "New1", syncOrder: 0 }),
+    ]);
+
+    const result = await repo.getAll();
+    expect(result.map((c) => c.address)).toEqual(["new1"]);
+  });
+
+  it("replaceAll with empty array clears the table", async () => {
+    await db.channels.bulkPut([makeChannel({ address: "old1", syncOrder: 0 })]);
+
+    await repo.replaceAll([]);
+
+    expect(await repo.getAll()).toEqual([]);
+  });
+
+  it("bulkUpsert appends new entries and updates existing ones in-place", async () => {
+    await db.channels.bulkPut([
+      makeChannel({ address: "a", name: "A", syncOrder: 0 }),
+      makeChannel({ address: "b", name: "B", syncOrder: 1 }),
+    ]);
+
+    await repo.bulkUpsert([
+      makeChannel({ address: "b", name: "B-renamed", syncOrder: 1 }),
+      makeChannel({ address: "c", name: "C", syncOrder: 2 }),
+    ]);
+
+    const result = await repo.getAll();
+    expect(result.map((c) => `${c.address}:${c.name}`)).toEqual([
+      "a:A",
+      "b:B-renamed",
+      "c:C",
+    ]);
+  });
+
+  it("bulkUpsert with an empty array is a no-op", async () => {
+    await db.channels.bulkPut([makeChannel({ address: "a", syncOrder: 0 })]);
+    await repo.bulkUpsert([]);
+    expect((await repo.getAll()).map((c) => c.address)).toEqual(["a"]);
+  });
+
+  it("clear removes every persisted channel", async () => {
+    await db.channels.bulkPut([
+      makeChannel({ address: "a", syncOrder: 0 }),
+      makeChannel({ address: "b", syncOrder: 1 }),
+    ]);
+
+    await repo.clear();
+
+    expect(await repo.getAll()).toEqual([]);
+  });
+
+  it("preserves the full last-content payload for cold-start rehydration", async () => {
+    await repo.replaceAll([
+      makeChannel({
+        address: "a",
+        name: "A",
+        avatar: "https://example.test/avatar.png",
+        lastContent: {
+          txid: "tx-1",
+          type: "share",
+          caption: "Hello",
+          message: "World",
+          time: 1700000000,
+          height: 5000000,
+          scoreSum: 12,
+          scoreCnt: 4,
+          comments: 3,
+          images: ["img1"],
+          url: "https://example.test",
+          tags: ["news"],
+          settings: { v: "a" },
+        },
+        syncOrder: 0,
+      }),
+    ]);
+
+    const [stored] = await repo.getAll();
+    expect(stored.lastContent).toEqual({
+      txid: "tx-1",
+      type: "share",
+      caption: "Hello",
+      message: "World",
+      time: 1700000000,
+      height: 5000000,
+      scoreSum: 12,
+      scoreCnt: 4,
+      comments: 3,
+      images: ["img1"],
+      url: "https://example.test",
+      tags: ["news"],
+      settings: { v: "a" },
+    });
+    expect(stored.avatar).toBe("https://example.test/avatar.png");
+  });
+});

--- a/src/shared/lib/local-db/channel-repository.ts
+++ b/src/shared/lib/local-db/channel-repository.ts
@@ -1,0 +1,38 @@
+import type { ChatDatabase, LocalChannel } from "./schema";
+
+/**
+ * Persistence layer for Bastyon channel subscriptions. Owned by the
+ * `channel-store` so its sidebar renders from Dexie immediately on
+ * cold-start, before the Pocketnet RPC `getsubscribeschannels` response
+ * arrives (slow under Tor / cold cache). See WEE-24.
+ */
+export class ChannelRepository {
+  constructor(private db: ChatDatabase) {}
+
+  /** Returns all persisted channels in their original RPC order. */
+  async getAll(): Promise<LocalChannel[]> {
+    return this.db.channels.orderBy("syncOrder").toArray();
+  }
+
+  /** Replace the persisted channel set with `channels`. Used after a `reset=true`
+   *  RPC fetch so unsubscribed channels are removed locally too. Atomic. */
+  async replaceAll(channels: LocalChannel[]): Promise<void> {
+    await this.db.transaction("rw", this.db.channels, async () => {
+      await this.db.channels.clear();
+      if (channels.length > 0) {
+        await this.db.channels.bulkPut(channels);
+      }
+    });
+  }
+
+  /** Append a page of freshly fetched channels. Dedupes by primary key. */
+  async bulkUpsert(channels: LocalChannel[]): Promise<void> {
+    if (channels.length === 0) return;
+    await this.db.channels.bulkPut(channels);
+  }
+
+  /** Remove all persisted channels — invoked on logout via the chat-db lifecycle. */
+  async clear(): Promise<void> {
+    await this.db.channels.clear();
+  }
+}

--- a/src/shared/lib/local-db/index.ts
+++ b/src/shared/lib/local-db/index.ts
@@ -16,6 +16,8 @@ export type {
   DecryptionJob,
   ListenedMessage,
   SearchCacheRow,
+  LocalChannel,
+  ChannelLastContent,
 } from "./schema";
 export { DecryptionWorker } from "./decryption-worker";
 export { ListenedRepository } from "./listened-repository";
@@ -31,6 +33,7 @@ export {
 } from "./timeline-sort";
 export { RoomRepository } from "./room-repository";
 export type { RoomChange } from "./room-repository";
+export { ChannelRepository } from "./channel-repository";
 export { UserRepository } from "./user-repository";
 export { SyncEngine } from "./sync-engine";
 export { EventWriter } from "./event-writer";
@@ -51,6 +54,7 @@ export type { BufferedWrite, WriteBufferOptions } from "./write-buffer";
 import { ChatDatabase } from "./schema";
 import { MessageRepository } from "./message-repository";
 import { RoomRepository } from "./room-repository";
+import { ChannelRepository } from "./channel-repository";
 import { UserRepository } from "./user-repository";
 import { SyncEngine } from "./sync-engine";
 import { EventWriter } from "./event-writer";
@@ -63,6 +67,7 @@ export interface ChatDbKit {
   db: ChatDatabase;
   messages: MessageRepository;
   rooms: RoomRepository;
+  channels: ChannelRepository;
   users: UserRepository;
   syncEngine: SyncEngine;
   eventWriter: EventWriter;
@@ -110,6 +115,7 @@ export function initChatDb(
   const db = new ChatDatabase(userId);
   const messages = new MessageRepository(db);
   const rooms = new RoomRepository(db);
+  const channels = new ChannelRepository(db);
   const users = new UserRepository(db);
   const listened = new ListenedRepository(db);
   const searchCache = new SearchCacheRepository(db);
@@ -178,7 +184,7 @@ export function initChatDb(
     console.warn("[local-db] SearchCache GC failed:", e);
   });
 
-  currentKit = { db, messages, rooms, users, syncEngine, eventWriter, decryptionWorker, listened, searchCache, retryRoomDecryption: retryRoomDebounced, dispose: disposeRetryTriggers };
+  currentKit = { db, messages, rooms, channels, users, syncEngine, eventWriter, decryptionWorker, listened, searchCache, retryRoomDecryption: retryRoomDebounced, dispose: disposeRetryTriggers };
   currentUserId = userId;
 
   return currentKit;

--- a/src/shared/lib/local-db/schema.ts
+++ b/src/shared/lib/local-db/schema.ts
@@ -213,6 +213,40 @@ export interface SearchCacheRow {
   expiresAt: number;               // Unix ms — entry is considered stale past this
 }
 
+// ---------------------------------------------------------------------------
+// Channels (Bastyon broadcast subscriptions)
+// ---------------------------------------------------------------------------
+
+export interface ChannelLastContent {
+  txid: string;
+  type: "video" | "share" | "article";
+  caption: string;
+  message: string;
+  time: number;
+  height: number;
+  scoreSum: number;
+  scoreCnt: number;
+  comments: number;
+  images?: string[];
+  url?: string;
+  tags?: string[];
+  settings?: { v?: string };
+}
+
+/** Persisted Bastyon channel subscription. Source of truth for cold-start render
+ *  before the Pocketnet RPC `getsubscribeschannels` response arrives. */
+export interface LocalChannel {
+  address: string;                 // PK: channel author Bastyon address
+  name: string;
+  avatar: string;
+  lastContent: ChannelLastContent | null;
+  /** Preserves the order returned by Pocketnet RPC across cold-starts.
+   *  Lower = higher in the list. Backfilled per fetch page. */
+  syncOrder: number;
+  /** Timestamp of the latest RPC refresh that touched this entry. */
+  updatedAt: number;
+}
+
 /** Queued decryption retry job */
 export interface DecryptionJob {
   id?: number;                   // Auto PK
@@ -241,6 +275,7 @@ export class ChatDatabase extends Dexie {
   decryptionQueue!: Table<DecryptionJob>;
   listenedMessages!: Table<ListenedMessage>;
   searchCache!: Table<SearchCacheRow>;
+  channels!: Table<LocalChannel>;
 
   constructor(userId: string) {
     super(`bastyon-chat-${userId}`);
@@ -609,6 +644,24 @@ export class ChatDatabase extends Dexie {
       decryptionQueue: "++id, eventId, roomId, status, [status+nextAttemptAt]",
       listenedMessages: "messageId",
       searchCache: "query, expiresAt",
+    });
+
+    // Version 14: add channels table. Bastyon broadcast subscriptions used to
+    // live only in transient Pinia state, so a slow Pocketnet RPC response on
+    // cold-start showed an empty sidebar — users reported it as data loss
+    // (forta-bugs#736, #553, #762, #471, WEE-24). PK: channel address;
+    // syncOrder index preserves RPC list order across restarts.
+    this.version(14).stores({
+      rooms: "id, updatedAt, membership, isDeleted",
+      messages: "++localId, eventId, clientId, [roomId+timestamp], [roomId+status], senderId",
+      users: "address, updatedAt, aliasUpdatedAt",
+      pendingOps: "++id, [roomId+createdAt], status, clientId, [status+nextAttemptAt]",
+      syncState: "key",
+      attachments: "++id, messageLocalId, status",
+      decryptionQueue: "++id, eventId, roomId, status, [status+nextAttemptAt]",
+      listenedMessages: "messageId",
+      searchCache: "query, expiresAt",
+      channels: "address, syncOrder, updatedAt",
     });
   }
 }

--- a/src/widgets/sidebar/ChatSidebar.vue
+++ b/src/widgets/sidebar/ChatSidebar.vue
@@ -30,8 +30,11 @@ useAndroidBackHandler("chat-selection", 92, () => {
   return false;
 });
 
-onMounted(() => {
+onMounted(async () => {
   chatStore.loadCachedRooms();
+  // Show persisted channel list immediately, then refresh from RPC in
+  // the background — same pattern chatStore already uses for rooms (WEE-24).
+  await channelStore.hydrateFromDexie();
   channelStore.fetchChannels(true);
 });
 


### PR DESCRIPTION
## Summary

- **Channels (H1)** — `channel-store` now hydrates from a new Dexie `channels` table on cold-start so the sidebar paints instantly. Slow Pocketnet RPC under Tor used to leave the list empty for ~10–20s on every boot, which users reported as "channels disappeared". Each `fetchChannels` response is persisted (`replaceAll` on `reset=true`, `bulkUpsert` on pagination).
- **Groups (H2)** — `chat-store.addRoom` (the createGroup landing pad) now mirrors the room to Dexie via `bulkSyncRooms` immediately. Previously the optimistic write only lived in Pinia and the next Matrix `/sync` was responsible for persistence — if the user closed the app in that window the new group was lost.
- **Schema v14** adds the `channels` table (`address` PK, indexed by `syncOrder`, `updatedAt`). Dexie auto-creates the empty table; no data migration required.
- **In-flight guard** in `fetchChannels` dedupes the ChatSidebar/ChannelList race (both kick off `fetchChannels(true)` from their `onMounted`).

## Linear

- Resolves [WEE-24](https://linear.app/wwwee/issue/WEE-24/groups-gruppykanaly-propadayut-posle-povtornogo-zapuska-prilozheniya)

## Closes

- Closes greenShirtMystery/forta-bugs#736
- Closes greenShirtMystery/forta-bugs#553
- Closes greenShirtMystery/forta-bugs#762
- Closes greenShirtMystery/forta-bugs#471

## Test plan

- [x] `vite build` succeeds
- [x] 86/86 tests pass across channel-repository, channel-store, chat-store, room-repository
- [x] New regression tests:
  - `channel-repository.test.ts` — CRUD against fake-indexeddb (7)
  - `channel-store-persistence.test.ts` — hydrate / persist / no-overwrite / idempotent / "no flash empty" / concurrent dedup / Dexie failure (11)
  - `chat-store-add-room-persist.test.ts` — addRoom Dexie write present/absent/error path (4)
- [ ] Manual QA on Android (Tor):
  - Cold-start with Tor enabled — channel list renders from Dexie immediately
  - Create a new group, force-quit before sync — group survives restart
  - Logout / re-login as a different user — channel list reflects the new account (per-user Dexie isolation already in place)