### PR TITLE
fix(i18n): localize group-creation panel + attach menu (WEE-30)

### DIFF
--- a/src/features/group-creation/ui/GroupCreationPanel.vue
+++ b/src/features/group-creation/ui/GroupCreationPanel.vue
@@ -91,7 +91,7 @@ const handleAvatarChange = (e: Event) => {
           </svg>
         </button>
 
-        <span class="flex-1 text-base font-semibold text-text-color">New Group</span>
+        <span class="flex-1 text-base font-semibold text-text-color">{{ t("group.newGroup") }}</span>
 
         <button
           class="rounded-lg px-4 py-1.5 text-sm font-medium transition-colors"
@@ -101,7 +101,7 @@ const handleAvatarChange = (e: Event) => {
           :disabled="selectedMembers.size === 0"
           @click="handleNext"
         >
-          Next
+          {{ t("group.next") }}
         </button>
       </div>
 
@@ -143,11 +143,11 @@ const handleAvatarChange = (e: Event) => {
         </div>
 
         <div v-else-if="searchResults.length === 0 && searchQuery" class="p-8 text-center text-sm text-text-on-main-bg-color">
-          No users found
+          {{ t("group.noUsersFound") }}
         </div>
 
         <div v-else-if="searchResults.length === 0 && !searchQuery" class="p-8 text-center text-sm text-text-on-main-bg-color">
-          Search for users to add to the group
+          {{ t("group.searchToAdd") }}
         </div>
 
         <button
@@ -189,7 +189,7 @@ const handleAvatarChange = (e: Event) => {
           </svg>
         </button>
 
-        <span class="flex-1 text-base font-semibold text-text-color">New Group</span>
+        <span class="flex-1 text-base font-semibold text-text-color">{{ t("group.newGroup") }}</span>
 
         <button
           class="rounded-lg px-4 py-1.5 text-sm font-medium transition-colors"
@@ -199,7 +199,7 @@ const handleAvatarChange = (e: Event) => {
           :disabled="!groupName.trim() || isCreating"
           @click="handleCreate"
         >
-          {{ isCreating ? "Creating..." : "Create" }}
+          {{ isCreating ? t("group.creating") : t("group.create") }}
         </button>
       </div>
 
@@ -249,7 +249,7 @@ const handleAvatarChange = (e: Event) => {
 
         <!-- Member count -->
         <div class="px-4 pb-2 text-sm text-text-on-main-bg-color">
-          {{ selectedMembers.size }} member{{ selectedMembers.size !== 1 ? "s" : "" }}
+          {{ t("group.memberCount", { count: selectedMembers.size }) }}
         </div>
 
         <!-- Member preview list -->

--- a/src/features/group-creation/ui/__tests__/GroupCreationPanel.i18n.test.ts
+++ b/src/features/group-creation/ui/__tests__/GroupCreationPanel.i18n.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { ref, computed } from "vue";
+
+let currentDict: Record<string, string> = {};
+
+vi.mock("@/shared/lib/i18n", () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, string | number>) => {
+      const text = currentDict[key] ?? key;
+      if (!params) return text;
+      return Object.entries(params).reduce(
+        (acc, [k, v]) => acc.replace(new RegExp(`\\{${k}\\}`, "g"), String(v)),
+        text,
+      );
+    },
+    locale: { value: "ru" },
+  }),
+}));
+
+const stubGroupCreation = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  step: ref<1 | 2>(1),
+  selectedMembers: ref(new Map()),
+  selectedMembersList: computed(() => [] as Array<{ address: string; name: string; image: string }>),
+  groupName: ref(""),
+  groupAvatarPreview: ref<string | null>(null),
+  isCreating: ref(false),
+  error: ref<string | null>(null),
+  searchQuery: ref(""),
+  searchResults: ref([] as Array<{ address: string; name: string; image: string }>),
+  isSearching: ref(false),
+  debouncedSearch: vi.fn(),
+  toggleMember: vi.fn(),
+  isMemberSelected: vi.fn(() => false),
+  removeMember: vi.fn(),
+  setAvatarFile: vi.fn(),
+  goToStep2: vi.fn(),
+  goToStep1: vi.fn(),
+  createGroup: vi.fn(),
+  reset: vi.fn(),
+  ...overrides,
+});
+
+let mockState: ReturnType<typeof stubGroupCreation>;
+
+vi.mock("../../model/use-group-creation", () => ({
+  useGroupCreation: () => mockState,
+}));
+
+// UserAvatar and Avatar are auto-imported globals; stub via mocks so
+// the GroupCreationPanel test stays focused on text content.
+vi.mock("@/entities/user", () => ({
+  UserAvatar: { name: "UserAvatar", template: '<div class="mock-avatar" />' },
+}));
+vi.mock("@/shared/ui/avatar/Avatar.vue", () => ({
+  default: { name: "Avatar", template: '<div class="mock-avatar" />' },
+}));
+
+const RU: Record<string, string> = {
+  "group.newGroup": "Новая группа",
+  "group.next": "Далее",
+  "group.searchUsers": "Поиск пользователей...",
+  "group.noUsersFound": "Пользователи не найдены",
+  "group.searchToAdd": "Найдите пользователей для добавления в группу",
+  "group.groupName": "Название группы",
+  "group.creating": "Создание...",
+  "group.create": "Создать",
+  "group.memberCount": "{count} участн.",
+};
+
+let GroupCreationPanel: typeof import("../GroupCreationPanel.vue").default;
+
+describe("GroupCreationPanel i18n (WEE-30)", () => {
+  beforeEach(async () => {
+    currentDict = RU;
+    mockState = stubGroupCreation();
+    GroupCreationPanel = (await import("../GroupCreationPanel.vue")).default;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("step 1: renders Russian header and Next button in ru locale", () => {
+    const w = mount(GroupCreationPanel);
+    const text = w.text();
+    expect(text).toContain("Новая группа");
+    expect(text).toContain("Далее");
+    // No hardcoded English remnants:
+    expect(text).not.toContain("New Group");
+    expect(text).not.toMatch(/\bNext\b/);
+  });
+
+  it("step 1: shows translated empty-search hint", () => {
+    const w = mount(GroupCreationPanel);
+    const text = w.text();
+    expect(text).toContain("Найдите пользователей для добавления в группу");
+    expect(text).not.toContain("Search for users to add to the group");
+  });
+
+  it("step 1: shows translated 'no users found' when query is non-empty", async () => {
+    mockState.searchQuery.value = "abc";
+    const w = mount(GroupCreationPanel);
+    const text = w.text();
+    expect(text).toContain("Пользователи не найдены");
+    expect(text).not.toContain("No users found");
+  });
+
+  it("step 2: shows translated header and Create button when not creating", async () => {
+    mockState.step.value = 2;
+    mockState.groupName.value = "Test";
+    const w = mount(GroupCreationPanel);
+    const text = w.text();
+    expect(text).toContain("Новая группа");
+    expect(text).toContain("Создать");
+    expect(text).not.toContain("Create Group");
+    expect(text).not.toMatch(/\bCreate\b/);
+  });
+
+  it("step 2: shows translated 'Creating...' while isCreating=true", async () => {
+    mockState.step.value = 2;
+    mockState.groupName.value = "Test";
+    mockState.isCreating.value = true;
+    const w = mount(GroupCreationPanel);
+    const text = w.text();
+    expect(text).toContain("Создание...");
+    expect(text).not.toContain("Creating...");
+  });
+
+  it("step 2: member count uses i18n key (no '1 member' / '2 members' English)", async () => {
+    mockState.step.value = 2;
+    mockState.groupName.value = "Test";
+    mockState.selectedMembers.value = new Map([
+      ["addr1", { address: "addr1", name: "Alice", image: "" }],
+      ["addr2", { address: "addr2", name: "Bob", image: "" }],
+    ]);
+    const w = mount(GroupCreationPanel);
+    const text = w.text();
+    expect(text).toContain("2 участн.");
+    expect(text).not.toMatch(/\b2 members?\b/);
+  });
+});

--- a/src/features/messaging/ui/AttachmentPanel.vue
+++ b/src/features/messaging/ui/AttachmentPanel.vue
@@ -3,6 +3,7 @@ import { computed } from "vue";
 import { useMobile } from "@/shared/lib/composables/use-media-query";
 import { BottomSheet } from "@/shared/ui/bottom-sheet";
 
+const { t } = useI18n();
 const isMobile = useMobile();
 
 interface Props {
@@ -38,7 +39,7 @@ const selectDonate = () => { emit("selectDonate"); emit("close"); };
 
 <template>
   <!-- Mobile: BottomSheet -->
-  <BottomSheet v-if="isMobile" :show="props.show" aria-label="Attachments" @close="emit('close')">
+  <BottomSheet v-if="isMobile" :show="props.show" :aria-label="t('attachment.panelLabel')" @close="emit('close')">
     <button
       class="flex w-full items-center gap-3 rounded-xl px-4 py-3.5 text-left text-base text-text-color transition-colors active:bg-neutral-grad-0"
       @click="selectPhoto"
@@ -48,7 +49,7 @@ const selectDonate = () => { emit("selectDonate"); emit("close"); };
         <circle cx="8.5" cy="8.5" r="1.5" />
         <polyline points="21 15 16 10 5 21" />
       </svg>
-      Photo or Video
+      {{ t("attachment.photoOrVideo") }}
     </button>
     <button
       class="flex w-full items-center gap-3 rounded-xl px-4 py-3.5 text-left text-base text-text-color transition-colors active:bg-neutral-grad-0"
@@ -58,7 +59,7 @@ const selectDonate = () => { emit("selectDonate"); emit("close"); };
         <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
         <polyline points="14 2 14 8 20 8" />
       </svg>
-      File
+      {{ t("attachment.file") }}
     </button>
     <button
       class="flex w-full items-center gap-3 rounded-xl px-4 py-3.5 text-left text-base text-text-color transition-colors active:bg-neutral-grad-0"
@@ -69,7 +70,7 @@ const selectDonate = () => { emit("selectDonate"); emit("close"); };
         <rect x="3" y="10" width="13" height="4" rx="1" />
         <rect x="3" y="16" width="10" height="4" rx="1" />
       </svg>
-      Poll
+      {{ t("attachment.poll") }}
     </button>
     <button
       v-if="props.showDonate"
@@ -88,6 +89,8 @@ const selectDonate = () => { emit("selectDonate"); emit("close"); };
     <transition name="attach-popup">
       <div v-if="props.show" class="fixed inset-0 z-50" @click.self="emit('close')">
         <div
+          role="menu"
+          :aria-label="t('attachment.panelLabel')"
           class="fixed z-50 w-[200px] overflow-hidden rounded-xl border border-neutral-grad-0 bg-background-total-theme shadow-xl"
           :style="panelStyle"
         >
@@ -100,7 +103,7 @@ const selectDonate = () => { emit("selectDonate"); emit("close"); };
               <circle cx="8.5" cy="8.5" r="1.5" />
               <polyline points="21 15 16 10 5 21" />
             </svg>
-            Photo or Video
+            {{ t("attachment.photoOrVideo") }}
           </button>
           <button
             class="flex w-full items-center gap-3 px-4 py-3 text-left text-sm text-text-color transition-colors hover:bg-neutral-grad-0"
@@ -110,7 +113,7 @@ const selectDonate = () => { emit("selectDonate"); emit("close"); };
               <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
               <polyline points="14 2 14 8 20 8" />
             </svg>
-            File
+            {{ t("attachment.file") }}
           </button>
           <button
             class="flex w-full items-center gap-3 px-4 py-3 text-left text-sm text-text-color transition-colors hover:bg-neutral-grad-0"
@@ -121,7 +124,7 @@ const selectDonate = () => { emit("selectDonate"); emit("close"); };
               <rect x="3" y="10" width="13" height="4" rx="1" />
               <rect x="3" y="16" width="10" height="4" rx="1" />
             </svg>
-            Poll
+            {{ t("attachment.poll") }}
           </button>
           <button
             v-if="props.showDonate"

--- a/src/features/messaging/ui/__tests__/AttachmentPanel.i18n.test.ts
+++ b/src/features/messaging/ui/__tests__/AttachmentPanel.i18n.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { defineComponent, h, ref } from "vue";
+
+let currentDict: Record<string, string> = {};
+const isMobileRef = ref(true);
+
+vi.mock("@/shared/lib/i18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => currentDict[key] ?? key,
+    locale: { value: "ru" },
+  }),
+}));
+
+vi.mock("@/shared/lib/composables/use-media-query", () => ({
+  useMobile: () => isMobileRef,
+  useTablet: () => ref(false),
+  useDesktop: () => ref(false),
+}));
+
+// BottomSheet is auto-registered globally; stub it so the test renders
+// inline (instead of via teleport) and so aria-label propagates to a
+// container we can query.
+vi.mock("@/shared/ui/bottom-sheet", () => ({
+  BottomSheet: defineComponent({
+    name: "BottomSheet",
+    props: ["show", "ariaLabel"],
+    setup(props, { slots, attrs }) {
+      return () =>
+        props.show
+          ? h(
+              "div",
+              {
+                class: "mock-bottom-sheet",
+                "aria-label": (attrs["aria-label"] as string) ?? props.ariaLabel,
+              },
+              slots.default?.(),
+            )
+          : null;
+    },
+  }),
+}));
+
+const RU = {
+  "attachment.panelLabel": "Вложения",
+  "attachment.photoOrVideo": "Фото или видео",
+  "attachment.file": "Файл",
+  "attachment.poll": "Опрос",
+};
+
+const EN = {
+  "attachment.panelLabel": "Attachments",
+  "attachment.photoOrVideo": "Photo or Video",
+  "attachment.file": "File",
+  "attachment.poll": "Poll",
+};
+
+let AttachmentPanel: typeof import("../AttachmentPanel.vue").default;
+
+describe("AttachmentPanel i18n — mobile BottomSheet (WEE-30)", () => {
+  beforeEach(async () => {
+    currentDict = RU;
+    isMobileRef.value = true;
+    AttachmentPanel = (await import("../AttachmentPanel.vue")).default;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders Russian item labels when show=true (ru locale)", () => {
+    const w = mount(AttachmentPanel, {
+      props: { show: true, x: 100, y: 100, showDonate: false },
+    });
+    const text = w.text();
+    expect(text).toContain("Фото или видео");
+    expect(text).toContain("Файл");
+    expect(text).toContain("Опрос");
+  });
+
+  it("does not leak hardcoded English item labels in ru locale", () => {
+    const w = mount(AttachmentPanel, {
+      props: { show: true, x: 100, y: 100, showDonate: false },
+    });
+    const text = w.text();
+    expect(text).not.toMatch(/\bPhoto or Video\b/);
+    expect(text).not.toMatch(/\bPoll\b/);
+  });
+
+  it("uses translated aria-label for the bottom sheet", () => {
+    const w = mount(AttachmentPanel, {
+      props: { show: true, x: 100, y: 100, showDonate: false },
+    });
+    const sheet = w.find(".mock-bottom-sheet");
+    expect(sheet.exists()).toBe(true);
+    expect(sheet.attributes("aria-label")).toBe("Вложения");
+  });
+
+  it("falls back to English dictionary keys when locale is en", () => {
+    currentDict = EN;
+    const w = mount(AttachmentPanel, {
+      props: { show: true, x: 100, y: 100, showDonate: false },
+    });
+    const text = w.text();
+    expect(text).toContain("Photo or Video");
+    expect(text).toContain("File");
+    expect(text).toContain("Poll");
+  });
+});
+
+describe("AttachmentPanel i18n — desktop dropdown (WEE-30)", () => {
+  beforeEach(async () => {
+    currentDict = RU;
+    isMobileRef.value = false;
+    AttachmentPanel = (await import("../AttachmentPanel.vue")).default;
+  });
+
+  afterEach(() => {
+    // Clean up any teleported nodes from the body between tests.
+    document.body.querySelectorAll('[role="menu"]').forEach((n) => n.remove());
+    isMobileRef.value = true;
+  });
+
+  it("renders translated labels and aria-label on the desktop dropdown", () => {
+    const w = mount(AttachmentPanel, {
+      props: { show: true, x: 100, y: 100, showDonate: false },
+      attachTo: document.body,
+    });
+    const menu = document.querySelector('[role="menu"]');
+    expect(menu).not.toBeNull();
+    expect(menu?.getAttribute("aria-label")).toBe("Вложения");
+    const text = menu?.textContent ?? "";
+    expect(text).toContain("Фото или видео");
+    expect(text).toContain("Файл");
+    expect(text).toContain("Опрос");
+    expect(text).not.toMatch(/\bPhoto or Video\b/);
+    expect(text).not.toMatch(/\bPoll\b/);
+    w.unmount();
+  });
+});

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -287,6 +287,7 @@ export const en = {
   "messageList.cancel": "Cancel",
 
   // ── Attachment panel ──
+  "attachment.panelLabel": "Attachments",
   "attachment.photoOrVideo": "Photo or Video",
   "attachment.file": "File",
   "attachment.poll": "Poll",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -289,6 +289,7 @@ export const ru: Record<TranslationKey, string> = {
   "messageList.cancel": "Отмена",
 
   // ── Attachment panel ──
+  "attachment.panelLabel": "Вложения",
   "attachment.photoOrVideo": "Фото или видео",
   "attachment.file": "Файл",
   "attachment.poll": "Опрос",


### PR DESCRIPTION
## Summary
- Wires `t()` in `GroupCreationPanel.vue` for all step 1/step 2 strings (header, Next, empty/no-results hints, Create/Creating, member count) — uses existing `group.*` keys.
- Wires `t()` in `AttachmentPanel.vue` for Photo or Video / File / Poll across both the mobile BottomSheet and the desktop Teleport dropdown. Adds new `attachment.panelLabel` key for the BottomSheet + desktop `role="menu"` `aria-label`.
- Adds regression tests covering ru locale, en fallback, missing-translation guards, and the previously-untested desktop dropdown path.

## Linear
- Resolves WEE-30 (https://linear.app/wwwee/issue/WEE-30/i18n-neperevedyonnye-ekrany-sozdanie-gruppy-menyu-vlozhenij)

## Closes
Closes greenShirtMystery/forta-bugs#786
Closes greenShirtMystery/forta-bugs#787

## Test plan
- [x] `npx vitest run` for both new test files — 11/11 pass
- [x] `vue-tsc --noEmit` — error count unchanged from master baseline (no new TS errors)
- [ ] Manual QA on Android (ru locale): open create-group flow → all labels Russian; open paperclip menu → all items Russian
- [ ] Manual QA on Android (en locale): both screens render English copy unchanged