### PR TITLE
fix(video-bubble): modern Telegram-style frame + thumbnail + duration overlay (WEE-32)

### DIFF
--- a/src/features/messaging/model/video-thumbnail.test.ts
+++ b/src/features/messaging/model/video-thumbnail.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { formatVideoDuration, extractVideoFrameThumbnail } from "./video-thumbnail";
+
+/**
+ * UX regression for WEE-32 (forta-bugs#788, #789).
+ *
+ * Video bubbles in chat must display a Telegram-style duration badge and a
+ * generated first-frame poster. These helpers underpin both: `formatVideoDuration`
+ * formats the duration shown in the bottom-right badge; `extractVideoFrameThumbnail`
+ * produces the poster shown before the user taps play.
+ */
+
+describe("formatVideoDuration — Telegram-style M:SS / H:MM:SS", () => {
+  it("formats sub-minute durations as M:SS with zero-padded seconds", () => {
+    expect(formatVideoDuration(0)).toBe("0:00");
+    expect(formatVideoDuration(5)).toBe("0:05");
+    expect(formatVideoDuration(30)).toBe("0:30");
+    expect(formatVideoDuration(59)).toBe("0:59");
+  });
+
+  it("formats minute-range durations as M:SS without hour padding", () => {
+    expect(formatVideoDuration(60)).toBe("1:00");
+    expect(formatVideoDuration(65)).toBe("1:05");
+    expect(formatVideoDuration(605)).toBe("10:05");
+    expect(formatVideoDuration(3599)).toBe("59:59");
+  });
+
+  it("switches to H:MM:SS once the duration crosses one hour", () => {
+    expect(formatVideoDuration(3600)).toBe("1:00:00");
+    expect(formatVideoDuration(3725)).toBe("1:02:05");
+    expect(formatVideoDuration(36005)).toBe("10:00:05");
+  });
+
+  it("floors fractional seconds (does not round up)", () => {
+    expect(formatVideoDuration(59.9)).toBe("0:59");
+    expect(formatVideoDuration(0.99)).toBe("0:00");
+  });
+
+  it("returns empty string for invalid input so callers can hide the badge", () => {
+    expect(formatVideoDuration(undefined)).toBe("");
+    expect(formatVideoDuration(null)).toBe("");
+    expect(formatVideoDuration(Number.NaN)).toBe("");
+    expect(formatVideoDuration(Number.POSITIVE_INFINITY)).toBe("");
+    expect(formatVideoDuration(-5)).toBe("");
+  });
+});
+
+describe("extractVideoFrameThumbnail — first-frame poster generation", () => {
+  // happy-dom does not decode video frames or back canvas.toBlob with a real
+  // encoder, so we stub the DOM seams the helper uses. These tests verify the
+  // orchestration contract (seek, draw, encode, revoke on failure) rather than
+  // the image data itself.
+
+  let createdVideos: FakeVideo[];
+  let createdCanvases: FakeCanvas[];
+  let originalCreateElement: typeof document.createElement;
+  let originalCreateObjectURL: typeof URL.createObjectURL;
+
+  type Listener = () => void;
+
+  class FakeVideo {
+    src = "";
+    preload = "";
+    muted = false;
+    crossOrigin: string | null = null;
+    playsInline = false;
+    currentTime = 0;
+    videoWidth = 320;
+    videoHeight = 240;
+    duration = 12.5;
+    listeners: Record<string, Listener[]> = {};
+    addEventListener(name: string, fn: Listener) {
+      (this.listeners[name] ||= []).push(fn);
+    }
+    removeEventListener(name: string, fn: Listener) {
+      this.listeners[name] = (this.listeners[name] ?? []).filter((l) => l !== fn);
+    }
+    removeAttribute() {/* noop */}
+    load() {/* noop */}
+    fire(name: string) {
+      for (const l of this.listeners[name] ?? []) l();
+    }
+  }
+
+  class FakeCanvas {
+    width = 0;
+    height = 0;
+    drawn = false;
+    toBlobArgs: { type?: string; quality?: number } = {};
+    getContext() {
+      return {
+        drawImage: () => { this.drawn = true; },
+      };
+    }
+    toBlob(cb: (b: Blob | null) => void, type?: string, quality?: number) {
+      this.toBlobArgs = { type, quality };
+      // Resolve asynchronously so the helper's promise chain mirrors real browsers.
+      queueMicrotask(() => cb(new Blob(["fake"], { type: type ?? "image/jpeg" })));
+    }
+  }
+
+  beforeEach(() => {
+    createdVideos = [];
+    createdCanvases = [];
+    originalCreateElement = document.createElement.bind(document);
+    originalCreateObjectURL = URL.createObjectURL.bind(URL);
+
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      if (tag === "video") {
+        const v = new FakeVideo();
+        createdVideos.push(v);
+        return v as unknown as HTMLVideoElement;
+      }
+      if (tag === "canvas") {
+        const c = new FakeCanvas();
+        createdCanvases.push(c);
+        return c as unknown as HTMLCanvasElement;
+      }
+      return originalCreateElement(tag);
+    });
+    vi.spyOn(URL, "createObjectURL").mockImplementation(() => "blob:fake/thumb");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    void originalCreateObjectURL;
+  });
+
+  it("seeks past the first keyframe, draws to canvas, and resolves with a blob URL", async () => {
+    const promise = extractVideoFrameThumbnail("blob:fake/video");
+    // Flush microtask so the helper has attached listeners and set src.
+    await Promise.resolve();
+    const video = createdVideos[0];
+    expect(video).toBeDefined();
+    video.fire("loadeddata");
+    // Helper should request a seek shortly after loadeddata.
+    expect(video.currentTime).toBeGreaterThan(0);
+    video.fire("seeked");
+    const url = await promise;
+    expect(url).toBe("blob:fake/thumb");
+    const canvas = createdCanvases[0];
+    expect(canvas).toBeDefined();
+    expect(canvas.drawn).toBe(true);
+    expect(canvas.toBlobArgs.type).toBe("image/jpeg");
+  });
+
+  it("resolves to null and does not draw when the video errors before metadata loads", async () => {
+    const promise = extractVideoFrameThumbnail("blob:fake/broken");
+    await Promise.resolve();
+    const video = createdVideos[0];
+    video.fire("error");
+    const url = await promise;
+    expect(url).toBeNull();
+    expect(createdCanvases.length === 0 || createdCanvases[0].drawn === false).toBe(true);
+  });
+
+  it("clamps the seek target to the video's duration to avoid seeking past the end", async () => {
+    const promise = extractVideoFrameThumbnail("blob:fake/short", { seekSeconds: 30 });
+    await Promise.resolve();
+    const video = createdVideos[0];
+    video.duration = 1.0;
+    video.fire("loadeddata");
+    // currentTime must stay inside the playable window.
+    expect(video.currentTime).toBeLessThan(video.duration);
+    video.fire("seeked");
+    await promise;
+  });
+
+  it("resolves to null when the video reports zero dimensions (decoder failed)", async () => {
+    const promise = extractVideoFrameThumbnail("blob:fake/empty");
+    await Promise.resolve();
+    const video = createdVideos[0];
+    video.videoWidth = 0;
+    video.videoHeight = 0;
+    video.fire("loadeddata");
+    video.fire("seeked");
+    const url = await promise;
+    expect(url).toBeNull();
+  });
+});

--- a/src/features/messaging/model/video-thumbnail.ts
+++ b/src/features/messaging/model/video-thumbnail.ts
@@ -1,0 +1,131 @@
+/**
+ * Video bubble helpers — WEE-32 (forta-bugs#788, #789).
+ *
+ * Two small, pure-ish utilities that let MessageBubble render Telegram-style
+ * video previews: a duration badge and a generated first-frame poster.
+ */
+
+/** Format duration in seconds as "M:SS" or "H:MM:SS" — Telegram-style.
+ *  Returns an empty string for invalid/unknown durations so callers can
+ *  conditionally hide the badge instead of showing "NaN:NaN". */
+export function formatVideoDuration(seconds: number | undefined | null): string {
+  if (typeof seconds !== "number" || !Number.isFinite(seconds) || seconds < 0) return "";
+  const total = Math.floor(seconds);
+  const s = total % 60;
+  const m = Math.floor(total / 60) % 60;
+  const h = Math.floor(total / 3600);
+  const ss = s.toString().padStart(2, "0");
+  if (h > 0) {
+    const mm = m.toString().padStart(2, "0");
+    return `${h}:${mm}:${ss}`;
+  }
+  return `${m}:${ss}`;
+}
+
+interface ExtractOptions {
+  /** Where to seek before grabbing the frame. Defaults to 0.1s so we skip
+   *  the leading black frame some encoders emit. Clamped to `duration - 0.1`. */
+  seekSeconds?: number;
+  /** JPEG quality, 0..1. Defaults to 0.8 — small enough to keep memory low
+   *  but still readable in a chat bubble. */
+  quality?: number;
+  /** Longest side of the resulting thumbnail in CSS pixels. Defaults to 640. */
+  maxDimension?: number;
+}
+
+/** Extract a first-frame JPEG poster from a video URL and return a blob: URL
+ *  to the result. Resolves with `null` (never rejects) on any failure — the
+ *  caller falls back to the native HTML5 placeholder.
+ *
+ *  Caller owns the returned blob URL and must `URL.revokeObjectURL` it when
+ *  the thumbnail is no longer needed. */
+export async function extractVideoFrameThumbnail(
+  videoUrl: string,
+  options: ExtractOptions = {},
+): Promise<string | null> {
+  const seekSeconds = options.seekSeconds ?? 0.1;
+  const quality = options.quality ?? 0.8;
+  const maxDimension = options.maxDimension ?? 640;
+
+  return new Promise<string | null>((resolve) => {
+    let settled = false;
+    const finish = (value: string | null) => {
+      if (settled) return;
+      settled = true;
+      try { video.removeAttribute("src"); } catch { /* ignore */ }
+      try { video.load(); } catch { /* ignore */ }
+      resolve(value);
+    };
+
+    const video = document.createElement("video");
+    video.preload = "auto";
+    video.muted = true;
+    video.crossOrigin = "anonymous";
+    video.playsInline = true;
+
+    const onError = () => finish(null);
+
+    const onSeeked = () => {
+      try {
+        const width = video.videoWidth;
+        const height = video.videoHeight;
+        if (!width || !height) {
+          finish(null);
+          return;
+        }
+        const longest = Math.max(width, height);
+        const scale = longest > maxDimension ? maxDimension / longest : 1;
+        const w = Math.max(1, Math.round(width * scale));
+        const h = Math.max(1, Math.round(height * scale));
+        const canvas = document.createElement("canvas");
+        canvas.width = w;
+        canvas.height = h;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) {
+          finish(null);
+          return;
+        }
+        ctx.drawImage(video, 0, 0, w, h);
+        canvas.toBlob(
+          (blob) => {
+            if (!blob) {
+              finish(null);
+              return;
+            }
+            try {
+              finish(URL.createObjectURL(blob));
+            } catch {
+              finish(null);
+            }
+          },
+          "image/jpeg",
+          quality,
+        );
+      } catch {
+        finish(null);
+      }
+    };
+
+    const onLoadedData = () => {
+      try {
+        const safeDuration = Number.isFinite(video.duration) && video.duration > 0
+          ? video.duration
+          : seekSeconds + 1;
+        const target = Math.min(seekSeconds, Math.max(0, safeDuration - 0.1));
+        video.currentTime = target;
+      } catch {
+        finish(null);
+      }
+    };
+
+    video.addEventListener("error", onError, { once: true });
+    video.addEventListener("loadeddata", onLoadedData, { once: true });
+    video.addEventListener("seeked", onSeeked, { once: true });
+
+    try {
+      video.src = videoUrl;
+    } catch {
+      finish(null);
+    }
+  });
+}

--- a/src/features/messaging/ui/MessageBubble.vue
+++ b/src/features/messaging/ui/MessageBubble.vue
@@ -8,6 +8,7 @@ import { useBugReport } from "@/features/bug-report";
 import { tRaw } from "@/shared/lib/i18n";
 import { useToast } from "@/shared/lib/use-toast";
 import { useVideoStatePreservation } from "@/shared/lib/composables/use-video-state-preservation";
+import { formatVideoDuration, extractVideoFrameThumbnail } from "../model/video-thumbnail";
 import MessageContent from "./MessageContent.vue";
 import MessageStatusIcon from "./MessageStatusIcon.vue";
 import PollCard from "./PollCard.vue";
@@ -196,6 +197,93 @@ const fileState = computed(() => getState(fileCacheKey.value));
 
 const inlineVideoRef = ref<HTMLVideoElement | null>(null);
 useVideoStatePreservation(inlineVideoRef, fileCacheKey, { dontResumePlay: true });
+
+// Telegram-style video bubble (WEE-32): show a generated first-frame poster
+// + center play button + bottom-right duration badge instead of a bare
+// `<video controls>`. Native controls only appear once the user taps play.
+const isVideoPlaying = ref(false);
+const videoPosterUrl = ref<string | null>(null);
+const videoMetaDuration = ref<number | null>(null);
+const lastPosterSource = ref<string | null>(null);
+// Tracks whether this component instance is still alive: the virtual scroller
+// recycles bubbles aggressively, so an in-flight `extractVideoFrameThumbnail`
+// can resolve after the bubble's scope is gone. Writing to a dead ref would
+// leak the generated blob URL until the page reloads.
+let isBubbleAlive = true;
+
+const videoDurationSeconds = computed(() => {
+  const fromMeta = props.message.fileInfo?.duration;
+  if (typeof fromMeta === "number" && fromMeta > 0) return fromMeta;
+  return videoMetaDuration.value ?? undefined;
+});
+const videoDurationText = computed(() => formatVideoDuration(videoDurationSeconds.value));
+
+const revokePoster = () => {
+  if (videoPosterUrl.value) {
+    try { URL.revokeObjectURL(videoPosterUrl.value); } catch { /* ignore */ }
+    videoPosterUrl.value = null;
+  }
+};
+
+watch(
+  () => fileState.value.objectUrl,
+  async (url, prevUrl) => {
+    if (url === prevUrl) return;
+    if (props.message.type !== MessageType.video) return;
+    revokePoster();
+    lastPosterSource.value = url ?? null;
+    if (!url) return;
+    const source = url;
+    const thumb = await extractVideoFrameThumbnail(source);
+    // Bail if the bubble was recycled or unmounted before extraction finished
+    // — the poster would belong to a different (or no) video.
+    if (!thumb) return;
+    if (!isBubbleAlive || lastPosterSource.value !== source) {
+      try { URL.revokeObjectURL(thumb); } catch { /* ignore */ }
+      return;
+    }
+    videoPosterUrl.value = thumb;
+  },
+  { immediate: true },
+);
+
+watch(
+  () => props.message.id,
+  () => {
+    isVideoPlaying.value = false;
+    videoMetaDuration.value = null;
+    // Recycled bubble: drop the stale poster + source guard so the next
+    // objectUrl write triggers a fresh extraction (the `url === prevUrl`
+    // short-circuit can otherwise pin us to the previous message's poster).
+    revokePoster();
+    lastPosterSource.value = null;
+  },
+);
+
+onBeforeUnmount(() => {
+  isBubbleAlive = false;
+  revokePoster();
+});
+
+const onInlineVideoLoadedMetadata = () => {
+  const el = inlineVideoRef.value;
+  if (el && Number.isFinite(el.duration) && el.duration > 0) {
+    videoMetaDuration.value = el.duration;
+  }
+};
+
+const playInlineVideo = () => {
+  const el = inlineVideoRef.value;
+  if (!el) return;
+  // `isVideoPlaying` is wired to the @play / @pause / @ended events on the
+  // <video> element, so the overlay hides only once playback is actually
+  // running. Flipping it here would briefly show native controls on a paused
+  // element if play() rejects (autoplay/focus interrupt on Android WebView).
+  const result = el.play();
+  if (result && typeof (result as Promise<void>).catch === "function") {
+    (result as Promise<void>).catch(() => { /* @pause handler resets state */ });
+  }
+};
 
 /** Telegram-style sender colors (same palette as Avatar) */
 const SENDER_COLORS = ["#E17076", "#FAA774", "#A695E7", "#7BC862", "#6EC9CB", "#65AADD", "#EE7AAE"];
@@ -607,14 +695,47 @@ const replyPreviewSender = computed(() => {
             <div class="truncate text-[11px] opacity-70">{{ replyPreviewText }}</div>
           </div>
         </div>
-        <div class="relative">
-          <video v-if="fileState.objectUrl" ref="inlineVideoRef" :src="fileState.objectUrl" controls playsinline class="block max-h-[360px] max-w-full" preload="metadata" />
-          <div v-else-if="fileState.loading" class="flex h-48 w-64 items-center justify-center bg-neutral-grad-0">
+        <div class="relative aspect-video w-full overflow-hidden bg-black/90">
+          <video
+            v-if="fileState.objectUrl"
+            ref="inlineVideoRef"
+            :src="fileState.objectUrl"
+            :poster="videoPosterUrl ?? undefined"
+            :controls="isVideoPlaying"
+            :controlslist="isVideoPlaying ? 'nodownload' : undefined"
+            playsinline
+            preload="metadata"
+            class="block h-full w-full object-cover"
+            @loadedmetadata="onInlineVideoLoadedMetadata"
+            @play="isVideoPlaying = true"
+            @pause="isVideoPlaying = false"
+            @ended="isVideoPlaying = false"
+          />
+          <div v-else-if="fileState.loading" class="flex h-full w-full items-center justify-center bg-neutral-grad-0">
             <div class="contain-strict h-8 w-8 animate-spin rounded-full border-2 border-color-bg-ac border-t-transparent" />
           </div>
-          <button v-else class="flex h-48 w-64 items-center justify-center bg-neutral-grad-0 transition-colors hover:bg-neutral-grad-2" @click="handleVideoAudioLoad">
-            <svg width="48" height="48" viewBox="0 0 24 24" fill="currentColor" class="text-color-bg-ac"><polygon points="5 3 19 12 5 21 5 3" /></svg>
+          <button v-else type="button" class="flex h-full w-full items-center justify-center bg-neutral-grad-0 transition-colors hover:bg-neutral-grad-2" @click="handleVideoAudioLoad">
+            <span class="flex h-14 w-14 items-center justify-center rounded-full bg-color-bg-ac/90 text-white shadow-lg">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor"><polygon points="6 4 20 12 6 20 6 4" /></svg>
+            </span>
           </button>
+          <button
+            v-if="fileState.objectUrl && !isVideoPlaying && !isUploading && !isSending && !isFailed"
+            type="button"
+            class="absolute inset-0 flex items-center justify-center bg-black/15 transition-colors hover:bg-black/25"
+            aria-label="Play video"
+            @click.stop="playInlineVideo"
+          >
+            <span class="flex h-14 w-14 items-center justify-center rounded-full bg-black/55 backdrop-blur-sm shadow-lg ring-1 ring-white/15">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="white"><polygon points="6 4 20 12 6 20 6 4" /></svg>
+            </span>
+          </button>
+          <div
+            v-if="videoDurationText && !isVideoPlaying"
+            class="pointer-events-none absolute bottom-2 right-2 rounded-md bg-black/65 px-1.5 py-0.5 text-[11px] font-medium leading-none text-white"
+          >
+            {{ videoDurationText }}
+          </div>
           <!-- Upload progress overlay for video -->
           <div v-if="isUploading" class="absolute inset-0 flex items-center justify-center bg-black/30">
             <button class="relative flex h-14 w-14 items-center justify-center" @click.stop="emit('cancelUpload', message)">

--- a/src/features/messaging/ui/__tests__/message-bubble-video-ux.test.ts
+++ b/src/features/messaging/ui/__tests__/message-bubble-video-ux.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * UX regression for WEE-32 (forta-bugs#788, #789).
+ *
+ * Video bubbles in chat must look like Telegram/WhatsApp, not a bare HTML5
+ * `<video controls>`. The bubble has to render:
+ *   1. A generated first-frame poster (or `<video poster>`), not a generic grey
+ *      placeholder.
+ *   2. A Telegram-style duration badge in the bottom-right corner.
+ *   3. A circular play-button overlay centered on the frame when not playing.
+ *   4. Rounded corners + an aspect-aware frame that doesn't collapse to 64x192.
+ *
+ * Mounting the 946-line MessageBubble.vue requires ~10 store/composable mocks,
+ * which is out of proportion with the wiring we want to verify. A source-level
+ * assertion matches the existing decrypt-error-UX regression test and keeps the
+ * verification surface focused on the changes.
+ */
+const getSource = (): string =>
+  readFileSync(resolve(__dirname, "../MessageBubble.vue"), "utf-8");
+
+const getVideoBlock = (): string => {
+  const source = getSource();
+  const start = source.indexOf("<!-- Video message -->");
+  expect(start, "Video message block should exist in MessageBubble.vue").toBeGreaterThan(-1);
+  // The next sibling block is the audio/voice message — slice up to it so
+  // assertions only fire against the inline video bubble.
+  const nextBlock = source.indexOf("<!-- Audio", start);
+  const end = nextBlock > -1 ? nextBlock : source.indexOf("<!-- File", start);
+  expect(end, "Should find a sibling block after the video bubble").toBeGreaterThan(start);
+  return source.slice(start, end);
+};
+
+describe("MessageBubble — modern video bubble UX (WEE-32)", () => {
+  it("imports the shared video-thumbnail helpers", () => {
+    const source = getSource();
+    expect(source).toMatch(/from\s+["']\.\.\/model\/video-thumbnail["']/);
+    expect(source).toContain("formatVideoDuration");
+    expect(source).toContain("extractVideoFrameThumbnail");
+  });
+
+  it("renders a duration badge bottom-right when the duration is known", () => {
+    const source = getSource();
+    const block = getVideoBlock();
+    // The badge must be positioned bottom-right with a translucent dark
+    // background — that's the Telegram/WhatsApp convention.
+    expect(source).toMatch(/formatVideoDuration\(/);
+    expect(block).toContain("videoDurationText");
+    expect(block).toMatch(/absolute[^"]*bottom-[12]/);
+    expect(block).toMatch(/right-[12]/);
+  });
+
+  it("renders a centered circular play-button overlay when the video is paused", () => {
+    const block = getVideoBlock();
+    // The overlay must hide once playback starts so the native controls take
+    // over. Look for the play-icon polygon and a guard on `isVideoPlaying`.
+    expect(block).toContain("isVideoPlaying");
+    expect(block).toMatch(/rounded-full/);
+    expect(block).toMatch(/polygon\s+points="6\s+4\s+20\s+12\s+6\s+20\s+6\s+4"|polygon\s+points="5\s+3\s+19\s+12\s+5\s+21\s+5\s+3"/);
+  });
+
+  it("does not show native <video controls> while the play-button overlay is visible", () => {
+    const block = getVideoBlock();
+    // Native controls must be reactive to playback state — a hard-coded
+    // `controls` attribute would clash with our custom overlay.
+    expect(block).not.toMatch(/<video[^>]*\scontrols(?!\s*=|\s*:)/);
+    expect(block).toMatch(/:controls=/);
+  });
+
+  it("wires the play-button overlay to play() the inline <video> element", () => {
+    const source = getSource();
+    // The button click must imperatively start playback through the existing
+    // inlineVideoRef so the same element is reused (preserves position state).
+    expect(source).toContain("playInlineVideo");
+    const fnStart = source.indexOf("const playInlineVideo");
+    expect(fnStart).toBeGreaterThan(-1);
+    const fn = source.slice(fnStart, source.indexOf("};", fnStart));
+    expect(fn).toMatch(/inlineVideoRef\.value/);
+    expect(fn).toMatch(/\.play\(\)/);
+  });
+
+  it("uses a generated poster URL on the inline <video> tag", () => {
+    const block = getVideoBlock();
+    // The poster must reflect the lazily-extracted first frame; a missing
+    // poster binding regresses to the generic grey HTML5 placeholder.
+    expect(block).toMatch(/:poster=/);
+  });
+
+  it("revokes the generated poster blob URL on unmount to avoid leaks", () => {
+    const source = getSource();
+    // The poster is held as a blob URL — without an explicit revoke the URL
+    // outlives the component scope and leaks until the page reloads.
+    expect(source).toMatch(/revokeObjectURL/);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace bare `<video controls>` chat bubbles with a Telegram-style frame: aspect-video wrapper, lazily-generated first-frame poster, centered round play button, bottom-right duration badge.
- New `extractVideoFrameThumbnail` (canvas + seek) + `formatVideoDuration` helpers; poster blob URLs revoked on unmount, on bubble recycling, and on stale-source races (virtual scroller safe).
- Native `<video controls>` only mount once playback actually starts (driven by `@play` / `@pause` / `@ended`), so the custom overlay never coexists with native UI.

## Linear

- Resolves [WEE-32](https://linear.app/wwwee/issue/WEE-32) — video player UX (preview placeholder + frame layout polish)

## Closes

Closes greenShirtMystery/forta-bugs#788
Closes greenShirtMystery/forta-bugs#789

## Test plan

- [x] `vitest run src/features/messaging/model/video-thumbnail.test.ts src/features/messaging/ui/__tests__/message-bubble-video-ux.test.ts` — 16 new tests, all green
- [x] `vitest run` full suite — 2014 pass; the 9 pre-existing failures on master are unrelated (chat-helpers, display-result, open-profile-url, video-embed)
- [x] `vite build` — production bundle builds clean
- [ ] Manual QA on Android: send a video → bubble shows first-frame poster + duration badge + center play button → tap to play → native controls appear, overlay hides

## Acceptance criteria

- **A1** ✅ First-frame thumbnail (generated client-side via Canvas, no upload path changes)
- **A2** ✅ Duration overlay bottom-right in M:SS / H:MM:SS format
- **A3** ✅ Centered play button; tap plays inline (existing fullscreen via long-press / `openMedia` preserved)
- **A4** ✅ Rounded frame inherits from existing `rounded-bubble` + new `aspect-video` constraint

## Out of scope

- Upload-time thumbnail generation + encrypted transport (would require touching `sendVideo` + miscreant SIV, far beyond P3 polish).
- WEE-21 video playback functional issues (orthogonal).