### PR TITLE
feat(chat-info): pencil icon для rename собеседника в DM-карточке (WEE-37)

### DIFF
--- a/src/features/chat-info/lib/should-show-rename-pencil.test.ts
+++ b/src/features/chat-info/lib/should-show-rename-pencil.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { shouldShowPeerRenamePencil } from "./should-show-rename-pencil";
+
+describe("shouldShowPeerRenamePencil (WEE-37)", () => {
+  const peer = "0x1111111111111111111111111111111111111111";
+  const me = "0x2222222222222222222222222222222222222222";
+
+  it("shows pencil for 1:1 DM with resolved peer different from me", () => {
+    expect(shouldShowPeerRenamePencil(false, peer, me)).toBe(true);
+  });
+
+  it("hides pencil for group chats (only member-list pencils belong there)", () => {
+    expect(shouldShowPeerRenamePencil(true, peer, me)).toBe(false);
+  });
+
+  it("hides pencil for self DM (peerAddress === myAddress)", () => {
+    expect(shouldShowPeerRenamePencil(false, me, me)).toBe(false);
+  });
+
+  it("hides pencil when peer address has not resolved yet (null)", () => {
+    expect(shouldShowPeerRenamePencil(false, null, me)).toBe(false);
+  });
+
+  it("hides pencil when peer address has not resolved yet (undefined)", () => {
+    expect(shouldShowPeerRenamePencil(false, undefined, me)).toBe(false);
+  });
+
+  it("hides pencil when peer address is empty string", () => {
+    expect(shouldShowPeerRenamePencil(false, "", me)).toBe(false);
+  });
+
+  it("hides pencil before auth resolves my address (null)", () => {
+    expect(shouldShowPeerRenamePencil(false, peer, null)).toBe(false);
+  });
+
+  it("hides pencil before auth resolves my address (empty string)", () => {
+    expect(shouldShowPeerRenamePencil(false, peer, "")).toBe(false);
+  });
+});

--- a/src/features/chat-info/lib/should-show-rename-pencil.ts
+++ b/src/features/chat-info/lib/should-show-rename-pencil.ts
@@ -1,0 +1,10 @@
+export function shouldShowPeerRenamePencil(
+  isGroup: boolean,
+  peerAddress: string | null | undefined,
+  myAddress: string | null | undefined,
+): boolean {
+  if (isGroup) return false;
+  if (!peerAddress) return false;
+  if (!myAddress) return false;
+  return peerAddress !== myAddress;
+}

--- a/src/features/chat-info/ui/ChatInfoPanel.vue
+++ b/src/features/chat-info/ui/ChatInfoPanel.vue
@@ -14,6 +14,7 @@ import type { ContextMenuItem } from "@/shared/ui/context-menu/ContextMenu.vue";
 import Toggle from "@/shared/ui/toggle/Toggle.vue";
 import ChatInfoGallery from "./ChatInfoGallery.vue";
 import RenameContactDialog from "./RenameContactDialog.vue";
+import { shouldShowPeerRenamePencil } from "../lib/should-show-rename-pencil";
 import { useResolvedRoomName } from "@/entities/chat/lib/use-resolved-room-name";
 import { openBastyonProfile } from "@/shared/lib/open-profile-url";
 import { copyToClipboard, shareLink } from "@/shared/lib/share-link";
@@ -509,6 +510,10 @@ const copyAddress = async () => {
 const renameTarget = ref<string | null>(null);
 const myAddress = computed(() => authStore.address ?? "");
 
+const showPeerRenamePencil = computed(() =>
+  shouldShowPeerRenamePencil(room.value?.isGroup ?? false, peerAddress.value, myAddress.value),
+);
+
 const openRenameDialog = (address: string) => {
   if (!address) return;
   // Never let the user "rename themselves" via this flow — that lives in
@@ -613,8 +618,23 @@ const openGallery = (tab: "media" | "files" | "links" | "voice" = "media") => {
                 />
               </div>
               <div class="text-center">
-                <h2 v-if="isUnresolvedName(roomDisplayName)" class="mx-auto h-5 w-32 animate-pulse rounded bg-neutral-grad-2" />
-                <h2 v-else class="text-lg font-semibold text-text-color">{{ roomDisplayName }}</h2>
+                <div class="flex items-center justify-center gap-2">
+                  <h2 v-if="isUnresolvedName(roomDisplayName)" class="h-5 w-32 animate-pulse rounded bg-neutral-grad-2" />
+                  <h2 v-else class="text-lg font-semibold text-text-color">{{ roomDisplayName }}</h2>
+                  <button
+                    v-if="showPeerRenamePencil && peerAddress"
+                    data-test="rename-peer-btn"
+                    class="shrink-0 rounded p-1 text-text-on-main-bg-color transition-colors hover:bg-neutral-grad-2/40 hover:text-text-color"
+                    :title="chatStore.hasLocalAlias(peerAddress) ? t('contact.editAlias') : t('contact.addAlias')"
+                    :aria-label="chatStore.hasLocalAlias(peerAddress) ? t('contact.editAlias') : t('contact.addAlias')"
+                    @click="openRenameDialog(peerAddress)"
+                  >
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                      <path d="M12 20h9" />
+                      <path d="M16.5 3.5a2.121 2.121 0 1 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+                    </svg>
+                  </button>
+                </div>
                 <p class="text-sm text-text-on-main-bg-color">
                   {{ room.isGroup ? t("info.members", { count: chatStore.getRoomMemberCount(room.id) }) : t("info.directMessage") }}
                 </p>


### PR DESCRIPTION
## Summary

- DM `ChatInfoPanel` теперь показывает pencil icon рядом с именем собеседника — discoverability gap для existing rename flow (Session 51 `e9e24c4`).
- Tap pencil → opens existing `RenameContactDialog` через `openRenameDialog(peerAddress)` (тот же flow что в context menu и long-press).
- Guard: pencil скрыт в group chats (там pencil уже есть per-member), в self DM (`peerAddress === myAddress`), и пока адрес/auth не резолвится.

## Linear

- Resolves [WEE-37](https://linear.app/wwwee/issue/WEE-37/contacts-pencil-icon-dlya-rename-ryadom-s-imenem-sobesednika-v-dm)

## Implementation

- `src/features/chat-info/lib/should-show-rename-pencil.ts` — pure helper (`!isGroup && peerAddress && peerAddress !== myAddress`). Вынесен из template, чтобы было что unit-тестировать без mount'а 1100-строчного SFC.
- `src/features/chat-info/lib/should-show-rename-pencil.test.ts` — 8 cases: DM happy / group / self-DM / null+undefined+empty peer / null+empty myAddress.
- `src/features/chat-info/ui/ChatInfoPanel.vue` — обёрнут `<h2>` во flex-контейнер + добавлен `<button data-test="rename-peer-btn">` с SVG идентичным group-member pencil pattern (lines 902-913).

## Acceptance criteria

- [x] A1: DM header имеет pencil icon button рядом с именем
- [x] A2: Group chat header — НЕТ pencil (только members list)
- [x] A3: Tap pencil → RenameContactDialog → save → header обновляется
- [x] A4: Self DM (peerAddress === myAddress) → pencil hidden
- [x] A5: Context menu rename + long-press на chat — без изменений

## Test plan

- [x] `npm run build` — PASS
- [x] `npx vue-tsc --noEmit` — no new errors in changed files
- [x] `npx vitest run src/features/chat-info/` — 8/8 PASS
- [x] Full test suite — 2049 pass / 9 preexisting failures (open-profile-url, video-embed, chat-helpers, display-result — не затронуты этим PR)
- [ ] Manual: open 1:1 chat → tap header → pencil viz → tap → dialog opens → rename → header refreshes
- [ ] Manual: open group chat → pencil НЕ виден в header (только member rows)
- [ ] Manual: self DM (если applicable) → pencil НЕ виден