### PR TITLE
fix(video): respect aspect ratio + mirror only front camera (WEE-36)

### DIFF
--- a/src/features/messaging/model/video-layout.test.ts
+++ b/src/features/messaging/model/video-layout.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeVideoAspectStyle,
+  resolveVideoDimensions,
+} from "./video-layout";
+
+describe("computeVideoAspectStyle (WEE-36 / forta-bugs#804)", () => {
+  it("preserves portrait (9:16) ratio for vertical video", () => {
+    const style = computeVideoAspectStyle({ w: 720, h: 1280 });
+    expect(style.aspectRatio).toBe("720 / 1280");
+  });
+
+  it("preserves landscape ratio for horizontal video", () => {
+    const style = computeVideoAspectStyle({ w: 1920, h: 1080 });
+    expect(style.aspectRatio).toBe("1920 / 1080");
+  });
+
+  it("preserves square ratio", () => {
+    const style = computeVideoAspectStyle({ w: 720, h: 720 });
+    expect(style.aspectRatio).toBe("720 / 720");
+  });
+
+  it("falls back to 16/9 when dimensions are missing", () => {
+    expect(computeVideoAspectStyle(null).aspectRatio).toBe("16 / 9");
+    expect(computeVideoAspectStyle(undefined).aspectRatio).toBe("16 / 9");
+  });
+
+  it("falls back to 16/9 when dimensions are non-positive", () => {
+    expect(computeVideoAspectStyle({ w: 0, h: 1280 }).aspectRatio).toBe("16 / 9");
+    expect(computeVideoAspectStyle({ w: 720, h: 0 }).aspectRatio).toBe("16 / 9");
+    expect(computeVideoAspectStyle({ w: -1, h: -1 }).aspectRatio).toBe("16 / 9");
+  });
+});
+
+describe("resolveVideoDimensions", () => {
+  it("prefers fileInfo dimensions when present", () => {
+    expect(
+      resolveVideoDimensions({ w: 720, h: 1280 }, { w: 1920, h: 1080 }),
+    ).toEqual({ w: 720, h: 1280 });
+  });
+
+  it("falls back to natural dimensions when fileInfo is missing", () => {
+    expect(resolveVideoDimensions(null, { w: 720, h: 1280 })).toEqual({
+      w: 720,
+      h: 1280,
+    });
+  });
+
+  it("falls back to natural dimensions when fileInfo has zero values", () => {
+    expect(
+      resolveVideoDimensions({ w: 0, h: 0 }, { w: 720, h: 1280 }),
+    ).toEqual({ w: 720, h: 1280 });
+  });
+
+  it("returns null when neither source has usable dimensions", () => {
+    expect(resolveVideoDimensions(null, null)).toBeNull();
+    expect(
+      resolveVideoDimensions({ w: 0, h: 0 }, { w: 0, h: 0 }),
+    ).toBeNull();
+  });
+});

--- a/src/features/messaging/model/video-layout.ts
+++ b/src/features/messaging/model/video-layout.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure helpers for chat-video bubble layout (WEE-36 / forta-bugs#804).
+ *
+ * Vertical (9:16) videos were rendered with a fixed `aspect-video` (16:9)
+ * container, stretching portrait clips into a horizontal letterbox. These
+ * helpers compute the bubble width and the container aspect-ratio from the
+ * known media dimensions so the original ratio is preserved.
+ */
+
+export interface VideoDimensions {
+  w: number;
+  h: number;
+}
+
+const DEFAULT_ASPECT_RATIO = "16 / 9";
+
+/**
+ * Choose the best-known video dimensions: prefer upload metadata
+ * (`fileInfo.w/h`), fall back to the video element's natural size once
+ * `loadedmetadata` has fired.
+ */
+export function resolveVideoDimensions(
+  fileInfo: VideoDimensions | null | undefined,
+  natural: VideoDimensions | null | undefined,
+): VideoDimensions | null {
+  if (fileInfo && fileInfo.w > 0 && fileInfo.h > 0) return { w: fileInfo.w, h: fileInfo.h };
+  if (natural && natural.w > 0 && natural.h > 0) return { w: natural.w, h: natural.h };
+  return null;
+}
+
+/**
+ * Inline style for the bubble's video container. Locks aspect-ratio to the
+ * original media so portrait clips stay portrait.
+ */
+export function computeVideoAspectStyle(
+  dim: VideoDimensions | null | undefined,
+): { aspectRatio: string } {
+  if (dim && dim.w > 0 && dim.h > 0) {
+    return { aspectRatio: `${dim.w} / ${dim.h}` };
+  }
+  return { aspectRatio: DEFAULT_ASPECT_RATIO };
+}

--- a/src/features/messaging/ui/MessageBubble.vue
+++ b/src/features/messaging/ui/MessageBubble.vue
@@ -14,6 +14,7 @@ import {
   VIDEO_LOAD_TIMEOUT_MS,
   type VideoPlaybackError,
 } from "../model/video-error";
+import { computeVideoAspectStyle, resolveVideoDimensions } from "../model/video-layout";
 import MessageContent from "./MessageContent.vue";
 import MessageStatusIcon from "./MessageStatusIcon.vue";
 import PollCard from "./PollCard.vue";
@@ -209,7 +210,24 @@ useVideoStatePreservation(inlineVideoRef, fileCacheKey, { dontResumePlay: true }
 const isVideoPlaying = ref(false);
 const videoPosterUrl = ref<string | null>(null);
 const videoMetaDuration = ref<number | null>(null);
+const videoNaturalDim = ref<{ w: number; h: number } | null>(null);
 const lastPosterSource = ref<string | null>(null);
+
+// Fix forta-bugs#804 (WEE-36): bubble previously used a fixed `aspect-video`
+// (16:9) container, so vertical clips were squashed into a horizontal frame.
+// We now lock the container's aspect-ratio to the original media size
+// (upload metadata when available, otherwise the natural size reported by the
+// <video> element after `loadedmetadata`).
+const videoAspectStyle = computed(() =>
+  computeVideoAspectStyle(
+    resolveVideoDimensions(
+      props.message.fileInfo
+        ? { w: props.message.fileInfo.w ?? 0, h: props.message.fileInfo.h ?? 0 }
+        : null,
+      videoNaturalDim.value,
+    ),
+  ),
+);
 // Tracks whether this component instance is still alive: the virtual scroller
 // recycles bubbles aggressively, so an in-flight `extractVideoFrameThumbnail`
 // can resolve after the bubble's scope is gone. Writing to a dead ref would
@@ -257,6 +275,7 @@ watch(
   () => {
     isVideoPlaying.value = false;
     videoMetaDuration.value = null;
+    videoNaturalDim.value = null;
     // Recycled bubble: drop the stale poster + source guard so the next
     // objectUrl write triggers a fresh extraction (the `url === prevUrl`
     // short-circuit can otherwise pin us to the previous message's poster).
@@ -281,8 +300,16 @@ const onInlineVideoLoadedMetadata = () => {
   clearVideoLoadTimer();
   videoPlaybackError.value = null;
   const el = inlineVideoRef.value;
-  if (el && Number.isFinite(el.duration) && el.duration > 0) {
+  if (!el) return;
+  if (Number.isFinite(el.duration) && el.duration > 0) {
     videoMetaDuration.value = el.duration;
+  }
+  // Surface the natural pixel size so the bubble can lock the right
+  // aspect-ratio even when upload metadata (`fileInfo.w/h`) is missing.
+  const w = el.videoWidth;
+  const h = el.videoHeight;
+  if (w > 0 && h > 0) {
+    videoNaturalDim.value = { w, h };
   }
 };
 
@@ -804,7 +831,11 @@ const replyPreviewSender = computed(() => {
             <div class="truncate text-[11px] opacity-70">{{ replyPreviewText }}</div>
           </div>
         </div>
-        <div class="relative aspect-video w-full overflow-hidden bg-black/90">
+        <div
+          class="video-bubble-frame relative w-full overflow-hidden bg-black/90"
+          :style="videoAspectStyle"
+          data-testid="video-bubble-frame"
+        >
           <video
             v-if="fileState.objectUrl"
             ref="inlineVideoRef"
@@ -814,7 +845,7 @@ const replyPreviewSender = computed(() => {
             :controlslist="isVideoPlaying ? 'nodownload' : undefined"
             playsinline
             preload="metadata"
-            class="block h-full w-full object-cover"
+            class="block h-full w-full object-contain"
             @loadedmetadata="onInlineVideoLoadedMetadata"
             @canplay="onInlineVideoCanPlay"
             @error="onInlineVideoError"

--- a/src/features/video-calls/model/camera-facing.test.ts
+++ b/src/features/video-calls/model/camera-facing.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { isFrontFacingStream, isFrontFacingTrack } from "./camera-facing";
+
+function makeTrack(facingMode: string | undefined): MediaStreamTrack {
+  return {
+    getSettings: () => (facingMode === undefined ? {} : { facingMode }),
+  } as unknown as MediaStreamTrack;
+}
+
+function makeStream(facingMode: string | undefined): MediaStream {
+  const track = makeTrack(facingMode);
+  return {
+    getVideoTracks: () => [track],
+  } as unknown as MediaStream;
+}
+
+describe("isFrontFacingTrack (WEE-36 / forta-bugs#749)", () => {
+  it("returns true for user-facing (selfie) camera — local preview must mirror", () => {
+    expect(isFrontFacingTrack(makeTrack("user"))).toBe(true);
+  });
+
+  it("returns false for back camera — local preview must NOT mirror", () => {
+    expect(isFrontFacingTrack(makeTrack("environment"))).toBe(false);
+  });
+
+  it("returns false for side-mounted cameras", () => {
+    expect(isFrontFacingTrack(makeTrack("left"))).toBe(false);
+    expect(isFrontFacingTrack(makeTrack("right"))).toBe(false);
+  });
+
+  it("defaults to true when facingMode is missing (desktop webcam)", () => {
+    expect(isFrontFacingTrack(makeTrack(undefined))).toBe(true);
+  });
+
+  it("returns true when track is null/undefined (no stream yet)", () => {
+    expect(isFrontFacingTrack(null)).toBe(true);
+    expect(isFrontFacingTrack(undefined)).toBe(true);
+  });
+
+  it("returns true when getSettings throws (older WebView)", () => {
+    const track = {
+      getSettings: () => {
+        throw new Error("not supported");
+      },
+    } as unknown as MediaStreamTrack;
+    expect(isFrontFacingTrack(track)).toBe(true);
+  });
+});
+
+describe("isFrontFacingStream", () => {
+  it("inspects the first video track", () => {
+    expect(isFrontFacingStream(makeStream("environment"))).toBe(false);
+    expect(isFrontFacingStream(makeStream("user"))).toBe(true);
+  });
+
+  it("returns true when the stream has no video track", () => {
+    const empty = { getVideoTracks: () => [] } as unknown as MediaStream;
+    expect(isFrontFacingStream(empty)).toBe(true);
+  });
+
+  it("returns true when the stream itself is null", () => {
+    expect(isFrontFacingStream(null)).toBe(true);
+  });
+});

--- a/src/features/video-calls/model/camera-facing.ts
+++ b/src/features/video-calls/model/camera-facing.ts
@@ -1,0 +1,49 @@
+/**
+ * Camera facing-mode detection (WEE-36 / forta-bugs#749).
+ *
+ * The local self-view was unconditionally mirrored, which felt fine for the
+ * default front camera but looked wrong once the user flipped to the back
+ * camera — text and lefts/rights appeared reversed for the local user.
+ * This helper inspects the active video track's `facingMode` so the bubble's
+ * `mirror` flag is only set when the camera is genuinely user-facing.
+ *
+ * The mirror class is CSS-only (`scale-x-[-1]` on the local `<video>`),
+ * so the outgoing WebRTC track sent to the peer is never affected by it.
+ */
+
+/**
+ * Returns `true` when the given video track is a user-facing (selfie) camera,
+ * i.e. its local preview should be mirrored.
+ *
+ * Heuristic:
+ *   - `facingMode === "user"` (or unset) → front camera → mirror.
+ *   - `facingMode === "environment" | "left" | "right"` → not front → no mirror.
+ *
+ * Default for unknown/desktop sources is `true` because typical laptop webcams
+ * are user-facing and users expect a mirrored self-view.
+ */
+export function isFrontFacingTrack(
+  track: MediaStreamTrack | null | undefined,
+): boolean {
+  if (!track) return true;
+
+  let facing: string | undefined;
+  try {
+    facing = track.getSettings?.().facingMode;
+  } catch {
+    facing = undefined;
+  }
+
+  if (facing === "environment" || facing === "left" || facing === "right") {
+    return false;
+  }
+  return true;
+}
+
+/** Convenience: read the first video track from a MediaStream and inspect it. */
+export function isFrontFacingStream(
+  stream: MediaStream | null | undefined,
+): boolean {
+  const track = stream?.getVideoTracks?.()[0] ?? null;
+  return isFrontFacingTrack(track);
+}

--- a/src/features/video-calls/ui/CallWindow.vue
+++ b/src/features/video-calls/ui/CallWindow.vue
@@ -3,6 +3,7 @@ import { useCallStore, CallStatus } from "@/entities/call";
 import { UserAvatar } from "@/entities/user";
 import { formatDuration } from "@/shared/lib/format";
 import { useCallService } from "../model/call-service";
+import { isFrontFacingStream } from "../model/camera-facing";
 import CallControls from "./CallControls.vue";
 import VideoTile from "./VideoTile.vue";
 import { useAndroidBackHandler } from "@/shared/lib/composables/use-android-back-handler";
@@ -175,6 +176,14 @@ const peerName = computed(() => callStore.activeCall?.peerName ?? "");
 const peerAddress = computed(() => callStore.activeCall?.peerAddress ?? "");
 const myAddress = computed(() => "");
 
+// Mirror the local self-view ONLY when the active camera is user-facing
+// (forta-bugs#749 / WEE-36). Reading `callStore.localStream` here keeps the
+// flag reactive when the user flips between front/back cameras via
+// `setVideoDevice`, which swaps the video track and calls `triggerRef`.
+const localCameraMirror = computed(() =>
+  isFrontFacingStream(callStore.localStream),
+);
+
 function makeTile(
   id: string,
   stream: MediaStream | null,
@@ -215,7 +224,7 @@ const allTiles = computed<TileData[]>(() => {
       callStore.videoMuted,
       callStore.audioMuted,
       false,
-      true,
+      localCameraMirror.value,
       true,
     ),
   );
@@ -638,7 +647,7 @@ const isAnyScreenSharing = computed(
               >
                 <VideoTile
                   :stream="callStore.screenSharing && callStore.localScreenStream ? callStore.localScreenStream : callStore.localStream"
-                  :mirror="!callStore.screenSharing"
+                  :mirror="!callStore.screenSharing && localCameraMirror"
                   :video-off="callStore.videoMuted && !callStore.screenSharing"
                   object-fit="cover"
                   muted


### PR DESCRIPTION
## Summary

Two orientation bugs in chat video and video calls:

- **forta-bugs#804** — Vertical chat video shown as horizontal: the bubble had a fixed `aspect-video` (16:9) container that squashed portrait clips into a landscape frame. Now the container locks its aspect-ratio to the actual media size (upload metadata `fileInfo.w/h` first; falls back to `<video>.videoWidth/videoHeight` from `loadedmetadata`).
- **forta-bugs#749** — Back-camera self-view was mirrored: the local tile and PiP were unconditionally `scale-x-[-1]`, so text appeared reversed for the user once they flipped to the back camera. Now the mirror flag reads `MediaStreamTrack.getSettings().facingMode` and only applies for `user` (or unknown desktop webcam). The CSS mirror was always local-only — peers continue to receive an unmirrored outgoing stream.

## Linear
- Resolves WEE-36 (https://linear.app/wwwee/issue/WEE-36/video-orientation-vertikalnoe-video-pokazyvaetsya-kak-gorizontalnoe)

## Closes
- Closes greenShirtMystery/forta-bugs#804
- Closes greenShirtMystery/forta-bugs#749

## Files

- `src/features/messaging/model/video-layout.ts` — new pure helpers (`computeVideoAspectStyle`, `resolveVideoDimensions`)
- `src/features/messaging/model/video-layout.test.ts` — 9 regression tests
- `src/features/messaging/ui/MessageBubble.vue` — replaces `aspect-video` with dynamic `:style="videoAspectStyle"`; tracks natural dimensions; resets on virtual-scroller recycling
- `src/features/video-calls/model/camera-facing.ts` — new helper `isFrontFacingTrack` / `isFrontFacingStream`
- `src/features/video-calls/model/camera-facing.test.ts` — 9 regression tests
- `src/features/video-calls/ui/CallWindow.vue` — `localCameraMirror` computed used by both the tile composition and PiP self-view

## Test plan

- [x] `vite build` passes (vue-tsc shows 49 pre-existing errors on master, identical count on this branch)
- [x] 18 new unit tests added and passing
- [x] Code review (superpowers:code-reviewer) — approved, no CRITICAL/HIGH findings
- [ ] Manual QA: record portrait 9:16 video → send → bubble appears portrait
- [ ] Manual QA: video call → toggle to back camera → local preview no longer mirrors
- [ ] Manual QA: switch back to front camera → mirror restored