### PR TITLE
fix(video-player): typed playback state machine + load timeout (WEE-21)

### DIFF
--- a/src/features/messaging/model/video-error.test.ts
+++ b/src/features/messaging/model/video-error.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import {
+  videoPlaybackErrorFromMediaError,
+  VIDEO_LOAD_TIMEOUT_MS,
+  type VideoPlaybackError,
+} from "./video-error";
+
+/**
+ * Regression for WEE-21 (forta-bugs#761, #748, #679, #652, #532).
+ *
+ * Video bubbles in chat used to spin forever when decoding failed:
+ * H.265-encoded files on older Android WebView surface as a "green Android"
+ * placeholder, decode errors looked identical to "still buffering", and a
+ * silent stall (no progress event fires) left the user with no recourse.
+ *
+ * The mapping below is the contract between the raw HTML5 MediaError code
+ * and the typed UX shown in the bubble — codec-unsupported gets only a
+ * Download fallback (retry won't help), decode/generic gets a retry button.
+ */
+describe("videoPlaybackErrorFromMediaError", () => {
+  it("maps MEDIA_ERR_SRC_NOT_SUPPORTED (4) → codec-unsupported", () => {
+    // H.265 (HEVC) on a WebView without the codec is the dominant cause of
+    // the green-placeholder bug on Huawei/older Xiaomi devices.
+    expect(videoPlaybackErrorFromMediaError(4)).toBe<VideoPlaybackError>("codec-unsupported");
+  });
+
+  it("maps MEDIA_ERR_DECODE (3) → decode", () => {
+    expect(videoPlaybackErrorFromMediaError(3)).toBe<VideoPlaybackError>("decode");
+  });
+
+  it("maps MEDIA_ERR_NETWORK (2) → generic so the bubble offers retry", () => {
+    expect(videoPlaybackErrorFromMediaError(2)).toBe<VideoPlaybackError>("generic");
+  });
+
+  it("maps MEDIA_ERR_ABORTED (1) → generic", () => {
+    expect(videoPlaybackErrorFromMediaError(1)).toBe<VideoPlaybackError>("generic");
+  });
+
+  it("falls back to generic when the code is undefined", () => {
+    // Some WebViews emit the `error` event without populating `MediaError`.
+    // The UX must still degrade gracefully instead of crashing the handler.
+    expect(videoPlaybackErrorFromMediaError(undefined)).toBe<VideoPlaybackError>("generic");
+  });
+
+  it("falls back to generic for unknown numeric codes", () => {
+    expect(videoPlaybackErrorFromMediaError(0)).toBe<VideoPlaybackError>("generic");
+    expect(videoPlaybackErrorFromMediaError(99)).toBe<VideoPlaybackError>("generic");
+  });
+});
+
+describe("VIDEO_LOAD_TIMEOUT_MS", () => {
+  it("exposes a 10-second load timeout (matches WEE-21 acceptance criteria)", () => {
+    // 10s gives a slow LTE connection room to deliver the first frame while
+    // still failing loudly on a truly stalled decode. Acceptance criteria A1
+    // talks about "playback within 5s on WiFi" — 10s is the upper bound for
+    // a still-recoverable load.
+    expect(VIDEO_LOAD_TIMEOUT_MS).toBe(10000);
+  });
+});

--- a/src/features/messaging/model/video-error.ts
+++ b/src/features/messaging/model/video-error.ts
@@ -1,0 +1,47 @@
+/**
+ * Typed playback errors for the inline chat video bubble (WEE-21).
+ *
+ * Split off as a pure module so the MediaError → UX mapping can be
+ * unit-tested without mounting the 1k-line MessageBubble.vue and its
+ * ~10 store/composable mocks.
+ */
+export type VideoPlaybackError =
+  | "codec-unsupported"
+  | "decode"
+  | "timeout"
+  | "generic";
+
+/**
+ * Map an HTMLMediaElement `MediaError.code` to a typed playback error.
+ *
+ * Codes per the HTML spec
+ * (https://html.spec.whatwg.org/multipage/media.html#error-codes):
+ *   1 MEDIA_ERR_ABORTED        — fetch aborted by user
+ *   2 MEDIA_ERR_NETWORK        — network failure mid-load
+ *   3 MEDIA_ERR_DECODE         — corrupt frame / decoder crash
+ *   4 MEDIA_ERR_SRC_NOT_SUPPORTED — codec / container not supported
+ *                                  (H.265 on older Android WebView, etc.)
+ *
+ * Only code 4 disables the retry button — re-fetching the same blob with
+ * the same codec won't suddenly start playing. Everything else is
+ * potentially transient, so the bubble offers a retry.
+ */
+export function videoPlaybackErrorFromMediaError(
+  code: number | undefined,
+): VideoPlaybackError {
+  if (code === 4) return "codec-unsupported";
+  if (code === 3) return "decode";
+  return "generic";
+}
+
+/**
+ * Deadline for the inline `<video>` to fire `loadedmetadata` / `canplay`
+ * after the decrypted blob URL becomes available. Silent stalls (no event
+ * ever fires on older WebView) used to leave the user with an eternal
+ * spinner; the timeout flips the bubble into a typed `timeout` error so
+ * the retry / download fallback is reachable.
+ *
+ * 10s gives a slow LTE connection room to deliver the first frame while
+ * still failing loudly on a truly stuck decode.
+ */
+export const VIDEO_LOAD_TIMEOUT_MS = 10000;

--- a/src/features/messaging/ui/MessageBubble.vue
+++ b/src/features/messaging/ui/MessageBubble.vue
@@ -9,6 +9,11 @@ import { tRaw } from "@/shared/lib/i18n";
 import { useToast } from "@/shared/lib/use-toast";
 import { useVideoStatePreservation } from "@/shared/lib/composables/use-video-state-preservation";
 import { formatVideoDuration, extractVideoFrameThumbnail } from "../model/video-thumbnail";
+import {
+  videoPlaybackErrorFromMediaError,
+  VIDEO_LOAD_TIMEOUT_MS,
+  type VideoPlaybackError,
+} from "../model/video-error";
 import MessageContent from "./MessageContent.vue";
 import MessageStatusIcon from "./MessageStatusIcon.vue";
 import PollCard from "./PollCard.vue";
@@ -257,15 +262,24 @@ watch(
     // short-circuit can otherwise pin us to the previous message's poster).
     revokePoster();
     lastPosterSource.value = null;
+    // Drop the previous video's playback error so the next message doesn't
+    // inherit a stale codec-unsupported overlay (WEE-21).
+    videoPlaybackError.value = null;
+    clearVideoLoadTimer();
   },
 );
 
 onBeforeUnmount(() => {
   isBubbleAlive = false;
   revokePoster();
+  clearVideoLoadTimer();
 });
 
 const onInlineVideoLoadedMetadata = () => {
+  // First successful frame of metadata = decoder is alive. Disarm the
+  // 10s timeout so a slow `canplay` on a long video doesn't trip it.
+  clearVideoLoadTimer();
+  videoPlaybackError.value = null;
   const el = inlineVideoRef.value;
   if (el && Number.isFinite(el.duration) && el.duration > 0) {
     videoMetaDuration.value = el.duration;
@@ -284,6 +298,101 @@ const playInlineVideo = () => {
     (result as Promise<void>).catch(() => { /* @pause handler resets state */ });
   }
 };
+
+// ── Video playback state machine (WEE-21) ──
+// Pre-fix, a failed decrypt/decode/codec-mismatch surfaced as an eternal
+// spinner or the bare Android WebView "green icon" placeholder. The state
+// below routes those failures into a typed UX with a retry / download
+// fallback. See `model/video-error.ts` for the MediaError → typed mapping.
+const videoPlaybackError = ref<VideoPlaybackError | null>(null);
+let videoLoadTimer: ReturnType<typeof setTimeout> | null = null;
+
+const clearVideoLoadTimer = () => {
+  if (videoLoadTimer !== null) {
+    clearTimeout(videoLoadTimer);
+    videoLoadTimer = null;
+  }
+};
+
+const armVideoLoadTimer = () => {
+  clearVideoLoadTimer();
+  videoLoadTimer = setTimeout(() => {
+    videoLoadTimer = null;
+    // Only surface a timeout if the element never reached a playable state.
+    // `loadedmetadata` is the earliest signal that decoding works at all;
+    // once that fires we clear the timer eagerly so the deadline is moot.
+    // The `videoPlaybackError === null` guard prevents the timer from
+    // clobbering a more specific error (decode / codec-unsupported) that
+    // arrived via `@error` between arming and the deadline — Android WebView
+    // can fire synchronous errors on `el.load()` during retry, so without
+    // this check the typed copy would silently revert to "timeout" 10s later.
+    if (
+      !isVideoPlaying.value &&
+      videoMetaDuration.value === null &&
+      videoPlaybackError.value === null
+    ) {
+      videoPlaybackError.value = "timeout";
+    }
+  }, VIDEO_LOAD_TIMEOUT_MS);
+};
+
+const onInlineVideoError = (event: Event) => {
+  clearVideoLoadTimer();
+  const target = event.target as HTMLVideoElement | null;
+  videoPlaybackError.value = videoPlaybackErrorFromMediaError(target?.error?.code);
+};
+
+const onInlineVideoCanPlay = () => {
+  clearVideoLoadTimer();
+  videoPlaybackError.value = null;
+};
+
+const videoErrorMessage = computed(() => {
+  switch (videoPlaybackError.value) {
+    case "codec-unsupported":
+      return t("message.videoUnsupportedFormat");
+    case "decode":
+    case "timeout":
+    case "generic":
+      return t("message.videoLoadFailed");
+    default:
+      return "";
+  }
+});
+
+// Codec-unsupported can't be retried — the WebView genuinely lacks the
+// decoder, so re-fetching the same bytes won't help. All other errors
+// (decode/timeout/generic) are potentially transient, so a retry is the
+// right affordance alongside the download fallback.
+const videoCanRetry = computed(() => videoPlaybackError.value !== "codec-unsupported");
+
+const retryVideoPlayback = () => {
+  videoPlaybackError.value = null;
+  const el = inlineVideoRef.value;
+  if (el) {
+    try { el.load(); } catch { /* WebView edge case — ignore */ }
+  }
+  if (fileState.value.objectUrl) {
+    armVideoLoadTimer();
+  } else {
+    download(props.message);
+  }
+};
+
+// Arm the load-deadline as soon as a fresh blob URL is wired into <video>.
+// Disarming happens on `loadedmetadata` / `canplay` (success) or in
+// `onInlineVideoError` (failure) — no leak even if the bubble unmounts
+// mid-load, because `onBeforeUnmount` also calls `clearVideoLoadTimer`.
+watch(
+  () => fileState.value.objectUrl,
+  (url, prevUrl) => {
+    if (url === prevUrl) return;
+    if (props.message.type !== MessageType.video) return;
+    clearVideoLoadTimer();
+    videoPlaybackError.value = null;
+    if (url) armVideoLoadTimer();
+  },
+);
 
 /** Telegram-style sender colors (same palette as Avatar) */
 const SENDER_COLORS = ["#E17076", "#FAA774", "#A695E7", "#7BC862", "#6EC9CB", "#65AADD", "#EE7AAE"];
@@ -707,6 +816,8 @@ const replyPreviewSender = computed(() => {
             preload="metadata"
             class="block h-full w-full object-cover"
             @loadedmetadata="onInlineVideoLoadedMetadata"
+            @canplay="onInlineVideoCanPlay"
+            @error="onInlineVideoError"
             @play="isVideoPlaying = true"
             @pause="isVideoPlaying = false"
             @ended="isVideoPlaying = false"
@@ -720,7 +831,7 @@ const replyPreviewSender = computed(() => {
             </span>
           </button>
           <button
-            v-if="fileState.objectUrl && !isVideoPlaying && !isUploading && !isSending && !isFailed"
+            v-if="fileState.objectUrl && !isVideoPlaying && !isUploading && !isSending && !isFailed && !videoPlaybackError"
             type="button"
             class="absolute inset-0 flex items-center justify-center bg-black/15 transition-colors hover:bg-black/25"
             aria-label="Play video"
@@ -731,10 +842,45 @@ const replyPreviewSender = computed(() => {
             </span>
           </button>
           <div
-            v-if="videoDurationText && !isVideoPlaying"
+            v-if="videoDurationText && !isVideoPlaying && !videoPlaybackError"
             class="pointer-events-none absolute bottom-2 right-2 rounded-md bg-black/65 px-1.5 py-0.5 text-[11px] font-medium leading-none text-white"
           >
             {{ videoDurationText }}
+          </div>
+          <!--
+            Typed playback-error overlay (WEE-21). Sits above the duration
+            badge / play-button overlay so a failed decode shows specific
+            UX instead of an eternal spinner. Codec-unsupported renders
+            only the download button; transient errors add a retry.
+          -->
+          <div
+            v-if="videoPlaybackError && !isUploading && !isSending"
+            class="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-black/70 px-4 text-center text-white"
+          >
+            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="12" cy="12" r="10" />
+              <line x1="12" y1="8" x2="12" y2="12" />
+              <line x1="12" y1="16" x2="12.01" y2="16" />
+            </svg>
+            <span class="text-xs font-medium">{{ videoErrorMessage }}</span>
+            <div class="flex gap-2">
+              <button
+                v-if="videoCanRetry"
+                type="button"
+                class="rounded-md bg-white/15 px-3 py-1.5 text-xs font-medium transition-colors hover:bg-white/25"
+                @click.stop="retryVideoPlayback"
+              >
+                {{ t('message.retry') }}
+              </button>
+              <button
+                type="button"
+                class="rounded-md bg-color-bg-ac px-3 py-1.5 text-xs font-medium text-text-on-bg-ac-color transition-opacity hover:opacity-90 disabled:opacity-60"
+                :disabled="isSavingFile"
+                @click.stop="handleFileDownload"
+              >
+                {{ t('message.videoDownload') }}
+              </button>
+            </div>
           </div>
           <!-- Upload progress overlay for video -->
           <div v-if="isUploading" class="absolute inset-0 flex items-center justify-center bg-black/30">
@@ -753,7 +899,7 @@ const replyPreviewSender = computed(() => {
           <div v-else-if="isSending" class="absolute inset-0 flex items-center justify-center bg-black/30">
             <div class="contain-strict h-8 w-8 animate-spin rounded-full border-3 border-white border-t-transparent" />
           </div>
-          <div v-if="isFailed && hasFileInfo" class="absolute inset-0 flex items-center justify-center bg-black/40">
+          <div v-if="isFailed && hasFileInfo && !videoPlaybackError" class="absolute inset-0 flex items-center justify-center bg-black/40">
             <button class="flex flex-col items-center gap-1 text-white" @click.stop="emit('retryMedia', message)">
               <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <polyline points="23 4 23 10 17 10" /><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />

--- a/src/features/messaging/ui/__tests__/message-bubble-video-playback-error.test.ts
+++ b/src/features/messaging/ui/__tests__/message-bubble-video-playback-error.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression for WEE-21 (forta-bugs#761, #748, #679, #652, #532).
+ *
+ * Before the fix, the inline video bubble had no `@error` handler and no
+ * load timeout — a failed decrypt/decode/codec-mismatch would either spin
+ * forever or surface the bare Android WebView placeholder (the infamous
+ * "green icon"). The state machine here guarantees:
+ *
+ *   1. `@error` is bound and routes MediaError codes into typed states.
+ *   2. A 10s deadline arms when the blob URL arrives and disarms on
+ *      `loadedmetadata` / `canplay` — so a silent stall surfaces as a
+ *      typed timeout instead of an eternal spinner.
+ *   3. The bubble renders an error overlay with localized copy + a
+ *      Download fallback. Retry is only offered for transient errors;
+ *      codec-unsupported needs a download, not a re-try.
+ *   4. Recycling the bubble (virtual scroller swaps `message.id`) clears
+ *      the error so a stale failure does not bleed into the next video.
+ *
+ * Source-level assertions keep the verification surface focused without
+ * mounting the 1k-line MessageBubble.vue + 10 store mocks. The same pattern
+ * already in `message-bubble-video-ux.test.ts` / decrypt-error-ux test.
+ */
+const getSource = (): string =>
+  readFileSync(resolve(__dirname, "../MessageBubble.vue"), "utf-8");
+
+const getVideoBlock = (): string => {
+  const source = getSource();
+  const start = source.indexOf("<!-- Video message -->");
+  expect(start, "Video message block should exist in MessageBubble.vue").toBeGreaterThan(-1);
+  const end = source.indexOf("<!-- Audio", start);
+  expect(end, "Should find the audio block after the video bubble").toBeGreaterThan(start);
+  return source.slice(start, end);
+};
+
+describe("MessageBubble — video playback state machine (WEE-21)", () => {
+  it("binds @error on the inline <video> to a typed handler", () => {
+    const block = getVideoBlock();
+    expect(block).toMatch(/@error=/);
+    // The handler name itself is asserted so wiring stays explicit.
+    expect(block).toContain("onInlineVideoError");
+  });
+
+  it("tracks the typed error in a reactive `videoPlaybackError` ref", () => {
+    const source = getSource();
+    expect(source).toContain("videoPlaybackError");
+    // The ref must be typed nullable so the absence of error is the
+    // initial / cleared state.
+    expect(source).toMatch(/videoPlaybackError\s*=\s*ref<\s*VideoPlaybackError\s*\|\s*null\s*>/);
+  });
+
+  it("delegates MediaError → typed error to the pure helper module", () => {
+    const source = getSource();
+    // The script imports the pure mapper so the logic is unit-testable
+    // without mounting Vue.
+    expect(source).toMatch(/from\s+["']\.\.\/model\/video-error["']/);
+    expect(source).toContain("videoPlaybackErrorFromMediaError");
+  });
+
+  it("arms a load timeout when the decrypted blob URL becomes available", () => {
+    const source = getSource();
+    // The timer module constant must be imported, not redefined inline.
+    expect(source).toContain("VIDEO_LOAD_TIMEOUT_MS");
+    // The constant must end up as the delay argument of a setTimeout call
+    // — `[\s\S]*?` keeps the regex tolerant of the arrow-fn body in between.
+    expect(source).toMatch(/setTimeout\([\s\S]*?VIDEO_LOAD_TIMEOUT_MS\s*\)/);
+    // The "timeout" state must be reachable.
+    expect(source).toMatch(/videoPlaybackError\.value\s*=\s*["']timeout["']/);
+  });
+
+  it("guards the timeout write so it cannot clobber a more specific error", () => {
+    const source = getSource();
+    // After @error sets "decode"/"codec-unsupported", the still-pending
+    // timer must NOT replace it with "timeout" 10s later. The guard checks
+    // `videoPlaybackError === null` before assigning "timeout".
+    const armStart = source.indexOf("const armVideoLoadTimer");
+    expect(armStart, "armVideoLoadTimer must exist").toBeGreaterThan(-1);
+    const armEnd = source.indexOf("};", armStart);
+    const block = source.slice(armStart, armEnd);
+    expect(block).toMatch(/videoPlaybackError\.value\s*===\s*null/);
+  });
+
+  it("clears the timeout on @loadedmetadata and @canplay so it cannot fire late", () => {
+    const block = getVideoBlock();
+    expect(block).toMatch(/@loadedmetadata=/);
+    expect(block).toMatch(/@canplay=/);
+    const source = getSource();
+    expect(source).toContain("clearVideoLoadTimer");
+  });
+
+  it("renders an error overlay with the localized message and a download button", () => {
+    const block = getVideoBlock();
+    expect(block).toContain("videoPlaybackError");
+    expect(block).toContain("videoErrorMessage");
+    // The download fallback reuses the existing save-to-gallery handler so
+    // a codec-unsupported video still ends up on the user's device.
+    expect(block).toContain("handleFileDownload");
+  });
+
+  it("references the new localization keys for the error overlay", () => {
+    const source = getSource();
+    expect(source).toContain("message.videoUnsupportedFormat");
+    expect(source).toContain("message.videoLoadFailed");
+    expect(source).toContain("message.videoDownload");
+  });
+
+  it("offers retry for transient errors but not for codec-unsupported", () => {
+    const source = getSource();
+    expect(source).toContain("retryVideoPlayback");
+    // `videoCanRetry` must explicitly exclude codec-unsupported — a re-try
+    // on a missing codec can't succeed and would just bait the user.
+    expect(source).toContain("videoCanRetry");
+    const fnStart = source.indexOf("const videoCanRetry");
+    expect(fnStart).toBeGreaterThan(-1);
+    const fn = source.slice(fnStart, source.indexOf(";", fnStart) + 1);
+    expect(fn).toContain("codec-unsupported");
+  });
+
+  it("resets playback error when the bubble is recycled to a new message", () => {
+    const source = getSource();
+    // The existing watch on props.message.id (added for WEE-32) must also
+    // clear the playback error — otherwise a recycled bubble inherits the
+    // previous video's failure overlay. Walk to the closing `},\n);` of
+    // the watch call so inner `revokePoster();` does not truncate the block.
+    const watchStart = source.indexOf("watch(\n  () => props.message.id,");
+    expect(watchStart, "watch on message.id must exist").toBeGreaterThan(-1);
+    const closing = source.indexOf("\n);", watchStart);
+    expect(closing, "watch call must close with \\n);").toBeGreaterThan(watchStart);
+    const block = source.slice(watchStart, closing + 3);
+    expect(block).toMatch(/videoPlaybackError\.value\s*=\s*null/);
+  });
+
+  it("clears the load timer on unmount to avoid late writes to a dead ref", () => {
+    const source = getSource();
+    const lifecycleStart = source.indexOf("onBeforeUnmount(() => {");
+    expect(lifecycleStart).toBeGreaterThan(-1);
+    const block = source.slice(lifecycleStart, source.indexOf("});", lifecycleStart) + 3);
+    expect(block).toContain("clearVideoLoadTimer");
+  });
+});
+
+describe("MessageBubble — localization keys for video error UX (WEE-21)", () => {
+  const loadLocale = (filename: string): string =>
+    readFileSync(
+      resolve(__dirname, "../../../../shared/lib/i18n/locales", filename),
+      "utf-8",
+    );
+
+  it("defines Russian copy for the three new error keys", () => {
+    const ru = loadLocale("ru.ts");
+    expect(ru).toContain("message.videoUnsupportedFormat");
+    expect(ru).toContain("message.videoLoadFailed");
+    expect(ru).toContain("message.videoDownload");
+  });
+
+  it("defines English copy for the three new error keys", () => {
+    const en = loadLocale("en.ts");
+    expect(en).toContain("message.videoUnsupportedFormat");
+    expect(en).toContain("message.videoLoadFailed");
+    expect(en).toContain("message.videoDownload");
+  });
+});

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -261,6 +261,9 @@ export const en = {
   "message.retry": "Retry",
   "message.failedToLoadImage": "Failed to load image",
   "message.tapToRetry": "Tap to retry",
+  "message.videoUnsupportedFormat": "Video format not supported",
+  "message.videoLoadFailed": "Failed to load video",
+  "message.videoDownload": "Download",
 
   // ── Message context menu ──
   "contextMenu.reply": "Reply",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -263,6 +263,9 @@ export const ru: Record<TranslationKey, string> = {
   "message.retry": "Повторить",
   "message.failedToLoadImage": "Не удалось загрузить",
   "message.tapToRetry": "Нажмите для повтора",
+  "message.videoUnsupportedFormat": "Формат видео не поддерживается",
+  "message.videoLoadFailed": "Не удалось воспроизвести видео",
+  "message.videoDownload": "Скачать",
 
   // ── Message context menu ──
   "contextMenu.reply": "Ответить",


### PR DESCRIPTION
## Summary
- New typed video-playback state machine in `MessageBubble.vue` — `@error` routes `MediaError` codes through a pure mapper (`model/video-error.ts`) into `codec-unsupported` / `decode` / `timeout` / `generic`. A 10s load deadline armed on every new blob URL catches silent stalls; `@loadedmetadata` / `@canplay` disarm it.
- Localized error overlay with **Retry** + **Download** affordances. `codec-unsupported` hides Retry (re-fetching the same codec can't help) — only Download. The timer guard refuses to clobber a more specific `@error` that arrived between arming and the deadline.
- Three new flat i18n keys in `ru.ts` / `en.ts` (`message.videoUnsupportedFormat`, `message.videoLoadFailed`, `message.videoDownload`).
- Pure mapper has dedicated unit tests; wiring asserted via source-level regression (matches the existing pattern in `message-bubble-video-ux.test.ts` — mounting the full component requires ~10 store mocks and is out of proportion).
- Code review surfaced one HIGH (timer could overwrite the specific `@error` with `"timeout"` 10s later) and one MEDIUM (`isFailed` overlay could stack on top of the new error overlay) — both addressed in the same commit; unit test added for the timer guard.

## Linear
- Resolves [WEE-21](https://linear.app/wwwee/issue/WEE-21/media-video-ne-vosproizvoditsya-v-chate-vechnaya-buferizaciya-zelyonyj)

## Closes
- Closes greenShirtMystery/forta-bugs#761
- Closes greenShirtMystery/forta-bugs#748
- Closes greenShirtMystery/forta-bugs#679
- Closes greenShirtMystery/forta-bugs#652
- Closes greenShirtMystery/forta-bugs#532

## Test plan
- [x] vite build passes (vue-tsc has ~49 pre-existing errors identical on master — 49 == 49, zero new)
- [x] Vitest: 119 tests in messaging UI + video-error pass; baseline failures on master (open-profile-url / video-embed / chat-helpers) unchanged
- [x] Code review (code-reviewer agent): 1 HIGH + 1 MEDIUM both fixed, regression test added for the timer guard
- [ ] Manual QA on Android — tap a video with a known H.265 sample: should show "Формат видео не поддерживается" + Download (no Retry)
- [ ] Manual QA on Android — kill network mid-load: should show "Не удалось воспроизвести видео" + Retry + Download after 10s
- [ ] Manual QA — recycled bubble (scroll fast through chats) does not inherit a previous video's error overlay

## Files
- `src/features/messaging/model/video-error.ts` (new — pure mapper)
- `src/features/messaging/model/video-error.test.ts` (new — unit tests)
- `src/features/messaging/ui/MessageBubble.vue` (state machine + handlers + error overlay)
- `src/features/messaging/ui/__tests__/message-bubble-video-playback-error.test.ts` (new — source-level wiring regression)
- `src/shared/lib/i18n/locales/{ru,en}.ts` (3 new keys each)