### PR TITLE
fix(messages): hide false-failed retry indicator on delivered messages (WEE-40)

### DIFF
--- a/src/features/messaging/model/message-failed-state.test.ts
+++ b/src/features/messaging/model/message-failed-state.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { isMessageFailedForRetry } from "./message-failed-state";
+import { MessageStatus, MessageType } from "@/entities/chat/model/types";
+import type { Message } from "@/entities/chat/model/types";
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: "client_123",
+    _key: "client_123",
+    roomId: "!room:server",
+    senderId: "@alice:server",
+    content: "hello",
+    timestamp: 0,
+    status: MessageStatus.failed,
+    type: MessageType.text,
+    ...overrides,
+  };
+}
+
+describe("isMessageFailedForRetry", () => {
+  it("flags a never-delivered failed message (id still equals clientId)", () => {
+    const msg = makeMessage({ id: "cli_1", _key: "cli_1", status: MessageStatus.failed });
+    expect(isMessageFailedForRetry(msg)).toBe(true);
+  });
+
+  it("hides retry for a confirmed message whose id flipped to eventId (WEE-40)", () => {
+    // localToMessage sets id = eventId once confirmSent runs. If the queue
+    // later runs markMessageFailed because the SDK threw on the read side
+    // after the server accepted the event, this guard keeps the UI silent
+    // instead of slapping a red retry icon on a delivered bubble.
+    const msg = makeMessage({
+      id: "$server_event_id",
+      _key: "cli_1",
+      status: MessageStatus.failed,
+    });
+    expect(isMessageFailedForRetry(msg)).toBe(false);
+  });
+
+  it("returns false for non-failed statuses regardless of id/_key", () => {
+    expect(isMessageFailedForRetry(makeMessage({ status: MessageStatus.sent }))).toBe(false);
+    expect(isMessageFailedForRetry(makeMessage({ status: MessageStatus.sending }))).toBe(false);
+    expect(isMessageFailedForRetry(makeMessage({ status: MessageStatus.read }))).toBe(false);
+  });
+
+  it("falls back to status-only when _key is missing", () => {
+    const failed: Pick<Message, "status" | "id"> & { _key?: undefined } = {
+      id: "anything",
+      status: MessageStatus.failed,
+      _key: undefined,
+    };
+    expect(isMessageFailedForRetry(failed)).toBe(true);
+
+    const ok: Pick<Message, "status" | "id"> & { _key?: undefined } = {
+      id: "anything",
+      status: MessageStatus.sent,
+      _key: undefined,
+    };
+    expect(isMessageFailedForRetry(ok)).toBe(false);
+  });
+});

--- a/src/features/messaging/model/message-failed-state.ts
+++ b/src/features/messaging/model/message-failed-state.ts
@@ -1,0 +1,26 @@
+import type { Message } from "@/entities/chat/model/types";
+import { MessageStatus } from "@/entities/chat/model/types";
+
+/**
+ * Decide whether a UI Message should render the red "retry" indicator.
+ *
+ * A message is "failed for retry" only when:
+ *  1. Its derived status is `MessageStatus.failed`, AND
+ *  2. The server-issued eventId never replaced the clientId in `Message.id`
+ *     (i.e. `id === _key`, where `_key` is the stable clientId set in
+ *     `localToMessage`).
+ *
+ * When `id !== _key` the local row already picked up an eventId — that
+ * happens via `confirmSent` on a successful send, or via `upsertFromServer`
+ * when the Matrix `/sync` echo arrives before the queue's catch-handler
+ * runs. In both cases the peer received the message; showing a retry button
+ * on top of it is the WEE-40 false-failed bug.
+ */
+export function isMessageFailedForRetry(message: Pick<Message, "status" | "id" | "_key">): boolean {
+  if (message.status !== MessageStatus.failed) return false;
+  // Without a `_key` we cannot tell whether the id has flipped; fall back to
+  // the status alone so this helper stays robust against missing fields
+  // from mapper edge cases.
+  if (message._key === undefined) return true;
+  return message.id === message._key;
+}

--- a/src/features/messaging/model/use-file-download-heal.test.ts
+++ b/src/features/messaging/model/use-file-download-heal.test.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect, beforeEach, vi, type Mock } from "vitest";
+
+/**
+ * Regression coverage for WEE-40 lazy heal: a row whose fileInfo.url is
+ * still `blob:` after a reload (confirmMediaSent never ran, /sync echo
+ * won the race) must be self-healed at download-time by refetching the
+ * event from Matrix and persisting the recovered fileInfo.
+ */
+
+// --- Mocks ---
+let mockIsNative = false;
+let mockIsElectron = false;
+let mockIsAndroid = false;
+vi.mock("@/shared/lib/platform", () => ({
+  get isNative() { return mockIsNative; },
+  get isElectron() { return mockIsElectron; },
+  get isAndroid() { return mockIsAndroid; },
+}));
+
+vi.mock("@/entities/auth", () => ({
+  useAuthStore: vi.fn(() => ({ get pcrypto() { return null; } })),
+}));
+
+vi.mock("@capacitor/filesystem", () => ({
+  Filesystem: { writeFile: vi.fn() },
+  Directory: { Cache: "CACHE" },
+}));
+vi.mock("@capacitor-community/file-opener", () => ({ FileOpener: { open: vi.fn() } }));
+vi.mock("@capacitor/share", () => ({ Share: { share: vi.fn() } }));
+vi.mock("@capacitor/core", () => ({ registerPlugin: vi.fn(() => ({ save: vi.fn() })) }));
+
+vi.mock("@/shared/lib/matrix/functions", () => ({
+  hexEncode: vi.fn((s: string) => s),
+}));
+
+vi.mock("@/features/bug-report", () => ({
+  useBugReport: vi.fn(() => ({ open: vi.fn() })),
+}));
+vi.mock("@/shared/lib/i18n", () => ({ tRaw: (k: string) => k }));
+
+const mockToast: Mock = vi.fn();
+vi.mock("@/shared/lib/use-toast", () => ({
+  useToast: () => ({ toast: mockToast, close: vi.fn(), message: { value: "" }, type: { value: "info" }, show: { value: false } }),
+}));
+
+// fetchRoomEvent is the heal pivot — tests override it per case.
+const mockFetchRoomEvent: Mock = vi.fn();
+const mockMxcToHttp: Mock = vi.fn((mxc: string) =>
+  mxc.startsWith("mxc://") ? `https://homeserver/_matrix/media/r0/download/${mxc.slice(6)}` : null,
+);
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: vi.fn(() => ({
+    fetchRoomEvent: mockFetchRoomEvent,
+    mxcToHttp: mockMxcToHttp,
+  })),
+}));
+
+// updateFileInfo is the persistence pivot — assert it gets called with
+// the healed shape.
+const mockUpdateFileInfo: Mock = vi.fn(() => Promise.resolve());
+let mockChatDbReady = true;
+vi.mock("@/shared/lib/local-db", () => ({
+  getChatDb: () => ({
+    messages: { updateFileInfo: mockUpdateFileInfo },
+  }),
+  isChatDbReady: () => mockChatDbReady,
+}));
+
+vi.mock("@/shared/lib/media-cache", () => ({ getMediaCache: () => null }));
+
+const mockFetchResponse = {
+  ok: true,
+  blob: () => Promise.resolve(new Blob(["healed"], { type: "image/jpeg" })),
+  arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)),
+};
+global.fetch = vi.fn(() => Promise.resolve(mockFetchResponse)) as Mock;
+
+const { tryHealStaleBlobFileInfo } = await import("./use-file-download");
+
+describe("tryHealStaleBlobFileInfo (WEE-40 lazy heal)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockChatDbReady = true;
+  });
+
+  it("recovers mxc:// URL + secrets from a Matrix event and persists to Dexie", async () => {
+    mockFetchRoomEvent.mockResolvedValueOnce({
+      content: {
+        msgtype: "m.image",
+        body: "photo.jpg",
+        url: "mxc://server/realphoto",
+        info: {
+          mimetype: "image/jpeg",
+          secrets: { block: 1, keys: "deadbeef", v: 1 },
+        },
+      },
+    });
+
+    const local = {
+      name: "photo.jpg",
+      type: "image/jpeg",
+      size: 2048,
+      url: "blob:http://localhost:5173/stale",
+    };
+
+    const healed = await tryHealStaleBlobFileInfo("$evt", "!room:server", local);
+
+    expect(healed).not.toBeNull();
+    expect(healed!.url).toBe("mxc://server/realphoto");
+    expect(healed!.secrets).toEqual({ block: 1, keys: "deadbeef", v: 1 });
+    // Other fields preserved from local snapshot.
+    expect(healed!.name).toBe("photo.jpg");
+    expect(healed!.size).toBe(2048);
+
+    // Persisted under the eventId so future renders skip the fetch.
+    expect(mockUpdateFileInfo).toHaveBeenCalledWith("$evt", healed);
+  });
+
+  it("falls back to top-level content.secrets when content.info.secrets is absent", async () => {
+    // Older m.file shape from Bastyon clients puts secrets at the top.
+    mockFetchRoomEvent.mockResolvedValueOnce({
+      content: {
+        msgtype: "m.file",
+        body: "doc.pdf",
+        url: "mxc://server/docfile",
+        secrets: { block: 2, keys: "topsecret", v: 1 },
+      },
+    });
+
+    const local = {
+      name: "doc.pdf",
+      type: "application/pdf",
+      size: 1024,
+      url: "blob:http://localhost:5173/stale",
+    };
+
+    const healed = await tryHealStaleBlobFileInfo("$evt2", "!room:server", local);
+    expect(healed?.url).toBe("mxc://server/docfile");
+    expect(healed?.secrets).toEqual({ block: 2, keys: "topsecret", v: 1 });
+  });
+
+  it("falls back to content.pbody.secrets for legacy Bastyon-shape events", async () => {
+    // Some older Bastyon clients put secrets under content.pbody alongside
+    // the body — downloadAndDecrypt already reads from this path. The heal
+    // must too, otherwise decryption silently fails after url heal.
+    mockFetchRoomEvent.mockResolvedValueOnce({
+      content: {
+        msgtype: "m.image",
+        body: "photo.jpg",
+        url: "mxc://server/legacypbody",
+        pbody: {
+          secrets: { block: 3, keys: "pbodykey", v: 1 },
+        },
+      },
+    });
+
+    const local = {
+      name: "photo.jpg",
+      type: "image/jpeg",
+      size: 2048,
+      url: "blob:http://localhost:5173/stale",
+    };
+
+    const healed = await tryHealStaleBlobFileInfo("$evt_pbody", "!room:server", local);
+    expect(healed?.url).toBe("mxc://server/legacypbody");
+    expect(healed?.secrets).toEqual({ block: 3, keys: "pbodykey", v: 1 });
+  });
+
+  it("returns null when the server event has no usable url", async () => {
+    mockFetchRoomEvent.mockResolvedValueOnce({
+      content: {
+        msgtype: "m.image",
+        body: "photo.jpg",
+        // url missing — sender's send pipeline never finalised either
+      },
+    });
+
+    const local = {
+      name: "photo.jpg",
+      type: "image/jpeg",
+      size: 2048,
+      url: "blob:http://localhost:5173/stale",
+    };
+
+    const healed = await tryHealStaleBlobFileInfo("$evt3", "!room:server", local);
+    expect(healed).toBeNull();
+    // Nothing to persist when heal failed.
+    expect(mockUpdateFileInfo).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the event content itself carries a blob: url (sender lost it too)", async () => {
+    mockFetchRoomEvent.mockResolvedValueOnce({
+      content: {
+        msgtype: "m.image",
+        body: "photo.jpg",
+        url: "blob:http://something/else",
+      },
+    });
+
+    const local = {
+      name: "photo.jpg",
+      type: "image/jpeg",
+      size: 2048,
+      url: "blob:http://localhost:5173/stale",
+    };
+
+    expect(await tryHealStaleBlobFileInfo("$evt4", "!room:server", local)).toBeNull();
+  });
+
+  it("returns null when fetchRoomEvent yields null (event not in timeline / offline)", async () => {
+    mockFetchRoomEvent.mockResolvedValueOnce(null);
+
+    const local = {
+      name: "photo.jpg",
+      type: "image/jpeg",
+      size: 2048,
+      url: "blob:http://localhost:5173/stale",
+    };
+
+    expect(await tryHealStaleBlobFileInfo("$evt5", "!room:server", local)).toBeNull();
+  });
+
+  it("still returns healed fileInfo even when Dexie persist throws (heal must not block render)", async () => {
+    mockFetchRoomEvent.mockResolvedValueOnce({
+      content: {
+        msgtype: "m.image",
+        body: "photo.jpg",
+        url: "mxc://server/recovered",
+      },
+    });
+    mockUpdateFileInfo.mockRejectedValueOnce(new Error("Dexie closed"));
+
+    const local = {
+      name: "photo.jpg",
+      type: "image/jpeg",
+      size: 2048,
+      url: "blob:http://localhost:5173/stale",
+    };
+
+    const healed = await tryHealStaleBlobFileInfo("$evt6", "!room:server", local);
+    expect(healed?.url).toBe("mxc://server/recovered");
+  });
+
+  it("skips Dexie persist when chat-db is not initialised (logout race)", async () => {
+    mockChatDbReady = false;
+    mockFetchRoomEvent.mockResolvedValueOnce({
+      content: {
+        msgtype: "m.image",
+        body: "photo.jpg",
+        url: "mxc://server/nodb",
+      },
+    });
+
+    const local = {
+      name: "photo.jpg",
+      type: "image/jpeg",
+      size: 2048,
+      url: "blob:http://localhost:5173/stale",
+    };
+
+    const healed = await tryHealStaleBlobFileInfo("$evt7", "!room:server", local);
+    expect(healed?.url).toBe("mxc://server/nodb");
+    expect(mockUpdateFileInfo).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/messaging/model/use-file-download.test.ts
+++ b/src/features/messaging/model/use-file-download.test.ts
@@ -513,6 +513,94 @@ describe("useFileDownload", () => {
       scope.stop();
     });
 
+    it("short-circuits and reuses the live blob URL while the upload is still in flight (no toast, no overlay)", async () => {
+      // Optimistic outbound media: the row is status="sending", localBlobUrl
+      // is alive, mappers.ts surfaces it as fileInfo.url. The previous
+      // behaviour fell through to the WEE-28 fast-fail and produced a
+      // misleading "Файл повреждён или не пришёл с источника" toast plus a
+      // momentary retry overlay until confirmMediaSent flipped the row.
+      // After the fix, download() must return the blob URL as-is, with no
+      // fetch, no toast, no error state.
+      const fetchSpy = global.fetch as Mock;
+      fetchSpy.mockClear();
+      mockToast.mockClear();
+
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download } = useFileDownload();
+        const blobUrl = "blob:http://localhost:5173/optimistic-photo";
+        const message = {
+          id: "client_inflight",
+          _key: "client_inflight",
+          roomId: "!room:server",
+          senderId: "@me:server",
+          content: "photo.jpg",
+          timestamp: Date.now(),
+          // MessageStatus.sending is the canonical "upload in flight" signal.
+          status: "sending",
+          type: "image",
+          uploadProgress: 42,
+          fileInfo: {
+            name: "photo.jpg",
+            type: "image/jpeg",
+            size: 2048,
+            url: blobUrl,
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        const result = await download(message);
+
+        expect(result).toBe(blobUrl);
+        // Network must not be touched — the blob is local.
+        expect(fetchSpy).not.toHaveBeenCalled();
+        // No error toast must fire while the upload is still in flight.
+        expect(mockToast).not.toHaveBeenCalled();
+      });
+      scope.stop();
+    });
+
+    it("still fast-fails blob: URLs for non-sending status (WEE-28 dead-blob defense intact)", async () => {
+      // Guard parity: a row that survived a crashed upload comes back from
+      // Dexie with status="failed" (or "sent" if echo confirmed it) and a
+      // dead blob: URL. The short-circuit must NOT swallow that case —
+      // downloadAndDecrypt still has to throw MissingUrlError so the user
+      // sees an actionable "no usable file URL" state instead of a stuck
+      // <img> with a 404 from the browser.
+      const fetchSpy = global.fetch as Mock;
+      fetchSpy.mockClear();
+
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download } = useFileDownload();
+        const message = {
+          id: "$evt_dead_blob",
+          _key: "client_dead_blob",
+          roomId: "!room:server",
+          senderId: "@u:server",
+          content: "stuck.pdf",
+          timestamp: Date.now(),
+          status: "failed",
+          type: "file",
+          fileInfo: {
+            name: "stuck.pdf",
+            type: "application/pdf",
+            size: 1024,
+            url: "blob:http://localhost:5173/dead-blob",
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        const result = await download(message);
+
+        // No fetch — the WEE-28 guard short-circuits before the network.
+        expect(fetchSpy).not.toHaveBeenCalled();
+        // Returns null/undefined (download() reports errors via state, not throw).
+        expect(result).toBeFalsy();
+      });
+      scope.stop();
+    });
+
     it("does NOT mangle blob:/data: URLs with cache-bust (those schemes do not accept query strings)", () => {
       // Regression safety net for WEE-17 review: appending `?cb=` to a blob:
       // URL breaks the URL grammar and the next fetch would fail spuriously.

--- a/src/features/messaging/model/use-file-download.ts
+++ b/src/features/messaging/model/use-file-download.ts
@@ -20,6 +20,7 @@ import { waitForRoomCrypto } from "@/entities/matrix/model/wait-for-crypto";
 import { enqueueDecrypt } from "./decrypt-queue";
 import { getMediaCache, type MediaCacheCategory } from "@/shared/lib/media-cache";
 import { MessageType, MessageStatus } from "@/entities/chat";
+import { getChatDb, isChatDbReady } from "@/shared/lib/local-db";
 
 /** Classify a message into the Settings → Storage tab buckets.
  *  - `media` = photos + videos + video circles
@@ -238,6 +239,76 @@ function surfaceTypedErrorToast(err: unknown, cacheKey: string): void {
     // (worker contexts, headless tests without scope) it may throw.
     // Don't let a failed toast mask the original download error.
     console.warn("[use-file-download] toast surface failed:", toastErr);
+  }
+}
+
+/** Refetch a Matrix event by id and extract a fresh FileInfo with the
+ *  server URL + secrets. Used to recover from rows where an optimistic
+ *  `blob:` URL survived a reload because confirmMediaSent never ran —
+ *  e.g. the /sync echo won the race against the queue's catch path
+ *  (WEE-40). Returns the healed FileInfo, or null when the event is
+ *  unavailable or doesn't carry a usable url.
+ *
+ *  Side effect: persists the healed FileInfo to Dexie so future renders
+ *  of the same message skip this fetch entirely. Persistence failures
+ *  are non-fatal — the caller will still get the healed FileInfo for
+ *  the current download attempt. */
+export async function tryHealStaleBlobFileInfo(
+  eventId: string,
+  roomId: string,
+  fileInfo: FileInfo,
+): Promise<FileInfo | null> {
+  try {
+    const matrix = getMatrixClientService();
+    const event = await matrix.fetchRoomEvent(roomId, eventId);
+    if (!event) return null;
+    const content = event.content as Record<string, unknown> | undefined;
+    if (!content) return null;
+    const rawUrl = typeof content.url === "string" ? content.url : undefined;
+    if (!rawUrl || rawUrl.startsWith("blob:") || rawUrl.startsWith("data:")) {
+      // Event itself carries no real server URL — sender lost it too.
+      return null;
+    }
+
+    // Secrets may live under three shapes depending on the sending client:
+    //  - `content.info.secrets`   — modern m.image / m.video / m.audio with explicit info
+    //  - `content.secrets`        — older m.file shape that emits top-level secrets
+    //  - `content.pbody.secrets`  — legacy Bastyon shape; downloadAndDecrypt
+    //                                already reads from this path (use-file-download.ts:471)
+    // Cover all three so a heal on a legacy-format encrypted attachment
+    // doesn't silently lose its keys and surface a crypto failure on next
+    // decrypt attempt.
+    let secrets: FileInfo["secrets"] | undefined;
+    const info = content.info as Record<string, unknown> | undefined;
+    const pbody = content.pbody as Record<string, unknown> | undefined;
+    if (info && info.secrets && typeof info.secrets === "object") {
+      secrets = info.secrets as FileInfo["secrets"];
+    } else if (content.secrets && typeof content.secrets === "object") {
+      secrets = content.secrets as FileInfo["secrets"];
+    } else if (pbody && pbody.secrets && typeof pbody.secrets === "object") {
+      secrets = pbody.secrets as FileInfo["secrets"];
+    }
+
+    const healed: FileInfo = {
+      ...fileInfo,
+      url: rawUrl,
+      ...(secrets ? { secrets } : {}),
+    };
+
+    if (isChatDbReady()) {
+      try {
+        await getChatDb().messages.updateFileInfo(eventId, healed);
+      } catch (persistErr) {
+        // Heal still works for this attempt — only future renders pay
+        // the refetch cost again. Don't bubble.
+        console.warn("[use-file-download] heal: persist failed:", persistErr);
+      }
+    }
+
+    return healed;
+  } catch (e) {
+    console.warn("[use-file-download] heal: fetchRoomEvent failed:", e);
+    return null;
   }
 }
 
@@ -785,6 +856,34 @@ export function useFileDownload() {
     state.error = null;
     state.errorKind = null;
 
+    // Lazy heal: a row whose fileInfo.url is still blob:/data: after the
+    // page reload almost always means confirmMediaSent never ran on the
+    // sender side (race with /sync echo, queue catch-path dropped the op,
+    // etc.). The event itself does have a real mxc URL on the server —
+    // refetch it and patch the row before falling through to
+    // downloadAndDecrypt, which would otherwise fast-fail with
+    // MissingUrlError and show a misleading "файл повреждён" toast on a
+    // message the peer actually received (WEE-40).
+    let effectiveFileInfo = message.fileInfo;
+    const looksOptimisticAndStale =
+      effectiveFileInfo.url !== undefined &&
+      (effectiveFileInfo.url.startsWith("blob:") || effectiveFileInfo.url.startsWith("data:")) &&
+      message.status !== MessageStatus.sending &&
+      // `id` flips from clientId to eventId in localToMessage on
+      // confirmSent; `_key` always holds clientId. They differ exactly
+      // when a server eventId is known — the only case where heal can
+      // hope to succeed.
+      message._key !== undefined &&
+      message.id !== message._key;
+    if (looksOptimisticAndStale) {
+      const healed = await tryHealStaleBlobFileInfo(
+        message.id,
+        message.roomId,
+        effectiveFileInfo,
+      );
+      if (healed) effectiveFileInfo = healed;
+    }
+
     // Fast path: persistent media cache hit (Telegram/WhatsApp-style).
     // Cacheable when the source is a remote URL we can stably key by —
     // any `mxc://` or `http(s)://`. Local schemes (`blob:` / `data:`) are
@@ -792,7 +891,7 @@ export function useFileDownload() {
     // for free, so caching them gains nothing and pollutes the index.
     // Cache lookup failures are swallowed: a missing cache layer just falls
     // through to the network path with no user-visible difference.
-    const mxc = message.fileInfo.url;
+    const mxc = effectiveFileInfo.url;
     const isCacheableUrl = !!mxc &&
       (mxc.startsWith("mxc://") || mxc.startsWith("http://") || mxc.startsWith("https://"));
     const mediaCache = getMediaCache();
@@ -800,7 +899,7 @@ export function useFileDownload() {
       try {
         const cachedBlob = await mediaCache.get(mxc);
         if (cachedBlob) {
-          const mimeType = message.fileInfo.type || cachedBlob.type || "application/octet-stream";
+          const mimeType = effectiveFileInfo.type || cachedBlob.type || "application/octet-stream";
           const typedBlob = cachedBlob.type === mimeType
             ? cachedBlob
             : new Blob([cachedBlob], { type: mimeType });
@@ -818,13 +917,13 @@ export function useFileDownload() {
 
     try {
       const blob = await downloadAndDecrypt(
-        message.fileInfo,
+        effectiveFileInfo,
         message.roomId,
         message.senderId,
         message.timestamp,
         signal,
       );
-      const mimeType = message.fileInfo.type || "application/octet-stream";
+      const mimeType = effectiveFileInfo.type || "application/octet-stream";
       const typedBlob = new Blob([blob], { type: mimeType });
       const url = URL.createObjectURL(typedBlob);
 
@@ -840,7 +939,7 @@ export function useFileDownload() {
         mediaCache.put(mxc!, typedBlob, {
           roomId: message.roomId,
           category: classifyForCache(message.type, mimeType),
-          fileName: message.fileInfo.name,
+          fileName: effectiveFileInfo.name,
         }).catch((err) => {
           console.warn("[use-file-download] media cache write failed:", err);
         });

--- a/src/features/messaging/model/use-file-download.ts
+++ b/src/features/messaging/model/use-file-download.ts
@@ -19,7 +19,7 @@ import {
 import { waitForRoomCrypto } from "@/entities/matrix/model/wait-for-crypto";
 import { enqueueDecrypt } from "./decrypt-queue";
 import { getMediaCache, type MediaCacheCategory } from "@/shared/lib/media-cache";
-import { MessageType } from "@/entities/chat";
+import { MessageType, MessageStatus } from "@/entities/chat";
 
 /** Classify a message into the Settings → Storage tab buckets.
  *  - `media` = photos + videos + video circles
@@ -752,6 +752,30 @@ export function useFileDownload() {
       const state = getState(cacheKey);
       state.objectUrl = cache.get(cacheKey)!;
       return state.objectUrl;
+    }
+
+    // Optimistic-upload fast path: the message is still going through the
+    // outbound queue (status=sending), `localBlobUrl` is alive, and
+    // `mappers.ts` has surfaced it as fileInfo.url. Running the full
+    // server-fetch pipeline here would fast-fail in downloadAndDecrypt's
+    // blob:/data: guard (defence against WEE-28 dead blob remnants), which
+    // pops a misleading "Файл повреждён или не пришёл с источника" toast
+    // and a momentary red retry overlay while the sender's own upload is
+    // still in flight. Bypass the pipeline: use the blob URL as-is, do not
+    // pollute the long-lived `cache` (the blob is revoked ~5s after
+    // confirmMediaSent), and let the watch-on-id re-trigger download once
+    // the row flips to status=sent with a real mxc URL.
+    const fileUrl = message.fileInfo.url;
+    if (
+      fileUrl?.startsWith("blob:") &&
+      message.status === MessageStatus.sending
+    ) {
+      const state = getState(cacheKey);
+      state.objectUrl = fileUrl;
+      state.loading = false;
+      state.error = null;
+      state.errorKind = null;
+      return fileUrl;
     }
 
     const state = getState(cacheKey);

--- a/src/features/messaging/ui/MessageBubble.vue
+++ b/src/features/messaging/ui/MessageBubble.vue
@@ -4,6 +4,7 @@ import { useChatStore, MessageStatus, MessageType } from "@/entities/chat";
 import { formatTime } from "@/shared/lib/format";
 import { stripMentionAddresses, stripBastyonLinks } from "@/shared/lib/message-format";
 import { useFileDownload } from "../model/use-file-download";
+import { isMessageFailedForRetry } from "../model/message-failed-state";
 import { useBugReport } from "@/features/bug-report";
 import { tRaw } from "@/shared/lib/i18n";
 import { useToast } from "@/shared/lib/use-toast";
@@ -297,7 +298,11 @@ const isUploading = computed(() =>
   props.message.status === MessageStatus.sending &&
   props.message.uploadProgress !== undefined
 );
-const isFailed = computed(() => props.message.status === MessageStatus.failed);
+// Treat failed-status only as actual retry-worthy when the server never
+// accepted the event. See `isMessageFailedForRetry` for the rationale — this
+// guard suppresses the WEE-40 false-failed indicator on messages that the
+// peer actually received.
+const isFailed = computed(() => isMessageFailedForRetry(props.message));
 
 const fileIcon = computed(() => {
   const type = props.message.fileInfo?.type ?? "";
@@ -1055,7 +1060,7 @@ const replyPreviewSender = computed(() => {
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <polyline points="23 4 23 10 17 10" /><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
           </svg>
-          {{ t('message.retrySend', 'Tap to retry') }}
+          {{ t('message.tapToRetry') }}
         </div>
 
         <!-- Reactions row -->

--- a/src/shared/lib/i18n/retry-keys.test.ts
+++ b/src/shared/lib/i18n/retry-keys.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { en } from "./locales/en";
+import { ru } from "./locales/ru";
+
+/**
+ * Regression: WEE-40 surfaced a literal "message.retrySend" string in the
+ * UI because the key did not exist in any locale and the second arg to t()
+ * was a string instead of a params object. The fix swapped the call site to
+ * `message.tapToRetry`; these tests pin that ru/en both define the keys the
+ * retry indicator actually uses, so a future renaming doesn't silently
+ * regress the bubble back to a raw key on screen.
+ */
+describe("i18n retry keys (WEE-40)", () => {
+  it("defines message.tapToRetry in both locales", () => {
+    expect(typeof en["message.tapToRetry"]).toBe("string");
+    expect(en["message.tapToRetry"].length).toBeGreaterThan(0);
+    expect(typeof ru["message.tapToRetry"]).toBe("string");
+    expect(ru["message.tapToRetry"].length).toBeGreaterThan(0);
+  });
+
+  it("defines message.retry in both locales (used by media-bubble overlay)", () => {
+    expect(typeof en["message.retry"]).toBe("string");
+    expect(en["message.retry"].length).toBeGreaterThan(0);
+    expect(typeof ru["message.retry"]).toBe("string");
+    expect(ru["message.retry"].length).toBeGreaterThan(0);
+  });
+
+  it("does not ship the broken 'message.retrySend' key (would mean it's still referenced)", () => {
+    // Sanity check — if a future commit accidentally re-introduces this key,
+    // the test still passes (we only check current absence), but a referencing
+    // call site would fail TypeScript's TranslationKey narrowing. The test
+    // documents intent: the key was a typo and should stay deleted.
+    expect((en as Record<string, string>)["message.retrySend"]).toBeUndefined();
+    expect((ru as Record<string, string>)["message.retrySend"]).toBeUndefined();
+  });
+});

--- a/src/shared/lib/local-db/__tests__/message-repository-fileinfo-heal.test.ts
+++ b/src/shared/lib/local-db/__tests__/message-repository-fileinfo-heal.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Dexie from "dexie";
+import "fake-indexeddb/auto";
+import { MessageRepository } from "../message-repository";
+import type { ChatDatabase, LocalMessage } from "../schema";
+import { MessageType } from "@/entities/chat/model/types";
+
+/**
+ * Regression coverage for WEE-40 (second wave): the optimistic path in
+ * `use-messages.ts` writes `fileInfo.url = localBlobUrl` (a `blob:` URL)
+ * into Dexie at send time. If the Matrix `/sync` echo wins the race
+ * against `confirmMediaSent` — or the queue's catch branch drops the op
+ * because the row is already "synced" (the WEE-40 race guard) —
+ * `confirmMediaSent` never runs and `fileInfo.url` stays `blob:` forever.
+ * After a page reload the bubble fast-fails through `downloadAndDecrypt`'s
+ * blob-guard and the user sees a misleading "Файл повреждён или не пришёл
+ * с источника" toast on a message that actually reached the peer.
+ *
+ * Fix: `upsertFromServer` and `bulkInsert` self-heal — they accept the
+ * server-side `fileInfo` (carrying `mxc://` or `http(s)://`) whenever the
+ * local copy still holds a `blob:`/`data:` URL.
+ */
+
+class TestDb extends Dexie {
+  messages!: Dexie.Table<LocalMessage, number>;
+  rooms!: Dexie.Table<unknown, string>;
+  decryptionQueue!: Dexie.Table<unknown, number>;
+  listenedMessages!: Dexie.Table<unknown, string>;
+  pendingOps!: Dexie.Table<unknown, number>;
+  users!: Dexie.Table<unknown, string>;
+  syncState!: Dexie.Table<unknown, string>;
+  attachments!: Dexie.Table<unknown, number>;
+
+  constructor(name: string) {
+    super(name, { indexedDB, IDBKeyRange });
+    this.version(1).stores({
+      messages:
+        "++localId, eventId, clientId, [roomId+timestamp], [roomId+status], senderId",
+      rooms: "id, updatedAt, membership, isDeleted",
+      decryptionQueue: "++id, status, [status+nextAttemptAt]",
+      listenedMessages: "eventId",
+      pendingOps: "++id, status",
+      users: "address",
+      syncState: "key",
+      attachments: "++id, messageLocalId, status",
+    });
+  }
+}
+
+function makeLocalMsg(overrides: Partial<LocalMessage> = {}): LocalMessage {
+  return {
+    eventId: overrides.eventId ?? null,
+    clientId:
+      overrides.clientId ?? `cli_${Math.random().toString(36).slice(2)}`,
+    roomId: overrides.roomId ?? "!room:server",
+    senderId: overrides.senderId ?? "@me:server",
+    content: overrides.content ?? "Image",
+    timestamp: overrides.timestamp ?? Date.now(),
+    type: overrides.type ?? MessageType.image,
+    status: overrides.status ?? "pending",
+    version: 1,
+    softDeleted: false,
+    ...overrides,
+  } as LocalMessage;
+}
+
+describe("MessageRepository.upsertFromServer — fileInfo self-heal (WEE-40)", () => {
+  let db: TestDb;
+  let repo: MessageRepository;
+
+  beforeEach(async () => {
+    db = new TestDb(`heal-${Date.now()}-${Math.random()}`);
+    await db.open();
+    repo = new MessageRepository(db as unknown as ChatDatabase);
+  });
+
+  afterEach(async () => {
+    await db.delete();
+  });
+
+  it("replaces optimistic blob: fileInfo URL with the server mxc:// URL from /sync echo", async () => {
+    // Local optimistic insert (mimics createLocal in use-messages.ts)
+    const clientId = "client_abc";
+    await db.messages.add(
+      makeLocalMsg({
+        clientId,
+        status: "synced", // echo already flipped the row to synced
+        eventId: null,
+        fileInfo: {
+          name: "photo.jpg",
+          type: "image/jpeg",
+          size: 2048,
+          url: "blob:http://localhost:5173/optimistic-photo",
+        },
+      }),
+    );
+
+    // /sync echo carries the server-side fileInfo
+    const echo = makeLocalMsg({
+      clientId,
+      eventId: "$server_event",
+      status: "synced",
+      fileInfo: {
+        name: "photo.jpg",
+        type: "image/jpeg",
+        size: 2048,
+        url: "mxc://server/abc123",
+        secrets: { block: 1, keys: "deadbeef", v: 1 },
+      },
+    });
+
+    const result = await repo.upsertFromServer(echo);
+    expect(result).toBe("updated");
+
+    const updated = await repo.getByClientId(clientId);
+    expect(updated?.fileInfo?.url).toBe("mxc://server/abc123");
+    expect(updated?.fileInfo?.secrets).toEqual({ block: 1, keys: "deadbeef", v: 1 });
+    expect(updated?.eventId).toBe("$server_event");
+    expect(updated?.status).toBe("synced");
+  });
+
+  it("does NOT overwrite a healthy mxc:// fileInfo URL on subsequent echoes", async () => {
+    // After confirmMediaSent has already written the real URL.
+    const clientId = "client_def";
+    await db.messages.add(
+      makeLocalMsg({
+        clientId,
+        status: "synced",
+        eventId: "$server_event",
+        fileInfo: {
+          name: "doc.pdf",
+          type: "application/pdf",
+          size: 4096,
+          url: "mxc://server/realurl",
+          secrets: { block: 1, keys: "originalkey", v: 1 },
+        },
+      }),
+    );
+
+    // A re-delivery of the same echo (or a slightly stale snapshot).
+    const reEcho = makeLocalMsg({
+      clientId,
+      eventId: "$server_event",
+      status: "synced",
+      fileInfo: {
+        name: "doc.pdf",
+        type: "application/pdf",
+        size: 4096,
+        url: "mxc://server/realurl",
+        secrets: { block: 1, keys: "shouldNotReplace", v: 1 },
+      },
+    });
+
+    await repo.upsertFromServer(reEcho);
+    const after = await repo.getByClientId(clientId);
+    // Existing fileInfo with a real URL is the source of truth — must not
+    // be rewritten on every echo.
+    expect(after?.fileInfo?.secrets).toEqual({ block: 1, keys: "originalkey", v: 1 });
+  });
+
+  it("heals fileInfo even when the upload is still in flight (localBlobUrl present)", async () => {
+    // Mid-upload state: localBlobUrl still set, status=pending. The
+    // existing in-flight branch must NOT lose the chance to heal — if
+    // the echo arrives with a real URL, store it now so any later
+    // reload sees a server URL.
+    const clientId = "client_inflight";
+    await db.messages.add(
+      makeLocalMsg({
+        clientId,
+        status: "pending",
+        eventId: null,
+        localBlobUrl: "blob:http://localhost:5173/inflight",
+        fileInfo: {
+          name: "video.mp4",
+          type: "video/mp4",
+          size: 8192,
+          url: "blob:http://localhost:5173/inflight",
+        },
+      }),
+    );
+
+    const echo = makeLocalMsg({
+      clientId,
+      eventId: "$inflight_evt",
+      status: "synced",
+      fileInfo: {
+        name: "video.mp4",
+        type: "video/mp4",
+        size: 8192,
+        url: "mxc://server/video123",
+        secrets: { block: 2, keys: "vidkey", v: 1 },
+      },
+    });
+
+    await repo.upsertFromServer(echo);
+    const after = await repo.getByClientId(clientId);
+    expect(after?.fileInfo?.url).toBe("mxc://server/video123");
+    expect(after?.fileInfo?.secrets).toEqual({ block: 2, keys: "vidkey", v: 1 });
+    // Status path for in-flight uploads stays as it was — confirmMediaSent
+    // owns the pending → synced transition, the heal only touches fileInfo.
+    expect(after?.status).toBe("pending");
+    // localBlobUrl is preserved while the upload is still in flight (the
+    // in-flight branch does not touch it).
+    expect(after?.localBlobUrl).toBe("blob:http://localhost:5173/inflight");
+  });
+
+  it("heals when the local row has no fileInfo at all (defence in depth)", async () => {
+    // An old row that somehow lost its fileInfo (legacy migration, corrupt
+    // write) must still pick up the echo's server fileInfo — otherwise it
+    // would render as a placeholder forever even though the server has
+    // the real media.
+    const clientId = "client_no_fileinfo";
+    await db.messages.add(
+      makeLocalMsg({
+        clientId,
+        status: "synced",
+        eventId: "$prev",
+        fileInfo: undefined,
+      }),
+    );
+
+    const echo = makeLocalMsg({
+      clientId,
+      eventId: "$prev",
+      status: "synced",
+      fileInfo: {
+        name: "recovered.jpg",
+        type: "image/jpeg",
+        size: 512,
+        url: "mxc://server/recover",
+      },
+    });
+
+    await repo.upsertFromServer(echo);
+    const after = await repo.getByClientId(clientId);
+    expect(after?.fileInfo?.url).toBe("mxc://server/recover");
+    expect(after?.fileInfo?.name).toBe("recovered.jpg");
+  });
+
+  it("does not invent fileInfo when the echo carries no media payload", async () => {
+    // Defence: a text echo with no fileInfo must not wipe out a media row's
+    // existing fileInfo, and must not write `undefined` into the column.
+    const clientId = "client_text_echo";
+    await db.messages.add(
+      makeLocalMsg({
+        clientId,
+        status: "synced",
+        eventId: "$old",
+        fileInfo: {
+          name: "img.png",
+          type: "image/png",
+          size: 1024,
+          url: "blob:http://localhost:5173/orphan",
+        },
+      }),
+    );
+
+    const echo = makeLocalMsg({
+      clientId,
+      eventId: "$old",
+      status: "synced",
+      // no fileInfo on the echo
+    });
+
+    await repo.upsertFromServer(echo);
+    const after = await repo.getByClientId(clientId);
+    // fileInfo stays exactly as it was — no overwrite with undefined.
+    expect(after?.fileInfo?.name).toBe("img.png");
+    expect(after?.fileInfo?.url).toBe("blob:http://localhost:5173/orphan");
+  });
+});
+
+describe("MessageRepository.bulkInsert — fileInfo self-heal (WEE-40)", () => {
+  let db: TestDb;
+  let repo: MessageRepository;
+
+  beforeEach(async () => {
+    db = new TestDb(`heal-bulk-${Date.now()}-${Math.random()}`);
+    await db.open();
+    repo = new MessageRepository(db as unknown as ChatDatabase);
+  });
+
+  afterEach(async () => {
+    await db.delete();
+  });
+
+  it("upgrades a pending local row's fileInfo from blob: to mxc:// on timeline replay", async () => {
+    const clientId = "client_bulk";
+    await db.messages.add(
+      makeLocalMsg({
+        clientId,
+        status: "pending",
+        eventId: null,
+        fileInfo: {
+          name: "photo.jpg",
+          type: "image/jpeg",
+          size: 2048,
+          url: "blob:http://localhost:5173/bulk-photo",
+        },
+      }),
+    );
+
+    const incoming = makeLocalMsg({
+      clientId,
+      eventId: "$bulk_evt",
+      status: "synced",
+      fileInfo: {
+        name: "photo.jpg",
+        type: "image/jpeg",
+        size: 2048,
+        url: "mxc://server/bulkphoto",
+        secrets: { block: 1, keys: "bulkkey", v: 1 },
+      },
+    });
+
+    await repo.bulkInsert([incoming]);
+
+    const after = await repo.getByClientId(clientId);
+    expect(after?.fileInfo?.url).toBe("mxc://server/bulkphoto");
+    expect(after?.fileInfo?.secrets).toEqual({ block: 1, keys: "bulkkey", v: 1 });
+    expect(after?.eventId).toBe("$bulk_evt");
+    expect(after?.status).toBe("synced");
+  });
+});

--- a/src/shared/lib/local-db/__tests__/message-repository-fileinfo-heal.test.ts
+++ b/src/shared/lib/local-db/__tests__/message-repository-fileinfo-heal.test.ts
@@ -270,6 +270,53 @@ describe("MessageRepository.upsertFromServer — fileInfo self-heal (WEE-40)", (
   });
 });
 
+describe("MessageRepository.updateFileInfo — clears localBlobUrl (WEE-40)", () => {
+  let db: TestDb;
+  let repo: MessageRepository;
+
+  beforeEach(async () => {
+    db = new TestDb(`heal-update-${Date.now()}-${Math.random()}`);
+    await db.open();
+    repo = new MessageRepository(db as unknown as ChatDatabase);
+  });
+
+  afterEach(async () => {
+    await db.delete();
+  });
+
+  it("nulls localBlobUrl so the mapper does not re-mask the healed url on next render", async () => {
+    // Without clearing localBlobUrl, mappers.ts:33 (`url: local.localBlobUrl ||
+    // local.fileInfo.url`) would resurface the dead blob: URL on every reload,
+    // defeating the heal. The clear ensures the heal persists across renders.
+    await db.messages.add(
+      makeLocalMsg({
+        clientId: "cli_clear",
+        eventId: "$clear_evt",
+        status: "synced",
+        localBlobUrl: "blob:http://localhost:5173/zombie",
+        fileInfo: {
+          name: "photo.jpg",
+          type: "image/jpeg",
+          size: 2048,
+          url: "blob:http://localhost:5173/zombie",
+        },
+      }),
+    );
+
+    await repo.updateFileInfo("$clear_evt", {
+      name: "photo.jpg",
+      type: "image/jpeg",
+      size: 2048,
+      url: "mxc://server/healed",
+      secrets: { block: 1, keys: "healedkey", v: 1 },
+    });
+
+    const after = await repo.getByClientId("cli_clear");
+    expect(after?.fileInfo?.url).toBe("mxc://server/healed");
+    expect(after?.localBlobUrl).toBeUndefined();
+  });
+});
+
 describe("MessageRepository.bulkInsert — fileInfo self-heal (WEE-40)", () => {
   let db: TestDb;
   let repo: MessageRepository;

--- a/src/shared/lib/local-db/__tests__/sync-engine-false-failed.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-false-failed.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Dexie from "dexie";
+import "fake-indexeddb/auto";
+import { SyncEngine } from "../sync-engine";
+import type { PendingOperation, LocalMessage, LocalRoom } from "../schema";
+
+/**
+ * Regression coverage for WEE-40: successfully-delivered messages must never
+ * end up with status="failed". Two race paths can leak a "failed" badge onto
+ * a synced message:
+ *
+ *   1. matrix-js-sdk throws on the read side after the server accepted the
+ *      event. The /sync echo arrives via upsertFromServer and flips the local
+ *      row to "synced" with an eventId, but the queue catch-handler later
+ *      runs markMessageFailed and downgrades it back to "failed".
+ *
+ *   2. maxRetries is reached after the echo already confirmed the message.
+ *      Same problem — the bookkeeping in processTick must yield to the row's
+ *      current state.
+ *
+ * Both paths are covered here. The fix lives in
+ * `sync-engine.ts:isMessageAlreadyConfirmed` and the catch branch of
+ * processTick that drops the op when the message is already confirmed.
+ */
+
+const mockMatrix = {
+  sendEncryptedText: vi.fn<
+    (roomId: string, content: unknown, clientId?: string) => Promise<string>
+  >(async () => "$server_event_id"),
+  sendText: vi.fn<(roomId: string, body: string) => Promise<string>>(async () => "$server_event_id"),
+  sendReaction: vi.fn<(roomId: string, eventId: string, emoji: string) => Promise<string>>(
+    async () => "$reaction_id",
+  ),
+  redactEvent: vi.fn<(roomId: string, eventId: string) => Promise<void>>(async () => undefined),
+  sendPollStart: vi.fn<(roomId: string, content: unknown) => Promise<string>>(
+    async () => "$poll_id",
+  ),
+  sendPollResponse: vi.fn<(roomId: string, content: unknown) => Promise<void>>(
+    async () => undefined,
+  ),
+  uploadContentMxc: vi.fn<(blob: Blob) => Promise<string>>(async () => "mxc://server/file"),
+};
+
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: () => mockMatrix,
+}));
+
+class TestDb extends Dexie {
+  messages!: Dexie.Table<LocalMessage, number>;
+  rooms!: Dexie.Table<LocalRoom, string>;
+  pendingOps!: Dexie.Table<PendingOperation, number>;
+  attachments!: Dexie.Table<{ id?: number; localBlob?: Blob; size?: number }, number>;
+  users!: Dexie.Table<{ address: string }, string>;
+  syncState!: Dexie.Table<{ key: string; value: string | number }, string>;
+  decryptionQueue!: Dexie.Table<{ id?: number; status: string }, number>;
+  listenedMessages!: Dexie.Table<{ messageId: string }, string>;
+
+  constructor(name: string) {
+    super(name, { indexedDB, IDBKeyRange });
+    this.version(1).stores({
+      messages:
+        "++localId, eventId, clientId, [roomId+timestamp], [roomId+status], senderId",
+      rooms: "id, updatedAt, membership, isDeleted",
+      pendingOps:
+        "++id, [roomId+createdAt], status, clientId, [status+nextAttemptAt]",
+      attachments: "++id, messageLocalId, status",
+      users: "address, updatedAt",
+      syncState: "key",
+      decryptionQueue: "++id, status, [status+nextAttemptAt]",
+      listenedMessages: "messageId",
+    });
+  }
+}
+
+interface MessageRepoStub {
+  confirmSent: ReturnType<typeof vi.fn>;
+  updateStatus: ReturnType<typeof vi.fn>;
+  getByEventId: ReturnType<typeof vi.fn>;
+  updateReactions: ReturnType<typeof vi.fn>;
+  getByClientId: ReturnType<typeof vi.fn>;
+}
+
+interface Harness {
+  db: TestDb;
+  engine: SyncEngine;
+  messageRepo: MessageRepoStub;
+  roomRepo: { updateRoom: ReturnType<typeof vi.fn> };
+  /** Backing store the messageRepo stub reads from. Tests mutate this to
+   *  simulate Matrix /sync echoes arriving mid-flight. */
+  rows: Map<string, Partial<LocalMessage>>;
+}
+
+function makeHarness(name: string): Harness {
+  const db = new TestDb(name);
+  const rows = new Map<string, Partial<LocalMessage>>();
+  const messageRepo: MessageRepoStub = {
+    confirmSent: vi.fn(async (clientId: string, eventId: string) => {
+      const current = rows.get(clientId) ?? {};
+      rows.set(clientId, { ...current, eventId, status: "synced" });
+    }),
+    updateStatus: vi.fn(async (id: { clientId?: string; eventId?: string }, status: string) => {
+      const key = id.clientId ?? id.eventId;
+      if (!key) return;
+      const current = rows.get(key) ?? {};
+      rows.set(key, { ...current, status: status as LocalMessage["status"] });
+    }),
+    getByEventId: vi.fn(async () => undefined),
+    updateReactions: vi.fn(async () => undefined),
+    getByClientId: vi.fn(async (clientId: string) => rows.get(clientId)),
+  };
+  const roomRepo = { updateRoom: vi.fn(async () => undefined) };
+  const getRoomCrypto = vi.fn(async () => undefined);
+  const engine = new SyncEngine(
+    db as never,
+    messageRepo as never,
+    roomRepo as never,
+    getRoomCrypto,
+  );
+  return { db, engine, messageRepo, roomRepo, rows };
+}
+
+async function seedOp(
+  db: TestDb,
+  overrides: Partial<PendingOperation> = {},
+): Promise<number> {
+  return db.pendingOps.add({
+    type: "send_message",
+    roomId: "!room:server",
+    payload: { content: "hello" },
+    status: "pending",
+    retries: 0,
+    maxRetries: 2,
+    createdAt: Date.now(),
+    clientId: `cli_${Math.random().toString(36).slice(2)}`,
+    nextAttemptAt: 0,
+    ...overrides,
+  } as PendingOperation);
+}
+
+describe("SyncEngine — WEE-40: false-failed status on delivered messages", () => {
+  let h: Harness;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    h = makeHarness(`sync-engine-false-failed-${Date.now()}-${Math.random()}`);
+    await h.db.open();
+  });
+
+  afterEach(async () => {
+    h.engine.dispose();
+    // dispose clears scheduled timers but in-flight microtasks (the catch
+    // block of processTick) can still race against db.delete() and raise
+    // DexieClosedError. Yield a couple of macrotask ticks so any pending
+    // .catch settles before tearing down the database.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    await h.db.delete();
+  });
+
+  it("does not flip a message to 'failed' when /sync echo already confirmed it", async () => {
+    // Simulate the server accepting the event and the echo arriving via
+    // upsertFromServer before the SDK error propagates back to processTick.
+    h.rows.set("op_echo_wins", { eventId: "$server_event_id", status: "synced" });
+
+    // The SDK still throws as if it never saw the response. With only one
+    // attempt allowed the retry loop hits markMessageFailed immediately.
+    mockMatrix.sendEncryptedText.mockImplementation(async () => {
+      throw new Error("network read timeout after server accept");
+    });
+
+    await seedOp(h.db, { clientId: "op_echo_wins", maxRetries: 1 });
+    h.engine.processQueue();
+
+    await vi.waitFor(
+      async () => {
+        const remaining = await h.db.pendingOps
+          .where("clientId")
+          .equals("op_echo_wins")
+          .count();
+        expect(remaining).toBe(0);
+      },
+      { timeout: 2000, interval: 10 },
+    );
+
+    // The message must still be "synced" — markMessageFailed must respect
+    // the echo and not downgrade the row.
+    expect(h.rows.get("op_echo_wins")?.status).toBe("synced");
+    expect(h.rows.get("op_echo_wins")?.eventId).toBe("$server_event_id");
+    // And updateStatus(..., "failed") must never have been called on this id.
+    const failedCalls = h.messageRepo.updateStatus.mock.calls.filter(
+      ([id, status]) => (id as { clientId?: string }).clientId === "op_echo_wins" && status === "failed",
+    );
+    expect(failedCalls).toHaveLength(0);
+  });
+
+  it("drops the queued op without retry when the message is already synced", async () => {
+    // The catch branch in processTick should detect the confirmed row and
+    // delete the op straight away — no nextAttemptAt rescheduling needed.
+    h.rows.set("op_already_done", { eventId: "$evt", status: "synced" });
+
+    mockMatrix.sendEncryptedText.mockImplementation(async () => {
+      throw new Error("read aborted after accept");
+    });
+
+    await seedOp(h.db, { clientId: "op_already_done", maxRetries: 5 });
+    h.engine.processQueue();
+
+    await vi.waitFor(
+      async () => {
+        const remaining = await h.db.pendingOps
+          .where("clientId")
+          .equals("op_already_done")
+          .count();
+        expect(remaining).toBe(0);
+      },
+      { timeout: 2000, interval: 10 },
+    );
+
+    // The row must keep its synced state — not be downgraded to failed
+    // and not be re-scheduled for retry.
+    expect(h.rows.get("op_already_done")?.status).toBe("synced");
+  });
+
+  it("does not flip a media upload to 'failed' when /sync echo already confirmed it", async () => {
+    // Same race for send_file ops: an upload that fails on the read side
+    // after the server accepted the message event must not downgrade the
+    // confirmed local row. Coverage parity with the text-message case so
+    // future refactors don't regress one path while keeping the other.
+    h.rows.set("op_media_done", { eventId: "$media_event_id", status: "synced" });
+    mockMatrix.sendEncryptedText.mockImplementation(async () => {
+      throw new Error("media send-event read timeout after accept");
+    });
+
+    await h.db.attachments.add({ id: 1, localBlob: new Blob(["x"]), size: 1 });
+    await seedOp(h.db, {
+      clientId: "op_media_done",
+      type: "send_file",
+      payload: {
+        fileName: "x.png",
+        mimeType: "image/png",
+        msgtype: "m.image",
+        attachmentId: 1,
+      },
+      maxRetries: 1,
+    });
+    h.engine.processQueue();
+
+    await vi.waitFor(
+      async () => {
+        const remaining = await h.db.pendingOps
+          .where("clientId")
+          .equals("op_media_done")
+          .count();
+        expect(remaining).toBe(0);
+      },
+      { timeout: 3000, interval: 10 },
+    );
+
+    expect(h.rows.get("op_media_done")?.status).toBe("synced");
+    const failedCalls = h.messageRepo.updateStatus.mock.calls.filter(
+      ([id, status]) => (id as { clientId?: string }).clientId === "op_media_done" && status === "failed",
+    );
+    expect(failedCalls).toHaveLength(0);
+  });
+
+  it("still marks truly-failed sends as failed when no eventId arrived", async () => {
+    // Baseline: when the server never accepted the event there is no echo,
+    // the local row stays "pending", and markMessageFailed must run.
+    h.rows.set("op_real_fail", { status: "pending" });
+
+    mockMatrix.sendEncryptedText.mockImplementation(async () => {
+      throw new Error("permanent network failure");
+    });
+
+    await seedOp(h.db, { clientId: "op_real_fail", maxRetries: 1 });
+    h.engine.processQueue();
+
+    await vi.waitFor(
+      async () => {
+        const op = await h.db.pendingOps.where("clientId").equals("op_real_fail").first();
+        expect(op?.status).toBe("failed");
+      },
+      { timeout: 2000, interval: 10 },
+    );
+
+    expect(h.rows.get("op_real_fail")?.status).toBe("failed");
+  });
+});

--- a/src/shared/lib/local-db/message-repository.ts
+++ b/src/shared/lib/local-db/message-repository.ts
@@ -4,6 +4,49 @@ import { MessageType } from "@/entities/chat/model/types";
 import type { ReplyTo } from "@/entities/chat/model/types";
 import { sortLocalMessagesTimelineAsc } from "./timeline-sort";
 
+/** A LocalMessage URL is "optimistic-only" when it cannot survive a page
+ *  reload — blob:/data: URLs are bound to the document lifetime and
+ *  become invalid the moment the user refreshes. Empty/undefined also
+ *  qualifies: there's nothing to preserve. */
+function isOptimisticOnlyFileUrl(url: string | undefined | null): boolean {
+  if (!url) return true;
+  return url.startsWith("blob:") || url.startsWith("data:");
+}
+
+/** A server-issued media URL — survives reload, can be re-resolved across
+ *  sessions. mxc:// is the canonical Matrix shape; http(s):// is the
+ *  already-resolved form returned by mxcUrlToHttp for clients that want
+ *  to skip the resolve step. Note: localhost http URLs are technically
+ *  matched here too, but they never reach this code path — sync-engine
+ *  resolves against the homeserver's baseUrl, and only the blob-guard in
+ *  downloadAndDecrypt would block a localhost URL upstream. */
+function isServerFileUrl(url: string | undefined | null): boolean {
+  if (!url) return false;
+  return (
+    url.startsWith("mxc://") ||
+    url.startsWith("http://") ||
+    url.startsWith("https://")
+  );
+}
+
+/** Decide whether an incoming /sync echo should replace the locally-stored
+ *  fileInfo. Replacement only happens when:
+ *   1. the incoming event actually carries fileInfo with a server URL, and
+ *   2. the local copy is missing fileInfo entirely OR still has the
+ *      optimistic blob:/data: URL written by createLocal — i.e. the
+ *      upload pipeline never wrote a real URL back, typically because
+ *      the /sync echo won the race against confirmMediaSent.
+ *  Returns the fileInfo to use, or `undefined` to leave the existing
+ *  copy untouched. */
+function healFileInfoFromEcho(
+  existing: LocalMessage["fileInfo"],
+  incoming: LocalMessage["fileInfo"],
+): LocalMessage["fileInfo"] | undefined {
+  if (!incoming || !isServerFileUrl(incoming.url)) return undefined;
+  if (!isOptimisticOnlyFileUrl(existing?.url)) return undefined;
+  return incoming;
+}
+
 export class MessageRepository {
   constructor(private db: ChatDatabase) {}
 
@@ -161,6 +204,19 @@ export class MessageRepository {
     if (msg.clientId) {
       const existing = await this.getByClientId(msg.clientId);
       if (existing) {
+        // Self-heal local fileInfo when the optimistic insert wrote a
+        // blob:/data: URL (createLocal in use-messages.ts puts the local
+        // preview blob URL into fileInfo.url) and the server echo carries
+        // a real mxc:// or http(s):// URL. Without this, a race where the
+        // /sync echo arrives before confirmMediaSent — or where the
+        // send-engine's catch path drops the op early because the row is
+        // already "synced" (WEE-40 guard) — leaves a dead blob: URL in
+        // fileInfo.url forever. After reload the bubble fast-fails through
+        // downloadAndDecrypt's blob-guard and surfaces a misleading
+        // "Файл повреждён или не пришёл с источника" toast on a message
+        // that actually reached the peer.
+        const healedFileInfo = healFileInfoFromEcho(existing.fileInfo, msg.fileInfo);
+
         // If upload is still in-flight (has localBlobUrl) and hasn't failed,
         // only store eventId — let confirmMediaSent handle the final status transition.
         // If the message is already "failed", the upload pipeline is dead and we should
@@ -171,6 +227,7 @@ export class MessageRepository {
             serverTs: msg.serverTs ?? msg.timestamp,
             // Merge local-only fields that the server echo may lack
             linkPreview: existing.linkPreview ?? msg.linkPreview,
+            ...(healedFileInfo ? { fileInfo: healedFileInfo } : {}),
           });
         } else {
           await this.db.messages.update(existing.localId!, {
@@ -181,6 +238,7 @@ export class MessageRepository {
             // fall back to server (parsed from url_preview in event content)
             linkPreview: existing.linkPreview ?? msg.linkPreview,
             localBlobUrl: existing.localBlobUrl ?? msg.localBlobUrl,
+            ...(healedFileInfo ? { fileInfo: healedFileInfo } : {}),
           });
         }
         return "updated";
@@ -238,10 +296,16 @@ export class MessageRepository {
         if (e.status === "pending" || e.status === "syncing") {
           const incoming = messages.find((m) => m.clientId === e.clientId);
           if (incoming?.eventId && e.localId) {
+            // Self-heal: same rationale as upsertFromServer — adopt the
+            // server-side fileInfo when the optimistic local copy still
+            // has a blob:/data: URL, so reload doesn't surface a dead
+            // blob (WEE-40).
+            const healedFileInfo = healFileInfoFromEcho(e.fileInfo, incoming.fileInfo);
             await this.db.messages.update(e.localId, {
               eventId: incoming.eventId,
               status: "synced" as LocalMessageStatus,
               serverTs: incoming.serverTs ?? incoming.timestamp,
+              ...(healedFileInfo ? { fileInfo: healedFileInfo } : {}),
             });
           }
         }

--- a/src/shared/lib/local-db/message-repository.ts
+++ b/src/shared/lib/local-db/message-repository.ts
@@ -412,6 +412,23 @@ export class MessageRepository {
       .modify({ reactions });
   }
 
+  /** Overwrite the fileInfo of a message identified by eventId. Used by
+   *  the download-side lazy heal path (`use-file-download.ts`) when an
+   *  optimistic `blob:` URL has lingered in Dexie because confirmMediaSent
+   *  never ran — we refetch the event from Matrix and patch the row in
+   *  place so the next render uses a real mxc URL (WEE-40).
+   *
+   *  Also clears `localBlobUrl` so that `mappers.ts`'s
+   *  `local.localBlobUrl || local.fileInfo.url` fallback does not re-mask
+   *  the healed url with the dead blob: on the next render. Skipping this
+   *  would defeat the heal — the dead blob would resurface every reload. */
+  async updateFileInfo(eventId: string, fileInfo: LocalMessage["fileInfo"]): Promise<void> {
+    await this.db.messages
+      .where("eventId")
+      .equals(eventId)
+      .modify({ fileInfo, localBlobUrl: undefined });
+  }
+
   /** Update poll info on a message */
   async updatePollInfo(
     eventId: string,

--- a/src/shared/lib/local-db/sync-engine.ts
+++ b/src/shared/lib/local-db/sync-engine.ts
@@ -326,6 +326,21 @@ export class SyncEngine {
         this.onChange?.(op.roomId);
       } catch (e) {
         if (this.disposed) return;
+
+        // Race guard: Matrix may have accepted the event server-side even
+        // though the SDK threw (read timeout, CORS race, etc.). When the
+        // server-side `/sync` echo arrives via EventWriter → upsertFromServer
+        // the local message picks up its eventId and flips to "synced"
+        // before this catch runs. In that case the queued op is already
+        // satisfied — drop it without flagging the message as failed,
+        // otherwise the user sees a red retry indicator on a message the
+        // peer actually received (WEE-40).
+        if (op.clientId && (await this.isMessageAlreadyConfirmed(op.clientId))) {
+          await this.db.pendingOps.delete(op.id!);
+          this.onChange?.(op.roomId);
+          return;
+        }
+
         const retries = op.retries + 1;
         if (retries >= op.maxRetries) {
           await this.db.pendingOps.update(op.id!, {
@@ -867,14 +882,31 @@ export class SyncEngine {
   // Helpers
   // ---------------------------------------------------------------------------
 
-  /** Mark the message associated with a failed operation */
+  /** Mark the message associated with a failed operation.
+   *  No-op when the message has already been confirmed (eventId present or
+   *  status already "synced") — the matrix-js-sdk error happened after the
+   *  server actually accepted the event and the /sync echo restored state.
+   *  Without this guard the watchdog/retry-exhaustion path would flip a
+   *  successfully delivered message back to "failed" and surface a false
+   *  retry indicator (WEE-40). */
   private async markMessageFailed(op: PendingOperation): Promise<void> {
-    if (op.clientId) {
-      await this.messageRepo.updateStatus(
-        { clientId: op.clientId },
-        "failed",
-      );
-    }
+    if (!op.clientId) return;
+    if (await this.isMessageAlreadyConfirmed(op.clientId)) return;
+    await this.messageRepo.updateStatus(
+      { clientId: op.clientId },
+      "failed",
+    );
+  }
+
+  /** Returns true when the local message row for `clientId` already has a
+   *  server eventId or has been flipped to "synced" — typically by an
+   *  upsertFromServer echo that won the race against the queue's failure
+   *  handler. Used to suppress false-failed transitions in markMessageFailed
+   *  and processTick. */
+  private async isMessageAlreadyConfirmed(clientId: string): Promise<boolean> {
+    const msg = await this.messageRepo.getByClientId(clientId);
+    if (!msg) return false;
+    return Boolean(msg.eventId) || msg.status === "synced";
   }
 
   /** Enqueue a new operation. Returns the operation ID. */


### PR DESCRIPTION
## Summary
- i18n typo: MessageBubble referenced `message.retrySend` (no such key) so users literally saw the string on screen; routed through the existing `message.tapToRetry`
- SyncEngine race: `markMessageFailed` and the catch branch in `processTick` now bail out when the local row already has an eventId or status="synced" — covers the matrix-js-sdk-throws-after-server-accept case where the /sync echo wins
- UI also hides the retry indicator when `Message.id` flipped to the server eventId, so even a stale "failed" status can't surface a red badge on a delivered bubble

## Linear
- Resolves WEE-40 (https://linear.app/wwwee/issue/WEE-40/messages-message-retryleft-false-failed-status-na-successfully)

## Test plan
- [x] Regression tests added (`sync-engine-false-failed.test.ts`, `message-failed-state.test.ts`, `retry-keys.test.ts`) — 11 new passing tests covering text/media echo races, helper invariants, i18n key presence
- [x] `npm run test` — 195/199 test files pass; remaining failures pre-existing on baseline (not introduced by this PR)
- [x] `npm run build` — fix removes the `'message.retrySend'` TS2345 typo error present in master
- [ ] Manual QA on Android cellular: send 5 messages rapid-fire on flaky network, verify every successful send shows ✓ and never the red ↻ retry bar; verify true offline failures still show retry