### PR TITLE
fix(messaging): suppress 'file corrupted' toast during optimistic media upload

### DIFF
--- a/src/features/messaging/model/use-file-download.test.ts
+++ b/src/features/messaging/model/use-file-download.test.ts
@@ -513,6 +513,94 @@ describe("useFileDownload", () => {
       scope.stop();
     });
 
+    it("short-circuits and reuses the live blob URL while the upload is still in flight (no toast, no overlay)", async () => {
+      // Optimistic outbound media: the row is status="sending", localBlobUrl
+      // is alive, mappers.ts surfaces it as fileInfo.url. The previous
+      // behaviour fell through to the WEE-28 fast-fail and produced a
+      // misleading "Файл повреждён или не пришёл с источника" toast plus a
+      // momentary retry overlay until confirmMediaSent flipped the row.
+      // After the fix, download() must return the blob URL as-is, with no
+      // fetch, no toast, no error state.
+      const fetchSpy = global.fetch as Mock;
+      fetchSpy.mockClear();
+      mockToast.mockClear();
+
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download } = useFileDownload();
+        const blobUrl = "blob:http://localhost:5173/optimistic-photo";
+        const message = {
+          id: "client_inflight",
+          _key: "client_inflight",
+          roomId: "!room:server",
+          senderId: "@me:server",
+          content: "photo.jpg",
+          timestamp: Date.now(),
+          // MessageStatus.sending is the canonical "upload in flight" signal.
+          status: "sending",
+          type: "image",
+          uploadProgress: 42,
+          fileInfo: {
+            name: "photo.jpg",
+            type: "image/jpeg",
+            size: 2048,
+            url: blobUrl,
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        const result = await download(message);
+
+        expect(result).toBe(blobUrl);
+        // Network must not be touched — the blob is local.
+        expect(fetchSpy).not.toHaveBeenCalled();
+        // No error toast must fire while the upload is still in flight.
+        expect(mockToast).not.toHaveBeenCalled();
+      });
+      scope.stop();
+    });
+
+    it("still fast-fails blob: URLs for non-sending status (WEE-28 dead-blob defense intact)", async () => {
+      // Guard parity: a row that survived a crashed upload comes back from
+      // Dexie with status="failed" (or "sent" if echo confirmed it) and a
+      // dead blob: URL. The short-circuit must NOT swallow that case —
+      // downloadAndDecrypt still has to throw MissingUrlError so the user
+      // sees an actionable "no usable file URL" state instead of a stuck
+      // <img> with a 404 from the browser.
+      const fetchSpy = global.fetch as Mock;
+      fetchSpy.mockClear();
+
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download } = useFileDownload();
+        const message = {
+          id: "$evt_dead_blob",
+          _key: "client_dead_blob",
+          roomId: "!room:server",
+          senderId: "@u:server",
+          content: "stuck.pdf",
+          timestamp: Date.now(),
+          status: "failed",
+          type: "file",
+          fileInfo: {
+            name: "stuck.pdf",
+            type: "application/pdf",
+            size: 1024,
+            url: "blob:http://localhost:5173/dead-blob",
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        const result = await download(message);
+
+        // No fetch — the WEE-28 guard short-circuits before the network.
+        expect(fetchSpy).not.toHaveBeenCalled();
+        // Returns null/undefined (download() reports errors via state, not throw).
+        expect(result).toBeFalsy();
+      });
+      scope.stop();
+    });
+
     it("does NOT mangle blob:/data: URLs with cache-bust (those schemes do not accept query strings)", () => {
       // Regression safety net for WEE-17 review: appending `?cb=` to a blob:
       // URL breaks the URL grammar and the next fetch would fail spuriously.

--- a/src/features/messaging/model/use-file-download.ts
+++ b/src/features/messaging/model/use-file-download.ts
@@ -19,7 +19,7 @@ import {
 import { waitForRoomCrypto } from "@/entities/matrix/model/wait-for-crypto";
 import { enqueueDecrypt } from "./decrypt-queue";
 import { getMediaCache, type MediaCacheCategory } from "@/shared/lib/media-cache";
-import { MessageType } from "@/entities/chat";
+import { MessageType, MessageStatus } from "@/entities/chat";
 
 /** Classify a message into the Settings → Storage tab buckets.
  *  - `media` = photos + videos + video circles
@@ -752,6 +752,30 @@ export function useFileDownload() {
       const state = getState(cacheKey);
       state.objectUrl = cache.get(cacheKey)!;
       return state.objectUrl;
+    }
+
+    // Optimistic-upload fast path: the message is still going through the
+    // outbound queue (status=sending), `localBlobUrl` is alive, and
+    // `mappers.ts` has surfaced it as fileInfo.url. Running the full
+    // server-fetch pipeline here would fast-fail in downloadAndDecrypt's
+    // blob:/data: guard (defence against WEE-28 dead blob remnants), which
+    // pops a misleading "Файл повреждён или не пришёл с источника" toast
+    // and a momentary red retry overlay while the sender's own upload is
+    // still in flight. Bypass the pipeline: use the blob URL as-is, do not
+    // pollute the long-lived `cache` (the blob is revoked ~5s after
+    // confirmMediaSent), and let the watch-on-id re-trigger download once
+    // the row flips to status=sent with a real mxc URL.
+    const fileUrl = message.fileInfo.url;
+    if (
+      fileUrl?.startsWith("blob:") &&
+      message.status === MessageStatus.sending
+    ) {
+      const state = getState(cacheKey);
+      state.objectUrl = fileUrl;
+      state.loading = false;
+      state.error = null;
+      state.errorKind = null;
+      return fileUrl;
     }
 
     const state = getState(cacheKey);


### PR DESCRIPTION
## Summary
- When the sender uploads a photo/file the bubble briefly showed «Файл повреждён или не пришёл с источника» toast + a red "tap to retry" overlay before normalising — flicker during their own outbound upload.
- Root cause: `mappers.ts` surfaces the live `localBlobUrl` as `fileInfo.url` during upload. `MessageBubble.onMounted` calls `download()` for images, which hits the WEE-28 dead-blob fast-fail in `downloadAndDecrypt` → `MissingUrlError` → `surfaceTypedErrorToast('errors.missingUrl')` + `errorKind` set, until `confirmMediaSent` swaps in `mxc://` and watch-on-id re-runs the pipeline.
- Fix: short-circuit in `download()` — when `fileInfo.url` starts with `blob:` AND `message.status === MessageStatus.sending`, reuse the URL as-is. No fetch, no `cache` pollution (blob is revoked ~5s after confirmMediaSent), no toast, no errorKind. The WEE-28 guard stays intact for any non-sending status (e.g. crashed-upload row with `status="failed"`).

## Test plan
- [x] `npm run test` — 197/201 test files pass; 2 new regression tests added (in-flight short-circuit / WEE-28 guard preserved). Remaining 9 failures pre-existing on baseline master, not introduced by this PR.
- [x] `npx vue-tsc --noEmit` — no new type errors.
- [x] Code review — APPROVE (1 MEDIUM pre-existing edge case acknowledged; 1 LOW style note declined to avoid scope creep).
- [ ] Manual QA: send a photo on slow network — bubble shows progress overlay, then ✓; no "Файл повреждён" toast, no momentary red retry indicator on the sender side.