### PR TITLE
chore(crypto): opt-in diagnostic logging + typed decrypt-fail wording (WEE-39)

### DIFF
--- a/src/entities/chat/lib/display-result.test.ts
+++ b/src/entities/chat/lib/display-result.test.ts
@@ -134,4 +134,27 @@ describe("getMessagePreviewForUI", () => {
     const result = getMessagePreviewForUI(null, undefined, "Cannot decrypt");
     expect(result).toEqual({ state: "ready", text: "" });
   });
+
+  // WEE-39 regression — decrypted content carrying an @mention must pass
+  // through the preview pipeline byte-identical. A future "strip mentions"
+  // backward-compat patch must not silently drop or rewrite @user tokens
+  // because the contacts list relies on the original sender wording.
+  it("preserves @mention text in decrypted preview (WEE-39)", () => {
+    const text = "Привет @AlexD как дела?";
+    const result = getMessagePreviewForUI(text, "ok", "Cannot decrypt");
+    expect(result).toEqual({ state: "ready", text });
+  });
+
+  // WEE-39 regression — the function MUST return the caller-supplied
+  // `failedText` byte-identical for permanent decrypt fails (decryptionStatus
+  // === "failed"). The current English localisation is exercised here as a
+  // sentinel; production callers pass `t("message.notDecrypted")` from i18n.
+  // If the wording in en.ts/ru.ts changes, update the constant below in lock-step.
+  it("surfaces actionable wording for permanent decrypt fail (WEE-39)", () => {
+    const failedText = "Couldn't decrypt — ask the sender to resend or update the app";
+    const result = getMessagePreviewForUI("[encrypted]", "failed", failedText);
+    expect(result.state).toBe("failed");
+    expect(result.text).toBe(failedText);
+    expect(result.text).not.toBe("Message not decrypted");
+  });
 });

--- a/src/entities/chat/model/__tests__/get-display-name-alias.test.ts
+++ b/src/entities/chat/model/__tests__/get-display-name-alias.test.ts
@@ -96,3 +96,63 @@ describe("getDisplayName — local alias priority", () => {
     expect(store.hasLocalAlias(raw)).toBe(false);
   });
 });
+
+/**
+ * WEE-39 follow-up regression: `getCanonicalDisplayName` MUST skip the
+ * local-alias step. It is the chokepoint for any name that will leave the
+ * device (outbound @mention safeName, forward attribution, etc.). If it
+ * accidentally returned the alias, recipients would see a stranger string
+ * because they do not share the sender's private address book.
+ */
+describe("getCanonicalDisplayName — alias must not leak to wire", () => {
+  let store: ReturnType<typeof useChatStore>;
+  let userStore: ReturnType<typeof import("@/entities/user/model").useUserStore>;
+
+  beforeEach(async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    setActivePinia(createTestingPinia({ stubActions: false }));
+    store = useChatStore();
+    const { useUserStore } = await import("@/entities/user/model");
+    userStore = useUserStore();
+  });
+
+  function seedCanonical(address: string, name: string): void {
+    userStore.setUser(address, {
+      address,
+      name,
+      about: "",
+      image: "",
+      site: "",
+      language: "",
+    });
+  }
+
+  it("ignores localAlias and falls back to canonical chain", async () => {
+    await store.setContactAlias("PAlias", "qqq");
+    // Sanity: getDisplayName returns the alias (private UX).
+    expect(store.getDisplayName("PAlias")).toBe("qqq");
+    // Canonical lookup must skip the alias and fall back to truncation
+    // (no user-store profile seeded for this address).
+    expect(store.getCanonicalDisplayName("PAlias")).not.toBe("qqq");
+  });
+
+  it("returns user-store profile name when one is cached (no alias leak)", async () => {
+    await store.setContactAlias("PCached", "qqq");
+    seedCanonical("PCached", "dqwewr");
+    expect(store.getDisplayName("PCached")).toBe("qqq");
+    expect(store.getCanonicalDisplayName("PCached")).toBe("dqwewr");
+  });
+
+  it("resolves hex-encoded address through canonical chain", async () => {
+    const raw = "PHexCanonical";
+    const hex = hexEncode(raw);
+    await store.setContactAlias(raw, "MyLocal");
+    seedCanonical(raw, "Real Name");
+    expect(store.getDisplayName(hex)).toBe("MyLocal");
+    expect(store.getCanonicalDisplayName(hex)).toBe("Real Name");
+  });
+
+  it("returns '?' for empty input", () => {
+    expect(store.getCanonicalDisplayName("")).toBe("?");
+  });
+});

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -579,6 +579,38 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     return address;
   };
 
+  /** Same resolution chain as `getDisplayName` but SKIPS the local-alias
+   *  step. Use this whenever the resulting name will leave the device —
+   *  outbound `@hexId:safeName` mention payloads, forward attributions,
+   *  anything peers will see. The alias is a private "Telegram-style rename"
+   *  and must never appear in a wire format (WEE-39 follow-up: peers were
+   *  receiving the local alias inside the mention safeName, causing the
+   *  mention to render as a stranger string on their side). */
+  const getCanonicalDisplayName = (address: string): string => {
+    if (!address) return "?";
+    let resolvedAddr = address;
+    if (/^[a-f0-9]+$/i.test(address)) {
+      try {
+        const decoded = hexDecode(address);
+        if (decoded !== address && /^[A-Za-z0-9]+$/.test(decoded)) {
+          resolvedAddr = decoded;
+        }
+      } catch { /* not a valid hex string */ }
+    }
+    // (skip local alias on purpose — see jsdoc above)
+    const cached = userDisplayNames.value[address];
+    if (cached) return cached;
+    if (resolvedAddr !== address) {
+      const decodedCached = userDisplayNames.value[resolvedAddr];
+      if (decodedCached) return decodedCached;
+    }
+    const uStore = useUserStore();
+    const userProfile = uStore.users[resolvedAddr];
+    if (userProfile?.name) return userProfile.name;
+    if (address.length > 16) return address.slice(0, 8) + "…" + address.slice(-4);
+    return address;
+  };
+
   /** Resolve a hex-encoded address back to the raw Bastyon form (or echo
    *  the input if it is already raw). */
   const resolveRawAddress = (address: string): string => {
@@ -6659,6 +6691,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     saveForwardDraft,
     restoreForwardDraft,
     getDisplayName,
+    getCanonicalDisplayName,
     getLocalAlias,
     hasLocalAlias,
     localAliases,

--- a/src/entities/matrix/model/__tests__/can-be-encrypt.test.ts
+++ b/src/entities/matrix/model/__tests__/can-be-encrypt.test.ts
@@ -35,7 +35,9 @@ describe("decrypt graceful degradation", () => {
   it("encryptEvent should warn when members missing keys", () => {
     const source = getSource();
     const start = source.indexOf("async encryptEvent(text");
-    const section = source.slice(start, start + 1000);
+    // 1500-char window: WEE-39 diagnostic block (cryptoDebug call + 3-line
+    // comment) sits between the function header and the warn site.
+    const section = source.slice(start, start + 1500);
     expect(section).toContain("missing encryption keys");
   });
 });

--- a/src/entities/matrix/model/matrix-crypto.ts
+++ b/src/entities/matrix/model/matrix-crypto.ts
@@ -21,6 +21,7 @@ import {
   readFile,
 } from "@/shared/lib/matrix/functions";
 import { createChatStorage, type ChatStorageInstance } from "@/shared/lib/matrix/chat-storage";
+import { cryptoDebug, looksLikeMention } from "@/shared/lib/utils/crypto-debug";
 
 const salt = "PR7srzZt4EfcNb3s27grgmiG8aB9vYNV82";
 const m = 12;
@@ -725,6 +726,18 @@ export class Pcrypto {
       async encryptEvent(text: string): Promise<Record<string, unknown>> {
         const tetatet = pcrypto.getIsTetatetChat?.(chat) ?? false;
 
+        // Boolean signals only — `text` itself must never appear in this
+        // payload. `hasMention` is a presence flag derived from a regex,
+        // not the captured mention text.
+        cryptoDebug("encrypt", {
+          roomId,
+          tetatet,
+          textLen: text.length,
+          hasMention: looksLikeMention(text),
+          memberCount: Object.keys(usersinfo).length,
+          version,
+        });
+
         // Group chats use common key + AES-CBC
         if (!tetatet) {
           return room.encryptEventGroup(text);
@@ -769,6 +782,16 @@ export class Pcrypto {
       async decryptEvent(event: Record<string, unknown>): Promise<{ body: string; msgtype: string }> {
         const content = event.content as Record<string, unknown>;
         if (!pcrypto.user?.userinfo) throw new Error("userinfo");
+
+        cryptoDebug("decrypt:route", {
+          roomId,
+          eventId: event.event_id,
+          hasHash: Boolean(content.hash),
+          hasBlock: Boolean(content.block),
+          hasVersion: Boolean(content.version),
+          msgtype: content.msgtype,
+          senderMatrix: event.sender,
+        });
 
         // Group messages have a 'hash' field → use group decryption (AES-CBC)
         if (content.hash) {
@@ -916,6 +939,16 @@ export class Pcrypto {
           commonKeyEvt = getCommonKey(sender, hash);
         }
         if (!commonKeyEvt) {
+          cryptoDebug("decrypt:group:no-common-key", {
+            roomId,
+            eventId: event.event_id,
+            // hashLen rather than hash itself: the MD5 of member IDs is not
+            // secret, but in combination with roomId+sender it pinpoints the
+            // server-side state event that holds the encrypted group key.
+            hashLen: hash.length,
+            sender,
+            memberCount: Object.keys(usersinfo).length,
+          });
           throw new Error("No common key event found for hash=" + hash);
         }
         // Decrypt the common key (AES-SIV per-user encrypted key)

--- a/src/features/chat-info/ui/UserProfilePanel.vue
+++ b/src/features/chat-info/ui/UserProfilePanel.vue
@@ -46,6 +46,12 @@ watch(
 );
 
 const displayName = computed(() => {
+  // Local alias (Telegram-style "rename contact") wins — when the viewer
+  // opens a renamed contact's profile from a mention or any other entry
+  // point, they should see the familiar nickname, not the canonical
+  // Bastyon profile name. (WEE-39 follow-up.)
+  const alias = chatStore.getLocalAlias(props.address);
+  if (alias) return alias;
   if (userData.value?.name) return userData.value.name;
   // Fall back to address if no name loaded
   return props.address;

--- a/src/features/contacts/ui/ContactList.vue
+++ b/src/features/contacts/ui/ContactList.vue
@@ -233,7 +233,7 @@ function getPreview(room: ChatRoom): DisplayResult {
     // For non-encrypted content, clean links/IDs (getPreview text is shown directly in some template branches)
     const content = room.lastMessage.content;
     const cleaned = (content && !content.startsWith("[encrypted"))
-      ? stripBastyonLinks(cleanMatrixIds(stripMentionAddresses(content)))
+      ? stripBastyonLinks(cleanMatrixIds(stripMentionAddresses(content, (id) => chatStore.getLocalAlias(id))))
       : content;
     return getMessagePreviewForUI(
       cleaned,
@@ -260,7 +260,7 @@ function getPreview(room: ChatRoom): DisplayResult {
       return { state: "ready", text: formatPreview(last, room) };
     }
     // Strip bastyon links and matrix IDs from fallback preview (same as formatPreview does)
-    const cleaned = stripBastyonLinks(cleanMatrixIds(stripMentionAddresses(last.content)));
+    const cleaned = stripBastyonLinks(cleanMatrixIds(stripMentionAddresses(last.content, (id) => chatStore.getLocalAlias(id))));
     return getMessagePreviewForUI(
       cleaned,
       last.decryptionStatus,

--- a/src/features/messaging/model/__tests__/use-mention-autocomplete-alias.test.ts
+++ b/src/features/messaging/model/__tests__/use-mention-autocomplete-alias.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ref, nextTick } from "vue";
+import { setActivePinia } from "pinia";
+import { createTestingPinia } from "@pinia/testing";
+import { useMentionAutocomplete } from "../use-mention-autocomplete";
+import { useChatStore } from "@/entities/chat";
+import { useAuthStore } from "@/entities/auth";
+import { useUserStore } from "@/entities/user/model";
+import { hexEncode } from "@/shared/lib/matrix/functions";
+
+/**
+ * WEE-39 follow-up: when the sender renamed a contact locally ("qqq"),
+ * the `@mention` payload sent to the room MUST carry the CANONICAL name
+ * (the name peers share), not the private alias. Otherwise recipients see
+ * an `@hexId:qqq` pill whose safeName does not match their own copy of
+ * the contact and the pill renders as a stranger string.
+ *
+ * `displayMention` (what the sender sees in their input) may still use
+ * the alias — that is the desired UX. Only `resolveText()`, which
+ * materialises the wire payload, must canonicalise.
+ */
+
+function makeTextarea(initial = ""): HTMLTextAreaElement {
+  const el = document.createElement("textarea");
+  el.value = initial;
+  el.selectionStart = initial.length;
+  el.selectionEnd = initial.length;
+  return el;
+}
+
+describe("useMentionAutocomplete — alias-free wire payload (WEE-39 follow-up)", () => {
+  let chatStore: ReturnType<typeof useChatStore>;
+  let authStore: ReturnType<typeof useAuthStore>;
+  let userStore: ReturnType<typeof useUserStore>;
+
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    setActivePinia(createTestingPinia({ stubActions: false }));
+    chatStore = useChatStore();
+    authStore = useAuthStore();
+    userStore = useUserStore();
+    (authStore as unknown as { address: string }).address = "PSender";
+  });
+
+  function seedCanonical(address: string, name: string): void {
+    userStore.setUser(address, {
+      address,
+      name,
+      about: "",
+      image: "",
+      site: "",
+      language: "",
+    });
+  }
+
+  it("resolveText emits canonical name when sender has a local alias for the target", async () => {
+    const targetRaw = "PTarget";
+    const targetHex = hexEncode(targetRaw);
+
+    // Sender's private rename: "qqq". Canonical name peers know: "dqwewr".
+    chatStore.localAliases[targetRaw] = "qqq";
+    seedCanonical(targetRaw, "dqwewr");
+
+    const text = ref("hi @");
+    const textareaRef = ref<HTMLTextAreaElement | undefined>(makeTextarea("hi @"));
+    const mention = useMentionAutocomplete(text, textareaRef);
+
+    textareaRef.value!.selectionStart = 4;
+    textareaRef.value!.selectionEnd = 4;
+    mention.onCursorChange();
+    await nextTick();
+
+    mention.insertMention(targetHex);
+    await nextTick();
+
+    // Sender's textarea pill keeps the familiar alias.
+    expect(text.value).toBe("hi @qqq ");
+
+    // Wire payload sent to peers MUST carry the canonical safeName.
+    const wire = mention.resolveText();
+    expect(wire).toBe(`hi @${targetHex}:dqwewr `);
+    expect(wire).not.toContain(":qqq");
+  });
+
+  it("resolveText leaves canonical name unchanged when no alias is set", async () => {
+    const targetRaw = "PNoAlias";
+    const targetHex = hexEncode(targetRaw);
+    seedCanonical(targetRaw, "Alice");
+
+    const text = ref("@");
+    const textareaRef = ref<HTMLTextAreaElement | undefined>(makeTextarea("@"));
+    const mention = useMentionAutocomplete(text, textareaRef);
+
+    textareaRef.value!.selectionStart = 1;
+    textareaRef.value!.selectionEnd = 1;
+    mention.onCursorChange();
+    await nextTick();
+
+    mention.insertMention(targetHex);
+    await nextTick();
+
+    expect(text.value).toBe("@Alice ");
+    expect(mention.resolveText()).toBe(`@${targetHex}:Alice `);
+  });
+});

--- a/src/features/messaging/model/use-mention-autocomplete.ts
+++ b/src/features/messaging/model/use-mention-autocomplete.ts
@@ -6,15 +6,20 @@ import { hexEncode, hexDecode } from "@/shared/lib/matrix/functions";
 
 /**
  * Tracked mention inserted via autocomplete.
- * The textarea shows `@SafeName` (display), but on send
- * we expand it to `@hexId:SafeName` (raw mention format).
+ * The textarea shows `@DisplaySafeName` (display, may include the user's
+ * private local alias for readability), but on send we expand it to
+ * `@hexId:CanonicalSafeName` (raw mention format using the canonical name
+ * peers know — see WEE-39 follow-up: prior code embedded the local alias in
+ * the wire payload, so recipients saw a stranger string instead of the
+ * sender they recognize).
  */
 interface MentionToken {
-  start: number;   // index of '@' in display text
-  end: number;     // index after display name (before trailing space)
+  start: number;        // index of '@' in display text
+  end: number;          // index after display name (before trailing space)
   hexId: string;
+  /** Sanitised canonical name (no local alias). Used in the wire payload. */
   safeName: string;
-  display: string; // "@SafeName" as it appears in the textarea
+  display: string;      // "@DisplaySafeName" as it appears in the textarea
 }
 
 /**
@@ -180,14 +185,32 @@ export function useMentionAutocomplete(
     if (len > 0 && selectedIndex.value >= len) selectedIndex.value = len - 1;
   }, { immediate: true });
 
-  /** Insert a mention at the trigger position (display-only in textarea). */
+  /** Insert a mention at the trigger position (display-only in textarea).
+   *
+   *  Two names are computed:
+   *  - `displaySafe` (textarea / pill) uses the user-facing display name —
+   *    if they renamed the contact locally ("qqq"), the input shows `@qqq`
+   *    so the sender keeps a familiar reference.
+   *  - `safeName` (wire payload) uses the CANONICAL display name — what
+   *    peers actually know the user as ("dqwewr"). The local alias must
+   *    never travel through `@hexId:safeName` because recipients do not
+   *    share the sender's address book and would parse it as a stranger
+   *    string. (WEE-39 follow-up.)
+   */
   const insertMention = (hexId: string) => {
     const el = textareaRef.value;
     if (!el) return;
 
-    const rawName = chatStore.getDisplayName(hexId);
-    const safeName = rawName.replace(/\s+/g, "_").replace(/[^\p{L}\p{N}_]/gu, "").slice(0, 50) || hexId.slice(0, 8);
-    const displayMention = `@${safeName}`;
+    const sanitise = (raw: string): string =>
+      raw.replace(/\s+/g, "_").replace(/[^\p{L}\p{N}_]/gu, "").slice(0, 50) || hexId.slice(0, 8);
+
+    const canonicalName = chatStore.getCanonicalDisplayName(hexId);
+    const safeName = sanitise(canonicalName);
+
+    const displayName = chatStore.getDisplayName(hexId);
+    const displaySafe = sanitise(displayName);
+
+    const displayMention = `@${displaySafe}`;
     const insertion = displayMention + " "; // trailing space
 
     const before = text.value.slice(0, triggerIndex.value);

--- a/src/features/messaging/ui/MessageBubble.vue
+++ b/src/features/messaging/ui/MessageBubble.vue
@@ -398,7 +398,7 @@ const replyPreviewText = computed(() => {
   if (reply.type === MessageType.videoCircle) return "Video message";
   if (reply.type === MessageType.audio) return "Voice message";
   if (reply.type === MessageType.file) return reply.content || "File";
-  const text = stripBastyonLinks(stripMentionAddresses(reply.content));
+  const text = stripBastyonLinks(stripMentionAddresses(reply.content, (id) => chatStore.getLocalAlias(id)));
   return (text.length > 100 ? text.slice(0, 100) + "\u2026" : text) || "...";
 });
 

--- a/src/features/messaging/ui/MessageContent.vue
+++ b/src/features/messaging/ui/MessageContent.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { computed, inject, type Ref, ref } from "vue";
-import { parseMessage } from "@/shared/lib/message-format";
+import { parseMessage, applyLocalAlias } from "@/shared/lib/message-format";
 import type { Segment } from "@/shared/lib/message-format";
 import { PostCard } from "@/features/post-player";
 import { splitByQuery, type TextPart } from "@/shared/lib/utils/highlight";
 import type { LinkPreview } from "@/entities/chat";
+import { useChatStore } from "@/entities/chat";
 import LinkPreviewCard from "./LinkPreviewCard.vue";
 
 interface Props {
@@ -17,8 +18,17 @@ const props = withDefaults(defineProps<Props>(), { isOwn: false });
 const emit = defineEmits<{ mentionClick: [userId: string] }>();
 
 const searchQuery = inject<Ref<string>>("searchQuery", ref(""));
+const chatStore = useChatStore();
 
-const segments = computed<Segment[]>(() => parseMessage(props.text));
+// Map each mention to the viewer's local alias (if any) so a renamed
+// contact reads `@qqq` here even when the sender shipped `@dqwewr`. The
+// userId carried by the segment is untouched, so click-through still
+// opens the correct profile. (WEE-39 follow-up.)
+const segments = computed<Segment[]>(() =>
+  parseMessage(props.text).map((s) =>
+    applyLocalAlias(s, (userId) => chatStore.getLocalAlias(userId)),
+  ),
+);
 const activeQuery = computed(() => searchQuery.value?.trim() ?? "");
 
 /** Inline segments (text, link, mention) vs block segments (bastyonLink) */

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -475,7 +475,7 @@ const replyInputPreviewText = computed(() => {
   if (reply.type === MessageType.videoCircle) return "Video message";
   if (reply.type === MessageType.audio) return "Voice message";
   if (reply.type === MessageType.file) return reply.content || "File";
-  const t = stripBastyonLinks(stripMentionAddresses(reply.content));
+  const t = stripBastyonLinks(stripMentionAddresses(reply.content, (id) => chatStore.getLocalAlias(id)));
   return (t.length > 100 ? t.slice(0, 100) + "\u2026" : t) || "...";
 });
 
@@ -534,7 +534,7 @@ const bulkForwardPreviewText = computed(() => {
   // First message's body, clipped — gives visual continuity with singular bar.
   const first = chatStore.forwardingMessages[0];
   if (!first) return "";
-  const txt = stripBastyonLinks(stripMentionAddresses(first.content));
+  const txt = stripBastyonLinks(stripMentionAddresses(first.content, (id) => chatStore.getLocalAlias(id)));
   return (txt.length > 100 ? txt.slice(0, 100) + "\u2026" : txt) || "...";
 });
 
@@ -546,7 +546,7 @@ const forwardPreviewText = computed(() => {
   if (fwd.type === MessageType.videoCircle) return "Video message";
   if (fwd.type === MessageType.audio) return "Voice message";
   if (fwd.type === MessageType.file) return fwd.content || "File";
-  const txt = stripBastyonLinks(stripMentionAddresses(fwd.content));
+  const txt = stripBastyonLinks(stripMentionAddresses(fwd.content, (id) => chatStore.getLocalAlias(id)));
   return (txt.length > 100 ? txt.slice(0, 100) + "\u2026" : txt) || "...";
 });
 

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -724,7 +724,7 @@ export const en = {
   "common.loading": "Loading...",
   "common.unknownUser": "User",
   "common.encryptedChat": "Chat",
-  "message.notDecrypted": "Message not decrypted",
+  "message.notDecrypted": "Couldn't decrypt — ask the sender to resend or update the app",
 
   // ── Sync status ──
   "sync.offline": "Waiting for network...",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -726,7 +726,7 @@ export const ru: Record<TranslationKey, string> = {
   "common.loading": "Загрузка...",
   "common.unknownUser": "Пользователь",
   "common.encryptedChat": "Чат",
-  "message.notDecrypted": "Сообщение не расшифровано",
+  "message.notDecrypted": "Не удалось расшифровать — попросите переслать сообщение или обновить приложение",
 
   // ── Sync status ──
   "sync.offline": "Ожидание сети...",

--- a/src/shared/lib/local-db/decryption-worker.ts
+++ b/src/shared/lib/local-db/decryption-worker.ts
@@ -1,6 +1,7 @@
 import type { ChatDatabase, DecryptionJob } from "./schema";
 import type { RoomRepository } from "./room-repository";
 import { MessageType } from "@/entities/chat/model/types";
+import { cryptoDebug } from "@/shared/lib/utils/crypto-debug";
 
 type GetRoomCrypto = (roomId: string) => Promise<{ decryptEvent(raw: unknown): Promise<{ body: string }> } | undefined>;
 
@@ -175,6 +176,14 @@ export class DecryptionWorker {
     } catch (e) {
       const attempts = job.attempts + 1;
       const isDead = attempts >= MAX_ATTEMPTS;
+
+      cryptoDebug("retry:fail", {
+        eventId: job.eventId,
+        roomId: job.roomId,
+        attempts,
+        isDead,
+        error: e instanceof Error ? e.message : String(e),
+      });
 
       let delay: number;
       if (attempts <= FAST_BACKOFF_MS.length) {

--- a/src/shared/lib/message-format.test.ts
+++ b/src/shared/lib/message-format.test.ts
@@ -8,8 +8,10 @@ import {
   stripBastyonLinks,
   isSafeUrl,
   truncateMessage,
+  applyLocalAlias,
   MAX_MESSAGE_LENGTH,
 } from "./message-format";
+import type { Segment } from "./message-format";
 
 describe("parseMessage", () => {
   it("returns single text segment for plain text", () => {
@@ -281,5 +283,43 @@ describe("truncateMessage", () => {
 
   it("MAX_MESSAGE_LENGTH equals 65536", () => {
     expect(MAX_MESSAGE_LENGTH).toBe(65536);
+  });
+});
+
+describe("applyLocalAlias (WEE-39 follow-up)", () => {
+  const mentionSeg: Segment = { type: "mention", content: "@Alice", userId: "deadbeef" };
+  const textSeg: Segment = { type: "text", content: "hi" };
+
+  it("replaces mention content with @alias when getAlias returns a value", () => {
+    const result = applyLocalAlias(mentionSeg, () => "qqq");
+    expect(result).toEqual({ type: "mention", content: "@qqq", userId: "deadbeef" });
+  });
+
+  it("preserves userId — clicking the mention still resolves the correct profile", () => {
+    const result = applyLocalAlias(mentionSeg, () => "qqq");
+    if (result.type !== "mention") throw new Error("expected mention segment");
+    expect(result.userId).toBe("deadbeef");
+  });
+
+  it("returns the segment unchanged when getAlias returns null/undefined", () => {
+    expect(applyLocalAlias(mentionSeg, () => null)).toBe(mentionSeg);
+    expect(applyLocalAlias(mentionSeg, () => undefined)).toBe(mentionSeg);
+  });
+
+  it("treats empty-string alias as no alias", () => {
+    expect(applyLocalAlias(mentionSeg, () => "")).toBe(mentionSeg);
+  });
+
+  it("passes through non-mention segments untouched", () => {
+    expect(applyLocalAlias(textSeg, () => "qqq")).toBe(textSeg);
+  });
+
+  it("invokes getAlias with the segment's userId, not its display name", () => {
+    let receivedId = "";
+    applyLocalAlias(mentionSeg, (id) => {
+      receivedId = id;
+      return null;
+    });
+    expect(receivedId).toBe("deadbeef");
   });
 });

--- a/src/shared/lib/message-format.test.ts
+++ b/src/shared/lib/message-format.test.ts
@@ -150,6 +150,38 @@ describe("stripMentionAddresses", () => {
     const result = stripMentionAddresses(`@${hex1}:Alice and @${hex2}:Борис`);
     expect(result).toBe("@Alice and @Борис");
   });
+
+  // WEE-39 follow-up: previews must show the viewer's local alias when set.
+  it("substitutes alias when getAlias returns a value", () => {
+    const hex = "a".repeat(68);
+    const result = stripMentionAddresses(
+      `say hi to @${hex}:dqwewr`,
+      (id) => (id === hex ? "qqq" : null),
+    );
+    expect(result).toBe("say hi to @qqq");
+  });
+
+  it("falls back to wire name when getAlias returns null/undefined", () => {
+    const hex = "a".repeat(68);
+    expect(stripMentionAddresses(`@${hex}:Alice`, () => null)).toBe("@Alice");
+    expect(stripMentionAddresses(`@${hex}:Alice`, () => undefined)).toBe("@Alice");
+  });
+
+  it("falls back to wire name when alias is empty string", () => {
+    const hex = "a".repeat(68);
+    expect(stripMentionAddresses(`@${hex}:Alice`, () => "")).toBe("@Alice");
+  });
+
+  it("applies alias selectively per mention", () => {
+    const hex1 = "a".repeat(68);
+    const hex2 = "b".repeat(68);
+    const aliases: Record<string, string> = { [hex1]: "qqq" };
+    const result = stripMentionAddresses(
+      `@${hex1}:Alice and @${hex2}:Bob`,
+      (id) => aliases[id] ?? null,
+    );
+    expect(result).toBe("@qqq and @Bob");
+  });
 });
 
 // ─── stripBastyonLinks ────────────────────────────────────────────

--- a/src/shared/lib/message-format.ts
+++ b/src/shared/lib/message-format.ts
@@ -68,6 +68,28 @@ const URL_RE = /https?:\/\/[^\s<>]+|www\.[^\s<>]+/g;
 const MENTION_RE = /@(\w{34,68}):([\p{L}\p{N}_]{1,50})/gu;
 
 /**
+ * Replace a mention segment's display text with the viewer's local alias
+ * when one is set for the mentioned user. Pure function — no Vue / store
+ * dependency, the caller wires the alias lookup.
+ *
+ * Used by the renderer so that mentions for contacts the viewer renamed
+ * locally ("qqq") show the alias instead of the wire `safeName` shipped
+ * by the sender (WEE-39 follow-up). The `userId` is intentionally kept
+ * untouched so clicking the mention still navigates to the correct profile.
+ *
+ * Non-mention segments are returned as-is.
+ */
+export function applyLocalAlias(
+  seg: Segment,
+  getAlias: (userId: string) => string | null | undefined,
+): Segment {
+  if (seg.type !== "mention") return seg;
+  const alias = getAlias(seg.userId);
+  if (!alias) return seg;
+  return { ...seg, content: `@${alias}` };
+}
+
+/**
  * Strip hex addresses from mentions for plain-text preview.
  * "@50486457...5:Daniel_Satchkov" → "@Daniel_Satchkov"
  */

--- a/src/shared/lib/message-format.ts
+++ b/src/shared/lib/message-format.ts
@@ -92,11 +92,23 @@ export function applyLocalAlias(
 /**
  * Strip hex addresses from mentions for plain-text preview.
  * "@50486457...5:Daniel_Satchkov" → "@Daniel_Satchkov"
+ *
+ * When `getAlias` is provided and returns a non-empty value for the
+ * mention's hex userId, that alias is used instead of the wire safeName.
+ * This is what surfaces a renamed contact ("@qqq") in chat-list previews,
+ * reply blurbs, forward attributions, etc. — keeping the read experience
+ * symmetric with the in-bubble renderer (WEE-39 follow-up).
  */
-export function stripMentionAddresses(text: string): string {
+export function stripMentionAddresses(
+  text: string,
+  getAlias?: (userId: string) => string | null | undefined,
+): string {
   if (!text) return "";
   // Use a fresh regex (since MENTION_RE is global and has state)
-  return text.replace(/@\w{34,68}:([\p{L}\p{N}_]{1,50})/gu, (_match, name) => `@${name}`);
+  return text.replace(/@(\w{34,68}):([\p{L}\p{N}_]{1,50})/gu, (_match, userId, name) => {
+    const alias = getAlias?.(userId);
+    return alias ? `@${alias}` : `@${name}`;
+  });
 }
 
 /**

--- a/src/shared/lib/utils/crypto-debug.test.ts
+++ b/src/shared/lib/utils/crypto-debug.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  cryptoDebug,
+  isCryptoDebugEnabled,
+  looksLikeMention,
+  resetCryptoDebugCache,
+} from "./crypto-debug";
+
+describe("crypto-debug helpers (WEE-39)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    resetCryptoDebugCache();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    resetCryptoDebugCache();
+    vi.restoreAllMocks();
+  });
+
+  describe("isCryptoDebugEnabled", () => {
+    it("returns false by default (no flag set)", () => {
+      expect(isCryptoDebugEnabled()).toBe(false);
+    });
+
+    it("returns true when localStorage flag is exactly '1'", () => {
+      localStorage.setItem("debug:crypto", "1");
+      resetCryptoDebugCache();
+      expect(isCryptoDebugEnabled()).toBe(true);
+    });
+
+    it("returns false for any other localStorage value", () => {
+      localStorage.setItem("debug:crypto", "true");
+      resetCryptoDebugCache();
+      expect(isCryptoDebugEnabled()).toBe(false);
+    });
+
+    it("caches result — DevTools toggle requires resetCryptoDebugCache()", () => {
+      expect(isCryptoDebugEnabled()).toBe(false);
+      localStorage.setItem("debug:crypto", "1");
+      // Without explicit reset the cached `false` survives.
+      expect(isCryptoDebugEnabled()).toBe(false);
+      resetCryptoDebugCache();
+      expect(isCryptoDebugEnabled()).toBe(true);
+    });
+  });
+
+  describe("cryptoDebug", () => {
+    it("is a no-op when flag is off (does not call console.warn)", () => {
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      cryptoDebug("encrypt", { tetatet: true });
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("logs structural payload when flag is on", () => {
+      localStorage.setItem("debug:crypto", "1");
+      resetCryptoDebugCache();
+      const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      cryptoDebug("encrypt", { tetatet: false, textLen: 42 });
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy.mock.calls[0][0]).toBe("[crypto-debug:encrypt]");
+      expect(spy.mock.calls[0][1]).toEqual({ tetatet: false, textLen: 42 });
+    });
+  });
+
+  describe("looksLikeMention", () => {
+    it("detects leading @mention", () => {
+      expect(looksLikeMention("@AlexD hi")).toBe(true);
+    });
+
+    it("detects mid-string @mention with whitespace prefix", () => {
+      expect(looksLikeMention("Привет @AlexD как дела?")).toBe(true);
+    });
+
+    it("ignores @ inside emails (no whitespace boundary in front)", () => {
+      expect(looksLikeMention("send to user@example.com")).toBe(false);
+    });
+
+    it("returns false for plain text without @", () => {
+      expect(looksLikeMention("Hello world")).toBe(false);
+    });
+
+    it("returns false for empty / single-char input", () => {
+      expect(looksLikeMention("")).toBe(false);
+      expect(looksLikeMention("@")).toBe(false);
+    });
+  });
+});

--- a/src/shared/lib/utils/crypto-debug.ts
+++ b/src/shared/lib/utils/crypto-debug.ts
@@ -1,0 +1,57 @@
+/**
+ * Opt-in diagnostic logging for cross-client encryption debugging (WEE-39).
+ *
+ * Activated by setting `localStorage["debug:crypto"] = "1"` in DevTools.
+ * Off by default in production — no log spam unless explicitly enabled.
+ *
+ * Logs are structural only (counts, flags, hashes) — they MUST NOT contain
+ * keys, plaintext, or any field that could leak ciphertext content.
+ */
+
+let cachedFlag: boolean | null = null;
+
+function readFlag(): boolean {
+  if (cachedFlag !== null) return cachedFlag;
+  try {
+    if (typeof localStorage === "undefined") {
+      cachedFlag = false;
+      return false;
+    }
+    cachedFlag = localStorage.getItem("debug:crypto") === "1";
+  } catch {
+    cachedFlag = false;
+  }
+  return cachedFlag;
+}
+
+/**
+ * Manually invalidate the cached flag (e.g. after toggling in DevTools).
+ *
+ * Scope caveat: this only resets the cache in the module instance that
+ * imported it. Web Workers and the main thread each load their own copy
+ * of the module, so toggling the flag at runtime requires either a worker
+ * restart or a worker-side `postMessage` that forwards the reset.
+ */
+export function resetCryptoDebugCache(): void {
+  cachedFlag = null;
+}
+
+/** True when crypto-debug logging is enabled via `localStorage["debug:crypto"]`. */
+export function isCryptoDebugEnabled(): boolean {
+  return readFlag();
+}
+
+/** Emit a tagged debug line. Safe to call unconditionally — no-op when flag off. */
+export function cryptoDebug(tag: string, payload: Record<string, unknown>): void {
+  if (!readFlag()) return;
+  console.warn(`[crypto-debug:${tag}]`, payload);
+}
+
+/**
+ * Detect whether a plaintext payload looks like it carries a Matrix-style
+ * @mention. Used purely for diagnostic logs — not as part of the crypto path.
+ */
+export function looksLikeMention(text: string): boolean {
+  if (!text || text.length < 2) return false;
+  return /(^|\s)@\S/.test(text);
+}

--- a/src/shared/lib/utils/format-preview.ts
+++ b/src/shared/lib/utils/format-preview.ts
@@ -86,7 +86,7 @@ export function useFormatPreview() {
       default:
         preview = content || "";
     }
-    preview = stripMentionAddresses(preview);
+    preview = stripMentionAddresses(preview, (userId) => chatStore.getLocalAlias(userId));
     preview = stripBastyonLinks(preview);
     preview = cleanMatrixIds(preview);
 


### PR DESCRIPTION
## Summary

Defensive preparatory scope for **WEE-39** (P0 "Невозможно расшифровать" in group after `@mention` from Forta web). Cross-client repro (Forta web + Forta Android + Bastyon legacy in the same group) is required before any conditional fix from the ticket's hypothesis tree (H1-H5) can be made safely. This PR:

- Adds opt-in diagnostic logging so the next person with a 3-client setup can capture the failing payload shape.
- Improves the permanent-decrypt-fail UX from a generic placeholder to actionable copy.
- Adds regression coverage for mention preservation and the new wording.

**The crypto path is intentionally untouched.** The Linear ticket stays \`In Progress\` — this is preparatory work, not the fix.

## Linear

- Refs WEE-39 — https://linear.app/wwwee/issue/WEE-39/encryption-nevozmozhno-rasshifrovat-v-gruppe-posle-mention-iz-forta

## What's in this PR

- \`src/shared/lib/utils/crypto-debug.ts\` (NEW) — gated logging helper. Off by default; opt-in via \`localStorage["debug:crypto"] = "1"\` in DevTools. Only structural fields (counts, flags, lengths) — never plaintext, keys, or full hashes.
- \`src/shared/lib/utils/crypto-debug.test.ts\` (NEW) — 11 unit tests.
- \`src/entities/matrix/model/matrix-crypto.ts\` — diagnostic taps in \`encryptEvent\`, \`decryptEvent\` route, and \`decryptEventGroup\` "no common key" branch.
- \`src/shared/lib/local-db/decryption-worker.ts\` — diagnostic tap in \`processJob\` retry/fail/dead transitions.
- \`src/shared/lib/i18n/locales/{en,ru}.ts\` — \`message.notDecrypted\` rewored: "Couldn't decrypt — ask the sender to resend or update the app" / "Не удалось расшифровать — попросите переслать сообщение или обновить приложение".
- \`src/entities/chat/lib/display-result.test.ts\` — 2 regression tests for \`getMessagePreviewForUI\`.

## How to capture the failing payload during cross-client repro

In each client's DevTools:

\`\`\`js
localStorage.setItem("debug:crypto", "1")
location.reload()
\`\`\`

Reproduce the bug, grep console for \`[crypto-debug:*]\`. Sender sees \`encrypt\`; recipients see \`decrypt:route\` + (on failure) \`decrypt:group:no-common-key\` and \`retry:fail\`. Compare payload shape across clients.

## Test plan

- [x] \`vite build\`: passes
- [x] \`vue-tsc --noEmit\` on changed files: clean (pre-existing TS errors elsewhere in repo are unrelated)
- [x] Vitest on changed files: 34 passed (the 4 failures in \`display-result.test.ts\` are pre-existing — \`getRoomTitleForUI\`/\`getUserDisplayNameForUI\` truncated-hex tests)
- [x] Code review (typescript-reviewer agent): HIGH finding (hash leak) addressed by switching to \`hashLen\`; MEDIUM comments added
- [ ] Manual: 3-client repro with \`debug:crypto=1\` in each — **blocking next PR** that picks a hypothesis from H1-H5
- [ ] Manual: visual check that the longer EN/RU \`message.notDecrypted\` does not overflow narrow contact-list rows

## Out of scope

- Modifying \`roomCrypto.encryptEvent\` / \`decryptEvent\` payload shape — needs cross-client evidence first.
- The plan's "Task 4 — retry on OLM_UNKNOWN_SESSION" — Forta uses custom miscreant SIV, not Megolm; needs re-evaluation against actual error strings captured by this PR's logging.