### PR TITLE
fix(emoji-picker): skip --emoji-picker-height publish on desktop (WEE-41)

### DIFF
--- a/src/features/messaging/ui/EmojiPicker.vue
+++ b/src/features/messaging/ui/EmojiPicker.vue
@@ -90,8 +90,8 @@ const publishPickerHeight = (h: number) => {
 };
 
 watch(
-  [() => props.show, panelRef, () => props.mode],
-  ([show, el, mode]) => {
+  [() => props.show, panelRef, () => props.mode, () => isMobile.value],
+  ([show, el, mode, mobile]) => {
     // Reaction-mode is hands-off: never read, never write — let the input
     // instance (if any) keep ownership of the var.
     if (mode !== "input") return;
@@ -99,6 +99,15 @@ watch(
     if (panelObserver) {
       panelObserver.disconnect();
       panelObserver = null;
+    }
+    // WEE-41: desktop picker is a floating popup anchored to the emoji
+    // button, not a bottom-sheet — pushing MessageList up would leave a
+    // huge empty gap. Session 59's push-up is mobile-only. Reset the var
+    // here too, so a mobile→desktop resize while the picker is open
+    // releases any padding-bottom previously reserved by MessageList.
+    if (!mobile) {
+      publishPickerHeight(0);
+      return;
     }
     if (!show || !el) {
       publishPickerHeight(0);
@@ -118,7 +127,11 @@ watch(
 onScopeDispose(() => {
   panelObserver?.disconnect();
   panelObserver = null;
-  // Only the owning instance resets — same gate as the watcher above.
+  // Reaction-mode picker never publishes the var, so stays hands-off.
+  // For input-mode we always reset to 0 here regardless of platform — on
+  // desktop the var is already 0 (no-op), on mobile this guarantees the
+  // var is cleared even if isMobile flipped mid-teardown (e.g. an unmount
+  // that races a viewport resize) so MessageList never keeps a stale gap.
   if (props.mode === "input") publishPickerHeight(0);
 });
 

--- a/src/features/messaging/ui/__tests__/EmojiPicker-height-var.test.ts
+++ b/src/features/messaging/ui/__tests__/EmojiPicker-height-var.test.ts
@@ -19,10 +19,11 @@ vi.mock("@/shared/lib/composables/use-android-back-handler", () => ({
   useAndroidBackHandler: vi.fn(),
 }));
 
-// Force mobile so the input-mode branch (which docks the picker and publishes
-// height) is exercised.
+// Shared ref so individual tests can flip the platform (mobile/desktop) and
+// exercise the platform-aware publish guard.
+const mockIsMobile = ref(true);
 vi.mock("@/shared/lib/composables/use-media-query", () => ({
-  useMobile: () => ref(true),
+  useMobile: () => mockIsMobile,
 }));
 
 // Local ResizeObserver mock — happy-dom doesn't deliver observe callbacks.
@@ -72,6 +73,7 @@ describe("EmojiPicker — publishes --emoji-picker-height", () => {
     vi.stubGlobal("ResizeObserver", ResizeObserverStub);
     document.documentElement.style.setProperty(CSS_VAR, "0px");
     setRectHeight(FAKE_PICKER_HEIGHT);
+    mockIsMobile.value = true;
   });
 
   afterEach(() => {
@@ -171,5 +173,97 @@ describe("EmojiPicker — publishes --emoji-picker-height", () => {
     expect(getVar()).toBe(`${FAKE_PICKER_HEIGHT}px`);
 
     input.unmount();
+  });
+});
+
+// WEE-41: on desktop the picker is a floating popup anchored to the emoji
+// button; it does NOT overlay the bottom of the viewport. Publishing
+// `--emoji-picker-height` would force MessageList to reserve padding-bottom
+// for nothing, leaving a large empty gap below the chat. Session 59's
+// push-up mechanism must stay scoped to mobile bottom-sheets only.
+describe("EmojiPicker — desktop floating popup must NOT publish picker height", () => {
+  beforeEach(() => {
+    vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+    document.documentElement.style.setProperty(CSS_VAR, "0px");
+    setRectHeight(FAKE_PICKER_HEIGHT);
+    mockIsMobile.value = false;
+  });
+
+  afterEach(() => {
+    document.documentElement.style.setProperty(CSS_VAR, "0px");
+    Element.prototype.getBoundingClientRect = originalRect;
+    vi.unstubAllGlobals();
+    mockIsMobile.value = true;
+  });
+
+  it("does NOT publish --emoji-picker-height when opened on desktop in input mode", async () => {
+    const wrapper = mount(EmojiPicker, {
+      props: { show: true, mode: "input", x: 0, y: 0 },
+      attachTo: document.body,
+    });
+    await nextTick();
+    await nextTick();
+
+    const v = getVar();
+    expect(v === "" || v === "0px").toBe(true);
+
+    wrapper.unmount();
+  });
+
+  it("leaves the var at 0px on unmount on desktop (no spurious writes)", async () => {
+    const wrapper = mount(EmojiPicker, {
+      props: { show: true, mode: "input", x: 0, y: 0 },
+      attachTo: document.body,
+    });
+    await nextTick();
+    await nextTick();
+
+    wrapper.unmount();
+    await nextTick();
+    const v = getVar();
+    expect(v === "" || v === "0px").toBe(true);
+  });
+
+  // Race scenario: picker opens on mobile (var = 320px), viewport flips to
+  // desktop *and then* component unmounts in the same teardown sequence. The
+  // dispose hook must reset the var unconditionally for input-mode so
+  // MessageList never holds onto a stale padding-bottom after teardown.
+  it("clears --emoji-picker-height on unmount even if isMobile flipped to false mid-teardown", async () => {
+    mockIsMobile.value = true;
+    const wrapper = mount(EmojiPicker, {
+      props: { show: true, mode: "input", x: 0, y: 0 },
+      attachTo: document.body,
+    });
+    await nextTick();
+    await nextTick();
+    expect(getVar()).toBe(`${FAKE_PICKER_HEIGHT}px`);
+
+    // Resize to desktop just before unmount — simulate the var still being
+    // non-zero (e.g. watcher hasn't fired yet).
+    mockIsMobile.value = false;
+    document.documentElement.style.setProperty(CSS_VAR, "240px");
+
+    wrapper.unmount();
+    await nextTick();
+    expect(getVar()).toBe("0px");
+  });
+
+  // Belt-and-braces: a stale non-zero var left over by an earlier mobile
+  // instance (e.g. on a resize from mobile→desktop) must be cleared once the
+  // desktop picker mounts, otherwise MessageList keeps the bottom gap.
+  it("clears any stale non-zero --emoji-picker-height when mounting on desktop", async () => {
+    document.documentElement.style.setProperty(CSS_VAR, "240px");
+
+    const wrapper = mount(EmojiPicker, {
+      props: { show: true, mode: "input", x: 0, y: 0 },
+      attachTo: document.body,
+    });
+    await nextTick();
+    await nextTick();
+
+    const v = getVar();
+    expect(v === "" || v === "0px").toBe(true);
+
+    wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Summary

- Desktop emoji picker is a floating popup anchored to the emoji button — it must NOT push messages up via Session 59's mobile bottom-sheet mechanism.
- Gate `publishPickerHeight()` behind `isMobile.value === true` in the watcher; reset to 0 on `mobile→desktop` resize so MessageList releases any padding-bottom.
- `onScopeDispose` resets unconditionally for `input` mode — guarantees no stale gap if a teardown races a viewport resize.

## Root cause

`EmojiPicker.vue` published `--emoji-picker-height` unconditionally for input-mode regardless of platform. `MessageList` (via `chat-list-style.ts`) consumed the var as `padding-bottom`, leaving a huge empty space below the chat on desktop while the floating popup hovered above the emoji button.

## Linear

- Resolves WEE-41 (https://linear.app/wwwee/issue/WEE-41/emoji-keyboard-desktop-picker-pushit-soobsheniya-naverh-hotya-sam)

## Test plan

- [x] `vite build` — passes
- [x] `vitest run src/features/messaging/ui/__tests__/EmojiPicker-height-var.test.ts` — 9/9 green (6 existing mobile + 3 new desktop regressions)
- [ ] Manual desktop QA: open chat → click emoji button → picker shows as floating popup, latest messages stay in place (no bottom gap).
- [ ] Manual mobile QA (Android): open chat → tap emoji button → picker bottom-sheet, messages shift up (Session 59 preserved).
- [ ] Resize browser between desktop and mobile widths while picker is open — push-up activates/deactivates correctly.

## Files changed

| File | Edit |
| --- | --- |
| src/features/messaging/ui/EmojiPicker.vue | added isMobile.value guard in watcher (incl. as reactive dep) + mobile→desktop resize handling; unconditional reset on input-mode dispose |
| src/features/messaging/ui/__tests__/EmojiPicker-height-var.test.ts | shared mockIsMobile ref + 3 new desktop regression tests (no publish on desktop, no stale value on resize, no stale value on unmount-race) |

## Not touched

- Picker positioning (fixed on mobile / absolute rounded-2xl on desktop) — unchanged.
- Picker content (emoji grid, search, GIF tab, reactions) — unchanged.
- Session 59 mobile push-up behavior — preserved.
- Reaction-mode picker (mode="reaction") — unchanged (already hands-off).