### PR TITLE
fix(messages): retry Matrix init with backoff + typed unreachable banner (WEE-46)

### DIFF
--- a/src/app/model/boot-status.test.ts
+++ b/src/app/model/boot-status.test.ts
@@ -16,6 +16,7 @@ describe("bootStatus", () => {
     expect(bootStatus.state.value).toBe("booting");
     expect(bootStatus.currentStep.value).toBe("scripts");
     expect(bootStatus.error.value).toBeNull();
+    expect(bootStatus.errorKind.value).toBeNull();
   });
 
   it("advances steps", () => {
@@ -33,11 +34,19 @@ describe("bootStatus", () => {
     expect(bootStatus.currentStep.value).toBe("ready");
   });
 
-  it("transitions to error", () => {
+  it("transitions to error with default generic kind", () => {
     bootStatus.setStep("matrix");
     bootStatus.setError("Connection refused");
     expect(bootStatus.state.value).toBe("error");
     expect(bootStatus.error.value).toBe("Connection refused");
+    expect(bootStatus.errorKind.value).toBe("generic");
+  });
+
+  it("preserves typed error kind", () => {
+    bootStatus.setStep("matrix");
+    bootStatus.setError("homeserver 503", "matrix-unreachable");
+    expect(bootStatus.errorKind.value).toBe("matrix-unreachable");
+    expect(bootStatus.error.value).toBe("homeserver 503");
   });
 
   it("ignores setStep after ready", () => {
@@ -52,12 +61,20 @@ describe("bootStatus", () => {
     expect(bootStatus.state.value).toBe("error");
   });
 
-  it("reset returns to initial state", () => {
+  it("ignores subsequent setError calls (does not overwrite kind or message)", () => {
+    bootStatus.setError("matrix offline", "matrix-unreachable");
+    bootStatus.setError("something else", "generic");
+    expect(bootStatus.error.value).toBe("matrix offline");
+    expect(bootStatus.errorKind.value).toBe("matrix-unreachable");
+  });
+
+  it("reset clears error kind and message", () => {
     bootStatus.setStep("matrix");
-    bootStatus.setError("fail");
+    bootStatus.setError("fail", "matrix-unreachable");
     bootStatus.reset();
     expect(bootStatus.state.value).toBe("booting");
     expect(bootStatus.currentStep.value).toBe("scripts");
     expect(bootStatus.error.value).toBeNull();
+    expect(bootStatus.errorKind.value).toBeNull();
   });
 });

--- a/src/app/model/boot-status.ts
+++ b/src/app/model/boot-status.ts
@@ -10,11 +10,23 @@ export type BootStep =
 
 export type BootState = "booting" | "ready" | "error";
 
+/**
+ * Discriminator for typed boot errors so the loading UI can choose
+ * an appropriate copy + retry affordance instead of a generic banner.
+ *
+ *  - `matrix-unreachable`: Matrix homeserver did not become ready within the
+ *    retry budget (timeouts, repeated transport failures, MIUI killing the
+ *    long-poll /sync etc.). See WEE-46.
+ *  - `generic`: any other boot-time failure.
+ */
+export type BootErrorKind = "matrix-unreachable" | "generic";
+
 const _bootStart = Date.now();
 const _stepStartedAt = ref(_bootStart);
 const _currentStep = ref<BootStep>("scripts");
 const _state = ref<BootState>("booting");
 const _errorMessage = ref<string | null>(null);
+const _errorKind = ref<BootErrorKind | null>(null);
 
 function elapsed(): number {
   return Date.now() - _stepStartedAt.value;
@@ -24,6 +36,7 @@ export const bootStatus = {
   state: computed(() => _state.value),
   currentStep: computed(() => _currentStep.value),
   error: computed(() => _errorMessage.value),
+  errorKind: computed(() => _errorKind.value),
 
   /** Advance to the next boot step. Logs timing of the previous step. */
   setStep(step: BootStep) {
@@ -43,11 +56,26 @@ export const bootStatus = {
     _currentStep.value = "ready";
   },
 
-  /** Mark boot as failed. Shows error UI in AppLoading. */
-  setError(msg: string) {
-    console.error(`[BOOT] ✗ Error at step "${_currentStep.value}": ${msg}`);
+  /**
+   * Mark boot as failed. Shows error UI in AppLoading.
+   *
+   * @param msg  Human-readable diagnostic. Surfaced in the generic banner copy.
+   * @param kind Optional classification used by AppLoading to pick a typed copy
+   *             and retry CTA. Defaults to `"generic"` for backward compat.
+   */
+  setError(msg: string, kind: BootErrorKind = "generic") {
+    // Guard symmetrical with `setStep` / `setReady`: once the boot has already
+    // resolved (ready or errored), a second call must not silently overwrite
+    // the first verdict (e.g. an account-switch race during a long retry
+    // window flipping `errorKind` from `"matrix-unreachable"` back to
+    // `"generic"`).
+    if (_state.value !== "booting") return;
+    console.error(
+      `[BOOT] ✗ Error at step "${_currentStep.value}" (${kind}): ${msg}`,
+    );
     _state.value = "error";
     _errorMessage.value = msg;
+    _errorKind.value = kind;
   },
 
   /** Reset to initial state (for retry). */
@@ -55,6 +83,7 @@ export const bootStatus = {
     _currentStep.value = "scripts";
     _state.value = "booting";
     _errorMessage.value = null;
+    _errorKind.value = null;
     _stepStartedAt.value = Date.now();
   },
 };

--- a/src/app/ui/app-loading/AppLoading.vue
+++ b/src/app/ui/app-loading/AppLoading.vue
@@ -6,6 +6,8 @@ import { tRaw, type TranslationKey } from "@/shared/lib/i18n";
 const t = tRaw;
 const state = computed(() => bootStatus.state.value);
 const error = computed(() => bootStatus.error.value);
+const errorKind = computed(() => bootStatus.errorKind.value);
+const isMatrixUnreachable = computed(() => errorKind.value === "matrix-unreachable");
 
 const stepKeys: Record<string, TranslationKey> = {
   scripts: "boot.loadingScripts",
@@ -78,7 +80,15 @@ const clearAndRetry = async () => {
           !
         </div>
 
-        <p class="text-sm text-red-400">{{ t("boot.failed") }}</p>
+        <p class="text-sm text-red-400">
+          {{ isMatrixUnreachable ? t("boot.matrixUnreachable") : t("boot.failed") }}
+        </p>
+        <p
+          v-if="isMatrixUnreachable"
+          class="max-w-xs text-center text-xs text-white/50"
+        >
+          {{ t("boot.matrixUnreachableHint") }}
+        </p>
         <p v-if="error" class="max-w-xs text-center text-xs text-white/40">
           {{ error }}
         </p>

--- a/src/entities/auth/lib/connect-matrix-with-retry.test.ts
+++ b/src/entities/auth/lib/connect-matrix-with-retry.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  connectMatrixWithRetry,
+  type RetryableMatrixService,
+} from "./connect-matrix-with-retry";
+
+function createService(plan: Array<"ready" | "not-ready" | Error>): RetryableMatrixService {
+  let step = 0;
+  let ready = false;
+  let error: string | false = false;
+
+  return {
+    init: async () => {
+      const outcome = plan[Math.min(step, plan.length - 1)];
+      step++;
+      if (outcome instanceof Error) {
+        error = outcome.message;
+        ready = false;
+        throw outcome;
+      }
+      if (outcome === "ready") {
+        ready = true;
+        error = false;
+      } else {
+        ready = false;
+        error = "transient";
+      }
+    },
+    isReady: () => ready,
+    get error() {
+      return error;
+    },
+  };
+}
+
+const instantSleep = () => Promise.resolve();
+
+describe("connectMatrixWithRetry", () => {
+  it("returns immediately when first attempt becomes ready", async () => {
+    const service = createService(["ready"]);
+    const result = await connectMatrixWithRetry(service, { sleep: instantSleep });
+
+    expect(result.ready).toBe(true);
+    expect(result.attempts).toBe(1);
+    expect(result.lastError).toBeNull();
+  });
+
+  it("retries with exponential backoff after a throw, then succeeds", async () => {
+    const sleep = vi.fn(instantSleep);
+    const service = createService([new Error("ECONNREFUSED"), "ready"]);
+
+    const onAttempt = vi.fn();
+    const onAttemptFail = vi.fn();
+
+    const result = await connectMatrixWithRetry(service, {
+      sleep,
+      onAttempt,
+      onAttemptFail,
+      baseDelayMs: 1_000,
+      maxAttempts: 3,
+    });
+
+    expect(result.ready).toBe(true);
+    expect(result.attempts).toBe(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(1_000);
+    expect(onAttempt).toHaveBeenCalledTimes(2);
+    expect(onAttemptFail).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats init() resolving with isReady=false as a transient failure and retries", async () => {
+    const sleep = vi.fn(instantSleep);
+    const service = createService(["not-ready", "not-ready", "ready"]);
+
+    const result = await connectMatrixWithRetry(service, {
+      sleep,
+      baseDelayMs: 1_000,
+      maxAttempts: 3,
+    });
+
+    expect(result.ready).toBe(true);
+    expect(result.attempts).toBe(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenNthCalledWith(1, 1_000);
+    expect(sleep).toHaveBeenNthCalledWith(2, 2_000);
+  });
+
+  it("caps backoff delay at maxDelayMs", async () => {
+    const sleep = vi.fn(instantSleep);
+    const service = createService(["not-ready", "not-ready", "not-ready", "ready"]);
+
+    await connectMatrixWithRetry(service, {
+      sleep,
+      baseDelayMs: 10_000,
+      maxDelayMs: 12_000,
+      maxAttempts: 4,
+    });
+
+    expect(sleep).toHaveBeenNthCalledWith(1, 10_000);
+    expect(sleep).toHaveBeenNthCalledWith(2, 12_000);
+    expect(sleep).toHaveBeenNthCalledWith(3, 12_000);
+  });
+
+  it("returns ready=false after exhausting attempts and surfaces lastError", async () => {
+    const sleep = vi.fn(instantSleep);
+    const failure = new Error("homeserver 503");
+    const service = createService([failure, failure, failure]);
+
+    const result = await connectMatrixWithRetry(service, {
+      sleep,
+      baseDelayMs: 1_000,
+      maxAttempts: 3,
+    });
+
+    expect(result.ready).toBe(false);
+    expect(result.attempts).toBe(3);
+    expect(result.lastError).toBe(failure);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("times out a stuck init() and retries the next attempt", async () => {
+    const sleep = vi.fn(instantSleep);
+    let attempts = 0;
+    const service: RetryableMatrixService = {
+      init: () => {
+        attempts++;
+        if (attempts < 2) {
+          // Never settles — withTimeout must reject.
+          return new Promise<void>(() => {});
+        }
+        return Promise.resolve();
+      },
+      isReady: () => attempts >= 2,
+      error: false,
+    };
+
+    const result = await connectMatrixWithRetry(service, {
+      sleep,
+      attemptTimeoutMs: 5,
+      baseDelayMs: 1,
+      maxAttempts: 3,
+    });
+
+    expect(result.ready).toBe(true);
+    expect(result.attempts).toBe(2);
+  });
+
+  it("never sleeps after the final attempt", async () => {
+    const sleep = vi.fn(instantSleep);
+    const service = createService(["not-ready"]);
+
+    await connectMatrixWithRetry(service, {
+      sleep,
+      baseDelayMs: 1_000,
+      maxAttempts: 1,
+    });
+
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("synthesises a diagnostic error when init() resolves but isReady() stays false", async () => {
+    const onAttemptFail = vi.fn();
+    const service: RetryableMatrixService = {
+      init: async () => {},
+      isReady: () => false,
+      error: false,
+    };
+
+    const result = await connectMatrixWithRetry(service, {
+      sleep: instantSleep,
+      onAttemptFail,
+      maxAttempts: 1,
+    });
+
+    expect(result.ready).toBe(false);
+    expect(onAttemptFail).toHaveBeenCalledTimes(1);
+    const passedError = onAttemptFail.mock.calls[0][1];
+    expect(passedError).toBeInstanceOf(Error);
+    expect((passedError as Error).message).toMatch(/not ready/i);
+  });
+
+  it("propagates service.error string into the synthesised not-ready failure", async () => {
+    const onAttemptFail = vi.fn();
+    const service: RetryableMatrixService = {
+      init: async () => {},
+      isReady: () => false,
+      error: "homeserver returned 503",
+    };
+
+    await connectMatrixWithRetry(service, {
+      sleep: instantSleep,
+      onAttemptFail,
+      maxAttempts: 1,
+    });
+
+    const passedError = onAttemptFail.mock.calls[0][1];
+    expect((passedError as Error).message).toBe("homeserver returned 503");
+  });
+});

--- a/src/entities/auth/lib/connect-matrix-with-retry.ts
+++ b/src/entities/auth/lib/connect-matrix-with-retry.ts
@@ -1,0 +1,108 @@
+import { withTimeout } from "@/shared/lib/with-timeout";
+
+/**
+ * Minimal subset of `MatrixClientService` consumed by the retry helper.
+ * Keeps the helper testable without pulling the whole service surface.
+ */
+export interface RetryableMatrixService {
+  init(): Promise<void>;
+  isReady(): boolean;
+  readonly error: string | false;
+}
+
+export interface ConnectMatrixWithRetryOptions {
+  /** Per-attempt timeout for `service.init()`. Defaults to 45_000 ms (Matrix HS connect budget). */
+  attemptTimeoutMs?: number;
+  /** Maximum attempts (initial + retries). Defaults to 3. */
+  maxAttempts?: number;
+  /** Base delay between attempts in ms (exponential: base * 2^i). Defaults to 1_000. */
+  baseDelayMs?: number;
+  /** Cap on backoff delay between attempts. Defaults to 30_000 ms. */
+  maxDelayMs?: number;
+  /** Sleeper, injectable for tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Per-attempt progress hook, e.g. for UI status text. */
+  onAttempt?: (attempt: number, maxAttempts: number) => void;
+  /** Per-attempt failure hook with the captured error. */
+  onAttemptFail?: (attempt: number, error: unknown) => void;
+}
+
+export interface ConnectMatrixWithRetryResult {
+  /** True when `service.isReady()` became true within budget. */
+  ready: boolean;
+  /** Number of attempts actually executed. */
+  attempts: number;
+  /** Captured error from the last attempt (when `ready === false`). */
+  lastError: unknown;
+}
+
+const DEFAULT_OPTIONS = {
+  attemptTimeoutMs: 45_000,
+  maxAttempts: 3,
+  baseDelayMs: 1_000,
+  maxDelayMs: 30_000,
+} as const;
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Drive `MatrixClientService.init()` until it reports ready or attempts are
+ * exhausted. Wraps each attempt in a timeout and waits with exponential backoff
+ * between failures. The helper is transport-agnostic and never touches Pinia
+ * or the boot UI — callers translate the result into typed boot state.
+ *
+ * Behaviour:
+ *  - `init()` is invoked sequentially, never concurrently.
+ *  - When `init()` returns but `service.isReady()` stays `false`, the attempt
+ *    is treated as a soft failure (transient transport / sync error). This is
+ *    the failure shape observed on Xiaomi MIUI when `/sync` long-polls die
+ *    before the SDK flips the ready flag.
+ *  - Final attempt does not pay an extra backoff wait.
+ */
+export async function connectMatrixWithRetry(
+  service: RetryableMatrixService,
+  options: ConnectMatrixWithRetryOptions = {},
+): Promise<ConnectMatrixWithRetryResult> {
+  const attemptTimeoutMs = options.attemptTimeoutMs ?? DEFAULT_OPTIONS.attemptTimeoutMs;
+  const maxAttempts = Math.max(1, options.maxAttempts ?? DEFAULT_OPTIONS.maxAttempts);
+  const baseDelayMs = options.baseDelayMs ?? DEFAULT_OPTIONS.baseDelayMs;
+  const maxDelayMs = options.maxDelayMs ?? DEFAULT_OPTIONS.maxDelayMs;
+  const sleep = options.sleep ?? defaultSleep;
+
+  let lastError: unknown = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    options.onAttempt?.(attempt, maxAttempts);
+
+    try {
+      await withTimeout(
+        service.init(),
+        attemptTimeoutMs,
+        `Matrix server connection (attempt ${attempt}/${maxAttempts})`,
+      );
+
+      if (service.isReady()) {
+        return { ready: true, attempts: attempt, lastError: null };
+      }
+
+      // init() resolved but the service is not ready — capture diagnostic
+      // and treat it as a transient failure worth retrying.
+      lastError =
+        service.error !== false && service.error
+          ? new Error(String(service.error))
+          : new Error("Matrix service not ready after init()");
+    } catch (e) {
+      lastError = e;
+    }
+
+    options.onAttemptFail?.(attempt, lastError);
+
+    if (attempt < maxAttempts) {
+      const delay = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+      await sleep(delay);
+    }
+  }
+
+  return { ready: false, attempts: maxAttempts, lastError };
+}

--- a/src/entities/auth/model/stores.ts
+++ b/src/entities/auth/model/stores.ts
@@ -50,6 +50,7 @@ import {
   clearSelfProfile,
   mergeSelfProfileWithRemote,
 } from "../lib";
+import { connectMatrixWithRetry } from "../lib/connect-matrix-with-retry";
 import { createKeyPair } from "./key-pair";
 
 const NAMESPACE = "auth";
@@ -618,9 +619,32 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
 
       matrixError.value = "Connecting to Matrix server...";
       bootStatus.setStep("matrix");
-      await withTimeout(matrixService.init(), 45_000, "Matrix server connection");
 
-      if (matrixService.isReady()) {
+      // WEE-46: Xiaomi MIUI / Android 14+ aggressively kills the long-poll
+      // before the SDK flips ready, leaving us in a silent "Matrix not ready"
+      // state on cold start. Retry-with-backoff turns a single brittle attempt
+      // into 3 attempts (1s/2s backoff, 45s per attempt) so transient transport
+      // failures don't surface as a fatal boot error.
+      const connectResult = await connectMatrixWithRetry(matrixService, {
+        attemptTimeoutMs: 45_000,
+        maxAttempts: 3,
+        baseDelayMs: 1_000,
+        maxDelayMs: 30_000,
+        onAttempt: (attempt, max) => {
+          matrixError.value =
+            attempt === 1
+              ? "Connecting to Matrix server..."
+              : `Reconnecting to Matrix server (attempt ${attempt}/${max})...`;
+        },
+        onAttemptFail: (attempt, err) => {
+          console.warn(
+            `[auth] Matrix connect attempt ${attempt} failed:`,
+            err instanceof Error ? err.message : err,
+          );
+        },
+      });
+
+      if (connectResult.ready) {
         bootStatus.setStep("sync");
         matrixReady.value = true;
         matrixError.value = null;
@@ -793,10 +817,20 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
         // here would run with 0 rooms (sync hasn't finished) and poison the
         // IndexedDB cache with an empty array.
       } else {
-        console.error("[auth] Matrix client NOT ready, error:", matrixService.error);
-        matrixError.value = matrixService.error || "Matrix init failed";
-        if (bootStatus.state.value === 'booting') {
-          bootStatus.setError(matrixError.value);
+        const lastErr = connectResult.lastError;
+        const reason =
+          lastErr instanceof Error
+            ? lastErr.message
+            : lastErr
+              ? String(lastErr)
+              : matrixService.error || "Matrix init failed";
+        console.error(
+          `[auth] Matrix client NOT ready after ${connectResult.attempts} attempt(s):`,
+          reason,
+        );
+        matrixError.value = reason;
+        if (bootStatus.state.value === "booting") {
+          bootStatus.setError(reason, "matrix-unreachable");
         }
       }
     } catch (e) {

--- a/src/entities/matrix/model/matrix-client.ts
+++ b/src/entities/matrix/model/matrix-client.ts
@@ -499,6 +499,12 @@ export class MatrixClientService {
 
   /** Full init: create client + init db */
   async init(): Promise<void> {
+    // Reset transient failure state from any previous attempt. Without this,
+    // `isReady()` would stay `false` on a successful retry because it ANDs
+    // `ready` with `!error`, and a stale error from attempt N would mask a
+    // healthy attempt N+1 — see WEE-46 retry path.
+    this.error = false;
+    this.ready = false;
     try {
       this.client = await this.getClient();
       if (this.client) {

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -762,6 +762,8 @@ export const en = {
   "boot.syncingMessages": "Syncing messages…",
   "boot.loading": "Loading Forta Chat…",
   "boot.failed": "Failed to start Forta Chat",
+  "boot.matrixUnreachable": "Couldn't reach the chat server",
+  "boot.matrixUnreachableHint": "Check your connection and try again. If the problem persists, the server may be temporarily unavailable.",
   "boot.retry": "Retry",
   "boot.clearing": "Clearing…",
   "boot.clearCache": "Clear cache & retry",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -764,6 +764,8 @@ export const ru: Record<TranslationKey, string> = {
   "boot.syncingMessages": "Синхронизация сообщений…",
   "boot.loading": "Загрузка Forta Chat…",
   "boot.failed": "Не удалось запустить Forta Chat",
+  "boot.matrixUnreachable": "Не удалось подключиться к серверу чата",
+  "boot.matrixUnreachableHint": "Проверьте соединение и повторите попытку. Если проблема не исчезает, сервер может быть временно недоступен.",
   "boot.retry": "Повторить",
   "boot.clearing": "Очистка…",
   "boot.clearCache": "Очистить кеш и повторить",


### PR DESCRIPTION
## Summary

- Adds exponential-backoff retry (3 attempts, 1s → 2s base, 30s cap, 45s per-attempt timeout) around `matrixService.init()` so transient transport failures on Xiaomi Android 14+ no longer surface as a fatal boot error.
- Clears stale `error`/`ready` state on each `matrixClientService.init()` entry — without this, a successful retry was masked by leftover error from a previous attempt.
- Introduces a typed `BootErrorKind = "matrix-unreachable" | "generic"`; `AppLoading.vue` renders a typed banner + hint instead of a generic "Failed to start" when the Matrix homeserver can't be reached.
- Adds a once-only guard to `bootStatus.setError` symmetrical to `setStep`/`setReady` (prevents an account-switch race from overwriting the first verdict).
- Tests: 9 cases for the retry helper + extended `boot-status` coverage for typed kind and guard. Full auth/matrix/app-model suite green (219 tests).

## Root cause

The boot path made a single `matrixService.init()` attempt wrapped in a 45s timeout. Xiaomi MIUI / Android 14+ aggressively kills the long-poll `/sync` mid-handshake, so the SDK never flipped ready and the UI was stuck on a silent generic boot error. Two compounding issues:

1. No retry around the initial connect attempt.
2. `MatrixClientService.error` is sticky between calls — even if a retry had been added naively, `isReady()` would still return false because of leftover error state.

## Linear

- Resolves WEE-46 (https://linear.app/wwwee/issue/WEE-46)

## Closes

Closes greenShirtMystery/forta-bugs#823
Closes greenShirtMystery/forta-bugs#824

## Out of scope

- Acceptance criterion A3 (offline-first sidebar rendering cached Dexie rooms before Matrix sync) — that requires re-architecting the chat-store hydration path (currently sourced from Matrix SDK, not Dexie). Tracked separately; the retry + typed banner already addresses the primary failure mode (A1/A2/A4).

## Test plan

- [x] `npx vitest run` for new retry helper + boot-status — 9 helper cases, 8 boot-status cases all green
- [x] Full `auth/matrix/app/model` suite — 219 passing, 0 failing, 0 regressions vs. master baseline
- [x] `vue-tsc --noEmit` — no new type errors introduced (count identical to master baseline)
- [ ] Manual smoke on Xiaomi Android 14+ cold-start with throttled network — verify chats load within retry budget and typed banner appears on persistent failure
- [ ] Manual smoke on OnePlus / generic Android — ensure no regression on healthy path