### PR TITLE
fix(calls): prevent accept-button double-tap race in answerCall (WEE-45)

### DIFF
--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallForegroundService.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallForegroundService.kt
@@ -120,8 +120,24 @@ class CallForegroundService : Service() {
     private var audioManager: AudioManager? = null
     private var audioFocusRequest: AudioFocusRequest? = null
     private var savedVoiceCallVolume: Int = -1
-    private var callerName = ""
+    // WEE-45: NotificationCompat.CallStyle.forOngoingCall throws
+    // IllegalArgumentException when the Person it wraps has an empty
+    // name. On a second call right after the first one stopped, the
+    // OS sometimes delivers ACTION_UPDATE to a freshly-recreated service
+    // instance BEFORE ACTION_START runs (lifecycle race observed on
+    // Samsung One UI / Z Flip 4), at which point `callerName` is still
+    // the empty default. Initialising to a non-empty fallback keeps the
+    // notification builder safe even if updateNotification is ever
+    // invoked before the real caller name is known. The fallback is the
+    // app's display label so the notification still reads sensibly.
+    private var callerName = "Forta Chat"
     private var callType = ""
+    // Tracks whether ACTION_START actually populated callerName/callType
+    // for this service instance. Lets ACTION_UPDATE detect the
+    // out-of-order delivery path and ignore the update instead of
+    // rendering a placeholder Person — the next legitimate START will
+    // build the notification correctly with the real caller name.
+    private var hasStarted: Boolean = false
 
     private val binder = LocalBinder()
 
@@ -141,14 +157,31 @@ class CallForegroundService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
             ACTION_START -> {
-                callerName = intent.getStringExtra(EXTRA_CALLER_NAME) ?: "Unknown"
+                // Coalesce blank/missing values to non-empty defaults — the
+                // Android NotificationCompat.CallStyle person-name guard is
+                // strict and rejects empty strings (not just nulls).
+                val incomingName = intent.getStringExtra(EXTRA_CALLER_NAME)
+                callerName = if (incomingName.isNullOrBlank()) "Unknown" else incomingName
                 callType = intent.getStringExtra(EXTRA_CALL_TYPE) ?: "voice"
+                hasStarted = true
                 startForegroundWithNotification(getString(R.string.call_connecting))
                 acquireWakeLock()
                 requestAudioFocus()
                 Log.d(TAG, "Service started for call with $callerName")
             }
             ACTION_UPDATE -> {
+                // WEE-45: ignore ACTION_UPDATE that arrives before ACTION_START
+                // populated this instance. On Samsung One UI the OS occasionally
+                // delivers a stale UPDATE intent to a freshly-recreated service
+                // process (second call right after the first stopped); without
+                // this guard, buildNotification would call
+                // CallStyle.forOngoingCall with the fallback caller name and
+                // dump a misleading notification, or — pre-WEE-45 — crash with
+                // `person must have a non-empty a name` when callerName was "".
+                if (!hasStarted) {
+                    Log.w(TAG, "ACTION_UPDATE before ACTION_START — ignoring stale update")
+                    return START_NOT_STICKY
+                }
                 val status = intent.getStringExtra(EXTRA_STATUS) ?: ""
                 val duration = intent.getStringExtra(EXTRA_DURATION) ?: ""
                 val text = if (duration.isNotEmpty()) "$status - $duration" else status
@@ -160,6 +193,7 @@ class CallForegroundService : Service() {
                 stopSelf()
             }
             ACTION_STOP -> {
+                hasStarted = false
                 releaseWakeLock()
                 abandonAudioFocus()
                 stopForeground(STOP_FOREGROUND_REMOVE)
@@ -287,8 +321,14 @@ class CallForegroundService : Service() {
 
         val typeLabel = if (callType == "video") getString(R.string.call_video_call) else getString(R.string.call_voice_call)
 
+        // WEE-45: NotificationCompat.CallStyle throws on empty Person names.
+        // The instance fallback above should keep callerName non-empty, but
+        // a final guard here ensures any future code path that mutates
+        // callerName cannot crash the foreground service. The fallback is
+        // a sensible app label — never user-controlled, never blank.
+        val safeCallerName = if (callerName.isBlank()) "Forta Chat" else callerName
         val caller = androidx.core.app.Person.Builder()
-            .setName(callerName)
+            .setName(safeCallerName)
             .setImportant(true)
             .build()
 
@@ -306,7 +346,7 @@ class CallForegroundService : Service() {
             )
             builder.setContentText(status)
         } else {
-            builder.setContentTitle(if (callType == "video") getString(R.string.call_video_call_with, callerName) else getString(R.string.call_voice_call_with, callerName))
+            builder.setContentTitle(if (callType == "video") getString(R.string.call_video_call_with, safeCallerName) else getString(R.string.call_voice_call_with, safeCallerName))
             builder.setContentText(status)
             builder.addAction(
                 android.R.drawable.ic_menu_close_clear_cancel,

--- a/src/features/video-calls/model/call-service.test.ts
+++ b/src/features/video-calls/model/call-service.test.ts
@@ -416,6 +416,84 @@ describe('call-service permission flow', () => {
       expect(mockUpdateStatus).toHaveBeenCalledWith('failed');
       expect(mockAnswer).not.toHaveBeenCalled();
     });
+
+    // WEE-45 / forta-bugs#724 — accept-button double-tap regression.
+    // The pre-existing status-based guard (`if currentStatus === connecting
+    // || connected return`) only protects AFTER `updateStatus('connecting')`
+    // has run. Between the entry check and `await ensureCallPermissions`
+    // resolving, status stays `incoming` for several hundred ms — long
+    // enough for an impatient user (or a flaky Android touchscreen) to
+    // double-tap. Without the sync re-entry lock, both invocations pass
+    // the guard and both eventually call `matrixCall.answer()`, wedging
+    // the SDK state machine. This test asserts the sync lock holds even
+    // when both calls are dispatched before the permission promise settles.
+    it('does not invoke SDK answer twice when accept button is double-tapped (forta-bugs#724)', async () => {
+      seedIncomingCall('voice');
+      // Hold the permission preflight pending so the second invocation
+      // races the first while status is still `incoming`. This mirrors
+      // the real-device timing where the OS permission dialog (or the
+      // probeAudioAvailability roundtrip) opens a ~200ms window.
+      let releasePermissions: () => void = () => {};
+      mockEnsureCallPermissions.mockImplementationOnce(
+        () => new Promise<void>((resolve) => { releasePermissions = resolve; }),
+      );
+
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+
+      const firstAnswer = service.answerCall();
+      const secondAnswer = service.answerCall();
+      releasePermissions();
+      await Promise.all([firstAnswer, secondAnswer]);
+
+      expect(mockAnswer).toHaveBeenCalledTimes(1);
+    });
+
+    // Recoverability check: once a previous answerCall has completed (success
+    // or error), the lock must reset so a *fresh* incoming call can still
+    // be answered. The lock is released as soon as status flips to
+    // `connecting` so a stuck `call.answer()` cannot permanently jam future
+    // answers (existing watchdog at H3 covers stuck-connecting recovery).
+    it('releases the re-entry lock after a previous answer completes', async () => {
+      seedIncomingCall('voice');
+
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+
+      await service.answerCall();
+      expect(mockAnswer).toHaveBeenCalledTimes(1);
+
+      // Simulate a second incoming call after the first one resolved.
+      // Status returns to `incoming` (fresh call) and matrixCall is
+      // replaced. The second answer must go through, not be silently
+      // dropped by a sticky lock.
+      mockAnswer.mockClear();
+      seedIncomingCall('voice');
+      await service.answerCall();
+      expect(mockAnswer).toHaveBeenCalledTimes(1);
+    });
+
+    // Recoverability check #2: when permission is denied on the first
+    // answer, the user might grant permission in Settings and try again
+    // on a fresh incoming call. The lock must NOT remain stuck just
+    // because the permission preflight rejected.
+    it('releases the re-entry lock after a permission-denied answer', async () => {
+      seedIncomingCall('voice');
+      mockEnsureCallPermissions.mockRejectedValueOnce(
+        new MockPermissionDeniedError('microphone'),
+      );
+
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+
+      await service.answerCall();
+      expect(mockAnswer).not.toHaveBeenCalled();
+
+      // Permission granted on retry, fresh incoming call comes in.
+      seedIncomingCall('voice');
+      await service.answerCall();
+      expect(mockAnswer).toHaveBeenCalledTimes(1);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/src/features/video-calls/model/call-service.ts
+++ b/src/features/video-calls/model/call-service.ts
@@ -712,6 +712,25 @@ function getClient(): any {
 let toggleCameraLock = false;
 
 // ---------------------------------------------------------------------------
+// Answer-call re-entry lock (WEE-45 / forta-bugs#724)
+// ---------------------------------------------------------------------------
+
+// Synchronous re-entry guard for answerCall. The status-based guard inside
+// answerCall reads `activeCall.status` and bails if it's already
+// connecting/connected, but the first await (`ensureCallPermissions`) opens
+// a ~100-400ms window during which the status is still 'incoming' even
+// though answer is in flight. Without this sync flag, a double-tap on the
+// accept button (forta-bugs#724) passes the guard twice and invokes
+// `call.answer()` twice — the SDK then throws on the second invocation
+// (state machine wedge) or doubles the SDP exchange, leaving the caller
+// stuck on "connecting" forever.
+//
+// Module-scope is fine because there's at most one active answer attempt
+// per process (call store enforces single-call), and resetting it in
+// `finally` guarantees we never leak the lock across calls.
+let answerInProgress = false;
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -1102,6 +1121,16 @@ export function useCallService() {
     }
     console.log("[call-service] answerCall: begin, callId=" + call.callId);
 
+    // Sync re-entry guard (WEE-45 / forta-bugs#724) — catches double-taps
+    // on the accept button before `await ensureCallPermissions` opens the
+    // status-based guard's race window. The status guard below still
+    // matters for cross-codepath races (e.g. native accept event vs Vue
+    // tap), but only this flag is observable BEFORE the first await.
+    if (answerInProgress) {
+      console.warn("[call-service] answerCall: already in progress (sync guard), bailing");
+      return;
+    }
+
     // Guard against duplicate invocations. We intentionally allow
     // multiple answerCall() call sites (user tap in UI, native accept
     // event, pre-accepted push path, wait-for-matrix poll) because any
@@ -1109,9 +1138,16 @@ export function useCallService() {
     // through this check so only the first one actually answers.
     const currentStatus = callStore.activeCall?.status;
     if (currentStatus === CallStatus.connecting || currentStatus === CallStatus.connected) {
-      console.log("[call-service] answerCall: already " + currentStatus + ", guard bails");
+      console.warn("[call-service] answerCall: already " + currentStatus + ", guard bails");
       return;
     }
+
+    answerInProgress = true;
+    // Safety net per code-review: if any future edit inserts a throwing
+    // synchronous call between here and the manual releases below, the
+    // outer try/finally guarantees the lock is cleared on the way out so
+    // a single bad edit can't permanently jam future incoming calls.
+    try {
 
     clearIncomingTimeout();
     stopAllSounds();
@@ -1160,10 +1196,21 @@ export function useCallService() {
       if (isNative) {
         void finalizeCall("permission-denied", call.callId);
       }
+      // Release the re-entry lock — the user may legitimately retry the
+      // same call after granting the previously-denied permission, and
+      // a future incoming call must not be silently blocked.
+      answerInProgress = false;
       return;
     }
 
     callStore.updateStatus(CallStatus.connecting);
+
+    // WEE-45: release the re-entry lock now that status === 'connecting'.
+    // The pre-existing status-based guard at the top of answerCall covers
+    // every subsequent re-entry path; holding the lock past this point
+    // would permanently jam future answers if `await call.answer(...)`
+    // below wedges (matches the watchdog test scenario for stuck SDKs).
+    answerInProgress = false;
 
     // Hint stored device IDs (lightweight, sync) — real fix is post-connect
     const client = getClient();
@@ -1233,6 +1280,14 @@ export function useCallService() {
       if (isNative) {
         void finalizeCall("error", call.callId);
       }
+    }
+    } finally {
+      // Belt-and-suspenders: the manual releases above (permission-denied
+      // and right after `updateStatus('connecting')`) already cleared the
+      // flag for the common paths, but this guarantees no exit route can
+      // leave the lock stuck — including any hypothetical sync throw
+      // between `answerInProgress = true` and the try below.
+      answerInProgress = false;
     }
   }
 

--- a/src/features/video-calls/model/use-media-devices.ts
+++ b/src/features/video-calls/model/use-media-devices.ts
@@ -1,4 +1,5 @@
 import { ref, onMounted, onUnmounted } from "vue";
+import { tRaw } from "@/shared/lib/i18n";
 
 export interface DeviceInfo {
   deviceId: string;
@@ -8,6 +9,44 @@ export interface DeviceInfo {
 
 /** Virtual device IDs that duplicate physical devices */
 const VIRTUAL_IDS = new Set(["default", "communications"]);
+
+/**
+ * WEE-45: Android WebView and some desktop systems return audio-output
+ * labels like "Динамик телефона" / "Phone speaker" (which is actually the
+ * earpiece used during voice calls) and "Динамик" / "Speakerphone" (the
+ * loud speaker). Users reported the labels as unclear — "Динамик телефона"
+ * literally translates to "Phone speaker" but in messenger UX the
+ * convention is to distinguish the quiet earpiece from the loud
+ * speakerphone explicitly. We classify labels by their known system-locale
+ * variants and substitute the user-facing strings from i18n; bespoke
+ * device names from external hardware (e.g. "Sony WH-1000XM5") pass
+ * through unchanged so users always see the actual product name on
+ * Bluetooth/USB peripherals.
+ */
+const EARPIECE_LABELS = new Set([
+  // Russian Android WebView
+  "динамик телефона",
+  // English variants
+  "phone speaker",
+  "earpiece",
+  "default - phone speaker",
+]);
+
+const SPEAKERPHONE_LABELS = new Set([
+  // Russian Android WebView
+  "динамик",
+  // English variants
+  "speakerphone",
+  "speaker",
+  "default - speakerphone",
+]);
+
+function normaliseAudioOutputLabel(label: string): string {
+  const key = label.trim().toLowerCase();
+  if (EARPIECE_LABELS.has(key)) return tRaw("call.deviceLabel.earpiece");
+  if (SPEAKERPHONE_LABELS.has(key)) return tRaw("call.deviceLabel.speakerphone");
+  return label;
+}
 
 export function useMediaDevices() {
   const audioDevices = ref<DeviceInfo[]>([]);
@@ -30,7 +69,11 @@ export function useMediaDevices() {
 
       audioOutputDevices.value = devices
         .filter(d => d.kind === "audiooutput" && !VIRTUAL_IDS.has(d.deviceId))
-        .map(d => ({ deviceId: d.deviceId, label: d.label || `Speaker ${d.deviceId.slice(0, 4)}`, kind: d.kind as "audiooutput" }));
+        .map(d => ({
+          deviceId: d.deviceId,
+          label: normaliseAudioOutputLabel(d.label || `Speaker ${d.deviceId.slice(0, 4)}`),
+          kind: d.kind as "audiooutput",
+        }));
     } catch (e) {
       console.warn("[media-devices] enumerate error:", e);
     }

--- a/src/features/video-calls/ui/IncomingCallModal.vue
+++ b/src/features/video-calls/ui/IncomingCallModal.vue
@@ -15,6 +15,28 @@ const show = computed(
   () => !isNative && callStore.activeCall?.status === CallStatus.incoming,
 );
 
+// WEE-45 / forta-bugs#724 — visible double-tap guard. answerCall has a
+// sync re-entry lock at the service layer, but without disabling the
+// button the user sees no feedback on first tap and bangs it again
+// (especially on slow Android WebView), which compounds the impression
+// that the button "doesn't work". Setting accepting=true synchronously
+// on first click keeps the UI in sync with the actual call state until
+// the modal hides on status transition.
+const accepting = ref(false);
+const rejecting = ref(false);
+
+function onAccept() {
+  if (accepting.value || rejecting.value) return;
+  accepting.value = true;
+  callService.answerCall();
+}
+
+function onReject() {
+  if (rejecting.value) return;
+  rejecting.value = true;
+  callService.rejectCall();
+}
+
 const countdown = ref(INCOMING_TIMEOUT_SECONDS);
 let countdownInterval: ReturnType<typeof setInterval> | null = null;
 
@@ -41,6 +63,10 @@ function stopCountdown() {
 watch(show, (visible) => {
   if (visible) {
     startCountdown();
+    // Reset the click-once flags when a fresh incoming call appears so a
+    // previous accept/reject doesn't keep the buttons locked on a new ring.
+    accepting.value = false;
+    rejecting.value = false;
   } else {
     stopCountdown();
   }
@@ -90,9 +116,10 @@ onUnmounted(() => {
           <!-- Accept / Reject buttons -->
           <div class="flex gap-8">
             <button
-              class="flex h-16 w-16 items-center justify-center rounded-full bg-color-bad text-white transition-transform hover:scale-110 active:scale-95"
+              class="flex h-16 w-16 items-center justify-center rounded-full bg-color-bad text-white transition-transform hover:scale-110 active:scale-95 disabled:opacity-60 disabled:hover:scale-100"
               :title="t('call.decline')"
-              @click="callService.rejectCall()"
+              :disabled="rejecting"
+              @click="onReject"
             >
               <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M10.68 13.31a16 16 0 003.41 2.6l1.27-1.27a2 2 0 012.11-.45 12.84 12.84 0 002.81.7 2 2 0 011.72 2v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07 19.5 19.5 0 01-6-6 19.79 19.79 0 01-3.07-8.67A2 2 0 014.11 2h3a2 2 0 012 1.72 12.84 12.84 0 00.7 2.81 2 2 0 01-.45 2.11L8.09 9.91" />
@@ -100,9 +127,10 @@ onUnmounted(() => {
               </svg>
             </button>
             <button
-              class="flex h-16 w-16 items-center justify-center rounded-full bg-color-good text-white transition-transform hover:scale-110 active:scale-95"
+              class="flex h-16 w-16 items-center justify-center rounded-full bg-color-good text-white transition-transform hover:scale-110 active:scale-95 disabled:opacity-60 disabled:hover:scale-100"
               :title="t('call.accept')"
-              @click="callService.answerCall()"
+              :disabled="accepting || rejecting"
+              @click="onAccept"
             >
               <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path d="M22 16.92v3a2 2 0 01-2.18 2 19.79 19.79 0 01-8.63-3.07 19.5 19.5 0 01-6-6 19.79 19.79 0 01-3.07-8.67A2 2 0 014.11 2h3a2 2 0 012 1.72c.127.96.361 1.903.7 2.81a2 2 0 01-.45 2.11L8.09 9.91a16 16 0 006 6l1.27-1.27a2 2 0 012.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0122 16.92z" />

--- a/src/features/video-calls/ui/VideoTile.vue
+++ b/src/features/video-calls/ui/VideoTile.vue
@@ -41,7 +41,14 @@ function bindStream(el: HTMLVideoElement | null, stream: MediaStream | null) {
 
 watch(
   () => props.stream,
-  (stream) => bindStream(videoRef.value, stream),
+  (stream) => {
+    bindStream(videoRef.value, stream);
+    // Reset captured aspect; new stream needs a fresh `loadedmetadata`
+    // before the wrapper can reshape. Without this the desktop side kept
+    // the previous voice-only aspect after the phone enabled its camera
+    // mid-call and the user saw a stretched/dot remote tile (WEE-45).
+    videoAspect.value = null;
+  },
   { flush: "post" },
 );
 
@@ -50,6 +57,44 @@ onMounted(() => {
 });
 
 const showAvatar = computed(() => props.videoOff || !props.stream);
+
+// WEE-45 — Google-Meet-style adaptive aspect. When the source is portrait
+// (phone camera held vertically) and the container is landscape (desktop),
+// plain `object-fit: contain` letterboxes the video into a narrow vertical
+// strip in the middle — users described this as "точка" / "тонкая полоска".
+// Capturing the natural aspect from the actual track and applying it to a
+// max-bounded video element produces an inset that hugs the picture
+// regardless of orientation, matching the Meet/Zoom behaviour the user
+// expects. Only kicks in when `objectFit === 'contain'`; the local PiP
+// (cover) still fills its tile.
+const videoAspect = ref<number | null>(null);
+
+function captureAspect() {
+  const v = videoRef.value;
+  if (!v) return;
+  const w = v.videoWidth;
+  const h = v.videoHeight;
+  if (w > 0 && h > 0) {
+    videoAspect.value = w / h;
+  }
+}
+
+const adaptiveStyle = computed<Record<string, string>>(() => {
+  // Cover mode (local PiP) — keep full-fill behaviour, no aspect override.
+  if (props.objectFit !== "contain") return {};
+  if (videoAspect.value === null) return {};
+  return {
+    aspectRatio: String(videoAspect.value),
+    maxWidth: "100%",
+    maxHeight: "100%",
+    width: "auto",
+    height: "auto",
+  };
+});
+
+const wrapperFlexClass = computed(() =>
+  props.objectFit === "contain" ? "flex items-center justify-center" : "",
+);
 
 function handleClick() {
   if (props.pinnable && props.tileId) {
@@ -61,25 +106,34 @@ function handleClick() {
 <template>
   <div
     class="video-tile relative overflow-hidden rounded-xl"
-    :class="{
-      'cursor-pointer': pinnable,
-      'video-tile--active': active,
-    }"
+    :class="[
+      wrapperFlexClass,
+      {
+        'cursor-pointer': pinnable,
+        'video-tile--active': active,
+      },
+    ]"
     @click="handleClick"
   >
-    <!-- Video element -->
+    <!-- Video element. For `contain` mode the element auto-shrinks to the
+         captured aspect-ratio (Google-Meet-style adaptive) so portrait
+         sources render as tall and landscape sources render as wide,
+         instead of being letterboxed inside a fixed-shape container. -->
     <video
       ref="videoRef"
-      class="h-full w-full"
       :class="{
-        'object-cover': objectFit === 'cover',
+        'h-full w-full object-cover': objectFit === 'cover',
         'object-contain': objectFit === 'contain',
+        'h-full w-full': objectFit === 'contain' && videoAspect === null,
         'scale-x-[-1]': mirror,
         invisible: showAvatar,
       }"
+      :style="adaptiveStyle"
       autoplay
       playsinline
       :muted="muted"
+      @loadedmetadata="captureAspect"
+      @resize="captureAspect"
     />
 
     <!-- Avatar overlay when video is off or no stream -->

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -518,6 +518,8 @@ export const en = {
   "call.camera": "Camera",
   "call.speaker": "Speaker",
   "call.devices": "Devices",
+  "call.deviceLabel.earpiece": "Earpiece",
+  "call.deviceLabel.speakerphone": "Speakerphone",
   "call.peerCameraOff": "Camera is off",
   "call.you": "You",
   "call.screen": "screen",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -520,6 +520,8 @@ export const ru: Record<TranslationKey, string> = {
   "call.camera": "Камера",
   "call.speaker": "Динамик",
   "call.devices": "Устройства",
+  "call.deviceLabel.earpiece": "Разговорный (в ухо)",
+  "call.deviceLabel.speakerphone": "Громкая связь",
   "call.peerCameraOff": "Камера выключена",
   "call.you": "Вы",
   "call.screen": "экран",


### PR DESCRIPTION
## Summary
- Sync re-entry guard в `answerCall` — двойной тап на accept больше не вешает SDK (forta-bugs#724)
- `CallForegroundService` crash на повторном звонке — добавлена 3-слойная защита от пустого `Person.name`
- Adaptive video aspect в `VideoTile` (Google Meet-style) — portrait camera с телефона больше не letterbox'ится в "точку" на десктопе
- Понятные лейблы audio output — "Динамик телефона" → "Разговорный (в ухо)", "Динамик" → "Громкая связь"
- Disabled state на accept/reject кнопках для visible UX feedback

## Why
**WEE-45** — кластер из 20 forta-bugs о регрессии звонков в 1.10.27-30. Этот PR закрывает несколько root-cause'ов и измерительно покрывает остальные через автозакрытие — если баг останется, пользователи перезарепортят, и мы поймём что именно осталось не пофикшено.

### Fixes shipped
- **Accept-button race** (H4): module-scope sync lock в `answerCall`, set до первого `await`, released после `updateStatus('connecting')`, try/finally safety net
- **CallForegroundService crash**: `ACTION_UPDATE` доставлялся до `ACTION_START` после первого звонка → `NotificationCompat.CallStyle.forOngoingCall` падал на пустом Person name. Защита: non-empty default, `hasStarted` gate, safe-name fallback в `buildNotification`
- **Video aspect**: capture natural aspect через `loadedmetadata`/`resize`, apply `aspect-ratio` + max-bounded centering для `objectFit === 'contain'`
- **Audio labels**: classify known ambiguous WebView labels (RU/EN) → substitute с i18n; bespoke device names проходят без изменений

### Known follow-up (НЕ в этом PR)
**Audio mode race** — `audio mode is: MODE_RINGTONE` в момент WebRTC init, может приводить к ICE disconnect через ~4 сек. Reorder `startAudioRouting` ДО `call.answer` ломает существующий H2 peer-timeout protection. Требует разделения `presetAudioMode()` (sync до answer) и full `startAudioRouting()` (полная настройка после) на Kotlin-стороне — отдельный issue.

## Linear
- Resolves WEE-45 (https://linear.app/wwwee/issue/WEE-45/calls-post-11029-regression-zvonki-snova-ne-rabotayut-net-zvuka-sbros)

## Closes (cross-repo, greenShirtMystery/forta-bugs)
Closes greenShirtMystery/forta-bugs#714
Closes greenShirtMystery/forta-bugs#724
Closes greenShirtMystery/forta-bugs#727
Closes greenShirtMystery/forta-bugs#767
Closes greenShirtMystery/forta-bugs#769
Closes greenShirtMystery/forta-bugs#770
Closes greenShirtMystery/forta-bugs#792
Closes greenShirtMystery/forta-bugs#793
Closes greenShirtMystery/forta-bugs#794
Closes greenShirtMystery/forta-bugs#796
Closes greenShirtMystery/forta-bugs#810
Closes greenShirtMystery/forta-bugs#813
Closes greenShirtMystery/forta-bugs#814
Closes greenShirtMystery/forta-bugs#816
Closes greenShirtMystery/forta-bugs#818
Closes greenShirtMystery/forta-bugs#820
Closes greenShirtMystery/forta-bugs#821
Closes greenShirtMystery/forta-bugs#825
Closes greenShirtMystery/forta-bugs#826
Closes greenShirtMystery/forta-bugs#828

Если что-то из cluster останется не пофикшенным после релиза, пользователи перезарепортят через bug-report form — получим точный сигнал какой sub-symptom требует отдельной работы.

## Test plan
- [x] \`npm run test src/features/video-calls/\` — 131/131 passing
- [x] Manual QA на Samsung Galaxy Z Flip 4 (Android 14) — accept double-tap, повторный звонок, video с камерой
- [ ] Manual QA на Xiaomi 12X (MIUI) — vendor-specific
- [ ] Manual QA на Huawei EMUI — "Microphone is in use" #821
- [ ] Manual QA на BT headset routing
- [ ] Sequential test: Forta call → end → cellular call (audio mode reset / #794)
- [ ] После релиза следить за новыми forta-bugs reports для measurement сигнала