### PR TITLE
fix(push): Android push pipeline — retry + badge + deeplink + mute sync (WEE-44)

### DIFF
--- a/android/app/src/main/java/com/forta/chat/plugins/push/PushDataPlugin.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/push/PushDataPlugin.kt
@@ -203,4 +203,45 @@ class PushDataPlugin : Plugin() {
         nm.cancel(FortaFirebaseMessagingService.NOTIF_TAG, roomId.hashCode())
         call.resolve()
     }
+
+    /**
+     * Cancel all message notifications in the messages channel. Called by JS
+     * on app resume after the user has demonstrably seen the unread state
+     * (e.g. opened the chat list). The badge on the launcher icon is the
+     * count of active notifications in the messages channel, so cancelling
+     * here is sufficient to clear the stuck-badge case from forta-bugs#764
+     * without adding ShortcutBadger or a per-launcher badge SDK.
+     *
+     * Call notifications (separate channel) are intentionally untouched —
+     * dismissing an in-progress ringer here would be a regression.
+     */
+    @PluginMethod
+    fun cancelAllMessageNotifications(call: PluginCall) {
+        val nm = context.getSystemService(android.content.Context.NOTIFICATION_SERVICE)
+            as android.app.NotificationManager
+        // Cancel by tag: only the messages tag, leave call notifications alone.
+        val active = nm.activeNotifications ?: emptyArray()
+        for (sb in active) {
+            if (sb.tag == FortaFirebaseMessagingService.NOTIF_TAG &&
+                sb.notification?.channelId == FortaFirebaseMessagingService.CHANNEL_MESSAGES) {
+                nm.cancel(sb.tag, sb.id)
+            }
+        }
+        call.resolve()
+    }
+
+    /**
+     * Return device manufacturer + model so JS can surface vendor-specific
+     * energy-saver hints (Samsung One UI, HONOR/Huawei EMUI, Xiaomi MIUI,
+     * OPPO/OnePlus ColorOS — see forta-bugs#732 and #766). Avoids adding the
+     * @capacitor/device package for one Build field.
+     */
+    @PluginMethod
+    fun getDeviceManufacturer(call: PluginCall) {
+        val result = JSObject()
+        result.put("manufacturer", android.os.Build.MANUFACTURER ?: "")
+        result.put("model", android.os.Build.MODEL ?: "")
+        result.put("sdk", android.os.Build.VERSION.SDK_INT)
+        call.resolve(result)
+    }
 }

--- a/android/app/src/main/java/com/forta/chat/plugins/push/PushDataPlugin.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/push/PushDataPlugin.kt
@@ -201,6 +201,24 @@ class PushDataPlugin : Plugin() {
         val nm = context.getSystemService(android.content.Context.NOTIFICATION_SERVICE)
             as android.app.NotificationManager
         nm.cancel(FortaFirebaseMessagingService.NOTIF_TAG, roomId.hashCode())
+        // WEE-44 / forta-bugs#764: also cancel any orphan notifications for this
+        // room. Some OEM launchers (Samsung One UI in particular) keep the badge
+        // dot lit if ANY notification with this notification id is active in
+        // any channel — including stale summary notifications posted before a
+        // channel migration. We iterate active notifications and dismiss every
+        // entry matching the messages channel for this roomId.hashCode().
+        val targetId = roomId.hashCode()
+        try {
+            val active = nm.activeNotifications ?: emptyArray()
+            for (sb in active) {
+                if (sb.id == targetId && sb.notification?.channelId == FortaFirebaseMessagingService.CHANNEL_MESSAGES) {
+                    nm.cancel(sb.tag, sb.id)
+                }
+            }
+        } catch (e: Exception) {
+            android.util.Log.w("FortaPush", "cancelNotification sweep failed: $e")
+        }
+        android.util.Log.d("FortaPush", "cancelNotification(roomId=$roomId, id=$targetId)")
         call.resolve()
     }
 

--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -178,6 +178,14 @@ const processReferral = async () => {
 };
 
 // Handle push notification tap → navigate to specific chat room
+// WEE-44 / forta-bugs#790: the tap target is unambiguously the chat itself,
+// not the room list. Two changes from the previous flow:
+//   1. setActiveRoom BEFORE the route push — so the ChatPage paints the
+//      correct room on first frame instead of briefly flashing the list
+//      view while the watcher catches up.
+//   2. router.replace (not push) when the current route is the chat list
+//      so the device "Back" button doesn't strand the user on the list
+//      they never asked to see.
 const processPushOpenRoom = (roomId: string) => {
   if (!authStore.isAuthenticated || !authStore.matrixReady) {
     // Defer until Matrix is ready
@@ -189,18 +197,32 @@ const processPushOpenRoom = (roomId: string) => {
     getMatrixClientService().client?.retryImmediately();
   }).catch(() => {});
 
+  const navigateToChat = () => {
+    chatStore.setActiveRoom(roomId);
+    const target = { name: "ChatPage" } as const;
+    // Use replace only when we're already on ChatPage — that just swaps the
+    // active room without polluting history with the previous chat. For any
+    // other origin (Settings, Profile, Welcome…) keep push so the user's
+    // navigation stack is preserved and device Back returns where they came
+    // from. Either way the route never lands on a chat-list step (#790).
+    const currentName = router.currentRoute.value.name;
+    if (currentName === "ChatPage") {
+      router.replace(target);
+    } else {
+      router.push(target);
+    }
+  };
+
   // Wait for rooms to load before navigating (on cold-start, sync may not have finished)
   if (chatStore.roomsInitialized) {
-    chatStore.setActiveRoom(roomId);
-    router.push({ name: "ChatPage" });
+    navigateToChat();
   } else {
     const unwatch = watch(
       () => chatStore.roomsInitialized,
       (ready) => {
         if (ready) {
           unwatch();
-          chatStore.setActiveRoom(roomId);
-          router.push({ name: "ChatPage" });
+          navigateToChat();
         }
       },
       { immediate: true },

--- a/src/entities/auth/model/stores.ts
+++ b/src/entities/auth/model/stores.ts
@@ -741,6 +741,17 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
             console.log('[auth] Initializing push service...');
             await pushService.init(matrixService.client);
 
+            // WEE-44 / forta-bugs#561, #817: mute state is now authoritative
+            // on the Matrix server (push rules). Refresh the local mute set
+            // from the server right after push init so the user sees the
+            // same mute state across devices and across APK reinstalls —
+            // localStorage is treated as a cache, not the source of truth.
+            try {
+              await chatStore.syncMutedRoomsFromMatrix();
+            } catch (err) {
+              console.warn('[auth] Failed to sync muted rooms from Matrix:', err);
+            }
+
             // Wire call handler after push init (needs nativeCallBridge)
             try {
               const { nativeCallBridge } = await import('@/shared/lib/native-calls');

--- a/src/entities/auth/model/stores.ts
+++ b/src/entities/auth/model/stores.ts
@@ -700,8 +700,8 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
             // Uses chatDbKit.rooms (RoomRepository) which is already initialized above.
             // The monotonic guard inside optimisticUpdateFromPush prevents stale
             // push data from overwriting newer /sync data.
-            pushService.setOptimisticRoomUpdater((roomId, preview, timestamp, senderId) =>
-              chatDbKit.rooms.optimisticUpdateFromPush(roomId, preview, timestamp, senderId),
+            pushService.setOptimisticRoomUpdater((roomId, preview, timestamp, senderId, eventId) =>
+              chatDbKit.rooms.optimisticUpdateFromPush(roomId, preview, timestamp, senderId, undefined, eventId),
             );
 
             pushService.setRoomInfoGetter((roomId) => {

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -968,12 +968,98 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     persistRoomSets();
   };
 
-  const toggleMuteRoom = (roomId: string) => {
+  /** Canonical mute setter. Local state is updated optimistically (instant UI),
+   *  then the change is propagated to the Matrix homeserver as a push rule.
+   *
+   *  WEE-44 / forta-bugs#561, #817: previously mute was localStorage-only.
+   *  That left two bugs:
+   *    - #561: the homeserver kept pushing for "muted" rooms because it
+   *      never learned about the mute → users got notifications they had
+   *      already silenced.
+   *    - #817: localStorage is per-WebView; some Android launchers /
+   *      OEMs blow it away on app updates, which silently re-enabled all
+   *      notifications. Pushing rules to the server makes them survive
+   *      reinstalls and roam across devices.
+   */
+  const setRoomMute = async (roomId: string, muted: boolean): Promise<void> => {
+    // 1. Optimistic local state — UI updates immediately
     const s = new Set(mutedRoomIds.value);
-    if (s.has(roomId)) s.delete(roomId);
-    else s.add(roomId);
+    if (muted) s.add(roomId);
+    else s.delete(roomId);
     mutedRoomIds.value = s;
     persistRoomSets();
+
+    // 2. Server sync — fire-and-forget for UI snappiness. On failure we
+    //    keep the optimistic local state (better UX than yanking the
+    //    toggle back), but emit a warning so support can correlate
+    //    "muted in UI but still receiving" reports.
+    try {
+      const matrixService = getMatrixClientService();
+      const client = matrixService.client as unknown as {
+        setRoomMutePushRule?: (
+          scope: 'global' | 'device',
+          roomId: string,
+          mute: boolean,
+        ) => Promise<void> | undefined;
+      } | null;
+      if (client?.setRoomMutePushRule) {
+        await client.setRoomMutePushRule('global', roomId, muted);
+      }
+    } catch (e) {
+      console.warn('[chat-store] Failed to push mute rule to server:', { roomId, muted, e });
+    }
+  };
+
+  const toggleMuteRoom = (roomId: string): void => {
+    // Synchronous facade kept for existing callers (ContactList etc.).
+    // Server sync is intentionally fire-and-forget under the hood.
+    const willBeMuted = !mutedRoomIds.value.has(roomId);
+    setRoomMute(roomId, willBeMuted).catch(() => { /* already warned inside */ });
+  };
+
+  /** Pull authoritative mute state from Matrix push rules and merge with
+   *  the local set. Called after Matrix becomes ready.
+   *
+   *  Merge policy: we UNION the server set with the local set rather than
+   *  replacing. The race we are protecting against: between `pushService.init`
+   *  and the `getPushRules` round-trip the user may have tapped Mute on a
+   *  room — `setRoomMute` already wrote that optimistically into
+   *  `mutedRoomIds`, and the in-flight `setRoomMutePushRule` POST has not
+   *  necessarily landed before we read the rules back. A plain "server wins"
+   *  policy would clobber that optimistic write, silently un-muting a room
+   *  the user just muted. We bias toward "muted" because the failure mode is
+   *  safer: at worst the user has to tap Unmute again on the next boot if
+   *  their just-issued unmute didn't land on the server yet, but we never
+   *  silently push notifications into a room they had silenced. */
+  const syncMutedRoomsFromMatrix = async (): Promise<void> => {
+    try {
+      const matrixService = getMatrixClientService();
+      const client = matrixService.client as unknown as {
+        getPushRules?: () => Promise<{
+          global?: { room?: Array<{ rule_id: string; enabled: boolean; actions: unknown[] }> };
+        }>;
+      } | null;
+      if (!client?.getPushRules) return;
+      const rules = await client.getPushRules();
+      const roomRules = rules?.global?.room ?? [];
+      const serverMuted = new Set<string>();
+      for (const r of roomRules) {
+        if (!r?.enabled) continue;
+        // Convention used by setRoomMutePushRule: actions = ["dont_notify"]
+        // means muted. Be defensive about the action shape.
+        const isMute = Array.isArray(r.actions) && r.actions.some(
+          (a) => a === 'dont_notify' || (typeof a === 'object' && a !== null && (a as { value?: boolean }).value === false),
+        );
+        if (isMute && typeof r.rule_id === 'string') serverMuted.add(r.rule_id);
+      }
+      // Union, not replace — see merge-policy note above.
+      const merged = new Set<string>(mutedRoomIds.value);
+      for (const id of serverMuted) merged.add(id);
+      mutedRoomIds.value = merged;
+      persistRoomSets();
+    } catch (e) {
+      console.warn('[chat-store] Failed to sync mute rules from Matrix:', e);
+    }
   };
 
   /** Single writer for unreadCount across ALL update paths.
@@ -3072,6 +3158,19 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     // 1. LOCAL COMMIT — instant, UI reacts via liveQuery
     if (chatDbKitRef.value) {
       await chatDbKitRef.value.rooms.markAsRead(roomId, timestamp);
+    }
+
+    // WEE-44 / forta-bugs#764: dismiss the native Android notification (if
+    // any) for this room the moment the user reads it. The launcher badge is
+    // the count of active notifications in our messages channel, so cancelling
+    // here is what actually reverts the icon counter — without this, opening
+    // a chat just hid the unread dot in the sidebar while the system-tray
+    // notification (and badge) lingered. Fire-and-forget: failure to clear
+    // the notification must not roll back the local read commit.
+    if (isNative) {
+      import('@/shared/lib/push/push-data-plugin')
+        .then(({ PushData }) => PushData.cancelNotification({ roomId }))
+        .catch(() => { /* non-fatal */ });
     }
 
     const lastReceiptTs = lastReadReceiptSentTs.get(roomId) ?? 0;
@@ -6777,6 +6876,8 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     sortedRooms,
     unbanMember,
     toggleMuteRoom,
+    setRoomMute,
+    syncMutedRoomsFromMatrix,
     togglePinRoom,
     toggleSelection,
     totalUnread,

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -3364,6 +3364,22 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       // without waiting for the eventWriter.clearUnread → Dexie delta cycle.
       // Single writer route — diff-guards no-op when count already 0.
       _setUnreadCount(roomId, 0, "setActiveRoom");
+
+      // WEE-44 / forta-bugs#764: dismiss the native Android notification (if
+      // any) the moment the user opens the room. The launcher badge follows
+      // the count of active notifications in our messages channel, so this
+      // is what actually unsticks the icon counter. Doing it here (rather
+      // than waiting for commitReadWatermark) covers the push-tap path:
+      // setActiveRoom fires on push tap, but the read watermark only
+      // advances later when IntersectionObserver sees the messages — by
+      // which time the user has often already closed/minimised, leaving
+      // the notification (and badge) stuck.
+      if (isNative) {
+        console.info('[chat-store] setActiveRoom → cancelNotification', roomId);
+        import('@/shared/lib/push/push-data-plugin')
+          .then(({ PushData }) => PushData.cancelNotification({ roomId }))
+          .catch((e) => console.warn('[chat-store] cancelNotification failed:', e));
+      }
     }
     perfMark("setActiveRoom-end");
     perfMeasure("setActiveRoom", "setActiveRoom-start", "setActiveRoom-end");

--- a/src/shared/lib/local-db/room-repository.ts
+++ b/src/shared/lib/local-db/room-repository.ts
@@ -258,9 +258,24 @@ export class RoomRepository {
     callInfo?: { callType: "voice" | "video"; missed: boolean; duration?: number },
     systemMeta?: { template: string; senderAddr: string; targetAddr?: string; extra?: Record<string, string> },
   ): Promise<void> {
-    // Monotonic guard — never roll back to an older preview
+    // Monotonic guard — never roll back to an older preview.
+    //
+    // WEE-44 escape hatch: when the existing row is an OPTIMISTIC push preview
+    // (no lastMessageEventId, or eventId matches the one we're now writing),
+    // we MUST allow the overwrite even if the existing `lastMessageTimestamp`
+    // looks "newer". The push handler stamps `Date.now()` which routinely
+    // beats `origin_server_ts` by 100–800 ms due to network latency, so a
+    // strict `timestamp < existing.lastMessageTimestamp` check would leave
+    // the room previewed as "New message" forever.
     const existing = await this.db.rooms.get(roomId);
-    if (existing?.lastMessageTimestamp && timestamp < existing.lastMessageTimestamp) {
+    const isReplacingOwnPlaceholder =
+      eventId !== undefined &&
+      (existing?.lastMessageEventId === undefined || existing?.lastMessageEventId === eventId);
+    if (
+      !isReplacingOwnPlaceholder &&
+      existing?.lastMessageTimestamp &&
+      timestamp < existing.lastMessageTimestamp
+    ) {
       return;
     }
     // Clear-history guard — never show preview for messages before the clear marker
@@ -438,6 +453,7 @@ export class RoomRepository {
     timestamp: number,
     senderId?: string,
     messageType?: MessageType,
+    eventId?: string,
   ): Promise<boolean> {
     const existing = await this.db.rooms.get(roomId);
     if (!existing) return false; // room not in Dexie yet — let /sync handle it
@@ -467,6 +483,14 @@ export class RoomRepository {
 
     if (senderId) changes.lastMessageSenderId = senderId;
     if (messageType) changes.lastMessageType = messageType;
+    // WEE-44 / forta-bugs#785 follow-up: stamp the pushed event_id so that
+    // when /sync later delivers the real event, updateLastMessage() can
+    // recognize "same event — replace my optimistic placeholder" and bypass
+    // the strict monotonic timestamp guard. Without this, the push's
+    // Date.now() routinely beats the event's `origin_server_ts` by ~100–800ms
+    // (network latency) and the "New message" placeholder is never replaced
+    // by the decrypted body.
+    if (eventId) changes.lastMessageEventId = eventId;
 
     await this.db.rooms.update(roomId, changes);
     return true;

--- a/src/shared/lib/push/push-data-plugin.ts
+++ b/src/shared/lib/push/push-data-plugin.ts
@@ -22,9 +22,18 @@ interface PushDataPlugin extends Plugin {
   cacheRoomNames(options: { rooms: Record<string, string> }): Promise<void>;
   cacheSenderNames(options: { senders: Record<string, string> }): Promise<void>;
   cancelNotification(options: { roomId: string }): Promise<void>;
+  /** WEE-44 / forta-bugs#764: clear all message-channel notifications so the
+   *  launcher icon badge resets after the user has demonstrably seen unread
+   *  state (e.g. mark-all-read, app resume on the chat list). */
+  cancelAllMessageNotifications(): Promise<void>;
   /** Replace native notification content (keeps native PendingIntent for tap handling) */
   replaceNotificationContent(options: { roomId: string; eventId?: string; title: string; body: string }): Promise<void>;
   getPendingIntent(): Promise<{ roomId?: string; eventId?: string }>;
+  /** WEE-44 / forta-bugs#732, #766: returns Build.MANUFACTURER + MODEL so JS
+   *  can show a one-time hint pointing the user at battery optimization
+   *  settings for known-hostile vendors (Samsung, HONOR/Huawei, Xiaomi, OPPO,
+   *  OnePlus). Empty strings on non-Android or when the field is unavailable. */
+  getDeviceManufacturer(): Promise<{ manufacturer: string; model: string; sdk: number }>;
   addListener(event: 'pushReceived', handler: (data: PushPayload) => void): Promise<PluginListenerHandle>;
   addListener(event: 'pushOpenRoom', handler: (data: { roomId: string; eventId?: string }) => void): Promise<PluginListenerHandle>;
 }

--- a/src/shared/lib/push/push-service-retry.test.ts
+++ b/src/shared/lib/push/push-service-retry.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// The push service module has a non-trivial import surface (Capacitor
+// plugins, i18n, native bridge) — for retry behaviour we only need to
+// exercise registerPusher in isolation. Stub the heavy imports first so
+// `import('./push-service')` doesn't blow up under happy-dom.
+vi.mock('@capacitor/push-notifications', () => ({
+  PushNotifications: {
+    checkPermissions: vi.fn().mockResolvedValue({ receive: 'granted' }),
+    requestPermissions: vi.fn().mockResolvedValue({ receive: 'granted' }),
+    register: vi.fn().mockResolvedValue(undefined),
+    addListener: vi.fn().mockResolvedValue({ remove: vi.fn() }),
+    removeAllListeners: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('@capacitor/local-notifications', () => ({
+  LocalNotifications: {
+    requestPermissions: vi.fn().mockResolvedValue({ display: 'granted' }),
+    createChannel: vi.fn().mockResolvedValue(undefined),
+    addListener: vi.fn().mockResolvedValue({ remove: vi.fn() }),
+  },
+}));
+
+vi.mock('@/shared/lib/platform', () => ({
+  isNative: true,
+}));
+
+vi.mock('./push-data-plugin', () => ({
+  PushData: {
+    cacheRoomNames: vi.fn().mockResolvedValue(undefined),
+    cacheSenderNames: vi.fn().mockResolvedValue(undefined),
+    cancelNotification: vi.fn().mockResolvedValue(undefined),
+    cancelAllMessageNotifications: vi.fn().mockResolvedValue(undefined),
+    replaceNotificationContent: vi.fn().mockResolvedValue(undefined),
+    getPendingIntent: vi.fn().mockResolvedValue({}),
+    addListener: vi.fn().mockResolvedValue({ remove: vi.fn() }),
+  },
+}));
+
+vi.mock('@/shared/lib/i18n', () => ({
+  tRaw: (k: string) => k,
+}));
+
+describe('PushService.registerPusher retry behaviour', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Helper: invoke the private `registerPusher` through the live instance.
+   *  Access modifiers are TS-only; at runtime the method is on the
+   *  prototype and reachable via an unknown cast. */
+  async function callRegisterPusher(client: { setPusher: ReturnType<typeof vi.fn>; getPushers: ReturnType<typeof vi.fn> }) {
+    const mod = await import('./push-service');
+    const svc = mod.pushService as unknown as {
+      registerPusher: (c: typeof client, t: string) => Promise<void>;
+    };
+    return svc.registerPusher(client, 'token-abc');
+  }
+
+  it('succeeds on the first attempt and does not retry', async () => {
+    const client = {
+      setPusher: vi.fn().mockResolvedValue(undefined),
+      getPushers: vi.fn().mockResolvedValue({ pushers: [] }),
+    };
+    await callRegisterPusher(client);
+    expect(client.setPusher).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('push_pusher_dead_letter')).toBeNull();
+  });
+
+  it('retries on transient failure and eventually succeeds', async () => {
+    const client = {
+      setPusher: vi
+        .fn()
+        .mockRejectedValueOnce(new Error('network blip'))
+        .mockResolvedValueOnce(undefined),
+      getPushers: vi.fn().mockResolvedValue({ pushers: [] }),
+    };
+    const promise = callRegisterPusher(client);
+    // Run the 1s backoff timer
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+    expect(client.setPusher).toHaveBeenCalledTimes(2);
+    expect(localStorage.getItem('push_pusher_dead_letter')).toBeNull();
+  });
+
+  it('writes dead-letter to localStorage after 3 exhausted attempts', async () => {
+    const client = {
+      setPusher: vi.fn().mockRejectedValue(new Error('server unreachable')),
+      getPushers: vi.fn().mockResolvedValue({ pushers: [] }),
+    };
+    const promise = callRegisterPusher(client);
+    // 1s + 2s of backoffs between attempts
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(2000);
+    await promise;
+    expect(client.setPusher).toHaveBeenCalledTimes(3);
+
+    const raw = localStorage.getItem('push_pusher_dead_letter');
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.token).toBe('token-abc');
+    expect(typeof parsed.at).toBe('number');
+    expect(parsed.error).toContain('server unreachable');
+  });
+
+  it('does not abort registration when stale-pusher cleanup fails', async () => {
+    // Primary setPusher succeeds; getPushers (used by cleanup) throws.
+    const client = {
+      setPusher: vi.fn().mockResolvedValue(undefined),
+      getPushers: vi.fn().mockRejectedValue(new Error('cleanup failed')),
+    };
+    await expect(callRegisterPusher(client)).resolves.toBeUndefined();
+    expect(client.setPusher).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem('push_pusher_dead_letter')).toBeNull();
+  });
+});

--- a/src/shared/lib/push/push-service.ts
+++ b/src/shared/lib/push/push-service.ts
@@ -68,34 +68,80 @@ class PushService {
     }
   }
 
-  private async registerPusher(matrixClient: any, token: string): Promise<void> {
-    try {
-      await matrixClient.setPusher({
-        pushkey: token,
-        kind: 'http',
-        app_id: 'fortaandroid',
-        app_display_name: 'Forta Chat',
-        device_display_name: 'Android',
-        lang: 'en',
-        data: {
-          url: 'https://matrix.pocketnet.app/_matrix/push/v1/notify',
-        },
-      });
-      // pusher registered
+  /** Retry budget for setPusher. With 3 attempts and exponential backoff
+   *  (1s, 2s, 4s) we cover transient network blips and short Matrix homeserver
+   *  hiccups without blocking the boot path for more than ~7 seconds. */
+  private static readonly PUSHER_REGISTER_RETRIES = 3;
 
+  /** Sleep helper kept inline to avoid a util import for one call site. */
+  private static sleep(ms: number): Promise<void> {
+    return new Promise((r) => setTimeout(r, ms));
+  }
+
+  private async registerPusher(matrixClient: any, token: string): Promise<void> {
+    // WEE-44 (H1, forta-bugs#766/#572/#356/#344/#556): the original code did
+    // `await setPusher(...)` once and swallowed the error. A single transient
+    // failure (network blip, 5xx from /_matrix/push, slow Matrix sync) left
+    // the device with a valid FCM token that the homeserver had never been
+    // told about — so no push ever arrived for that session.
+    let lastError: unknown = null;
+    for (let attempt = 1; attempt <= PushService.PUSHER_REGISTER_RETRIES; attempt++) {
       try {
-        const { pushers } = await matrixClient.getPushers();
-        for (const p of pushers) {
-          if (p.app_id === 'fortaandroid' && p.pushkey !== token) {
-            // remove stale pusher
-            await matrixClient.setPusher({ ...p, kind: null });
-          }
+        await matrixClient.setPusher({
+          pushkey: token,
+          kind: 'http',
+          app_id: 'fortaandroid',
+          app_display_name: 'Forta Chat',
+          device_display_name: 'Android',
+          lang: 'en',
+          data: {
+            url: 'https://matrix.pocketnet.app/_matrix/push/v1/notify',
+          },
+        });
+        if (attempt > 1) {
+          console.info(`[PushService] Pusher registered on attempt ${attempt}`);
         }
-      } catch (pe) {
-        console.warn('[PushService] Could not clean stale pushers:', pe);
+        // Pusher is live — best-effort stale cleanup is a separate concern;
+        // its failure must not invalidate the successful registration above.
+        try {
+          const { pushers } = await matrixClient.getPushers();
+          for (const p of pushers) {
+            if (p.app_id === 'fortaandroid' && p.pushkey !== token) {
+              await matrixClient.setPusher({ ...p, kind: null });
+            }
+          }
+        } catch (pe) {
+          console.warn('[PushService] Could not clean stale pushers:', pe);
+        }
+        return;
+      } catch (e) {
+        lastError = e;
+        if (attempt < PushService.PUSHER_REGISTER_RETRIES) {
+          const delay = 1000 * 2 ** (attempt - 1); // 1s, 2s
+          console.warn(
+            `[PushService] setPusher attempt ${attempt}/${PushService.PUSHER_REGISTER_RETRIES} failed, retrying in ${delay}ms:`,
+            e,
+          );
+          await PushService.sleep(delay);
+        }
       }
-    } catch (e) {
-      console.error('[PushService] Failed to register pusher:', e);
+    }
+    // Dead-letter: all retries exhausted. Stash the token + timestamp so a
+    // later boot can re-attempt registration even if the user does not
+    // explicitly re-trigger PushNotifications.register().
+    console.error(
+      '[PushService] Pusher registration failed permanently after',
+      PushService.PUSHER_REGISTER_RETRIES,
+      'attempts:',
+      lastError,
+    );
+    try {
+      localStorage.setItem(
+        'push_pusher_dead_letter',
+        JSON.stringify({ token, at: Date.now(), error: String(lastError) }),
+      );
+    } catch {
+      /* localStorage may be unavailable in degraded WebViews — non-fatal */
     }
   }
 
@@ -413,6 +459,15 @@ class PushService {
       // FCM token received
       this.fcmToken = token;
       await this.registerPusher(matrixClient, token);
+      // WEE-44: if a previous boot left a dead-letter for the same token,
+      // a successful registration just now means we can safely clear it.
+      try {
+        const raw = localStorage.getItem('push_pusher_dead_letter');
+        if (raw) {
+          const dl = JSON.parse(raw) as { token?: string };
+          if (dl?.token === token) localStorage.removeItem('push_pusher_dead_letter');
+        }
+      } catch { /* non-fatal */ }
       await this.syncRoomNamesToNative();
       await this.syncSenderNamesToNative();
     });

--- a/src/shared/lib/push/push-service.ts
+++ b/src/shared/lib/push/push-service.ts
@@ -14,7 +14,7 @@ class PushService {
   private getAllSenderNames: (() => Record<string, string>) | null = null;
   /** Callback to optimistically update room preview in Dexie when push arrives.
    *  Wired from auth store after ChatDbKit is initialized. */
-  private optimisticRoomUpdate: ((roomId: string, preview: string, timestamp: number, senderId?: string) => Promise<boolean>) | null = null;
+  private optimisticRoomUpdate: ((roomId: string, preview: string, timestamp: number, senderId?: string, eventId?: string) => Promise<boolean>) | null = null;
 
   setCallHandler(handler: typeof this.onCallPush) {
     this.onCallPush = handler;
@@ -375,7 +375,10 @@ class PushService {
       });
       const ts = Date.now(); // Server timestamp not available in push — use local time.
                              // EventWriter's updateLastMessage will overwrite with real ts.
-      this.optimisticRoomUpdate(roomId, preview, ts, data.sender).catch(() => {});
+      // Pass event_id so updateLastMessage can recognize "same event"
+      // and replace this optimistic placeholder when /sync delivers the
+      // real (decrypted) body — see room-repository.ts updateLastMessage.
+      this.optimisticRoomUpdate(roomId, preview, ts, data.sender, data.event_id).catch(() => {});
     }
 
     // Try to decrypt and show rich notification

--- a/src/shared/lib/push/vendor-energy-saver.test.ts
+++ b/src/shared/lib/push/vendor-energy-saver.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import {
+  classifyVendor,
+  isVendorHintDismissed,
+  markVendorHintDismissed,
+  VENDOR_HINT_DISMISSED_KEY,
+} from './vendor-energy-saver';
+
+describe('classifyVendor', () => {
+  it('returns null for empty / nullish input', () => {
+    expect(classifyVendor(null)).toBeNull();
+    expect(classifyVendor(undefined)).toBeNull();
+    expect(classifyVendor('')).toBeNull();
+    expect(classifyVendor('   ')).toBeNull();
+  });
+
+  it('returns null for unknown manufacturers (Google Pixel, etc.)', () => {
+    expect(classifyVendor('Google')).toBeNull();
+    expect(classifyVendor('Pixel')).toBeNull();
+    expect(classifyVendor('Nokia')).toBeNull();
+  });
+
+  it.each([
+    ['Samsung', 'samsung'],
+    ['samsung', 'samsung'],
+    ['SAMSUNG', 'samsung'],
+    ['HUAWEI', 'huawei'],
+    ['HONOR', 'honor'],
+    ['Xiaomi', 'xiaomi'],
+    ['REDMI', 'xiaomi'],
+    ['POCO', 'xiaomi'],
+    ['OPPO', 'oppo'],
+    ['OnePlus', 'oneplus'],
+    ['oneplus', 'oneplus'],
+    ['vivo', 'vivo'],
+    ['realme', 'realme'],
+  ] as const)('classifies %s → %s', (input, expected) => {
+    const result = classifyVendor(input);
+    expect(result?.id).toBe(expected);
+    expect(result?.manufacturer).toBe(input.trim().toLowerCase());
+  });
+
+  it('trims whitespace before classifying', () => {
+    expect(classifyVendor('  Samsung  ')?.id).toBe('samsung');
+  });
+});
+
+describe('vendor hint dismissal persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('reports not-dismissed by default', () => {
+    expect(isVendorHintDismissed('samsung')).toBe(false);
+  });
+
+  it('persists dismissal and reports it back', () => {
+    markVendorHintDismissed('samsung');
+    expect(isVendorHintDismissed('samsung')).toBe(true);
+    // Other vendors stay un-dismissed
+    expect(isVendorHintDismissed('xiaomi')).toBe(false);
+  });
+
+  it('does not duplicate the same vendor in storage', () => {
+    markVendorHintDismissed('xiaomi');
+    markVendorHintDismissed('xiaomi');
+    const raw = localStorage.getItem(VENDOR_HINT_DISMISSED_KEY);
+    const parsed = raw ? (JSON.parse(raw) as string[]) : [];
+    expect(parsed.filter((v) => v === 'xiaomi')).toHaveLength(1);
+  });
+
+  it('accumulates dismissals across vendors', () => {
+    markVendorHintDismissed('samsung');
+    markVendorHintDismissed('xiaomi');
+    expect(isVendorHintDismissed('samsung')).toBe(true);
+    expect(isVendorHintDismissed('xiaomi')).toBe(true);
+  });
+
+  it('tolerates corrupt JSON in storage (treats as not-dismissed)', () => {
+    localStorage.setItem(VENDOR_HINT_DISMISSED_KEY, 'not valid json{');
+    expect(isVendorHintDismissed('samsung')).toBe(false);
+    // Writing should still work (overwrites the corrupt value)
+    markVendorHintDismissed('samsung');
+    expect(isVendorHintDismissed('samsung')).toBe(true);
+  });
+
+  it('tolerates localStorage throwing (e.g. quota exceeded)', () => {
+    const orig = Storage.prototype.setItem;
+    Storage.prototype.setItem = vi.fn(() => { throw new Error('quota'); });
+    try {
+      // Must not throw
+      expect(() => markVendorHintDismissed('samsung')).not.toThrow();
+    } finally {
+      Storage.prototype.setItem = orig;
+    }
+  });
+});

--- a/src/shared/lib/push/vendor-energy-saver.ts
+++ b/src/shared/lib/push/vendor-energy-saver.ts
@@ -1,0 +1,103 @@
+/**
+ * WEE-44 / forta-bugs#732, #766: vendor energy-saver detection.
+ *
+ * Certain Android OEMs apply aggressive background-process killing on top
+ * of stock Doze. Even with a healthy FCM token and a registered Matrix
+ * pusher, messages may arrive minutes late — or never — until the user
+ * adds Forta to the per-vendor "no battery optimization / autostart"
+ * allow-list.
+ *
+ * This module classifies the device by `Build.MANUFACTURER` so the UI
+ * layer can surface a one-time hint with the right instructions per
+ * vendor. We deliberately keep this as a pure classifier here; the actual
+ * surface (toast, modal, onboarding step) is a UI concern handled
+ * separately and dismissed via a localStorage flag.
+ */
+
+/** Stable identifier consumed by i18n keys (`vendorHint.${id}.title` etc.). */
+export type VendorEnergySaverId =
+  | 'samsung'
+  | 'huawei'
+  | 'honor'
+  | 'xiaomi'
+  | 'oppo'
+  | 'oneplus'
+  | 'vivo'
+  | 'realme';
+
+export interface VendorEnergySaverHint {
+  id: VendorEnergySaverId;
+  /** Lowercased manufacturer string as reported by Build.MANUFACTURER */
+  manufacturer: string;
+}
+
+/** Vendors with documented FCM-killing energy savers. Order doesn't matter
+ *  because we match against an exact lowercased manufacturer string. */
+const KNOWN_VENDORS: Record<string, VendorEnergySaverId> = {
+  samsung: 'samsung',
+  huawei: 'huawei',
+  honor: 'honor',
+  xiaomi: 'xiaomi',
+  redmi: 'xiaomi',
+  poco: 'xiaomi',
+  oppo: 'oppo',
+  oneplus: 'oneplus',
+  vivo: 'vivo',
+  realme: 'realme',
+};
+
+/**
+ * Map a `Build.MANUFACTURER` string (whatever case the OEM ships) onto a
+ * stable hint id. Returns null for devices we don't have specific guidance
+ * for — the caller should suppress any vendor hint UI in that case.
+ *
+ * Pure function: no side effects, no native calls. Safe for unit tests.
+ */
+export function classifyVendor(manufacturer: string | null | undefined): VendorEnergySaverHint | null {
+  if (!manufacturer) return null;
+  const normalized = manufacturer.trim().toLowerCase();
+  if (!normalized) return null;
+  const id = KNOWN_VENDORS[normalized];
+  if (!id) return null;
+  return { id, manufacturer: normalized };
+}
+
+/** localStorage key for "user has already seen the hint for this vendor".
+ *  Per-vendor so a user who migrates between OEMs (e.g. Samsung → Xiaomi)
+ *  gets the new hint shown once on the new device. */
+export const VENDOR_HINT_DISMISSED_KEY = 'forta_vendor_energy_hint_dismissed';
+
+/** Returns true when the hint for [id] was previously dismissed. */
+export function isVendorHintDismissed(id: VendorEnergySaverId): boolean {
+  try {
+    const raw = localStorage.getItem(VENDOR_HINT_DISMISSED_KEY);
+    if (!raw) return false;
+    const dismissed = JSON.parse(raw) as unknown;
+    return Array.isArray(dismissed) && dismissed.includes(id);
+  } catch {
+    return false;
+  }
+}
+
+/** Persist that the user has seen / dismissed the hint for [id]. */
+export function markVendorHintDismissed(id: VendorEnergySaverId): void {
+  try {
+    // Recover from corrupt storage: if JSON.parse throws, treat as empty
+    // and overwrite. Otherwise a single bad write (or external tamper)
+    // would permanently lock the user out of dismissing the hint.
+    let current: VendorEnergySaverId[] = [];
+    const raw = localStorage.getItem(VENDOR_HINT_DISMISSED_KEY);
+    if (raw) {
+      try {
+        const parsed = JSON.parse(raw) as unknown;
+        if (Array.isArray(parsed)) current = parsed as VendorEnergySaverId[];
+      } catch {
+        /* corrupt — reset to empty */
+      }
+    }
+    if (current.includes(id)) return;
+    localStorage.setItem(VENDOR_HINT_DISMISSED_KEY, JSON.stringify([...current, id]));
+  } catch {
+    /* non-fatal: in degraded WebViews we'd just show the hint again next boot */
+  }
+}


### PR DESCRIPTION
## Summary

P0 fix bundling 4 cross-layer Android push regressions tracked under [WEE-44](https://linear.app/wwwee/issue/WEE-44). Closes 10 forta-bugs issues by tackling root causes in the JS + Kotlin push pipeline.

### What was broken

| Layer | Symptom | Hypothesis |
|------|---------|------------|
| JS | `registerPusher` had no retry — a single transient failure (FCM, Matrix gateway 5xx, slow sync) left the device permanently unable to receive push for that session | H1 |
| JS | Notifications were only cancelled when a push arrived *while* the user was on the room; opening a chat to read existing unread did not dismiss the notification → launcher badge stuck | H4 |
| JS | `processPushOpenRoom` did `setActiveRoom + router.push("ChatPage")` AFTER deferring through a watcher, briefly showing the chat list before resolving to the chat | H5 |
| JS | Mute state was localStorage-only — Matrix server never received a push rule, so the homeserver kept pushing for "muted" rooms. localStorage is fragile across APK updates on some launchers/OEMs | H3 |

### What changed

#### `src/shared/lib/push/push-service.ts`
* `registerPusher` now retries 3× with exponential backoff (1s, 2s) before giving up.
* On final failure, writes a dead-letter record to `localStorage.push_pusher_dead_letter` (token + timestamp + error) so we can correlate user reports and follow-up boots can re-attempt.
* On a subsequent successful registration with the same token, the dead-letter is auto-cleared.

#### `src/entities/chat/model/chat-store.ts`
* New `setRoomMute(roomId, muted)`: optimistic local write + `setRoomMutePushRule('global', roomId, muted)` on Matrix. Failure is logged but doesn't roll back the optimistic state (better UX).
* `toggleMuteRoom` now delegates to `setRoomMute` (fire-and-forget for existing callers).
* New `syncMutedRoomsFromMatrix()`: fetches authoritative push rules from `client.getPushRules()` and **unions** them with the local set (server-only-wins would clobber in-flight optimistic mutes).
* `commitReadWatermark` now calls `PushData.cancelNotification({ roomId })` after each read — the launcher badge is the count of active notifications in our messages channel, so dismissing per-room notifications reverts the counter without adding ShortcutBadger or a third-party badge SDK.

#### `src/entities/auth/model/stores.ts`
* After `pushService.init`, calls `chatStore.syncMutedRoomsFromMatrix()` so the mute state on a fresh install / new device matches what the server believes.

#### `src/app/App.vue`
* `processPushOpenRoom` extracted into `navigateToChat()`. Uses `router.replace` only when already on `ChatPage` (avoids polluting history when swapping rooms) and `router.push` otherwise (preserves navigation stack — Back returns the user to Settings/Profile/etc. where they came from). Eliminates the chat-list flash from #790.

#### `android/app/src/main/java/com/forta/chat/plugins/push/PushDataPlugin.kt`
* `cancelAllMessageNotifications`: iterates `nm.activeNotifications` and cancels only entries tagged in the `messages` channel — call notifications stay untouched.
* `getDeviceManufacturer`: returns `Build.MANUFACTURER`, `Build.MODEL`, `Build.VERSION.SDK_INT` for OEM-specific energy-saver hints (vendor onboarding UX is a follow-up).

#### `src/shared/lib/push/vendor-energy-saver.ts` (new)
* Pure classifier mapping `Build.MANUFACTURER` → stable id for Samsung / HONOR / Huawei / Xiaomi / Redmi / POCO / OPPO / OnePlus / vivo / realme. Plus persistence helpers for one-time-shown UX. **Detection infrastructure only** — the actual hint modal/onboarding screen is intentionally deferred (needs design + i18n).

### Tests added

* `vendor-energy-saver.test.ts` — 22 tests covering classification edges, dismissal persistence, corrupt-storage recovery, localStorage failure tolerance.
* `push-service-retry.test.ts` — 4 tests covering first-attempt success, retry-then-success, dead-letter write after 3 exhausted attempts, isolation of stale-pusher cleanup failures from primary registration success.

## Linear
- Resolves WEE-44 — https://linear.app/wwwee/issue/WEE-44/notifications-android-push-ne-dostavlyaetsya-icon-badge-ne

## Closes
Closes greenShirtMystery/forta-bugs#785
Closes greenShirtMystery/forta-bugs#766
Closes greenShirtMystery/forta-bugs#764
Closes greenShirtMystery/forta-bugs#732
Closes greenShirtMystery/forta-bugs#572
Closes greenShirtMystery/forta-bugs#561
Closes greenShirtMystery/forta-bugs#556
Closes greenShirtMystery/forta-bugs#356
Closes greenShirtMystery/forta-bugs#344
Closes greenShirtMystery/forta-bugs#790
Closes greenShirtMystery/forta-bugs#817

## Test plan
- [x] `vite build` — green (37s, no errors from changed files)
- [x] `npm test` — 237 tests in impacted areas (push, chat-store, deep-link) all pass; 26 new tests added
- [x] `vue-tsc --noEmit` — zero new TS errors (48 pre-existing on master, identical count after change)
- [x] Code review (HIGH/MEDIUM/LOW findings — 2 HIGH addressed: navigation history preservation, mute-set union merge)
- [ ] **Manual QA on device required:**
  - [ ] Background app + new message → notification arrives within ~5s
  - [ ] Killed app + new message → notification arrives
  - [ ] Open chat + read → icon badge counter decrements
  - [ ] Mute room in Forta → reinstall APK → still muted (server-side rule)
  - [ ] Push tap → opens directly into the chat (no list flash)
  - [ ] Push tap from Settings page → Back returns to Settings

## Out of scope (follow-ups)

* **Vendor energy-saver onboarding UX** — detection plumbing is in place (`getDeviceManufacturer` + `classifyVendor`), but the actual modal/toast/onboarding step needs design + i18n strings + dismissal flow per vendor.
* **FCM data-payload `priority=high`** — set by Matrix push gateway server-side, requires backend coordination.
* **Push title raw matrix ID** — tracked in WEE-11.