### PR TITLE
fix(calls): defer ADM init + seed activeCall on native accept (WEE-47)

### DIFF
--- a/android/app/src/main/java/com/forta/chat/plugins/webrtc/WebRTCPlugin.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/webrtc/WebRTCPlugin.kt
@@ -42,8 +42,16 @@ class WebRTCPlugin : Plugin() {
     }
 
     override fun load() {
+        // WEE-47 (#834): construct the manager but DO NOT call initialize().
+        // initialize() builds PeerConnectionFactory + JavaAudioDeviceModule,
+        // and the ADM eagerly probes the VOICE_COMMUNICATION mic session on
+        // Android 14+ / vivo OS 16 — claiming the input exclusively even
+        // before any call exists, so other messengers (WhatsApp/Telegram)
+        // cannot record audio after a cold-start of Forta. The factory is
+        // not needed until the SDK actually creates the first peer
+        // connection or local media stream; [ensureInitialized] guarantees
+        // it is set up exactly once on the first call-time entry point.
         manager = NativeWebRTCManager(context)
-        manager?.initialize()
 
         // Wire CallActivity native hangup → JS event
         com.forta.chat.plugins.calls.CallActivity.onNativeHangup = {
@@ -66,7 +74,27 @@ class WebRTCPlugin : Plugin() {
             })
         }
 
-        Log.d(TAG, "WebRTCPlugin loaded, manager initialized")
+        Log.d(TAG, "WebRTCPlugin loaded (manager constructed, init deferred)")
+    }
+
+    /**
+     * WEE-47 (#834): lazy factory init.
+     *
+     * Returns the manager with [NativeWebRTCManager.initialize] guaranteed
+     * to have run at least once. Called from the plugin methods that are
+     * the first entry points into call setup — `createPeerConnection` and
+     * `startLocalMedia`. `initialize()` itself is idempotent, so the cost
+     * on the hot path is a single `isInitialized` boolean check.
+     *
+     * Deferring init keeps `JavaAudioDeviceModule` out of the cold-start
+     * critical path; the ADM does not probe the VOICE_COMMUNICATION mic
+     * session until the first call actually exists, which is the contract
+     * the user expects (other apps' mic remains free on idle).
+     */
+    private fun ensureInitialized(): NativeWebRTCManager? {
+        val mgr = manager ?: return null
+        mgr.initialize()
+        return mgr
     }
 
     /**
@@ -95,7 +123,10 @@ class WebRTCPlugin : Plugin() {
 
     @PluginMethod
     fun createPeerConnection(call: PluginCall) {
-        val mgr = manager ?: run {
+        // WEE-47: lazily build the PeerConnectionFactory on the first call-time
+        // entry point. Pre-load init eagerly grabbed the VOICE_COMMUNICATION
+        // mic session on Android 14+ / vivo OS 16, blocking other messengers.
+        val mgr = ensureInitialized() ?: run {
             call.reject("Manager not initialized")
             return
         }
@@ -319,7 +350,10 @@ class WebRTCPlugin : Plugin() {
 
     @PluginMethod
     fun startLocalMedia(call: PluginCall) {
-        val mgr = manager ?: run {
+        // WEE-47: same lazy-init guard as createPeerConnection — covers the
+        // path where startLocalMedia races createPeerConnection (the SDK
+        // may fire either first depending on glare detection).
+        val mgr = ensureInitialized() ?: run {
             call.reject("Manager not initialized")
             return
         }

--- a/src/features/video-calls/model/call-service.test.ts
+++ b/src/features/video-calls/model/call-service.test.ts
@@ -897,6 +897,135 @@ describe('call-service permission flow', () => {
     });
   });
 
+  // -------------------------------------------------------------------------
+  // WEE-47 (#836): callee UI parity — control panel must render after accept
+  // on the native non-pre-accepted incoming flow.
+  //
+  // On Android, when Matrix /sync delivers `m.call.invite` before the user
+  // taps Accept on the native IncomingCallActivity, handleIncomingCall enters
+  // its `if (isNative)` branch which keeps callStore.activeCall null on
+  // purpose (so the Vue IncomingCallModal does not double-ring over the
+  // native one). When NativeCallBridge later fires callAnswered → answerCall,
+  // the function used to run with matrixCall set and activeCall still null —
+  // every subsequent store mutation (updateStatus, type upgrade) was a no-op,
+  // so CallWindow.show stayed false and the callee saw no mute/speaker/hangup
+  // controls (forta-bugs#836). The fix populates activeCall synchronously
+  // from matrixCall at the top of answerCall so the rest of the flow has a
+  // real CallInfo to mutate.
+  // -------------------------------------------------------------------------
+  describe('answerCall populates activeCall on native non-pre-accepted flow (WEE-47 / #836)', () => {
+    function seedMatrixCallOnly(type: 'voice' | 'video' = 'voice') {
+      mockCallStore.matrixCall = {
+        callId: 'native-ringer-call-id',
+        roomId: '!room:matrix.org',
+        type,
+        on: mockOn,
+        off: mockOff,
+        answer: mockAnswer,
+        reject: mockReject,
+        localUsermediaStream: null,
+        localScreensharingStream: null,
+        remoteUsermediaStream: null,
+        remoteScreensharingStream: null,
+        remoteUsermediaFeed: null,
+        getOpponentMember: vi.fn(() => ({ userId: '@peer:matrix.org' })),
+      };
+      mockCallStore.activeCall = null;
+    }
+
+    it('seeds callStore.activeCall from matrixCall before updateStatus(connecting)', async () => {
+      seedMatrixCallOnly('voice');
+
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      await service.answerCall();
+
+      // The seed must run before any updateStatus, otherwise the
+      // connecting transition is lost on an empty activeCall.
+      const seedSetCall = mockSetActiveCall.mock.calls.find(
+        ([info]) =>
+          (info as { callId?: string; status?: string }).callId === 'native-ringer-call-id'
+          && (info as { status?: string }).status === 'incoming',
+      );
+      expect(seedSetCall).toBeTruthy();
+      // The seeded CallInfo must carry the SDK call's type + roomId so the
+      // CallWindow.show gate (`status in {ringing, connecting, connected}`)
+      // and the type-aware UI (voice vs video layout) work post-accept.
+      expect(seedSetCall?.[0]).toMatchObject({
+        callId: 'native-ringer-call-id',
+        roomId: '!room:matrix.org',
+        type: 'voice',
+        direction: 'incoming',
+      });
+
+      // Sanity: SDK answer must still be invoked exactly once on this flow.
+      expect(mockAnswer).toHaveBeenCalledTimes(1);
+    });
+
+    it('seeds activeCall.type = "video" for a video incoming call', async () => {
+      seedMatrixCallOnly('video');
+
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      await service.answerCall();
+
+      const seedSetCall = mockSetActiveCall.mock.calls.find(
+        ([info]) =>
+          (info as { callId?: string }).callId === 'native-ringer-call-id'
+          && (info as { status?: string }).status === 'incoming',
+      );
+      expect(seedSetCall?.[0]).toMatchObject({ type: 'video' });
+      // videoMuted defaults to false for video so the local camera turns on.
+      expect(mockCallStore.videoMuted).toBe(false);
+    });
+
+    it('does NOT re-seed activeCall when it was already populated (pre-accepted / Vue ringer flow)', async () => {
+      // Pre-accepted path or web Vue ringer path: handleIncomingCall already
+      // wrote activeCall. The lazy-seed guard must be a strict `if (null)`
+      // so we don't overwrite the existing CallInfo (which may carry the
+      // refreshed peerName, startedAt sentinel, etc.).
+      mockCallStore.matrixCall = {
+        callId: 'pre-accepted-id',
+        roomId: '!room:matrix.org',
+        type: 'voice',
+        on: mockOn,
+        off: mockOff,
+        answer: mockAnswer,
+        reject: mockReject,
+        localUsermediaStream: null,
+        localScreensharingStream: null,
+        remoteUsermediaStream: null,
+        remoteScreensharingStream: null,
+        remoteUsermediaFeed: null,
+        getOpponentMember: vi.fn(() => ({ userId: '@peer:matrix.org' })),
+      };
+      mockCallStore.activeCall = {
+        callId: 'pre-accepted-id',
+        roomId: '!room:matrix.org',
+        type: 'voice',
+        direction: 'incoming',
+        peerName: 'Already Resolved',
+        status: 'incoming',
+      };
+
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      await service.answerCall();
+
+      // No seed setActiveCall with status='incoming' should fire — the
+      // existing activeCall must be left untouched by the lazy-seed branch.
+      // (Other setActiveCall calls — e.g. peer-name patch — are allowed but
+      // must NOT carry status='incoming', which is the seed signature.)
+      const seedSetCall = mockSetActiveCall.mock.calls.find(
+        ([info]) =>
+          (info as { callId?: string }).callId === 'pre-accepted-id'
+          && (info as { status?: string }).status === 'incoming'
+          && (info as { peerName?: string }).peerName !== 'Already Resolved',
+      );
+      expect(seedSetCall).toBeFalsy();
+    });
+  });
+
   describe('onAudioError listener', () => {
     it('registers onAudioError listener on module load for native', async () => {
       // Module-level code runs once at first import. Since vi.clearAllMocks()

--- a/src/features/video-calls/model/call-service.ts
+++ b/src/features/video-calls/model/call-service.ts
@@ -1149,6 +1149,47 @@ export function useCallService() {
     // a single bad edit can't permanently jam future incoming calls.
     try {
 
+    // WEE-47 (#836): on the native non-pre-accepted incoming flow,
+    // handleIncomingCall intentionally leaves callStore.activeCall null
+    // so the Vue ringer (IncomingCallModal) does not double up over the
+    // native IncomingCallActivity. When the user finally accepts from
+    // the native ringer, NativeCallBridge fires callAnswered → answerCall
+    // runs here with matrixCall set but activeCall still null. Every
+    // store mutation below (`updateStatus(connecting)`, `setActiveCall`
+    // in onState→connected, type upgrade in syncRemoteVideoMuted) is a
+    // no-op when activeCall is null, so:
+    //   - CallWindow.show stays false (callStore.activeCall?.status is
+    //     never in ringing/connecting/connected),
+    //   - the callee hears audio (native WebRTC pipeline) but sees a
+    //     bare chat without mute/speaker/hangup controls.
+    // Populate activeCall synchronously from matrixCall here — cached
+    // profile if available, raw address otherwise — and schedule the
+    // async profile refresh exactly like handleIncomingCall would have.
+    if (!callStore.activeCall) {
+      const opponentId =
+        (call.getOpponentMember?.() as { userId?: string } | undefined)?.userId ?? "";
+      const peerAddress = opponentId ? matrixIdToAddress(opponentId) : "";
+      const cached = peerAddress ? useUserStore().getUser(peerAddress) : null;
+      const peerName = cached?.name || peerAddress;
+      const seedInfo: CallInfo = {
+        callId: call.callId,
+        roomId: call.roomId ?? "",
+        peerId: opponentId,
+        peerAddress,
+        peerName,
+        type: call.type === "video" ? "video" : "voice",
+        direction: "incoming",
+        status: CallStatus.incoming,
+        startedAt: null,
+        endedAt: null,
+      };
+      callStore.setActiveCall(seedInfo);
+      callStore.videoMuted = seedInfo.type !== "video";
+      if (peerAddress && peerName === peerAddress) {
+        refreshPeerNameAsync(call.callId, peerAddress);
+      }
+    }
+
     clearIncomingTimeout();
     stopAllSounds();
 


### PR DESCRIPTION
## Summary

Two post-WEE-45 regressions surfaced on 1.10.31 (Vivo V2515, Android 16):

- **#834 (mic leak):** `WebRTCPlugin.load()` eagerly built `PeerConnectionFactory + JavaAudioDeviceModule` at cold-start. Android 14+ keeps the `VOICE_COMMUNICATION` mic session reserved against the package once the ADM is constructed, so WhatsApp / Telegram could not record audio. Now `load()` only constructs the manager; `initialize()` is invoked lazily on the first call-time entry (`createPeerConnection` / `startLocalMedia`) via an idempotent `ensureInitialized()` helper.
- **#836 (callee UI):** On the native non-pre-accepted incoming flow, `handleIncomingCall` intentionally leaves `callStore.activeCall` null (so the Vue ringer does not double-ring over `IncomingCallActivity`). When the user finally accepts via the native ringer, `answerCall` used to run with `matrixCall` set and `activeCall` still null — every store mutation became a no-op and `CallWindow.show` never flipped. Now `answerCall` seeds `activeCall` synchronously from `matrixCall` when missing (cached profile if available, raw address otherwise; schedules the async name refresh exactly like `handleIncomingCall`).

## Linear

- Resolves [WEE-47](https://linear.app/wwwee/issue/WEE-47/calls-11031-post-merge-regression-mic-global-capture-leak-callee-ui)
- Refs WEE-45

## Closes

Closes greenShirtMystery/forta-bugs#834
Closes greenShirtMystery/forta-bugs#836

## Test plan

- [x] `vitest run src/features/video-calls/model/call-service.test.ts` — 37/37 passing, includes 3 new regression tests for the #836 seed-on-accept contract
- [x] `vue-tsc --noEmit` — no new errors in touched files (49 pre-existing repo-wide errors unchanged)
- [ ] **Manual smoke (Vivo / Xiaomi / OEM device required):**
  - Cold-start Forta → open WhatsApp / Telegram → record voice note → audio captures correctly (mic not held by Forta on idle)
  - Place outgoing voice + video call → audio works both ways (WEE-45 acceptance not broken)
  - Incoming call → accept via native IncomingCallActivity → CallWindow shows full controls (mute / speaker / hangup / video toggle); both peers hear each other
  - Incoming video call → accept → camera turns on, controls visible
  - Hangup → other apps can immediately record audio (no stuck `MODE_IN_COMMUNICATION`)