### PR TITLE
fix(messaging): clickable links + selection-aware copy (WEE-42)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@capacitor-community/safe-area": "^8.0.1",
     "@capacitor/android": "^8.2.0",
     "@capacitor/app": "^8.0.1",
+    "@capacitor/browser": "^8.0.0",
     "@capacitor/camera": "^8.0.2",
     "@capacitor/cli": "^8.2.0",
     "@capacitor/core": "^8.2.0",

--- a/src/features/messaging/ui/MessageContent.vue
+++ b/src/features/messaging/ui/MessageContent.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, inject, type Ref, ref } from "vue";
+import { Capacitor } from "@capacitor/core";
 import { parseMessage, applyLocalAlias } from "@/shared/lib/message-format";
 import type { Segment } from "@/shared/lib/message-format";
 import { PostCard } from "@/features/post-player";
@@ -33,6 +34,32 @@ const activeQuery = computed(() => searchQuery.value?.trim() ?? "");
 
 /** Inline segments (text, link, mention) vs block segments (bastyonLink) */
 const hasBlockSegments = computed(() => segments.value.some(s => s.type === "bastyonLink"));
+
+// Capacitor Android WebView treats `<a target="_blank">` as a no-op (there is
+// no concept of a new tab), so a plain anchor leaves the user stuck. Intercept
+// the click and route through @capacitor/browser on native, fall back to
+// window.open everywhere else. (WEE-42, forta-bugs#815/#351.)
+function openExternalLink(href: string): void {
+  window.open(href, "_blank", "noopener,noreferrer");
+}
+
+async function handleLinkClick(event: MouseEvent, href: string): Promise<void> {
+  event.preventDefault();
+  event.stopPropagation();
+  if (!Capacitor.isNativePlatform()) {
+    openExternalLink(href);
+    return;
+  }
+  try {
+    const { Browser } = await import("@capacitor/browser");
+    await Browser.open({ url: href });
+  } catch (err) {
+    // Plugin missing or rejected — at least give the user *something*. On
+    // Capacitor Android `window.open` may still no-op, but it does no harm.
+    console.error("[MessageContent] Browser.open failed, falling back:", err);
+    openExternalLink(href);
+  }
+}
 </script>
 
 <template>
@@ -51,10 +78,9 @@ const hasBlockSegments = computed(() => segments.value.some(s => s.type === "bas
       <a
         v-else-if="seg.type === 'link'"
         :href="seg.href"
-        target="_blank"
         rel="noopener noreferrer"
         class="text-color-txt-ac underline hover:no-underline"
-        @click.stop
+        @click="handleLinkClick($event, seg.href)"
       >{{ seg.content }}</a>
       <span
         v-else-if="seg.type === 'mention'"
@@ -87,10 +113,9 @@ const hasBlockSegments = computed(() => segments.value.some(s => s.type === "bas
         <a
           v-else-if="seg.type === 'link'"
           :href="seg.href"
-          target="_blank"
           rel="noopener noreferrer"
           class="text-color-txt-ac underline hover:no-underline"
-          @click.stop
+          @click="handleLinkClick($event, seg.href)"
         >{{ seg.content }}</a>
         <span
           v-else-if="seg.type === 'mention'"

--- a/src/features/messaging/ui/MessageList.vue
+++ b/src/features/messaging/ui/MessageList.vue
@@ -131,9 +131,24 @@ const handleContextAction = (action: string, message: import("@/entities/chat").
     case "reply":
       chatStore.replyingTo = { id: message.id, senderId: message.senderId, content: message.content.slice(0, 150), type: message.type };
       break;
-    case "copy":
-      navigator.clipboard.writeText(message.content).then(() => toast(t("chat.copiedToClipboard")));
+    case "copy": {
+      // Honour an active text selection inside this bubble so users can copy a
+      // phone number / fragment instead of the whole message body. We scope to
+      // the bubble's DOM subtree so a selection elsewhere on the page doesn't
+      // hijack the copy. (WEE-42, forta-bugs#801/#579.)
+      const sel = window.getSelection();
+      const selectedText = sel?.toString().trim() ?? "";
+      const isSelectionInBubble =
+        sel != null
+        && sel.rangeCount > 0
+        && selectedText.length > 0
+        && (sel.anchorNode as Element | null)
+            ?.parentElement
+            ?.closest(`[data-message-id="${message.id}"]`) != null;
+      const payload = isSelectionInBubble ? selectedText : message.content;
+      navigator.clipboard.writeText(payload).then(() => toast(t("chat.copiedToClipboard")));
       break;
+    }
     case "edit":
       chatStore.editingMessage = { id: message.id, content: message.content };
       break;

--- a/src/features/messaging/ui/__tests__/message-content-link-click.test.ts
+++ b/src/features/messaging/ui/__tests__/message-content-link-click.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression for unclickable links inside chat messages on Capacitor Android
+ * (forta-bugs #815, #351, WEE-42).
+ *
+ * `<a target="_blank">` does not navigate inside a Capacitor WebView because
+ * Android WebView has no concept of "new tab". The fix intercepts clicks and
+ * opens the URL via `@capacitor/browser` on native or `window.open` elsewhere.
+ *
+ * Source-level assertion mirrors MessageContextMenu-save-action.test.ts —
+ * mounting MessageContent needs Pinia + parser shims, which adds a lot of
+ * brittleness for what is essentially a click-handler contract.
+ */
+const getSource = (): string =>
+  readFileSync(resolve(__dirname, "../MessageContent.vue"), "utf-8");
+
+describe("MessageContent — link click handler", () => {
+  it("imports Capacitor so it can branch on native vs web", () => {
+    const source = getSource();
+    expect(source).toMatch(/from\s+['"]@capacitor\/core['"]/);
+    expect(source).toMatch(/\bCapacitor\b/);
+  });
+
+  it("declares a handleLinkClick handler that prevents default navigation", () => {
+    const source = getSource();
+    expect(source).toMatch(/function\s+handleLinkClick|const\s+handleLinkClick\s*=/);
+    expect(source).toMatch(/\.preventDefault\(\)/);
+  });
+
+  it("opens links via @capacitor/browser on native platforms", () => {
+    const source = getSource();
+    expect(source).toMatch(/Capacitor\.isNativePlatform\(\)/);
+    expect(source).toMatch(/@capacitor\/browser/);
+    expect(source).toMatch(/Browser\.open/);
+  });
+
+  it("falls back to window.open with noopener on web/electron", () => {
+    const source = getSource();
+    expect(source).toMatch(/window\.open\([^)]*['"]_blank['"][^)]*noopener/);
+  });
+
+  it("wires the link template to the click handler instead of target=_blank", () => {
+    const source = getSource();
+    // Every <a> in the link branch should call handleLinkClick on click.
+    const linkBranches = source.match(/seg\.type === ['"]link['"][\s\S]*?<\/a>/g) ?? [];
+    expect(linkBranches.length).toBeGreaterThan(0);
+    for (const branch of linkBranches) {
+      expect(branch).toMatch(/@click[^=]*=\s*['"]handleLinkClick/);
+      // target="_blank" alone does nothing on Capacitor — the handler is the
+      // source of truth, so the attribute should be gone.
+      expect(branch).not.toMatch(/target=['"]_blank['"]/);
+    }
+  });
+});

--- a/src/features/messaging/ui/__tests__/message-list-selection-copy.test.ts
+++ b/src/features/messaging/ui/__tests__/message-list-selection-copy.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression for the "Copy" context-menu action copying the entire message
+ * body instead of the user's text selection (forta-bugs #801, #579, WEE-42).
+ *
+ * When the user long-presses a message and selects a phone number / fragment,
+ * tapping Copy should put just that fragment in the clipboard. Previously the
+ * handler wrote `message.content` unconditionally, dropping the selection.
+ *
+ * Source-level assertion mirrors MessageContextMenu-save-action.test.ts —
+ * the in-flight context menu setup is not worth mounting just to verify a
+ * single switch-case branch.
+ */
+const getSource = (): string =>
+  readFileSync(resolve(__dirname, "../MessageList.vue"), "utf-8");
+
+describe("MessageList — copy action prefers active text selection", () => {
+  it("reads the current selection inside the copy branch", () => {
+    const source = getSource();
+    const fnStart = source.indexOf("const handleContextAction");
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = source.indexOf("\n};", fnStart);
+    expect(fnEnd).toBeGreaterThan(fnStart);
+    const fn = source.slice(fnStart, fnEnd);
+
+    // Locate the copy branch and make sure it calls getSelection() before
+    // falling back to message.content — otherwise we regress to copying the
+    // whole bubble even when the user highlighted "1234567".
+    const copyIdx = fn.indexOf('case "copy"');
+    expect(copyIdx).toBeGreaterThan(-1);
+    const nextCase = fn.indexOf("case ", copyIdx + 1);
+    const copyBranch = fn.slice(copyIdx, nextCase === -1 ? undefined : nextCase);
+
+    expect(copyBranch).toMatch(/getSelection\(\)/);
+    expect(copyBranch).toMatch(/message\.content/);
+    expect(copyBranch).toMatch(/clipboard\.writeText/);
+  });
+
+  it("still falls back to message.content when no selection exists", () => {
+    const source = getSource();
+    const fnStart = source.indexOf("const handleContextAction");
+    const fnEnd = source.indexOf("\n};", fnStart);
+    const fn = source.slice(fnStart, fnEnd);
+    const copyIdx = fn.indexOf('case "copy"');
+    const nextCase = fn.indexOf("case ", copyIdx + 1);
+    const copyBranch = fn.slice(copyIdx, nextCase === -1 ? undefined : nextCase);
+
+    // The branch must guard for an empty selection (selection.toString() is
+    // "" outside the bubble) and fall back to the full message body.
+    expect(copyBranch).toMatch(/length\s*>\s*0|\.trim\(\)|\?\s*:|\|\|/);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,6 +62,11 @@
   resolved "https://registry.npmjs.org/@capacitor/app/-/app-8.1.0.tgz"
   integrity sha512-MlmttTOWHDedr/G4SrhNRxsXMqY+R75S4MM4eIgzsgCzOYhb/MpCkA5Q3nuOCfL1oHm26xjUzqZ5aupbOwdfYg==
 
+"@capacitor/browser@^8.0.0":
+  version "8.0.3"
+  resolved "https://registry.npmjs.org/@capacitor/browser/-/browser-8.0.3.tgz"
+  integrity sha512-WJWPHEPbweiFoHYmVlCbZf5yrqJ2Rchx2Xvbmd+3Lf+Zkpq3nXBThThY2CF69lYEg1NINGF9BcHThIOEU1gZlQ==
+
 "@capacitor/camera@^8.0.2":
   version "8.0.2"
   resolved "https://registry.npmjs.org/@capacitor/camera/-/camera-8.0.2.tgz"


### PR DESCRIPTION
## Summary

- **Links in chat are now clickable on Capacitor Android.** Intercept anchor clicks and route through `@capacitor/browser` (system browser / Chrome Custom Tabs) on native; fall back to `window.open(..., "_blank", "noopener,noreferrer")` on web/electron and on plugin failure.
- **Context-menu Copy honours the user's text selection.** Long-press → highlight a phone number / fragment → Copy now puts that fragment in the clipboard instead of the whole message body. Falls back to the full body when no selection is active. Scoped to the bubble via `data-message-id` so a stale selection elsewhere on the page cannot hijack the copy.
- Added `@capacitor/browser@^8.0.0` (aligned with Capacitor 8.x already in `package.json`).

## Linear

- Resolves [WEE-42](https://linear.app/wwwee/issue/WEE-42/messages-ssylki-v-chate-ne-klikabelny-capacitor-webview-kopirovanie)

## Closes

Closes greenShirtMystery/forta-bugs#815
Closes greenShirtMystery/forta-bugs#351
Closes greenShirtMystery/forta-bugs#801
Closes greenShirtMystery/forta-bugs#579

## Test plan

- [x] `vite build` — clean.
- [x] `vue-tsc --noEmit` — no new errors vs master (49 ↔ 49 pre-existing).
- [x] `vitest run` — 2195 passed, 9 pre-existing failures unrelated to this change (same on master).
- [x] New unit tests:
  - `src/features/messaging/ui/__tests__/message-content-link-click.test.ts` (5 cases)
  - `src/features/messaging/ui/__tests__/message-list-selection-copy.test.ts` (2 cases)
- [ ] Manual QA on Android — tap an `https://…` link in chat → opens system browser.
- [ ] Manual QA on Android — long-press a message, select "1234567", Copy → clipboard contains only `1234567`.
- [ ] Manual QA on Android — long-press a message, Copy without selection → clipboard contains full body (unchanged behavior).
- [ ] Manual QA on web — middle-click / Cmd-click a link → opens in new tab (rel="noopener noreferrer" preserved).

## Files changed

| File | Edit |
|------|------|
| `package.json`, `yarn.lock` | Add `@capacitor/browser@^8.0.0` |
| `src/features/messaging/ui/MessageContent.vue` | Replace `target="_blank"` with `@click` handler; route via `Browser.open` on native with `window.open` fallback |
| `src/features/messaging/ui/MessageList.vue` | `handleContextAction` case `"copy"` reads `window.getSelection()` scoped to the bubble |
| `src/features/messaging/ui/__tests__/message-content-link-click.test.ts` | New |
| `src/features/messaging/ui/__tests__/message-list-selection-copy.test.ts` | New |