### PR TITLE
fix(messages): stop 'message deleted' placeholder from sticking or false-positiving (WEE-43)

### DIFF
--- a/src/entities/chat/lib/last-message-builder.test.ts
+++ b/src/entities/chat/lib/last-message-builder.test.ts
@@ -52,6 +52,12 @@ describe("resolveLastMessagePreview", () => {
   it("returns undefined when raw is undefined", () => {
     expect(resolveLastMessagePreview(undefined)).toBeUndefined();
   });
+
+  it("normalises empty string to undefined so legacy redaction-empty rooms render as 'no messages' (WEE-43)", () => {
+    // Pre-fix builds wrote `lastMessagePreview: ""` on full-room redaction.
+    // Treating that as no-preview avoids the blank sidebar row.
+    expect(resolveLastMessagePreview("")).toBeUndefined();
+  });
 });
 
 describe("buildLastMessage", () => {

--- a/src/entities/chat/lib/last-message-builder.ts
+++ b/src/entities/chat/lib/last-message-builder.ts
@@ -4,12 +4,19 @@ import type { Message } from "../model/types";
 import { MessageType } from "../model/types";
 
 /** Resolve the effective preview body — prefer decrypted-cache value over
- *  raw "[encrypted]" / "m.bad.encrypted" / "** Unable to decrypt" placeholders. */
+ *  raw "[encrypted]" / "m.bad.encrypted" / "** Unable to decrypt" placeholders.
+ *
+ *  WEE-43: an empty `rawPreview` is normalised to `undefined` so callers like
+ *  `buildLastMessage` short-circuit to "no preview", letting `formatPreview`
+ *  surface the localised "no messages" hint instead of building a Message with
+ *  an empty content body. Older builds wrote `lastMessagePreview: ""` for
+ *  fully-redacted rooms — this keeps that legacy data from rendering blank
+ *  until the next message or redaction overwrites it. */
 export function resolveLastMessagePreview(
   rawPreview: string | undefined,
   decryptedPreview?: string,
 ): string | undefined {
-  if (rawPreview == null) return undefined;
+  if (rawPreview == null || rawPreview === "") return undefined;
   const isEncryptedPlaceholder = rawPreview === "[encrypted]"
     || rawPreview === "m.bad.encrypted"
     || rawPreview.startsWith("** Unable to decrypt");

--- a/src/features/contacts/ui/ContactList.vue
+++ b/src/features/contacts/ui/ContactList.vue
@@ -220,14 +220,11 @@ function getPreview(room: ChatRoom): DisplayResult {
   // Primary: use room.lastMessage from Dexie LiveRoom
   if (room.lastMessage) {
     const c = room.lastMessage.content;
-    // Explicit deletion markers only. `"[message]"` is a generic "preview
-    // unavailable" sentinel (see format-preview.ts), not a deletion marker —
-    // treating it as deleted here used to mislabel call/media events.
-    if (
-      room.lastMessage.deleted ||
-      (!c && room.lastMessage.type === MessageType.text) ||
-      c === "🚫 Message deleted"
-    ) {
+    // WEE-43: explicit deletion signals only — `msg.deleted` (mapper sets it
+    // from softDeleted) or the legacy literal "🚫 Message deleted" body.
+    // The previous "empty text → deleted" inference produced false positives
+    // for any room whose preview was transiently blank (push-driven, cold-start).
+    if (room.lastMessage.deleted || c === "🚫 Message deleted") {
       return { state: "ready", text: `🚫 ${t("message.deleted")}` };
     }
     // For non-encrypted content, clean links/IDs (getPreview text is shown directly in some template branches)
@@ -246,8 +243,8 @@ function getPreview(room: ChatRoom): DisplayResult {
   const msgs = chatStore.messages[room.id];
   if (msgs?.length) {
     const last = msgs[msgs.length - 1];
-    // Deleted message
-    if (last.deleted || (!last.content && last.type === MessageType.text)) {
+    // WEE-43: explicit deletion signal only — see comment in the primary branch.
+    if (last.deleted) {
       return { state: "ready", text: `🚫 ${t("message.deleted")}` };
     }
     // For group chats: if sender name isn't resolved yet, show skeleton instead of raw ID

--- a/src/shared/lib/local-db/__tests__/event-writer-redaction-preview.test.ts
+++ b/src/shared/lib/local-db/__tests__/event-writer-redaction-preview.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "fake-indexeddb/auto";
+import { ChatDatabase } from "../schema";
+import type { LocalMessage, LocalRoom } from "../schema";
+import { MessageRepository } from "../message-repository";
+import { RoomRepository } from "../room-repository";
+import { UserRepository } from "../user-repository";
+import { EventWriter } from "../event-writer";
+import { MessageType } from "@/entities/chat/model/types";
+
+let db: ChatDatabase;
+let msgRepo: MessageRepository;
+let roomRepo: RoomRepository;
+let userRepo: UserRepository;
+let eventWriter: EventWriter;
+
+const ROOM_ID = "!room:server";
+
+function makeMsg(overrides: Partial<LocalMessage> = {}): LocalMessage {
+  return {
+    eventId: overrides.eventId ?? `$evt_${Math.random().toString(36).slice(2)}`,
+    clientId: overrides.clientId ?? `cli_${Math.random().toString(36).slice(2)}`,
+    roomId: overrides.roomId ?? ROOM_ID,
+    senderId: overrides.senderId ?? "user1",
+    content: overrides.content ?? "hello",
+    timestamp: overrides.timestamp ?? Date.now(),
+    type: overrides.type ?? MessageType.text,
+    status: overrides.status ?? "synced",
+    version: 1,
+    softDeleted: false,
+    ...overrides,
+  } as LocalMessage;
+}
+
+function makeRoom(overrides: Partial<LocalRoom> = {}): LocalRoom {
+  return {
+    id: overrides.id ?? ROOM_ID,
+    name: "Test Room",
+    isGroup: false,
+    members: ["user1", "user2"],
+    membership: "join",
+    unreadCount: 0,
+    lastReadInboundTs: 0,
+    lastReadOutboundTs: 0,
+    updatedAt: Date.now(),
+    syncedAt: Date.now(),
+    hasMoreHistory: true,
+    isDeleted: false,
+    deletedAt: null,
+    deleteReason: null,
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  const name = `test-redaction-preview-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  db = new ChatDatabase(name);
+  await db.open();
+  msgRepo = new MessageRepository(db);
+  roomRepo = new RoomRepository(db);
+  userRepo = new UserRepository(db);
+  eventWriter = new EventWriter(db, msgRepo, roomRepo, userRepo);
+});
+
+afterEach(async () => {
+  await db.delete();
+});
+
+describe("EventWriter.writeRedaction — preview rollback (WEE-43)", () => {
+  it("rolls preview back to previous non-redacted message when last message is redacted", async () => {
+    // Setup: room where lastMessage is $msg3 (the one we're about to redact).
+    const room = makeRoom({
+      lastMessageEventId: "$msg3",
+      lastMessagePreview: "third",
+      lastMessageTimestamp: 3000,
+      lastMessageSenderId: "user1",
+      lastMessageType: MessageType.text,
+    });
+    await db.rooms.add(room);
+
+    await db.messages.add(makeMsg({ eventId: "$msg1", content: "first",  timestamp: 1000 }));
+    await db.messages.add(makeMsg({ eventId: "$msg2", content: "second", timestamp: 2000 }));
+    await db.messages.add(makeMsg({ eventId: "$msg3", content: "third",  timestamp: 3000 }));
+
+    await eventWriter.writeRedaction({ redactedEventId: "$msg3", roomId: ROOM_ID });
+
+    const updatedRoom = await roomRepo.getRoom(ROOM_ID);
+    // Critical: monotonic guard must NOT block the rollback to an older message.
+    expect(updatedRoom!.lastMessagePreview).toBe("second");
+    expect(updatedRoom!.lastMessageEventId).toBe("$msg2");
+    expect(updatedRoom!.lastMessageTimestamp).toBe(2000);
+  });
+
+  it("clears all lastMessage* fields when redacting the only remaining message", async () => {
+    const room = makeRoom({
+      lastMessageEventId: "$msg1",
+      lastMessagePreview: "only",
+      lastMessageTimestamp: 1000,
+      lastMessageSenderId: "user1",
+      lastMessageType: MessageType.text,
+    });
+    await db.rooms.add(room);
+
+    await db.messages.add(makeMsg({ eventId: "$msg1", content: "only", timestamp: 1000 }));
+
+    await eventWriter.writeRedaction({ redactedEventId: "$msg1", roomId: ROOM_ID });
+
+    const updatedRoom = await roomRepo.getRoom(ROOM_ID);
+    // Sidebar must not render the "deleted" placeholder when the room is effectively empty:
+    // every lastMessage* field is cleared so buildLastMessage() returns undefined.
+    expect(updatedRoom!.lastMessagePreview).toBeUndefined();
+    expect(updatedRoom!.lastMessageEventId).toBeUndefined();
+    expect(updatedRoom!.lastMessageTimestamp).toBeUndefined();
+    expect(updatedRoom!.lastMessageSenderId).toBeUndefined();
+    expect(updatedRoom!.lastMessageType).toBeUndefined();
+  });
+
+  it("clears lastMessage* fields when redacting the last remaining message among many redacted ones", async () => {
+    const room = makeRoom({
+      lastMessageEventId: "$msg3",
+      lastMessagePreview: "third",
+      lastMessageTimestamp: 3000,
+      lastMessageSenderId: "user1",
+      lastMessageType: MessageType.text,
+    });
+    await db.rooms.add(room);
+
+    await db.messages.add(makeMsg({ eventId: "$msg1", content: "",       timestamp: 1000, softDeleted: true }));
+    await db.messages.add(makeMsg({ eventId: "$msg2", content: "",       timestamp: 2000, softDeleted: true }));
+    await db.messages.add(makeMsg({ eventId: "$msg3", content: "third",  timestamp: 3000 }));
+
+    await eventWriter.writeRedaction({ redactedEventId: "$msg3", roomId: ROOM_ID });
+
+    const updatedRoom = await roomRepo.getRoom(ROOM_ID);
+    expect(updatedRoom!.lastMessagePreview).toBeUndefined();
+    expect(updatedRoom!.lastMessageEventId).toBeUndefined();
+  });
+
+  it("does not touch preview when redacting a non-last message", async () => {
+    const room = makeRoom({
+      lastMessageEventId: "$msg3",
+      lastMessagePreview: "third",
+      lastMessageTimestamp: 3000,
+      lastMessageSenderId: "user1",
+      lastMessageType: MessageType.text,
+    });
+    await db.rooms.add(room);
+
+    await db.messages.add(makeMsg({ eventId: "$msg1", content: "first",  timestamp: 1000 }));
+    await db.messages.add(makeMsg({ eventId: "$msg2", content: "second", timestamp: 2000 }));
+    await db.messages.add(makeMsg({ eventId: "$msg3", content: "third",  timestamp: 3000 }));
+
+    await eventWriter.writeRedaction({ redactedEventId: "$msg1", roomId: ROOM_ID });
+
+    const updatedRoom = await roomRepo.getRoom(ROOM_ID);
+    expect(updatedRoom!.lastMessagePreview).toBe("third");
+    expect(updatedRoom!.lastMessageEventId).toBe("$msg3");
+    expect(updatedRoom!.lastMessageTimestamp).toBe(3000);
+  });
+
+  it("soft-deletes the redacted message regardless of whether it was the last", async () => {
+    const room = makeRoom({
+      lastMessageEventId: "$msg2",
+      lastMessagePreview: "second",
+      lastMessageTimestamp: 2000,
+      lastMessageSenderId: "user1",
+      lastMessageType: MessageType.text,
+    });
+    await db.rooms.add(room);
+
+    await db.messages.add(makeMsg({ eventId: "$msg1", content: "first",  timestamp: 1000 }));
+    await db.messages.add(makeMsg({ eventId: "$msg2", content: "second", timestamp: 2000 }));
+
+    await eventWriter.writeRedaction({ redactedEventId: "$msg1", roomId: ROOM_ID });
+
+    const m1 = await db.messages.where("eventId").equals("$msg1").first();
+    expect(m1!.softDeleted).toBe(true);
+  });
+});

--- a/src/shared/lib/local-db/event-writer.ts
+++ b/src/shared/lib/local-db/event-writer.ts
@@ -505,33 +505,47 @@ export class EventWriter {
   // Redactions (deletions)
   // ---------------------------------------------------------------------------
 
-  /** Mark a message as soft-deleted and update room preview if needed */
+  /** Mark a message as soft-deleted and update room preview if needed.
+   *
+   *  WEE-43: redaction rollback was silently no-op'd by `updateLastMessage`'s
+   *  monotonic guard whenever the previous non-redacted message had an older
+   *  timestamp than the now-deleted lastMessage. We now (a) only touch the
+   *  preview when the redacted event WAS the lastMessage, (b) force-bypass the
+   *  monotonic guard on rollback, and (c) clear every lastMessage* field when
+   *  no non-redacted message remains so the sidebar shows the "no messages"
+   *  hint rather than a stale "deleted" placeholder. */
   async writeRedaction(redaction: ParsedRedaction): Promise<void> {
-    await this.messageRepo.softDelete(redaction.redactedEventId);
+    // Wrap soft-delete + preview rollback in a single transaction so a
+    // concurrent inbound message can't overwrite lastMessage* between our
+    // `getRoom` read and the `clearLastMessage`/`updateLastMessage` write,
+    // which would otherwise either revive a deleted preview or wipe a freshly
+    // arrived one.
+    await this.db.transaction("rw", [this.db.messages, this.db.rooms], async () => {
+      await this.messageRepo.softDelete(redaction.redactedEventId);
 
-    // Mark replyTo.deleted on messages referencing the redacted one in Dexie
-    await this.messageRepo.markReplyDeleted(redaction.redactedEventId);
+      // Mark replyTo.deleted on messages referencing the redacted one in Dexie
+      await this.messageRepo.markReplyDeleted(redaction.redactedEventId);
 
-    // Always update room preview after deletion
-    const clearedAtTs = this.clearedAtTsCache.get(redaction.roomId);
-    const prevMsg = await this.messageRepo.getLastNonDeleted(redaction.roomId, clearedAtTs);
-    if (prevMsg) {
-      await this.updateRoomPreviewFromLocal(prevMsg);
-    } else {
-      // All messages in room are deleted — write an empty preview so the UI
-      // can localise the "deleted" label itself via formatPreview (avoids
-      // bypassing i18n by hard-coding English here).
       const room = await this.roomRepo.getRoom(redaction.roomId);
-      if (room) {
-        await this.roomRepo.updateLastMessage(
-          redaction.roomId,
-          "",
-          room.updatedAt,
-          room.lastMessageSenderId ?? "",
-          room.lastMessageType,
-        );
+      const wasLastMessage = room?.lastMessageEventId === redaction.redactedEventId;
+
+      // Only roll the preview back when the redacted event was actually the
+      // lastMessage of the room — otherwise the preview is already pointing at
+      // a newer message and must stay untouched.
+      if (wasLastMessage) {
+        const clearedAtTs = this.clearedAtTsCache.get(redaction.roomId);
+        const prevMsg = await this.messageRepo.getLastNonDeleted(redaction.roomId, clearedAtTs);
+        if (prevMsg) {
+          await this.updateRoomPreviewFromLocal(prevMsg, /* force */ true);
+        } else {
+          // Every message in the room is redacted/cleared — wipe lastMessage*
+          // metadata entirely. buildLastMessage() returns undefined for rooms
+          // without preview state, which surfaces the localised "no messages"
+          // hint in formatPreview instead of a false-positive "deleted" placeholder.
+          await this.roomRepo.clearLastMessage(redaction.roomId);
+        }
       }
-    }
+    });
 
     this.onChange?.(redaction.roomId);
   }
@@ -722,8 +736,13 @@ export class EventWriter {
   }
 
   /** Update room preview from an existing LocalMessage (used after deletion).
-   *  Same fault-tolerance as updateRoomPreview — never stores empty preview. */
-  private async updateRoomPreviewFromLocal(msg: LocalMessage): Promise<void> {
+   *  Same fault-tolerance as updateRoomPreview — never stores empty preview.
+   *
+   *  `force` bypasses the monotonic guard in `updateLastMessage`. Callers that
+   *  intentionally roll the preview back to an older message (e.g. redaction
+   *  rollback in `writeRedaction`) must pass `force: true` — otherwise the
+   *  guard silently swallows the rollback and a stale preview stays put. */
+  private async updateRoomPreviewFromLocal(msg: LocalMessage, force = false): Promise<void> {
     let preview: string;
     try {
       preview = this.getPreviewText(
@@ -751,6 +770,7 @@ export class EventWriter {
       msg.eventId ?? undefined,
       msg.callInfo,
       msg.systemMeta,
+      force,
     );
   }
 

--- a/src/shared/lib/local-db/room-repository.ts
+++ b/src/shared/lib/local-db/room-repository.ts
@@ -247,7 +247,11 @@ export class RoomRepository {
 
   /** Update the last message preview for a room.
    *  Monotonic: skips the update if the existing preview is already newer,
-   *  preventing stale server data from overwriting fresher local-first writes. */
+   *  preventing stale server data from overwriting fresher local-first writes.
+   *
+   *  `force` bypasses the monotonic guard — required by redaction rollback,
+   *  which intentionally points the preview back to an older message after
+   *  the current `lastMessage` has been soft-deleted (WEE-43). */
   async updateLastMessage(
     roomId: string,
     preview: string,
@@ -257,6 +261,7 @@ export class RoomRepository {
     eventId?: string,
     callInfo?: { callType: "voice" | "video"; missed: boolean; duration?: number },
     systemMeta?: { template: string; senderAddr: string; targetAddr?: string; extra?: Record<string, string> },
+    force = false,
   ): Promise<void> {
     // Monotonic guard — never roll back to an older preview.
     //
@@ -272,6 +277,7 @@ export class RoomRepository {
       eventId !== undefined &&
       (existing?.lastMessageEventId === undefined || existing?.lastMessageEventId === eventId);
     if (
+      !force &&
       !isReplacingOwnPlaceholder &&
       existing?.lastMessageTimestamp &&
       timestamp < existing.lastMessageTimestamp
@@ -302,6 +308,25 @@ export class RoomRepository {
     if (updated === 0 && existing) {
       await this.db.rooms.update(roomId, changes);
     }
+  }
+
+  /** Clear all lastMessage* metadata for a room (WEE-43).
+   *  Used when every message in the room has been redacted/soft-deleted —
+   *  the sidebar should fall back to the "no messages yet" hint instead of
+   *  preserving a stale eventId/preview that points at a deleted message. */
+  async clearLastMessage(roomId: string): Promise<void> {
+    await this.db.rooms.where("id").equals(roomId).modify((room) => {
+      delete room.lastMessagePreview;
+      delete room.lastMessageTimestamp;
+      delete room.lastMessageSenderId;
+      delete room.lastMessageType;
+      delete room.lastMessageEventId;
+      delete room.lastMessageLocalStatus;
+      delete room.lastMessageDecryptionStatus;
+      delete room.lastMessageCallInfo;
+      delete room.lastMessageSystemMeta;
+      room.lastMessageReaction = null;
+    });
   }
 
   /** Update reaction on the last message (does NOT touch updatedAt) */

--- a/src/shared/lib/utils/format-preview.test.ts
+++ b/src/shared/lib/utils/format-preview.test.ts
@@ -140,12 +140,16 @@ describe("useFormatPreview", () => {
       expect(formatPreview(msg, room)).toBe("🚫 This message was deleted");
     });
 
-    it("renders 'deleted' for empty text with no fileInfo (legacy pattern)", () => {
+    it("does NOT render 'deleted' for empty text with no fileInfo when msg.deleted is false (WEE-43)", () => {
+      // Regression: the legacy heuristic `(!content && type === text && !fileInfo) → deleted`
+      // produced false positives (#395) — any text message with an empty preview was
+      // mislabeled as deleted. Only explicit signals (msg.deleted, literal "🚫 Message deleted")
+      // should drive the deletion label now.
       const { formatPreview } = useFormatPreview();
       const room = makeRoom({ isGroup: false });
       const msg = makeMsg({ content: "", type: MessageType.text });
 
-      expect(formatPreview(msg, room)).toBe("🚫 This message was deleted");
+      expect(formatPreview(msg, room)).toBe("");
     });
   });
 });

--- a/src/shared/lib/utils/format-preview.ts
+++ b/src/shared/lib/utils/format-preview.ts
@@ -29,10 +29,11 @@ export function useFormatPreview() {
     // to empty so type-specific branches produce the proper icon+label rather
     // than mislabelling the message as deleted.
     const content = msg.content === "[message]" ? "" : msg.content;
-    // Empty-body text with no attachment is the legacy "deleted text" pattern.
-    if (!content && msg.type === MessageType.text && !msg.fileInfo) {
-      return `🚫 ${t("message.deleted")}`;
-    }
+    // WEE-43: do NOT treat an empty text body as "deleted". Redaction is now
+    // surfaced through msg.deleted (mapper sets it from softDeleted) or the
+    // legacy "🚫 Message deleted" literal above. Inferring deletion from an
+    // empty preview produced false positives whenever updateLastMessage ran
+    // with an empty body (e.g. push-driven preview after a redaction race).
     let preview: string;
     switch (msg.type) {
       case MessageType.image:


### PR DESCRIPTION
## Summary
- `EventWriter.writeRedaction` now actually rolls the sidebar preview back to the previous non-redacted message (monotonic guard in `updateLastMessage` was silently swallowing every rollback) and clears every `lastMessage*` field when no non-redacted message remains, so a fully-redacted room falls back to the localised "no messages" hint.
- Removed the false-positive `(!content && type === text) → "сообщение удалено"` heuristic from `format-preview.ts` and both branches of `ContactList.vue` — only explicit signals (`msg.deleted`, legacy literal `🚫 Message deleted`) now drive the deletion label.
- `writeRedaction` is wrapped in a single `rw` transaction so concurrent inbound writes can't race the soft-delete + preview rollback. `resolveLastMessagePreview` normalises empty string to `undefined` so legacy rooms left with `lastMessagePreview: ""` by the pre-fix path don't render blank.

## Linear
- Resolves WEE-43 (https://linear.app/wwwee/issue/WEE-43/messages-soobshenie-udaleno-placeholder-ostayotsya-poyavlyaetsya-bez)

## Closes
Closes greenShirtMystery/forta-bugs#698
Closes greenShirtMystery/forta-bugs#395
Closes greenShirtMystery/forta-bugs#388

## Test plan
- [x] `npm run test` — 208 passed, 4 pre-existing failures unrelated to this PR (chat-helpers, display-result, open-profile-url, video-embed)
- [x] `vue-tsc --noEmit` — no new type errors in changed files
- [x] `vite build` — clean
- [x] New regression test `event-writer-redaction-preview.test.ts` (5 cases): rollback to previous non-redacted, clear-all when only message redacted, clear-all when all prior messages redacted, no-op for non-last redaction, softDelete still runs for non-last
- [x] Updated `format-preview.test.ts` to pin the no-false-positive contract
- [x] New `resolveLastMessagePreview("") → undefined` test in `last-message-builder.test.ts`
- [ ] Manual QA on Android: delete the last message in a chat — sidebar preview should immediately show the previous message; delete every message in a chat — sidebar should show "no messages" (not "сообщение удалено"); cold-start with a backlog of redactions — preview should be correct after first full sync

## Code review
- Two-pass `superpowers:code-reviewer` review: first pass found 1 critical + 3 high issues (false-positive heuristic still alive in `ContactList.vue`, dead-code heuristic, legacy-data migration, non-transactional `writeRedaction`); all four addressed and re-reviewed clean.