### PR TITLE
fix(deps): sync package-lock.json with @capacitor/browser (WEE-42)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@capacitor-community/safe-area": "^8.0.1",
         "@capacitor/android": "^8.2.0",
         "@capacitor/app": "^8.0.1",
+        "@capacitor/browser": "^8.0.0",
         "@capacitor/camera": "^8.0.2",
         "@capacitor/cli": "^8.2.0",
         "@capacitor/core": "^8.2.0",
@@ -194,6 +195,14 @@
       "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.0.tgz",
       "integrity": "sha512-MlmttTOWHDedr/G4SrhNRxsXMqY+R75S4MM4eIgzsgCzOYhb/MpCkA5Q3nuOCfL1oHm26xjUzqZ5aupbOwdfYg==",
       "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/browser": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/browser/-/browser-8.0.3.tgz",
+      "integrity": "sha512-WJWPHEPbweiFoHYmVlCbZf5yrqJ2Rchx2Xvbmd+3Lf+Zkpq3nXBThThY2CF69lYEg1NINGF9BcHThIOEU1gZlQ==",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
       }


### PR DESCRIPTION
## Summary

Follow-up to #146. `@capacitor/browser` was added to `package.json` and `yarn.lock` in the original PR, but `package-lock.json` was not updated. CI runs `npm ci`, which refuses to install when `package.json` and `package-lock.json` are out of sync.

Generated via `npm install --package-lock-only --no-audit --no-fund` — no behaviour change, no `node_modules` touched outside what's already declared.

## Related

- Follow-up to #146 (WEE-42)
- Linear: [WEE-42](https://linear.app/wwwee/issue/WEE-42)

## Test plan

- [x] `git diff origin/master..HEAD --stat` → `package-lock.json | 9 +++++++++`
- [x] Lockfile entry matches the `yarn.lock` entry merged in #146 (`@capacitor/browser@8.0.3`, sha512 matches npm registry).
- [ ] CI `npm ci` step passes.