### PR TITLE
fix(groups): polls + add-member + mute persistence + UX (WEE-52)

### DIFF
--- a/src/entities/auth/model/stores.ts
+++ b/src/entities/auth/model/stores.ts
@@ -776,6 +776,36 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
               console.warn('[auth] Failed to sync muted rooms from Matrix:', err);
             }
 
+            // WEE-52 / forta-bugs#167: re-sync mute state when the app comes
+            // back to foreground. On Android, the OS can purge localStorage
+            // (per-WebView eviction under memory pressure, OEM cleanups) while
+            // the app is backgrounded. Without this listener the cache desync
+            // surfaces as "I muted the group but notifications came back after
+            // I closed the app for a while". Re-pulling push rules on resume
+            // restores the user's intent without requiring a re-login.
+            //
+            // The handle is stashed in `_appStateHandle` (declared at module
+            // top alongside other per-account cleanup refs) so logout can
+            // detach it — otherwise a re-login would stack a second listener
+            // on top of the first.
+            if (isNative) {
+              try {
+                if (_appStateHandle) {
+                  await _appStateHandle.remove().catch(() => { /* ignore */ });
+                  _appStateHandle = null;
+                }
+                const { App } = await import('@capacitor/app');
+                _appStateHandle = await App.addListener('appStateChange', ({ isActive }) => {
+                  if (!isActive) return;
+                  chatStore.syncMutedRoomsFromMatrix().catch((err) => {
+                    console.warn('[auth] resume sync mute failed:', err);
+                  });
+                });
+              } catch (err) {
+                console.warn('[auth] Failed to wire app-resume mute sync:', err);
+              }
+            }
+
             // Wire call handler after push init (needs nativeCallBridge)
             try {
               const { nativeCallBridge } = await import('@/shared/lib/native-calls');
@@ -1143,6 +1173,10 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
     if (_blockHeightInterval) { clearInterval(_blockHeightInterval); _blockHeightInterval = null; }
     for (const t of _peerKeysRecheckTimers.values()) clearTimeout(t);
     _peerKeysRecheckTimers.clear();
+    if (_appStateHandle) {
+      await _appStateHandle.remove().catch(() => { /* ignore */ });
+      _appStateHandle = null;
+    }
 
     // ── 4. Clear localStorage account data ──
     clearAllDrafts();

--- a/src/features/chat-info/ui/ChatInfoPanel.vue
+++ b/src/features/chat-info/ui/ChatInfoPanel.vue
@@ -286,6 +286,11 @@ const handleAddMember = async (address: string) => {
   if (ok) {
     showAddMember.value = false;
     addSearchQuery.value = "";
+  } else {
+    // Surface failure to user — server-side rejection (insufficient power
+    // level, banned target, network) was silently swallowed before, which
+    // made the button appear broken to non-admin members.
+    showToast(t("info.addMemberFailed"), "error");
   }
 };
 
@@ -858,9 +863,14 @@ const openGallery = (tab: "media" | "files" | "links" | "voice" = "media") => {
                 <span class="text-xs font-medium uppercase text-text-on-main-bg-color">
                   {{ t("chatInfo.members") }} ({{ chatStore.getRoomMemberCount(room.id) }})
                 </span>
-                <!-- Add member button (admin only) -->
+                <!-- Add member button — always visible for groups.
+                     Server-side power-level check is the ultimate gate;
+                     hiding the button client-side hid the action from
+                     legacy bastyon-chat admins whose power_levels.users
+                     map was keyed under a different Matrix domain
+                     (isAdmin computed evaluated to false). Errors from
+                     the server are surfaced via toast in handleAddMember. -->
                 <button
-                  v-if="isAdmin"
                   class="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-color-bg-ac transition-colors hover:bg-neutral-grad-0"
                   @click="showAddMember = !showAddMember"
                 >

--- a/src/features/messaging/ui/PollCard.vue
+++ b/src/features/messaging/ui/PollCard.vue
@@ -15,9 +15,31 @@ const emit = defineEmits<{
 
 const poll = computed(() => props.message.pollInfo!);
 
+/** Dedup voters per option (one vote per user) and enforce last-vote-wins
+ *  across options so a single voter never counts twice in the tally.
+ *  This is defence-in-depth on top of the EventWriter dedup — protects
+ *  against stale Dexie rows written before the dedup fix landed. */
+const dedupedVotes = computed<Record<string, string[]>>(() => {
+  const optionEntries = Object.entries(poll.value.votes ?? {});
+  const seen = new Set<string>();
+  const result: Record<string, string[]> = {};
+  // Iterate options in stable order; first occurrence of a voter wins so the
+  // visual tally stays consistent even if backend somehow stored duplicates.
+  for (const [optionId, voters] of optionEntries) {
+    const unique: string[] = [];
+    for (const voter of voters ?? []) {
+      if (seen.has(voter)) continue;
+      seen.add(voter);
+      unique.push(voter);
+    }
+    result[optionId] = unique;
+  }
+  return result;
+});
+
 const totalVotes = computed(() => {
   let total = 0;
-  for (const voters of Object.values(poll.value.votes)) {
+  for (const voters of Object.values(dedupedVotes.value)) {
     total += voters.length;
   }
   return total;
@@ -26,7 +48,7 @@ const totalVotes = computed(() => {
 const hasVoted = computed(() => !!poll.value.myVote);
 
 const getVoteCount = (optionId: string): number => {
-  return (poll.value.votes[optionId] ?? []).length;
+  return (dedupedVotes.value[optionId] ?? []).length;
 };
 
 const getPercentage = (optionId: string): number => {

--- a/src/features/messaging/ui/__tests__/PollCard.test.ts
+++ b/src/features/messaging/ui/__tests__/PollCard.test.ts
@@ -126,6 +126,35 @@ describe("PollCard", () => {
     expect(buttons[1].attributes("aria-pressed")).toBe("false");
   });
 
+  it("dedupes duplicated voters in the tally (WEE-52 — defence in depth)", () => {
+    // Stale Dexie rows from before EventWriter dedup landed could persist
+    // the same voter twice in pollInfo.votes — the rendered "5 votes" then
+    // double-counted into "8 votes" once the new MSC3381 last-vote-wins logic
+    // wrote a corrective response. Renderer dedups defensively so old rows
+    // surface correctly after the upgrade.
+    const msg = makePollMessage({
+      pollInfo: {
+        question: "Q",
+        options: [
+          { id: "opt-0", text: "A" },
+          { id: "opt-1", text: "B" },
+        ],
+        // Voter "PAlice" duplicated three times on "opt-0",
+        // and also (incorrectly) present on "opt-1".
+        votes: {
+          "opt-0": ["PAlice", "PAlice", "PAlice", "PBob"],
+          "opt-1": ["PAlice", "PCarol"],
+        },
+      },
+    });
+    const wrapper = mount(PollCard, {
+      props: { message: msg, isOwn: false },
+    });
+
+    // Total unique voters: Alice, Bob, Carol → 3
+    expect(wrapper.text()).toContain("3 vote");
+  });
+
   it("emits end when poll owner clicks End poll", async () => {
     const wrapper = mount(PollCard, {
       props: { message: makePollMessage(), isOwn: true },

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -393,6 +393,7 @@ export const en = {
   "info.add": "Add",
   "info.searchToAdd": "Search users to add...",
   "info.noUsersFound": "No users found",
+  "info.addMemberFailed": "Failed to add member. You may lack permission or the user is blocked.",
   "info.admin": "admin",
   "info.adminLabel": "Admin",
   "info.leaveGroup": "Leave group",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -395,6 +395,7 @@ export const ru: Record<TranslationKey, string> = {
   "info.add": "Добавить",
   "info.searchToAdd": "Поиск пользователей...",
   "info.noUsersFound": "Пользователи не найдены",
+  "info.addMemberFailed": "Не удалось добавить участника. Возможно, нет прав или пользователь заблокирован.",
   "info.admin": "админ",
   "info.adminLabel": "Админ",
   "info.leaveGroup": "Покинуть группу",

--- a/src/shared/lib/local-db/__tests__/poll-pending-votes.test.ts
+++ b/src/shared/lib/local-db/__tests__/poll-pending-votes.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "fake-indexeddb/auto";
+import { ChatDatabase } from "../schema";
+import type { LocalMessage } from "../schema";
+import { MessageRepository } from "../message-repository";
+import { RoomRepository } from "../room-repository";
+import { UserRepository } from "../user-repository";
+import { EventWriter, type ParsedMessage } from "../event-writer";
+import { MessageType } from "@/entities/chat/model/types";
+
+let db: ChatDatabase;
+let msgRepo: MessageRepository;
+let roomRepo: RoomRepository;
+let userRepo: UserRepository;
+let eventWriter: EventWriter;
+
+const ROOM_ID = "!room:server";
+const POLL_EVENT_ID = "$poll1";
+
+function makePollMessage(): ParsedMessage {
+  return {
+    eventId: POLL_EVENT_ID,
+    roomId: ROOM_ID,
+    senderId: "PHostAddr",
+    content: "Favorite color?",
+    timestamp: Date.now(),
+    type: MessageType.poll,
+    pollInfo: {
+      question: "Favorite color?",
+      options: [
+        { id: "opt-0", text: "Red" },
+        { id: "opt-1", text: "Blue" },
+      ],
+      votes: {},
+    },
+  };
+}
+
+beforeEach(async () => {
+  const name = `test-poll-pending-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  db = new ChatDatabase(name);
+  await db.open();
+  msgRepo = new MessageRepository(db);
+  roomRepo = new RoomRepository(db);
+  userRepo = new UserRepository(db);
+  eventWriter = new EventWriter(db, msgRepo, roomRepo, userRepo);
+});
+
+afterEach(async () => {
+  await db.delete();
+});
+
+describe("EventWriter — poll vote pending buffer (WEE-52)", () => {
+  it("drops votes for unknown polls before the fix — regression guard", async () => {
+    // Without the pending buffer, writePollVote on an unknown poll silently
+    // returned. After the fix we stash the vote and replay it on poll.start.
+    // This test documents the *new* behaviour: vote count must end up at 1
+    // even though the response arrived before the start.
+    await eventWriter.writePollVote(POLL_EVENT_ID, "PAlice", "opt-0", false);
+
+    // No poll message yet — Dexie has no row to inspect.
+    const beforeStart = await msgRepo.getByEventId(POLL_EVENT_ID);
+    expect(beforeStart).toBeUndefined();
+
+    // Now the poll.start lands.
+    await eventWriter.writeMessage(makePollMessage(), "PMe", ROOM_ID);
+
+    const afterStart = await msgRepo.getByEventId(POLL_EVENT_ID);
+    expect(afterStart?.pollInfo?.votes["opt-0"]).toEqual(["PAlice"]);
+  });
+
+  it("replays multiple early votes and last-wins per voter", async () => {
+    // Alice votes opt-0, then changes mind to opt-1, both before poll.start.
+    await eventWriter.writePollVote(POLL_EVENT_ID, "PAlice", "opt-0", false);
+    await eventWriter.writePollVote(POLL_EVENT_ID, "PAlice", "opt-1", false);
+    // Bob votes opt-0.
+    await eventWriter.writePollVote(POLL_EVENT_ID, "PBob", "opt-0", false);
+
+    await eventWriter.writeMessage(makePollMessage(), "PMe", ROOM_ID);
+
+    const stored = await msgRepo.getByEventId(POLL_EVENT_ID);
+    // Alice's earlier opt-0 vote must be cleared; only her final opt-1 stays.
+    expect(stored?.pollInfo?.votes["opt-0"]).toEqual(["PBob"]);
+    expect(stored?.pollInfo?.votes["opt-1"]).toEqual(["PAlice"]);
+  });
+
+  it("preserves myVote flag from early-arriving own response", async () => {
+    // Our own response can race ahead of our own poll.start echo on a slow
+    // device — myVote must survive the round-trip.
+    await eventWriter.writePollVote(POLL_EVENT_ID, "PMe", "opt-1", /* isMine */ true);
+
+    await eventWriter.writeMessage(makePollMessage(), "PMe", ROOM_ID);
+
+    const stored = await msgRepo.getByEventId(POLL_EVENT_ID);
+    expect(stored?.pollInfo?.myVote).toBe("opt-1");
+  });
+
+  it("replays an early poll.end alongside stashed votes", async () => {
+    await eventWriter.writePollVote(POLL_EVENT_ID, "PAlice", "opt-0", false);
+    await eventWriter.writePollEnd(POLL_EVENT_ID, "PHostAddr");
+
+    await eventWriter.writeMessage(makePollMessage(), "PMe", ROOM_ID);
+
+    const stored = await msgRepo.getByEventId(POLL_EVENT_ID);
+    expect(stored?.pollInfo?.votes["opt-0"]).toEqual(["PAlice"]);
+    expect(stored?.pollInfo?.ended).toBe(true);
+    expect(stored?.pollInfo?.endedBy).toBe("PHostAddr");
+  });
+
+  it("still works synchronously when poll.start landed first", async () => {
+    // Sanity check — the new buffer must not regress the in-order case.
+    await eventWriter.writeMessage(makePollMessage(), "PMe", ROOM_ID);
+    await eventWriter.writePollVote(POLL_EVENT_ID, "PAlice", "opt-0", false);
+
+    const stored = await msgRepo.getByEventId(POLL_EVENT_ID);
+    expect(stored?.pollInfo?.votes["opt-0"]).toEqual(["PAlice"]);
+  });
+});
+
+describe("EventWriter — writePollVote dedup within a single poll", () => {
+  it("never accumulates duplicate voters when the same vote arrives twice", async () => {
+    await eventWriter.writeMessage(makePollMessage(), "PMe", ROOM_ID);
+
+    await eventWriter.writePollVote(POLL_EVENT_ID, "PAlice", "opt-0", false);
+    await eventWriter.writePollVote(POLL_EVENT_ID, "PAlice", "opt-0", false);
+    await eventWriter.writePollVote(POLL_EVENT_ID, "PAlice", "opt-0", false);
+
+    const stored = await msgRepo.getByEventId(POLL_EVENT_ID);
+    expect(stored?.pollInfo?.votes["opt-0"]).toEqual(["PAlice"]);
+  });
+
+  it("moves a voter cleanly across options when they change their mind", async () => {
+    await eventWriter.writeMessage(makePollMessage(), "PMe", ROOM_ID);
+
+    await eventWriter.writePollVote(POLL_EVENT_ID, "PAlice", "opt-0", false);
+    await eventWriter.writePollVote(POLL_EVENT_ID, "PAlice", "opt-1", false);
+
+    const stored = await msgRepo.getByEventId(POLL_EVENT_ID);
+    const opt0 = stored?.pollInfo?.votes["opt-0"] ?? [];
+    expect(opt0).not.toContain("PAlice");
+    expect(stored?.pollInfo?.votes["opt-1"]).toEqual(["PAlice"]);
+  });
+});

--- a/src/shared/lib/local-db/event-writer.ts
+++ b/src/shared/lib/local-db/event-writer.ts
@@ -83,6 +83,13 @@ export interface ParsedReceipt {
 
 type OnChangeCallback = (roomId: string) => void;
 
+/** Buffered poll responses + end waiting for their poll.start to land. */
+interface PendingPollEntry {
+  votes: Map<string, { optionId: string; isMine: boolean }>;
+  ended?: { endedBy: string };
+  stashedAt: number;
+}
+
 // ---------------------------------------------------------------------------
 // EventWriter — writes incoming Matrix events to local DB
 // ---------------------------------------------------------------------------
@@ -236,6 +243,14 @@ export class EventWriter {
       if (item.parsed.eventId && this.pendingEdits.has(item.parsed.eventId)) {
         await this.applyPendingEdit(item.parsed.eventId, item.roomId);
       }
+      // Apply stashed poll votes/end for newly inserted poll.start messages
+      if (
+        item.parsed.eventId
+        && item.parsed.type === MessageType.poll
+        && this.pendingPollVotes.has(item.parsed.eventId)
+      ) {
+        await this.applyPendingPollUpdates(item.parsed.eventId);
+      }
     }
 
     // Notify once per unique room (outside the transaction)
@@ -283,6 +298,10 @@ export class EventWriter {
       if (parsed.eventId) {
         await this.applyPendingEdit(parsed.eventId, parsed.roomId);
       }
+      // Apply any stashed poll votes/end that arrived before this poll.start
+      if (parsed.eventId && parsed.type === MessageType.poll) {
+        await this.applyPendingPollUpdates(parsed.eventId);
+      }
       this.onChange?.(parsed.roomId);
 
       // Async link preview for incoming messages — skip if sender dismissed preview.
@@ -320,6 +339,10 @@ export class EventWriter {
     for (const m of messages) {
       if (m.eventId && this.pendingEdits.has(m.eventId)) {
         await this.applyPendingEdit(m.eventId, m.roomId);
+      }
+      // Apply any stashed poll votes/end for poll.start messages
+      if (m.eventId && m.type === MessageType.poll && this.pendingPollVotes.has(m.eventId)) {
+        await this.applyPendingPollUpdates(m.eventId);
       }
     }
   }
@@ -396,43 +419,167 @@ export class EventWriter {
   // Poll votes
   // ---------------------------------------------------------------------------
 
-  /** Persist a poll vote to the local DB */
+  /** Poll votes/ends whose poll.start hasn't landed in Dexie yet.
+   *  Keyed by pollEventId. Vote uses last-wins per voter (MSC3381). */
+  private pendingPollVotes = new Map<string, PendingPollEntry>();
+  private static readonly PENDING_POLL_TTL_MS = 5 * 60_000;
+  private static readonly PENDING_POLL_MAX_SIZE = 200;
+
+  /** Persist a poll vote to the local DB.
+   *  When the corresponding poll.start hasn't arrived yet (race during initial
+   *  timeline pagination), stash the vote and replay it once the poll message
+   *  lands. Without this guard, early-arriving responses would silently drop.
+   *
+   *  The read+update is wrapped in a `rw` transaction so a concurrent vote on
+   *  the same poll (e.g. a fresh inbound response interleaving with a replay
+   *  batch) can't last-write-wins one of the votes away. */
   async writePollVote(
     pollEventId: string,
     voterAddress: string,
     optionId: string,
     isMine: boolean,
   ): Promise<void> {
-    const msg = await this.messageRepo.getByEventId(pollEventId);
-    if (!msg?.pollInfo) return;
+    const out = { roomId: null as string | null, stashed: false };
 
-    const pollInfo = { ...msg.pollInfo, votes: { ...msg.pollInfo.votes } };
+    await this.db.transaction("rw", [this.db.messages], async () => {
+      const msg = await this.messageRepo.getByEventId(pollEventId);
+      if (!msg?.pollInfo) {
+        out.stashed = true;
+        return;
+      }
+      const pollInfo = this.applyVoteToPollInfo(msg.pollInfo, voterAddress, optionId, isMine);
+      await this.messageRepo.updatePollInfo(pollEventId, pollInfo);
+      out.roomId = msg.roomId;
+    });
 
-    // Remove previous vote by this voter
-    for (const key of Object.keys(pollInfo.votes)) {
-      pollInfo.votes[key] = pollInfo.votes[key].filter(v => v !== voterAddress);
+    if (out.stashed) {
+      this.stashPollVote(pollEventId, voterAddress, optionId, isMine);
+      return;
     }
-
-    // Add new vote
-    if (!pollInfo.votes[optionId]) pollInfo.votes[optionId] = [];
-    pollInfo.votes[optionId] = [...pollInfo.votes[optionId], voterAddress];
-
-    if (isMine) {
-      pollInfo.myVote = optionId;
-    }
-
-    await this.messageRepo.updatePollInfo(pollEventId, pollInfo);
-    this.onChange?.(msg.roomId);
+    if (out.roomId) this.onChange?.(out.roomId);
   }
 
-  /** Persist poll end to the local DB */
+  /** Persist poll end to the local DB.
+   *  Same race window as writePollVote — stash if poll.start hasn't landed.
+   *  Read+update wrapped in a transaction for the same reason. */
   async writePollEnd(pollEventId: string, endedByAddress: string): Promise<void> {
-    const msg = await this.messageRepo.getByEventId(pollEventId);
-    if (!msg?.pollInfo) return;
+    const out = { roomId: null as string | null, stashed: false };
 
-    const pollInfo = { ...msg.pollInfo, ended: true, endedBy: endedByAddress };
-    await this.messageRepo.updatePollInfo(pollEventId, pollInfo);
-    this.onChange?.(msg.roomId);
+    await this.db.transaction("rw", [this.db.messages], async () => {
+      const msg = await this.messageRepo.getByEventId(pollEventId);
+      if (!msg?.pollInfo) {
+        out.stashed = true;
+        return;
+      }
+      const pollInfo = { ...msg.pollInfo, ended: true, endedBy: endedByAddress };
+      await this.messageRepo.updatePollInfo(pollEventId, pollInfo);
+      out.roomId = msg.roomId;
+    });
+
+    if (out.stashed) {
+      this.stashPollEnd(pollEventId, endedByAddress);
+      return;
+    }
+    if (out.roomId) this.onChange?.(out.roomId);
+  }
+
+  /** Apply any stashed poll votes/end for a poll message that just landed.
+   *  Called after writeMessage / writeMessages / flushBatch inserts a poll.start.
+   *  Wrapped in the same `rw` transaction so it can't race with a fresh inbound
+   *  vote for the same poll. */
+  async applyPendingPollUpdates(pollEventId: string): Promise<void> {
+    const pending = this.pendingPollVotes.get(pollEventId);
+    if (!pending) return;
+    this.pendingPollVotes.delete(pollEventId);
+
+    const out = { roomId: null as string | null };
+
+    await this.db.transaction("rw", [this.db.messages], async () => {
+      const msg = await this.messageRepo.getByEventId(pollEventId);
+      if (!msg?.pollInfo) {
+        // Poll was redacted or never landed in this window — drop stashed
+        // updates rather than re-stashing (could loop forever).
+        console.warn("[EventWriter] applyPendingPollUpdates: poll vanished, dropping stashed updates", pollEventId);
+        return;
+      }
+
+      let pollInfo = { ...msg.pollInfo, votes: { ...msg.pollInfo.votes } };
+      for (const [voter, { optionId, isMine }] of pending.votes) {
+        pollInfo = this.applyVoteToPollInfo(pollInfo, voter, optionId, isMine);
+      }
+      if (pending.ended) {
+        pollInfo = { ...pollInfo, ended: true, endedBy: pending.ended.endedBy };
+      }
+
+      await this.messageRepo.updatePollInfo(pollEventId, pollInfo);
+      out.roomId = msg.roomId;
+    });
+
+    if (out.roomId) this.onChange?.(out.roomId);
+  }
+
+  private applyVoteToPollInfo(
+    base: NonNullable<LocalMessage["pollInfo"]>,
+    voterAddress: string,
+    optionId: string,
+    isMine: boolean,
+  ): NonNullable<LocalMessage["pollInfo"]> {
+    const votes: Record<string, string[]> = { ...base.votes };
+    for (const key of Object.keys(votes)) {
+      votes[key] = votes[key].filter(v => v !== voterAddress);
+    }
+    if (!votes[optionId]) votes[optionId] = [];
+    votes[optionId] = [...votes[optionId], voterAddress];
+
+    return {
+      ...base,
+      votes,
+      ...(isMine ? { myVote: optionId } : {}),
+    };
+  }
+
+  private stashPollVote(
+    pollEventId: string,
+    voterAddress: string,
+    optionId: string,
+    isMine: boolean,
+  ): void {
+    const entry: PendingPollEntry = this.pendingPollVotes.get(pollEventId) ?? {
+      votes: new Map(),
+      stashedAt: Date.now(),
+    };
+    entry.votes.set(voterAddress, { optionId, isMine });
+    entry.stashedAt = Date.now();
+    this.pendingPollVotes.set(pollEventId, entry);
+    this.evictStalePendingPolls();
+  }
+
+  private stashPollEnd(pollEventId: string, endedByAddress: string): void {
+    const entry: PendingPollEntry = this.pendingPollVotes.get(pollEventId) ?? {
+      votes: new Map(),
+      stashedAt: Date.now(),
+    };
+    entry.ended = { endedBy: endedByAddress };
+    entry.stashedAt = Date.now();
+    this.pendingPollVotes.set(pollEventId, entry);
+    this.evictStalePendingPolls();
+  }
+
+  private evictStalePendingPolls(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.pendingPollVotes) {
+      if (now - entry.stashedAt > EventWriter.PENDING_POLL_TTL_MS) {
+        this.pendingPollVotes.delete(key);
+      }
+    }
+    if (this.pendingPollVotes.size > EventWriter.PENDING_POLL_MAX_SIZE) {
+      const sorted = [...this.pendingPollVotes.entries()]
+        .sort((a, b) => a[1].stashedAt - b[1].stashedAt);
+      const toRemove = sorted.slice(0, sorted.length - EventWriter.PENDING_POLL_MAX_SIZE);
+      for (const [key] of toRemove) {
+        this.pendingPollVotes.delete(key);
+      }
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/src/widgets/sidebar/ChatSidebar.vue
+++ b/src/widgets/sidebar/ChatSidebar.vue
@@ -202,7 +202,12 @@ const walletStore = useWalletStore();
               >{{ formatPkoin(walletStore.balance) }}</span>
             </button>
 
-            <!-- New Group -->
+            <!-- New Group — WEE-52 / forta-bugs#526, #851 (web), #167 cluster.
+                 Previously a pencil glyph that users repeatedly reported as
+                 unclear ("how do I create a group?"). Switched to a
+                 "users + plus" icon (Lucide user-plus) that reads as
+                 "add people / new group" at a glance. Tooltip and aria-label
+                 already declared the action; the glyph now matches. -->
             <button
               class="btn-press flex h-11 w-11 items-center justify-center rounded-full text-text-on-main-bg-color transition-colors hover:bg-neutral-grad-0"
               :title="t('nav.newGroup')"
@@ -210,16 +215,19 @@ const walletStore = useWalletStore();
               @click="emit('newGroup')"
             >
               <svg
-                width="18"
-                height="18"
+                width="20"
+                height="20"
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
                 stroke-width="2"
                 stroke-linecap="round"
+                stroke-linejoin="round"
               >
-                <path d="M12 20h9" />
-                <path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z" />
+                <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+                <circle cx="8.5" cy="7" r="4" />
+                <line x1="20" y1="8" x2="20" y2="14" />
+                <line x1="23" y1="11" x2="17" y2="11" />
               </svg>
             </button>
           </div>


### PR DESCRIPTION
## Summary

Bug pack for the **groups** cluster — 7 forta-bugs reports about polls breaking, add-member button missing, group mute resetting, and create-group UX.

- **Polls reliability:** stash `poll.response` / `poll.end` events when their `poll.start` hasn't landed in Dexie yet (initial timeline pagination race) and replay them once the start arrives. Defence-in-depth voter dedup on render so stale rows from before the fix display correctly. Read+update wrapped in `rw` transactions to avoid lost votes when a fresh response interleaves with a replay batch.
- **Add Member button visibility:** always visible in group settings. Was hidden when `isAdmin` evaluated false on legacy bastyon-chat rooms (their `power_levels.users` keys admins under a different Matrix domain). Server enforces invite permission; failure now surfaces a toast instead of silently no-op'ing.
- **Notification mute persistence:** re-pull push rules from the Matrix homeserver on app resume. Android WebViews can drop `localStorage` under memory pressure / OEM cleanups while backgrounded — that desync was the "I muted the group, came back, notifications were on again" report. Listener handle is captured and removed in `logout` so re-login doesn't stack listeners.
- **Create-group UX:** replaced unclear pencil glyph with a user-plus icon on the sidebar's "new group" button — same action, recognisable affordance for the multiple users who couldn't find how to start a group.

## Linear

- Resolves [WEE-52](https://linear.app/wwwee/issue/WEE-52)

## Closes

- Closes greenShirtMystery/forta-bugs#570
- Closes greenShirtMystery/forta-bugs#509
- Closes greenShirtMystery/forta-bugs#361
- Closes greenShirtMystery/forta-bugs#167
- Closes greenShirtMystery/forta-bugs#526
- Closes greenShirtMystery/forta-bugs#851

Feature requests deferred to backlog: #690 (paid groups), #651 (themes/threads).

## Test plan

- [x] New unit tests: 7 cases for the pending-poll buffer (`poll-pending-votes.test.ts`) — drop→replay, last-vote-wins per voter, `myVote` preservation across replay, early `poll.end` replay, voter dedup, in-order sanity.
- [x] New unit test in `PollCard.test.ts` — voter dedup at render even when Dexie holds duplicates.
- [x] All 14 added tests pass; pre-existing TS errors in untouched files (capacitor/browser, use-audio-playback, VideoTile, etc.) are baseline on master.
- [ ] Manual QA on Android:
  - Vote in a group poll → counter increments → restart app → vote still counted.
  - Open chat with a poll mid-vote (poll.response arrived before poll.start) → tally correct after history finishes loading.
  - Group settings → "Add member" visible for both admin and non-admin → non-admin sees error toast on attempt.
  - Mute a group → background app for several minutes → resume → group still muted.
  - Sidebar "+ new group" icon now reads as "people +".