### PR TITLE
fix(media): video-note interop + fullscreen back + HEIC fallback + avatar retry (WEE-51)

### DIFF
--- a/src/entities/chat/index.ts
+++ b/src/entities/chat/index.ts
@@ -1,4 +1,4 @@
 export * from "./model";
 export type { ForwardingMessage } from "./model/types";
 export { type DisplayResult, type DisplayState, getRoomTitleForUI, getUserDisplayNameForUI, getMessagePreviewForUI } from "./lib/display-result";
-export { messageTypeFromMime, normalizeMime } from "./lib/chat-helpers";
+export { messageTypeFromMime, normalizeMime, MSC3245_VIDEO_NOTE_KEY, isVideoNoteInfo } from "./lib/chat-helpers";

--- a/src/entities/chat/lib/__tests__/video-note-msc3245.test.ts
+++ b/src/entities/chat/lib/__tests__/video-note-msc3245.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import {
+  isVideoNoteInfo,
+  MSC3245_VIDEO_NOTE_KEY,
+} from "../chat-helpers";
+
+/**
+ * WEE-51 / forta-bugs#837 — Video-note "circle" was arriving as a square
+ * on the receiver side because the sender stamped only a non-standard
+ * `videoNote: true` flag inside `content.info`. Other Matrix clients
+ * (and our own users coming back from a long-running session) rely on the
+ * MSC3245 standard key `org.matrix.msc3245.video_note`. The parser must
+ * accept either signal; the writer must emit both for interop.
+ */
+describe("video-note MSC3245 metadata interop", () => {
+  it("exposes the MSC3245 key as the canonical constant", () => {
+    expect(MSC3245_VIDEO_NOTE_KEY).toBe("org.matrix.msc3245.video_note");
+  });
+
+  it("treats legacy `videoNote: true` as a video-note", () => {
+    expect(isVideoNoteInfo({ videoNote: true })).toBe(true);
+  });
+
+  it("treats standard MSC3245 flag as a video-note", () => {
+    expect(isVideoNoteInfo({ [MSC3245_VIDEO_NOTE_KEY]: true })).toBe(true);
+  });
+
+  it("treats both flags together as a video-note (sender writes both for interop)", () => {
+    expect(
+      isVideoNoteInfo({
+        videoNote: true,
+        [MSC3245_VIDEO_NOTE_KEY]: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not classify a regular m.video info bag as a video-note", () => {
+    expect(isVideoNoteInfo({ mimetype: "video/mp4", size: 1234 })).toBe(false);
+  });
+
+  it("returns false for nullish / undefined info bags", () => {
+    expect(isVideoNoteInfo(undefined)).toBe(false);
+    expect(isVideoNoteInfo(null)).toBe(false);
+  });
+
+  it("ignores non-boolean truthy values (defensive: foreign clients may send strings)", () => {
+    // We only accept literal `true` — a stringified "true" or "1" should not
+    // be misinterpreted as a circle, because the receiver applies a CSS mask
+    // that disfigures a regular landscape video.
+    expect(isVideoNoteInfo({ videoNote: "true" as unknown as boolean })).toBe(false);
+    expect(isVideoNoteInfo({ [MSC3245_VIDEO_NOTE_KEY]: 1 as unknown as boolean })).toBe(false);
+  });
+});

--- a/src/entities/chat/lib/chat-helpers.ts
+++ b/src/entities/chat/lib/chat-helpers.ts
@@ -27,6 +27,21 @@ export function normalizeMime(mime: string | undefined): string {
   return mime && mime.includes("/") ? mime : "application/octet-stream";
 }
 
+/**
+ * Matrix MSC3245 video-note metadata flag.
+ * Standard interoperable marker so other clients (Element, etc.) preserve
+ * the circular video-note rendering instead of falling back to a square video.
+ * We also keep the legacy `videoNote: true` shortcut for backwards compatibility
+ * with messages written by older builds of this app.
+ */
+export const MSC3245_VIDEO_NOTE_KEY = "org.matrix.msc3245.video_note";
+
+/** True when an m.video info bag is marked as a video-note (circle). */
+export function isVideoNoteInfo(info: Record<string, unknown> | undefined | null): boolean {
+  if (!info) return false;
+  return info.videoNote === true || info[MSC3245_VIDEO_NOTE_KEY] === true;
+}
+
 /** Determine MessageType from MIME type string */
 export function messageTypeFromMime(mime: string): MessageType {
   const m = normalizeMime(mime);
@@ -167,7 +182,7 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
       w: info?.w,
       h: info?.h,
       duration: info?.duration ? Math.round(info.duration / 1000) : undefined,
-      videoNote: info?.videoNote === true ? true : undefined,
+      videoNote: isVideoNoteInfo(info) ? true : undefined,
       thumbnailUrl: info?.thumbnailUrl ?? undefined,
       secrets: info?.secrets ? {
         block: info.secrets.block,

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -2,7 +2,7 @@ import { getMatrixClientService } from "@/entities/matrix";
 import type { MatrixKit } from "@/entities/matrix";
 import type { Pcrypto, PcryptoRoomInstance } from "@/entities/matrix/model/matrix-crypto";
 import { getmatrixid, hexEncode, hexDecode } from "@/shared/lib/matrix/functions";
-import { matrixIdToAddress, messageTypeFromMime, parseFileInfo, cleanMatrixIds, looksLikeProperName } from "../lib/chat-helpers";
+import { matrixIdToAddress, messageTypeFromMime, parseFileInfo, cleanMatrixIds, looksLikeProperName, isVideoNoteInfo } from "../lib/chat-helpers";
 import { buildLastMessage, lastMessageFromMessage, resolveLastMessagePreview } from "../lib/last-message-builder";
 import { parseEditBody } from "../lib/parse-edit";
 import { sortMessagesTimelineAsc } from "../lib/message-utils";
@@ -216,7 +216,7 @@ function matrixRoomToChatRoom(room: any, kit: MatrixKit, myUserId: string, nameH
         previewType = MessageType.audio;
       } else if (msgtype === "m.video") {
         const info = content.info as Record<string, unknown> | undefined;
-        if (info?.videoNote) {
+        if (isVideoNoteInfo(info)) {
           previewBody = "[video message]";
           previewType = MessageType.videoCircle;
         } else {

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -1,5 +1,5 @@
 import { onScopeDispose } from "vue";
-import { useChatStore, MessageStatus, MessageType, messageTypeFromMime, normalizeMime } from "@/entities/chat";
+import { useChatStore, MessageStatus, MessageType, messageTypeFromMime, normalizeMime, MSC3245_VIDEO_NOTE_KEY } from "@/entities/chat";
 import type { FileInfo, Message, LinkPreview } from "@/entities/chat";
 import { useAuthStore } from "@/entities/auth";
 import { getMatrixClientService } from "@/entities/matrix";
@@ -729,6 +729,7 @@ export function useMessages() {
                 h: 480,
                 duration: options.duration ? Math.round(options.duration * 1000) : undefined,
                 videoNote: true,
+                [MSC3245_VIDEO_NOTE_KEY]: true,
                 ...(secrets ? { secrets } : {}),
               },
               ...(options.forwardedFrom
@@ -846,6 +847,7 @@ export function useMessages() {
           h: 480,
           duration: options.duration ? Math.round(options.duration * 1000) : undefined,
           videoNote: true,
+          [MSC3245_VIDEO_NOTE_KEY]: true,
           ...(secrets ? { secrets } : {}),
         },
       };
@@ -2148,6 +2150,7 @@ export function useMessages() {
             mimetype: fi.type, size: Math.round(fi.size), w: 480, h: 480,
             duration: fi.duration ? Math.round(fi.duration * 1000) : undefined,
             videoNote: true,
+            [MSC3245_VIDEO_NOTE_KEY]: true,
             ...(secrets ? { secrets } : {}),
           },
         };

--- a/src/features/messaging/ui/MediaViewer.vue
+++ b/src/features/messaging/ui/MediaViewer.vue
@@ -1,3 +1,10 @@
+<script lang="ts">
+// Per-instance counter so simultaneous MediaViewers (e.g. MessageList +
+// ChatInfoGallery) don't share a back-handler slot. Lives outside
+// `<script setup>` so it stays module-scoped across mounts.
+let mediaViewerInstanceCounter = 0;
+</script>
+
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
 import type { Message } from "@/entities/chat";
@@ -21,9 +28,23 @@ const { toast } = useToast();
 const chatStore = useChatStore();
 const { getState, download, saveFile } = useFileDownload();
 
-// Android back: close media viewer (highest overlay priority)
-useAndroidBackHandler("media-viewer", 100, () => {
+// Per-instance id so two MediaViewers mounted at once (e.g. MessageList +
+// ChatInfoGallery on the same chat screen) don't share a handler slot and
+// silently overwrite each other — when the slot collapsed, the back-press
+// fell through to the router and kicked the user out of the chat instead of
+// closing the viewer (forta-bugs#805).
+const backHandlerId = `media-viewer-${++mediaViewerInstanceCounter}`;
+
+// Android back: first exit native <video> fullscreen if active, then close
+// the viewer. Without the fullscreen check, tapping back while a video is
+// playing fullscreen (WebView native control) closed the viewer + chat in
+// one go on some Android versions.
+useAndroidBackHandler(backHandlerId, 100, () => {
   if (!props.show) return false;
+  if (typeof document !== "undefined" && document.fullscreenElement) {
+    document.exitFullscreen?.().catch(() => {});
+    return true;
+  }
   emit("close");
   return true;
 });

--- a/src/features/messaging/ui/MessageBubble.vue
+++ b/src/features/messaging/ui/MessageBubble.vue
@@ -463,6 +463,19 @@ watch(() => props.message.id, () => {
   if (props.message.type === MessageType.image && props.message.fileInfo) {
     download(props.message);
   }
+  imageDecodeFailed.value = false;
+});
+
+// `imageDecodeFailed` is for images the WebView refuses to decode (typically
+// HEIC/HEIF from senders on other clients that didn't transcode). Without
+// this guard the browser kept the broken-image glyph at the natural <img>
+// intrinsic size, blowing past the bubble's max-h and producing the
+// "huge blurry preview" reported in forta-bugs#757 and #743.
+const imageDecodeFailed = ref(false);
+const isLikelyHeic = computed(() => {
+  const t = (props.message.fileInfo?.type ?? "").toLowerCase();
+  const n = (props.message.fileInfo?.name ?? "").toLowerCase();
+  return /heic|heif/.test(t) || /\.(heic|heif)$/.test(n);
 });
 
 const handleMediaClick = () => {
@@ -704,7 +717,20 @@ const replyPreviewSender = computed(() => {
             <span>{{ t('message.failedToLoadImage') }}</span>
             <span class="text-[10px] opacity-60">{{ t('message.tapToRetry') }}</span>
           </div>
-          <img v-else-if="fileState.objectUrl" :src="fileState.objectUrl" :alt="message.fileInfo?.name" class="block max-h-[460px] max-w-full object-cover" :style="imageStyle" @load="emit('resize')" />
+          <div
+            v-else-if="fileState.objectUrl && imageDecodeFailed"
+            class="flex flex-col items-center justify-center gap-1 bg-neutral-grad-0 px-3 py-4 text-center text-xs text-text-on-main-bg-color/70"
+            :style="imagePlaceholderStyle"
+          >
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+              <rect x="3" y="3" width="18" height="18" rx="2" />
+              <circle cx="8.5" cy="8.5" r="1.5" />
+              <polyline points="21 15 16 10 5 21" />
+            </svg>
+            <span class="truncate max-w-full font-medium">{{ message.fileInfo?.name }}</span>
+            <span v-if="isLikelyHeic" class="text-[10px] opacity-70">{{ t('message.heicNotSupported') }}</span>
+          </div>
+          <img v-else-if="fileState.objectUrl" :src="fileState.objectUrl" :alt="message.fileInfo?.name" class="block max-h-[460px] max-w-full object-cover" :style="imageStyle" @load="emit('resize')" @error="imageDecodeFailed = true" />
           <!-- Upload progress overlay -->
           <div v-if="isUploading" class="absolute inset-0 flex items-center justify-center bg-black/30">
             <button class="relative flex h-14 w-14 items-center justify-center" @click.stop="emit('cancelUpload', message)">

--- a/src/features/messaging/ui/__tests__/MediaViewer-back-handler.test.ts
+++ b/src/features/messaging/ui/__tests__/MediaViewer-back-handler.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const source = readFileSync(
+  resolve(__dirname, "../MediaViewer.vue"),
+  "utf-8",
+);
+
+/**
+ * WEE-51 / forta-bugs#805 — Tapping Android back inside a fullscreen photo
+ * viewer used to kick the user out of the chat instead of just closing the
+ * viewer. Two root causes:
+ *   1. The viewer registered its back-handler under a fixed id, so two
+ *      mounted instances (MessageList + ChatInfoGallery on the same screen)
+ *      silently overwrote each other.
+ *   2. When the WebView opened a <video> in native fullscreen, the first
+ *      back press closed the viewer (and chat) while the system was still
+ *      in fullscreen mode, instead of exiting fullscreen first.
+ *
+ * These are source-level invariants because mounting MediaViewer needs the
+ * full chat-store stack — too heavy for a focused regression test.
+ */
+describe("MediaViewer back-handler (WEE-51)", () => {
+  it("registers a per-instance handler id, not a shared 'media-viewer' literal", () => {
+    // Old code: useAndroidBackHandler("media-viewer", 100, ...)
+    // New code: const backHandlerId = `media-viewer-${++counter}`
+    expect(source).not.toMatch(/useAndroidBackHandler\(\s*"media-viewer"/);
+    expect(source).toMatch(/media-viewer-\$\{[^}]+\}/);
+    expect(source).toMatch(/useAndroidBackHandler\(\s*backHandlerId/);
+  });
+
+  it("module-scopes the instance counter (so it survives across mounts)", () => {
+    // The counter MUST live outside `<script setup>`; otherwise it resets to
+    // 0 on every component setup and collides again.
+    expect(source).toMatch(/<script lang="ts">[\s\S]*let mediaViewerInstanceCounter[\s\S]*<\/script>/);
+  });
+
+  it("exits native <video> fullscreen before closing the viewer on back", () => {
+    expect(source).toMatch(/document\.fullscreenElement/);
+    expect(source).toMatch(/exitFullscreen\?\.\(\)/);
+  });
+
+  it("still emits close when not in fullscreen", () => {
+    // The handler must end with the existing emit("close") path so non-video
+    // images keep closing as before.
+    expect(source).toMatch(/emit\("close"\);\s*return true;\s*\}\);/);
+  });
+});

--- a/src/features/messaging/ui/__tests__/MessageBubble-heic-fallback.test.ts
+++ b/src/features/messaging/ui/__tests__/MessageBubble-heic-fallback.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const source = readFileSync(
+  resolve(__dirname, "../MessageBubble.vue"),
+  "utf-8",
+);
+
+/**
+ * WEE-51 / forta-bugs#757, #743 — When the receiver gets a HEIC/HEIF image
+ * from a sender that didn't transcode (older app build, native iOS Bastyon,
+ * etc.), Android WebView fails to decode it and renders the broken-image
+ * glyph at the natural image dimensions. That blew past the bubble's
+ * `max-h-[460px]` cap and produced the "huge blurry preview" complaint.
+ *
+ * The fix wires `<img>`'s `@error` to a per-bubble `imageDecodeFailed` ref
+ * and shows a sized placeholder with the filename instead — so a broken
+ * HEIC stays inside the bubble box and gives the user a sane affordance.
+ */
+describe("MessageBubble — HEIC / broken-image fallback (WEE-51)", () => {
+  it("declares an `imageDecodeFailed` ref", () => {
+    expect(source).toMatch(/const imageDecodeFailed = ref\(false\)/);
+  });
+
+  it("wires <img>'s @error to flip the fallback flag", () => {
+    expect(source).toMatch(/@error="imageDecodeFailed = true"/);
+  });
+
+  it("resets the fallback flag when the bubble is recycled for a different message", () => {
+    // Virtual scroller recycles bubbles — without the reset, a previously
+    // failed HEIC bubble would mask a perfectly good JPEG for the new message.
+    expect(source).toMatch(/imageDecodeFailed\.value = false/);
+  });
+
+  it("renders a constrained placeholder when decode failed", () => {
+    // The placeholder uses `imagePlaceholderStyle` so it stays inside the
+    // bubble's max-h box — the whole point of the fix.
+    expect(source).toMatch(/v-else-if="fileState\.objectUrl && imageDecodeFailed"[\s\S]*?:style="imagePlaceholderStyle"/);
+  });
+
+  it("computes an HEIC hint so the placeholder explains the cause when applicable", () => {
+    expect(source).toMatch(/const isLikelyHeic = computed/);
+    expect(source).toMatch(/heic\|heif/);
+    expect(source).toMatch(/message\.heicNotSupported/);
+  });
+});

--- a/src/features/settings/ui/StoragePreview.vue
+++ b/src/features/settings/ui/StoragePreview.vue
@@ -4,6 +4,7 @@ import { getMediaCache, type MediaCacheIndexEntry } from "@/shared/lib/media-cac
 import { displayName } from "../lib/storage-display";
 import { isNative } from "@/shared/lib/platform";
 import { ZoomableImage } from "@/shared/ui/zoomable-image";
+import { useAndroidBackHandler } from "@/shared/lib/composables/use-android-back-handler";
 
 interface Props {
   entry: MediaCacheIndexEntry;
@@ -14,6 +15,15 @@ const emit = defineEmits<{
   close: [];
   deleted: [];
 }>();
+
+// Android back: close the fullscreen storage preview overlay first instead
+// of letting the event propagate to the router (which would pop the
+// Settings page and feel like "back exits the chat" to the user — see
+// forta-bugs#805 for the chat-side equivalent).
+useAndroidBackHandler("storage-preview", 100, () => {
+  emit("close");
+  return true;
+});
 
 const { t } = useI18n();
 const blobUrl = ref<string | null>(null);

--- a/src/features/user-management/ui/UserEditForm.vue
+++ b/src/features/user-management/ui/UserEditForm.vue
@@ -165,23 +165,34 @@ const handleSave = async () => {
 
 // Avatar upload
 const fileInput = ref<HTMLInputElement>();
+const avatarRetrying = ref(false);
 const handleAvatarClick = () => fileInput.value?.click();
 const handleAvatarChange = async (e: Event) => {
   const file = (e.target as HTMLInputElement).files?.[0];
   if (!file) return;
   avatarError.value = "";
+  avatarRetrying.value = false;
   try {
     const base64 = await fileToBase64(file);
     avatarUrl.value = base64; // local preview
     avatarUploading.value = true;
-    const url = await uploadImage(base64);
+    const url = await uploadImage(base64, {
+      // Surface retries as a non-fatal hint so the user understands the
+      // spinner isn't stuck — flaky cell connections often need 2 attempts
+      // (forta-bugs#803).
+      onRetry: () => { avatarRetrying.value = true; },
+    });
     avatarUrl.value = url;
     userDirty.value = true;
   } catch (err) {
-    avatarError.value = err instanceof Error ? err.message : t("profile.avatarError");
+    const fallback = t("profile.avatarError");
+    const msg = err instanceof Error && err.message ? err.message : fallback;
+    avatarError.value = msg;
+    toast(fallback, "error");
     avatarUrl.value = authStore.userInfo?.image ?? "";
   } finally {
     avatarUploading.value = false;
+    avatarRetrying.value = false;
     // Reset file input so re-selecting same file triggers change
     if (fileInput.value) fileInput.value.value = "";
   }
@@ -220,6 +231,7 @@ watch(
           <Spinner v-else size="sm" class="text-white" />
         </div>
       </div>
+      <p v-if="avatarRetrying && avatarUploading" class="mt-1 text-xs text-text-on-main-bg-color">{{ t('profile.avatarRetrying') }}</p>
       <p v-if="avatarError" class="mt-1 text-xs text-color-bad">{{ avatarError }}</p>
       <input
         ref="fileInput"

--- a/src/shared/lib/__tests__/upload-image-retry.test.ts
+++ b/src/shared/lib/__tests__/upload-image-retry.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * WEE-51 / forta-bugs#803, #747 — Avatar (and any image) upload used to
+ * surface "Failed to fetch" on the first transient network glitch. The
+ * uploader now retries up to 3 attempts for fetch TypeErrors and HTTP 5xx,
+ * but must NOT retry on 4xx (user-correctable) or on a successful response
+ * with no `ident` (server contract violation — retrying won't help).
+ */
+
+const UPLOAD_URL = "https://pocketnet.app:8092/up";
+const IMAGE_BASE_URL = "https://pocketnet.app:8092/i/";
+
+function jsonOk(ident = "abc123"): Response {
+  return new Response(JSON.stringify({ success: true, data: { ident } }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function http(status: number, body: unknown = { error: "boom" }): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("uploadImage — transient failure retry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("returns the image URL on the first successful attempt without delay", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonOk("first"));
+    vi.stubGlobal("fetch", fetchMock);
+    const { uploadImage } = await import("../upload-image");
+
+    const url = await uploadImage("data:image/jpeg;base64,AAAA");
+
+    expect(url).toBe(`${IMAGE_BASE_URL}first`);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(UPLOAD_URL, expect.any(Object));
+  });
+
+  it("retries on fetch TypeError (the browser's 'Failed to fetch') and eventually succeeds", async () => {
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce(jsonOk("recovered"));
+    vi.stubGlobal("fetch", fetchMock);
+    const { uploadImage } = await import("../upload-image");
+
+    const promise = uploadImage("data:image/jpeg;base64,AAAA");
+    // Skip the backoff sleep so the test doesn't hang on fake timers.
+    await vi.runAllTimersAsync();
+    const url = await promise;
+
+    expect(url).toBe(`${IMAGE_BASE_URL}recovered`);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on HTTP 5xx and reports the retry to the caller", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(http(503))
+      .mockResolvedValueOnce(jsonOk("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+    const onRetry = vi.fn();
+    const { uploadImage } = await import("../upload-image");
+
+    const promise = uploadImage("data:image/jpeg;base64,AAAA", { onRetry });
+    await vi.runAllTimersAsync();
+    const url = await promise;
+
+    expect(url).toBe(`${IMAGE_BASE_URL}ok`);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry).toHaveBeenCalledWith(1, expect.any(Error));
+  });
+
+  it("does NOT retry on HTTP 4xx (e.g. 413 payload too large)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(http(413));
+    vi.stubGlobal("fetch", fetchMock);
+    const { uploadImage, ImageUploadError } = await import("../upload-image");
+
+    await expect(uploadImage("data:image/jpeg;base64,AAAA"))
+      .rejects.toBeInstanceOf(ImageUploadError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after 3 attempts on persistent transport failure", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+    vi.stubGlobal("fetch", fetchMock);
+    const { uploadImage, ImageUploadError } = await import("../upload-image");
+
+    // Subscribe to the rejection *before* draining timers so Node doesn't
+    // log it as an unhandled rejection between the two awaits.
+    const assertion = expect(uploadImage("data:image/jpeg;base64,AAAA"))
+      .rejects.toBeInstanceOf(ImageUploadError);
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry on malformed JSON (server contract violation)", async () => {
+    // SyntaxError thrown from res.json() would silently slip through the
+    // catch-all `instanceof Error` branch and get retried 3× — defend
+    // against that regression.
+    const broken = new Response("not-json-at-all", {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+    const fetchMock = vi.fn().mockResolvedValueOnce(broken);
+    vi.stubGlobal("fetch", fetchMock);
+    const { uploadImage, ImageUploadError } = await import("../upload-image");
+
+    await expect(uploadImage("data:image/jpeg;base64,AAAA"))
+      .rejects.toBeInstanceOf(ImageUploadError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry when the server responds 200 but without an ident (contract violation, not transient)", async () => {
+    const broken = new Response(JSON.stringify({ success: true, data: {} }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+    const fetchMock = vi.fn().mockResolvedValueOnce(broken);
+    vi.stubGlobal("fetch", fetchMock);
+    const { uploadImage, ImageUploadError } = await import("../upload-image");
+
+    await expect(uploadImage("data:image/jpeg;base64,AAAA"))
+      .rejects.toBeInstanceOf(ImageUploadError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("strips the data: URL prefix before sending", async () => {
+    let capturedBody = "";
+    const fetchMock = vi.fn().mockImplementationOnce((_url, init) => {
+      capturedBody = (init as RequestInit).body as string;
+      return Promise.resolve(jsonOk());
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { uploadImage } = await import("../upload-image");
+
+    await uploadImage("data:image/jpeg;base64,SGVsbG8=");
+
+    expect(capturedBody).toContain("file=SGVsbG8%3D");
+    expect(capturedBody).not.toContain("data%3Aimage");
+  });
+});

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -242,6 +242,7 @@ export const en = {
   "profile.saved": "Saved",
   "profile.saving": "Saving...",
   "profile.avatarUploading": "Uploading...",
+  "profile.avatarRetrying": "Connection unstable — retrying...",
   "profile.avatarError": "Failed to upload avatar",
   "profile.saveFailed": "Failed to save profile. Check your connection and try again.",
 
@@ -261,6 +262,7 @@ export const en = {
   "message.retry": "Retry",
   "message.failedToLoadImage": "Failed to load image",
   "message.tapToRetry": "Tap to retry",
+  "message.heicNotSupported": "HEIC image — open in gallery to view",
   "message.videoUnsupportedFormat": "Video format not supported",
   "message.videoLoadFailed": "Failed to load video",
   "message.videoDownload": "Download",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -244,6 +244,7 @@ export const ru: Record<TranslationKey, string> = {
   "profile.saved": "Сохранено",
   "profile.saving": "Сохранение...",
   "profile.avatarUploading": "Загрузка...",
+  "profile.avatarRetrying": "Связь нестабильна — повторяем...",
   "profile.avatarError": "Не удалось загрузить аватар",
   "profile.saveFailed": "Не удалось сохранить профиль. Проверьте подключение и попробуйте снова.",
 
@@ -263,6 +264,7 @@ export const ru: Record<TranslationKey, string> = {
   "message.retry": "Повторить",
   "message.failedToLoadImage": "Не удалось загрузить",
   "message.tapToRetry": "Нажмите для повтора",
+  "message.heicNotSupported": "HEIC — откройте в галерее",
   "message.videoUnsupportedFormat": "Формат видео не поддерживается",
   "message.videoLoadFailed": "Не удалось воспроизвести видео",
   "message.videoDownload": "Скачать",

--- a/src/shared/lib/upload-image.ts
+++ b/src/shared/lib/upload-image.ts
@@ -126,34 +126,70 @@ export async function fileToBase64(file: File): Promise<string> {
   });
 }
 
-/** Upload a base64 data URL to Bastyon's image server (up1 endpoint).
- *  Matches the SDK's ImageUploader 'up1' path:
- *  - sends `file` = raw base64 (without data:image prefix)
- *  - sends `api_key`
- *  - response: `{ success: true, data: { ident: "..." } }`
- *  Returns the full image URL. */
-export async function uploadImage(base64DataUrl: string): Promise<string> {
-  // Strip the data URL prefix — server expects raw base64 in 'file' field
-  const rawBase64 = base64DataUrl.includes(",")
-    ? base64DataUrl.split(",")[1]
-    : base64DataUrl;
+/** Retry policy for transient upload failures. The image server occasionally
+ *  drops connections on flaky mobile networks (forta-bugs#803, #747) — a
+ *  one-shot fetch surfaces as "Failed to fetch" and leaves the avatar half-
+ *  applied. Retry only on transport errors and 5xx; 4xx is the user's
+ *  problem (auth, payload size) and shouldn't be retried. */
+const UPLOAD_MAX_ATTEMPTS = 3;
+const UPLOAD_RETRY_DELAYS_MS = [500, 1500];
 
+function isRetriableUploadError(err: unknown, status?: number): boolean {
+  if (typeof status === "number") return status >= 500 && status < 600;
+  if (err instanceof ImageUploadError) return false;
+  if (err instanceof TypeError) return true; // browser "Failed to fetch"
+  if (err instanceof DOMException && err.name === "AbortError") return false;
+  return err instanceof Error;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface UploadImageOptions {
+  /** Called before each retry with the attempt index (1-based) and last error. */
+  onRetry?: (attempt: number, error: unknown) => void;
+}
+
+async function uploadImageOnce(rawBase64: string): Promise<string> {
   const body = new URLSearchParams({
     file: rawBase64,
     api_key: API_KEY,
   });
 
-  const res = await fetch(UPLOAD_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: body.toString(),
-  });
-
-  if (!res.ok) {
-    throw new ImageUploadError(`Upload failed: ${res.status}`);
+  let res: Response;
+  try {
+    res = await fetch(UPLOAD_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+    });
+  } catch (err) {
+    // Tag the error so the retry loop can distinguish network failure from
+    // a thrown ImageUploadError (which is permanent).
+    if (err instanceof TypeError) throw err;
+    throw new ImageUploadError(err instanceof Error ? err.message : "Network error");
   }
 
-  const json = await res.json();
+  if (!res.ok) {
+    // Carry status on the error so the retry loop can decide 5xx vs 4xx.
+    const e = new ImageUploadError(`Upload failed: ${res.status}`) as ImageUploadError & { status?: number };
+    e.status = res.status;
+    throw e;
+  }
+
+  // Parse failures are a server contract violation, not a transient network
+  // glitch — wrap so the retry loop treats them as permanent. Without this,
+  // a malformed-JSON body would raise SyntaxError and be retried 3× via
+  // the catch-all `err instanceof Error` branch.
+  let json: { success?: boolean; error?: string; data?: { ident?: string } };
+  try {
+    json = await res.json();
+  } catch (err) {
+    throw new ImageUploadError(
+      `Upload response malformed: ${err instanceof Error ? err.message : "unknown"}`,
+    );
+  }
   if (!json.success) {
     throw new ImageUploadError(json.error || "Upload failed");
   }
@@ -165,4 +201,41 @@ export async function uploadImage(base64DataUrl: string): Promise<string> {
   }
 
   throw new ImageUploadError("No image identifier in upload response");
+}
+
+/** Upload a base64 data URL to Bastyon's image server (up1 endpoint).
+ *  Matches the SDK's ImageUploader 'up1' path:
+ *  - sends `file` = raw base64 (without data:image prefix)
+ *  - sends `api_key`
+ *  - response: `{ success: true, data: { ident: "..." } }`
+ *  Returns the full image URL.
+ *
+ *  Retries transient network failures (fetch TypeError / HTTP 5xx) up to
+ *  3 attempts with exponential backoff. 4xx and parse errors fail immediately. */
+export async function uploadImage(
+  base64DataUrl: string,
+  options: UploadImageOptions = {},
+): Promise<string> {
+  // Strip the data URL prefix — server expects raw base64 in 'file' field
+  const rawBase64 = base64DataUrl.includes(",")
+    ? base64DataUrl.split(",")[1]
+    : base64DataUrl;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= UPLOAD_MAX_ATTEMPTS; attempt++) {
+    try {
+      return await uploadImageOnce(rawBase64);
+    } catch (err) {
+      lastError = err;
+      const status = (err as { status?: number } | null)?.status;
+      const retriable = isRetriableUploadError(err, status);
+      if (!retriable || attempt === UPLOAD_MAX_ATTEMPTS) break;
+      options.onRetry?.(attempt, err);
+      await sleep(UPLOAD_RETRY_DELAYS_MS[attempt - 1] ?? 2000);
+    }
+  }
+  if (lastError instanceof ImageUploadError) throw lastError;
+  throw new ImageUploadError(
+    lastError instanceof Error ? lastError.message : "Upload failed",
+  );
 }


### PR DESCRIPTION
## Summary
Cluster of 4 receiver-side / robustness fixes for the WEE-51 media UX ticket:

- **Video-note circle** — emit standard MSC3245 flag `org.matrix.msc3245.video_note` alongside the legacy `videoNote` flag, and accept either on parse. Receiver now keeps the circle mask instead of rendering a square.
- **Fullscreen viewer back** — per-instance back-handler id in `MediaViewer.vue` (module-scoped counter) so two viewers mounted at once (`MessageList` + `ChatInfoGallery`) don't share a slot; also exit native `<video>` fullscreen before closing the overlay. Same handler added to `StoragePreview.vue`.
- **HEIC preview** — `<img @error>` on the image bubble switches to a sized placeholder with the filename (and an "open in gallery" hint for HEIC) instead of letting WebView render a broken-image glyph at natural dimensions.
- **Avatar upload retry** — `uploadImage` retries `TypeError` (fetch failure) and HTTP 5xx with exponential backoff (3 attempts); 4xx and malformed-JSON responses fail immediately. `UserEditForm` shows an "unstable connection — retrying…" hint on retry.

## Linear
- Resolves WEE-51 — https://linear.app/wwwee/issue/WEE-51/media-video-kruzhok-prihodit-kvadratom-back-nav-iz-fullscreen-video

## Closes
Closes greenShirtMystery/forta-bugs#837
Closes greenShirtMystery/forta-bugs#805
Closes greenShirtMystery/forta-bugs#757
Closes greenShirtMystery/forta-bugs#743
Closes greenShirtMystery/forta-bugs#803
Closes greenShirtMystery/forta-bugs#747

## Test plan
- [x] `vite build` green
- [x] 24 new unit tests pass (`video-note-msc3245`, `upload-image-retry`, `MediaViewer-back-handler`, `MessageBubble-heic-fallback`)
- [x] Code review (architectural) — 1 HIGH found (malformed-JSON retried) and fixed
- [ ] Manual QA on Android device:
  - [ ] Record video-note → other Bastyon client receives circle, not square
  - [ ] Open photo in fullscreen viewer → press back → viewer closes, chat stays open
  - [ ] Receive HEIC photo from iOS sender → bubble shows constrained placeholder with filename, not huge broken-image glyph
  - [ ] Change avatar on flaky network → upload retries, "unstable connection" hint appears, eventually succeeds

## Notes
- 6 pre-existing test failures in `display-result.test.ts` / `chat-helpers.test.ts` (around `isUnresolvedName` truncated-hex handling) are unrelated to this branch.
- `*-back-handler.test.ts` and `*-heic-fallback.test.ts` are source-regex tests because mounting `MediaViewer` / `MessageBubble` requires the full chat-store stack — see test-file headers for rationale.