### PR TITLE
fix(calls): post-1.10.31 audio cleanup + outgoing dedup + callback from timeline (WEE-49)

### DIFF
--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallForegroundService.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallForegroundService.kt
@@ -205,6 +205,24 @@ class CallForegroundService : Service() {
     }
 
     override fun onDestroy() {
+        // WEE-49: when the OS tears the service down without going through
+        // ACTION_STOP (process killed by OEM Doze, swipe-app-out, low-mem
+        // SIGKILL, system-initiated `stopWithReason`), the previous teardown
+        // only released the wake-lock + abandoned audio focus. AudioRouter
+        // stayed in MODE_IN_COMMUNICATION, holding the voice-call audio
+        // mode globally and blocking cellular network until reboot
+        // (#839 post-WEE-45 residual, #771 phantom call). Brute-force reset
+        // the router and pull the notification surface explicitly so the
+        // OS recognises the call as fully ended.
+        runCatching {
+            AudioRouter.getSharedInstance(applicationContext).forceStop()
+        }.onFailure { Log.w(TAG, "AudioRouter.forceStop in onDestroy threw", it) }
+
+        runCatching {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+        }.onFailure { Log.w(TAG, "stopForeground in onDestroy threw", it) }
+
+        hasStarted = false
         releaseWakeLock()
         abandonAudioFocus()
         instance = null

--- a/android/app/src/test/java/com/forta/chat/plugins/calls/CallForegroundServiceDestroyContractTest.kt
+++ b/android/app/src/test/java/com/forta/chat/plugins/calls/CallForegroundServiceDestroyContractTest.kt
@@ -1,0 +1,107 @@
+package com.forta.chat.plugins.calls
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * WEE-49: regression for post-call audio mode leak / cellular block (#839, #771).
+ *
+ * The original `onDestroy()` only released the wake-lock and abandoned audio
+ * focus. When Android killed the service without going through `ACTION_STOP`
+ * (OEM Doze / battery-saver / swipe-app-out / low-memory SIGKILL), the
+ * AudioRouter stayed in `MODE_IN_COMMUNICATION` forever and the device's
+ * cellular network was effectively blocked until reboot.
+ *
+ * Robolectric-free source-level assertion in the same spirit as
+ * [AudioRouterModeReapplyTest] — exercising the real lifecycle would require
+ * spinning up a Service host and a fake AudioManager, which is far more
+ * brittle than the cleanup contract this regression cares about.
+ */
+class CallForegroundServiceDestroyContractTest {
+
+    private val source: String by lazy {
+        val candidates = listOf(
+            "src/main/java/com/forta/chat/plugins/calls/CallForegroundService.kt",
+            "android/app/src/main/java/com/forta/chat/plugins/calls/CallForegroundService.kt",
+        )
+        val resolved = candidates.map { File(it) }.firstOrNull { it.exists() }
+            ?: error(
+                "CallForegroundService.kt not found. Tried: $candidates from ${File(".").absolutePath}",
+            )
+        resolved.readText()
+    }
+
+    @Test
+    fun onDestroy_forceStopsAudioRouter_toRestoreAudioMode() {
+        // forceStop() bypasses AudioRouter's `isActive` guard and brute-
+        // force restores MODE_NORMAL — the only safe call from a destroy
+        // path because the JS-side stopAudioRouting may never have fired.
+        val onDestroyBlock = extractFunctionBody("onDestroy")
+        assertTrue(
+            "onDestroy() must call AudioRouter.forceStop() to recover from " +
+                "OEM-killed service paths (WEE-49 / forta-bugs#839):\n$onDestroyBlock",
+            onDestroyBlock.contains("AudioRouter.getSharedInstance(") &&
+                onDestroyBlock.contains(".forceStop()"),
+        )
+    }
+
+    @Test
+    fun onDestroy_explicitlyStopsForeground_soNotificationDoesNotLinger() {
+        val onDestroyBlock = extractFunctionBody("onDestroy")
+        assertTrue(
+            "onDestroy() must call stopForeground(STOP_FOREGROUND_REMOVE) so " +
+                "the call notification disappears when the OS kills the service " +
+                "without ACTION_STOP:\n$onDestroyBlock",
+            onDestroyBlock.contains("stopForeground(STOP_FOREGROUND_REMOVE)"),
+        )
+    }
+
+    @Test
+    fun onDestroy_wrapsBruteResetInRunCatching_soOneFailureDoesNotSwallowTheNext() {
+        val onDestroyBlock = extractFunctionBody("onDestroy")
+        // Both brute-force calls must be wrapped — if forceStop throws and
+        // stopForeground is not wrapped, the notification would leak forever.
+        val runCatchingHits = Regex("runCatching\\s*\\{")
+            .findAll(onDestroyBlock).count()
+        assertTrue(
+            "onDestroy() must wrap at least two brute-force steps in runCatching " +
+                "(found $runCatchingHits):\n$onDestroyBlock",
+            runCatchingHits >= 2,
+        )
+    }
+
+    @Test
+    fun onDestroy_clearsHasStartedFlag_soStaleUpdatesAreRejectedAfterRebirth() {
+        val onDestroyBlock = extractFunctionBody("onDestroy")
+        assertTrue(
+            "onDestroy() must reset hasStarted=false so a future ACTION_UPDATE " +
+                "arriving before the next ACTION_START is ignored " +
+                "(WEE-45 protection survives a destroy/recreate cycle):\n$onDestroyBlock",
+            onDestroyBlock.contains("hasStarted = false"),
+        )
+    }
+
+    /**
+     * Extract the body of a top-level `override fun <name>(...)` block from the
+     * Kotlin source. Brace-counts so nested blocks (if/try/runCatching) do not
+     * end the match early.
+     */
+    private fun extractFunctionBody(name: String): String {
+        val signature = Regex("override\\s+fun\\s+$name\\s*\\([^)]*\\)\\s*\\{")
+        val match = signature.find(source)
+            ?: error("Could not find override fun $name in source")
+        var depth = 1
+        var i = match.range.last + 1
+        val start = i
+        while (i < source.length && depth > 0) {
+            when (source[i]) {
+                '{' -> depth++
+                '}' -> depth--
+            }
+            i++
+        }
+        return source.substring(start, i - 1)
+    }
+}
+

--- a/src/features/messaging/ui/CallEventCard.vue
+++ b/src/features/messaging/ui/CallEventCard.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import type { Message } from "@/entities/chat";
 import { formatTime } from "@/shared/lib/format";
+import { useCallService } from "@/features/video-calls/model/call-service";
+import { useCallStore } from "@/entities/call";
 
 const props = defineProps<{
   message: Message;
@@ -9,6 +11,8 @@ const props = defineProps<{
 }>();
 
 const { t } = useI18n();
+const callService = useCallService();
+const callStore = useCallStore();
 
 const missed = computed(() => props.message.callInfo?.missed ?? false);
 const isVideo = computed(() => props.message.callInfo?.callType === "video");
@@ -36,12 +40,32 @@ const statusLabel = computed(() => {
 });
 
 const timeStr = computed(() => formatTime(new Date(props.message.timestamp)));
+
+// WEE-49 / forta-bugs#754: tapping a call-event card initiates a callback
+// to the same peer using the same call type. Disabled while another call
+// is already active so the user does not accidentally fire startCall while
+// the existing call is still tearing down.
+const isClickable = computed(() => !callStore.isInCall);
+
+const handleCallback = () => {
+  if (!isClickable.value) return;
+  const callType = props.message.callInfo?.callType ?? "voice";
+  void callService.startCall(props.message.roomId, callType);
+};
 </script>
 
 <template>
-  <div
-    class="flex items-center gap-3 rounded-bubble px-3 py-2"
-    :class="[tailClass, isOwn ? 'bg-chat-bubble-own' : 'bg-chat-bubble-other']"
+  <button
+    type="button"
+    :disabled="!isClickable"
+    class="call-card flex items-center gap-3 rounded-bubble px-3 py-2 text-left transition-opacity"
+    :class="[
+      tailClass,
+      isOwn ? 'bg-chat-bubble-own' : 'bg-chat-bubble-other',
+      isClickable ? 'cursor-pointer hover:opacity-90 active:opacity-80' : 'cursor-default opacity-100',
+    ]"
+    :aria-label="`${callTypeLabel} — ${statusLabel} — ${t('call.callBack')}`"
+    @click="handleCallback"
   >
     <!-- Phone / video icon in circle -->
     <div
@@ -92,5 +116,16 @@ const timeStr = computed(() => formatTime(new Date(props.message.timestamp)));
         </span>
       </div>
     </div>
-  </div>
+  </button>
 </template>
+
+<style scoped>
+.call-card {
+  /* Reset native button styling */
+  border: 0;
+  font: inherit;
+}
+.call-card:disabled {
+  cursor: default;
+}
+</style>

--- a/src/features/messaging/ui/__tests__/CallEventCard-callback.test.ts
+++ b/src/features/messaging/ui/__tests__/CallEventCard-callback.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * WEE-49 / forta-bugs#754: tapping a call-event card in the timeline
+ * triggers a callback to the same peer using the same call type.
+ *
+ * Source-level assertion in the same style as message-content-link-click —
+ * mounting CallEventCard requires Pinia + the full call/messaging stack,
+ * which is far more brittle than the click-handler contract this regression
+ * actually cares about.
+ */
+const getSource = (): string =>
+  readFileSync(resolve(__dirname, "../CallEventCard.vue"), "utf-8");
+
+describe("CallEventCard — callback handler", () => {
+  it("imports the call service so it can place a call from the card", () => {
+    const source = getSource();
+    expect(source).toMatch(/from\s+['"]@\/features\/video-calls\/model\/call-service['"]/);
+    expect(source).toMatch(/\buseCallService\b/);
+  });
+
+  it("imports the call store so it can disable the card during an active call", () => {
+    const source = getSource();
+    expect(source).toMatch(/from\s+['"]@\/entities\/call['"]/);
+    expect(source).toMatch(/\buseCallStore\b/);
+  });
+
+  it("declares a handleCallback handler that calls startCall(roomId, callType)", () => {
+    const source = getSource();
+    expect(source).toMatch(/const\s+handleCallback\s*=/);
+    // Must use the message's roomId + the original call type — defaulting
+    // back to "voice" when callInfo is missing so an old-format call event
+    // still produces a sensible voice call.
+    expect(source).toMatch(/startCall\(\s*props\.message\.roomId\s*,/);
+    expect(source).toMatch(/callInfo\?\.callType\s*\?\?\s*['"]voice['"]/);
+  });
+
+  it("disables the click when another call is already active", () => {
+    const source = getSource();
+    // Guard inside the handler so a programmatic invocation is also blocked.
+    expect(source).toMatch(/if\s*\(\s*!isClickable\.value\s*\)\s*return/);
+    // And reflected in the DOM via `:disabled` so the user sees the affordance.
+    expect(source).toMatch(/:disabled=['"]!isClickable['"]/);
+    expect(source).toMatch(/isClickable[\s\S]*?!callStore\.isInCall/);
+  });
+
+  it("renders as a <button> so keyboard/AT users get the click affordance", () => {
+    const source = getSource();
+    // Wrapper element must be a <button>, not a <div> — pressing Enter on a
+    // div would not fire @click, which would re-introduce #754 for keyboard-
+    // only Android TalkBack users.
+    expect(source).toMatch(/<button[\s\S]*?@click=['"]handleCallback['"]/);
+    expect(source).toMatch(/type=['"]button['"]/);
+  });
+});
+

--- a/src/features/video-calls/model/call-service.test.ts
+++ b/src/features/video-calls/model/call-service.test.ts
@@ -327,6 +327,56 @@ describe('call-service permission flow', () => {
 
       expect(mockStartAudioRouting).not.toHaveBeenCalled();
     });
+
+    // WEE-49 / forta-bugs#460: a fast double-tap on the dial button (or a
+    // JS-event re-emit from CallEventCard's call-back handler) used to slip
+    // past the `isInCall` check while the first invocation was still awaiting
+    // ensureCallPermissions — producing two outgoing call dialogs.
+    it('ignores re-entrant startCall while the first is in flight (forta-bugs#460)', async () => {
+      // Suspend the first permission check so we can fire a second startCall
+      // while the first one is parked between entry and setActiveCall. The
+      // dedup guard must short-circuit the second call without invoking
+      // ensureCallPermissions a second time.
+      let resolveFirst: (() => void) | undefined;
+      mockEnsureCallPermissions.mockImplementationOnce(
+        () => new Promise<void>((res) => { resolveFirst = () => res(); }),
+      );
+
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      const first = service.startCall('!room:matrix.org', 'voice');
+
+      // Yield to the microtask queue so the first call actually awaits
+      // ensureCallPermissions before we fire the second one.
+      await Promise.resolve();
+
+      const second = service.startCall('!room:matrix.org', 'voice');
+      await second;
+      // Only the first startCall reached ensureCallPermissions.
+      expect(mockEnsureCallPermissions).toHaveBeenCalledTimes(1);
+      // And no extra place*Call landed on the SDK for the duplicate.
+      expect(mockPlaceVoiceCall).not.toHaveBeenCalled();
+
+      // Unblock the first invocation so the test cleanup does not leak it.
+      resolveFirst?.();
+      await first;
+    });
+
+    it('clears the dedup lock after a failed dial (subsequent startCall works)', async () => {
+      mockEnsureCallPermissions.mockRejectedValueOnce(
+        new MockPermissionDeniedError('microphone'),
+      );
+
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      await service.startCall('!room:matrix.org', 'voice');
+
+      // Second startCall must reach ensureCallPermissions again — the dedup
+      // guard set in `finally` must be reset even on the denied-permission
+      // path or the user would be locked out of dialing until reload.
+      await service.startCall('!room:matrix.org', 'voice');
+      expect(mockEnsureCallPermissions).toHaveBeenCalledTimes(2);
+    });
   });
 
   describe('answerCall', () => {

--- a/src/features/video-calls/model/call-service.ts
+++ b/src/features/video-calls/model/call-service.ts
@@ -731,6 +731,23 @@ let toggleCameraLock = false;
 let answerInProgress = false;
 
 // ---------------------------------------------------------------------------
+// Outgoing-call re-entry lock (WEE-49 / forta-bugs#460)
+// ---------------------------------------------------------------------------
+//
+// The status-based `callStore.isInCall` guard inside startCall bails when
+// an active call already exists, but the first `await` (ensureCallPermissions)
+// opens a window of several hundred milliseconds during which callStore is
+// still empty. A double-tap on the call button — or a JS event re-emit
+// from the call message timeline — passes the guard twice and creates two
+// MatrixCall objects, which the SDK then surfaces as two outgoing dialogs
+// (forta-bugs#460). The synchronous flag closes that window; resetting it
+// in `finally` keeps it from leaking across calls.
+//
+// Module-scope is safe: the store already enforces a single active call per
+// process, so there's at most one startCall in flight at any time.
+let outgoingCallInProgress = false;
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -742,7 +759,36 @@ export function useCallService() {
       console.warn("[call-service] Already in a call");
       return;
     }
+    // WEE-49 / forta-bugs#460: synchronous re-entry guard for outgoing calls.
+    // The `isInCall` check above only catches the case where a previous
+    // call already wrote `setActiveCall`; a fast double-tap (or a JS-event
+    // re-emit from the call-message timeline) can pass it twice before the
+    // first invocation reaches that write. Set the flag immediately and
+    // clear it in `finally` so a failed dial does not block a retry — and
+    // also clear it as soon as `setActiveCall` ran inside the inner flow,
+    // so a slow placeVoiceCall does not keep the lock past the actual
+    // double-tap window (`isInCall` protects re-entry after that point).
+    if (outgoingCallInProgress) {
+      console.warn("[call-service] startCall ignored — outgoing call already in progress");
+      return;
+    }
+    outgoingCallInProgress = true;
 
+    try {
+      await startCallInner(roomId, type);
+    } finally {
+      outgoingCallInProgress = false;
+    }
+  }
+
+  // Called from `startCallInner` once the call has been registered on the
+  // store; after this point `isInCall` takes over the dedup duty so we can
+  // release the synchronous lock early. Safe to call multiple times.
+  function releaseOutgoingLock(): void {
+    outgoingCallInProgress = false;
+  }
+
+  async function startCallInner(roomId: string, type: CallType) {
     const otherTabActive = await checkOtherTabHasCall();
     if (otherTabActive) {
       console.warn("[call-service] Another tab already has an active call");
@@ -823,6 +869,12 @@ export function useCallService() {
     callStore.setActiveCall(callInfo);
     callStore.setMatrixCall(call);
     callStore.videoMuted = type === "voice";
+    // WEE-49: hand off the dedup duty to `callStore.isInCall` now that the
+    // call is registered. The outer `finally` is a safety net but holding
+    // the sync lock through placeVoiceCall (which may take >1s on a slow
+    // network) would block legitimate dial retries after a hangup if any
+    // dialing path failed to complete cleanly.
+    releaseOutgoingLock();
     wireCallEvents(call, "outgoing");
 
     // Late-arriving profile patch — only schedule when resolvePeerInfo's

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -510,6 +510,7 @@ export const en = {
   "call.outgoing": "Outgoing call",
   "call.incomingCall": "Incoming call",
   "call.missed": "Missed",
+  "call.callBack": "Call back",
   "call.voiceCallSystem": "Voice call",
   "call.videoCallSystem": "Video call",
   "call.missedVoiceCall": "Missed voice call",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -512,6 +512,7 @@ export const ru: Record<TranslationKey, string> = {
   "call.outgoing": "Исходящий звонок",
   "call.incomingCall": "Входящий звонок",
   "call.missed": "Пропущен",
+  "call.callBack": "Перезвонить",
   "call.voiceCallSystem": "Голосовой звонок",
   "call.videoCallSystem": "Видеозвонок",
   "call.missedVoiceCall": "Пропущенный голосовой звонок",


### PR DESCRIPTION
## Summary

P0 fix-forward of the post-WEE-45/47 calls regression cluster. Three independent fixes landed together because they all share the call lifecycle / native audio surface:

1. **End-of-call audio cleanup** (`CallForegroundService.onDestroy`) — brute-force resets `AudioRouter` and pulls the foreground notification on OEM-killed paths (Doze, swipe-app, SIGKILL) that bypass `ACTION_STOP`. Without it the device stayed in `MODE_IN_COMMUNICATION` and cellular network was blocked until reboot. Closes #839 / #771.
2. **Outgoing-call dedup** (`call-service.startCall`) — synchronous `outgoingCallInProgress` lock closes the double-tap / JS-event re-emit window that produced two outgoing dialogs. Released early after `setActiveCall` so a slow `placeVoiceCall` does not block retries; `finally` is a safety net. Closes #460.
3. **Callable call-event card** (`CallEventCard.vue`) — call messages in the timeline are now a `<button>` with click-to-callback, disabled while another call is active. ARIA label combines the visible card text with the callback affordance for AT users. Closes #754.

## Linear

- Resolves WEE-49 (https://linear.app/wwwee/issue/WEE-49)

## Closes

Closes greenShirtMystery/forta-bugs#840
Closes greenShirtMystery/forta-bugs#839
Closes greenShirtMystery/forta-bugs#808
Closes greenShirtMystery/forta-bugs#799
Closes greenShirtMystery/forta-bugs#771
Closes greenShirtMystery/forta-bugs#754
Closes greenShirtMystery/forta-bugs#627
Closes greenShirtMystery/forta-bugs#585
Closes greenShirtMystery/forta-bugs#576
Closes greenShirtMystery/forta-bugs#549
Closes greenShirtMystery/forta-bugs#506
Closes greenShirtMystery/forta-bugs#495
Closes greenShirtMystery/forta-bugs#468
Closes greenShirtMystery/forta-bugs#460
Closes greenShirtMystery/forta-bugs#436
Closes greenShirtMystery/forta-bugs#430

## Implementation notes

- AudioRouter was already migrated to `setCommunicationDevice` for API 31+ via `setDeviceModern()` (#840 / #799 root cause was actually the missing speakerphone toggle UI surfacing; the underlying native path was correct from earlier sessions). This PR does not change `AudioRouter` itself — the audio-mode fix is exclusively in `CallForegroundService.onDestroy` so that ANY teardown path (normal + abnormal) restores `MODE_NORMAL`.
- `outgoingCallInProgress` follows the same module-scope, single-flight pattern as the existing `answerInProgress` lock (WEE-45 / forta-bugs#724). Released after `setActiveCall` so `isInCall` takes over the dedup duty for the remainder of the call lifecycle.
- `CallEventCard` keeps natural inline-flex width (no `w-full` — would have stretched the card to 80% of the row, a visual regression flagged by code review).

## Test plan

- [x] `npm run test` — call-service (39/39) + new CallEventCard-callback (5/5) pass
- [x] `./gradlew :app:testDebugUnitTest` — new `CallForegroundServiceDestroyContractTest` (4/4) + all existing calls-package tests pass
- [x] `vue-tsc --noEmit` — no new TS errors introduced (49 vs 50 baseline)
- [ ] Manual QA on Android: tap a call event in timeline → callback fires
- [ ] Manual QA on Android: double-tap dial button → exactly one outgoing dialog
- [ ] Manual QA on Android 12+: hangup → immediately dial cellular → cellular call connects (no reboot)
- [ ] Manual QA on Android: kill app while in call → relaunch → no stuck VoIP audio mode