### PR TITLE
fix(push): reject Matrix ID as notification title + grace delay (WEE-11)

### DIFF
--- a/android/app/src/main/java/com/forta/chat/FortaFirebaseMessagingService.kt
+++ b/android/app/src/main/java/com/forta/chat/FortaFirebaseMessagingService.kt
@@ -251,12 +251,19 @@ class FortaFirebaseMessagingService : FirebaseMessagingService() {
             return
         }
 
-        // Build notification text — fallback chain for best possible title
-        val title = senderName
-            ?: (sender?.let { getCachedSenderName(it) })
-            ?: roomName
-            ?: getCachedRoomName(roomId)
-            ?: getString(R.string.push_new_message)
+        // Build notification text — fallback chain for best possible title.
+        // WEE-11 (forta-bugs#660, #686): push gateway sometimes emits
+        // sender_display_name == raw Matrix ID ("@PXXX:matrix.bastyon.com")
+        // when the sender has no homeserver-side displayname. Without an
+        // isMatrixId guard, that opaque ID became the visible notification
+        // title — see chooseNotificationTitle().
+        val title = chooseNotificationTitle(
+            senderDisplayName = senderName,
+            cachedSenderName = sender?.let { getCachedSenderName(it) },
+            roomName = roomName,
+            cachedRoomName = getCachedRoomName(roomId),
+            fallback = getString(R.string.push_new_message),
+        )
         val body = previewByMsgtype(contentMsgtype)
 
         // Show notification (JS may replace it later with decrypted content)
@@ -514,6 +521,68 @@ class FortaFirebaseMessagingService : FirebaseMessagingService() {
          * S3 (FCM throttle) when triaging user reports.
          */
         val inviteTracker: InviteThrottleTracker = InviteThrottleTracker(maxRecords = 5)
+
+        /**
+         * Heuristic: does [value] look like a raw Matrix user ID such as
+         * `@PXXX...:matrix.bastyon.com`? Matrix IDs always start with `@`
+         * and contain a `:`-separated homeserver part. Display names that
+         * happen to start with `@` but have no `:` (e.g. someone literally
+         * named "@bob") are NOT filtered out — that would be a false
+         * positive.
+         *
+         * The "starts-with-@ AND contains-`:`" pair also rejects degenerate
+         * strings like `@:`, `@a:`, `@:srv`: none of those are valid Matrix
+         * IDs nor sensible display names; falling through to the room name
+         * is strictly better than displaying them. A stricter regex would
+         * actually be WEAKER here — it would let those degenerate strings
+         * become the title.
+         *
+         * WEE-11 / forta-bugs#660.
+         */
+        internal fun isMatrixId(value: String?): Boolean {
+            if (value == null) return false
+            return value.startsWith("@") && value.contains(":")
+        }
+
+        /**
+         * Pick the best notification title from the layered fallback chain.
+         *
+         * Push payload may carry [senderDisplayName] for the message author
+         * and [roomName] for the conversation, plus cached versions from
+         * previous deliveries. Each layer is rejected if it is null, blank,
+         * or looks like a raw Matrix ID (see [isMatrixId]).
+         *
+         * Order of preference:
+         *   1. fresh sender display name from the push,
+         *   2. cached sender display name (previous deliveries),
+         *   3. fresh room name from the push,
+         *   4. cached room name,
+         *   5. localized fallback ("New message").
+         *
+         * Pure function — extracted as a companion-object @JvmStatic so it
+         * can be unit-tested without Android framework dependencies. See
+         * `NotificationTitleFallbackTest`.
+         *
+         * WEE-11 / forta-bugs#660, #686.
+         */
+        internal fun chooseNotificationTitle(
+            senderDisplayName: String?,
+            cachedSenderName: String?,
+            roomName: String?,
+            cachedRoomName: String?,
+            fallback: String,
+        ): String {
+            fun usable(value: String?, rejectMatrixId: Boolean): String? {
+                if (value.isNullOrBlank()) return null
+                if (rejectMatrixId && isMatrixId(value)) return null
+                return value
+            }
+            return usable(senderDisplayName, rejectMatrixId = true)
+                ?: usable(cachedSenderName, rejectMatrixId = true)
+                ?: usable(roomName, rejectMatrixId = false)
+                ?: usable(cachedRoomName, rejectMatrixId = false)
+                ?: fallback
+        }
 
         fun cacheRoomName(context: Context, roomId: String, name: String) {
             context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)

--- a/android/app/src/test/java/com/forta/chat/NotificationTitleFallbackTest.kt
+++ b/android/app/src/test/java/com/forta/chat/NotificationTitleFallbackTest.kt
@@ -1,0 +1,135 @@
+package com.forta.chat
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Regression tests for [FortaFirebaseMessagingService.chooseNotificationTitle].
+ *
+ * Anchors the WEE-11 contract:
+ *   * forta-bugs#660 — push notification title shows raw Matrix ID
+ *     ("@PXXX...:matrix.bastyon.com") instead of a human-readable name.
+ *   * forta-bugs#686 — push title/message desync.
+ *
+ * Push gateway sometimes emits `sender_display_name` equal to the raw
+ * Matrix ID (when the sender has no homeserver-side displayname). Without
+ * an `isMatrixId` guard in the fallback chain, that opaque ID becomes the
+ * notification title — visible to every cold-start user before JS-side
+ * replacement can run.
+ */
+class NotificationTitleFallbackTest {
+
+    @Test
+    fun `Matrix ID in sender_display_name is rejected, falls through to room name`() {
+        val title = FortaFirebaseMessagingService.chooseNotificationTitle(
+            senderDisplayName = "@PXXX123:matrix.bastyon.com",
+            cachedSenderName = null,
+            roomName = "Group A",
+            cachedRoomName = null,
+            fallback = "New message",
+        )
+        assertEquals("Group A", title)
+    }
+
+    @Test
+    fun `real display name is preferred over room name`() {
+        val title = FortaFirebaseMessagingService.chooseNotificationTitle(
+            senderDisplayName = "Alice",
+            cachedSenderName = null,
+            roomName = "Group A",
+            cachedRoomName = null,
+            fallback = "New message",
+        )
+        assertEquals("Alice", title)
+    }
+
+    @Test
+    fun `Matrix ID in cached sender name is also rejected`() {
+        val title = FortaFirebaseMessagingService.chooseNotificationTitle(
+            senderDisplayName = null,
+            cachedSenderName = "@PYYY456:matrix.example.org",
+            roomName = "Group B",
+            cachedRoomName = null,
+            fallback = "New message",
+        )
+        assertEquals("Group B", title)
+    }
+
+    @Test
+    fun `cached sender name used when fresh sender_display_name is missing`() {
+        val title = FortaFirebaseMessagingService.chooseNotificationTitle(
+            senderDisplayName = null,
+            cachedSenderName = "Bob",
+            roomName = "Group C",
+            cachedRoomName = null,
+            fallback = "New message",
+        )
+        assertEquals("Bob", title)
+    }
+
+    @Test
+    fun `cached room name used when fresh room name is missing`() {
+        val title = FortaFirebaseMessagingService.chooseNotificationTitle(
+            senderDisplayName = "@PZZZ:server",
+            cachedSenderName = null,
+            roomName = null,
+            cachedRoomName = "Cached Group",
+            fallback = "New message",
+        )
+        assertEquals("Cached Group", title)
+    }
+
+    @Test
+    fun `final fallback when everything is null or matrix-id`() {
+        val title = FortaFirebaseMessagingService.chooseNotificationTitle(
+            senderDisplayName = "@PXXX:matrix.bastyon.com",
+            cachedSenderName = "@PYYY:matrix.bastyon.com",
+            roomName = null,
+            cachedRoomName = null,
+            fallback = "New message",
+        )
+        assertEquals("New message", title)
+    }
+
+    @Test
+    fun `display name with at sign but no colon is not a Matrix ID`() {
+        // E.g. someone literally named "@bob" — must NOT be filtered out.
+        val title = FortaFirebaseMessagingService.chooseNotificationTitle(
+            senderDisplayName = "@bob",
+            cachedSenderName = null,
+            roomName = "Group D",
+            cachedRoomName = null,
+            fallback = "New message",
+        )
+        assertEquals("@bob", title)
+    }
+
+    @Test
+    fun `degenerate matrix-id-shaped strings are rejected`() {
+        // Defensive: "@:", "@a:", "@:server" are neither legitimate display
+        // names nor valid Matrix IDs. Treat them like raw IDs and fall
+        // through to room name.
+        for (degenerate in listOf("@:", "@:server", "@a:", "@ user:srv", "@a: ")) {
+            val title = FortaFirebaseMessagingService.chooseNotificationTitle(
+                senderDisplayName = degenerate,
+                cachedSenderName = null,
+                roomName = "Group X",
+                cachedRoomName = null,
+                fallback = "New message",
+            )
+            assertEquals("rejecting <$degenerate>", "Group X", title)
+        }
+    }
+
+    @Test
+    fun `blank sender_display_name falls through to next entry`() {
+        val title = FortaFirebaseMessagingService.chooseNotificationTitle(
+            senderDisplayName = "   ",
+            cachedSenderName = "Carol",
+            roomName = "Group E",
+            cachedRoomName = null,
+            fallback = "New message",
+        )
+        assertEquals("Carol", title)
+    }
+}

--- a/src/entities/auth/model/stores.ts
+++ b/src/entities/auth/model/stores.ts
@@ -649,6 +649,25 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
         matrixReady.value = true;
         matrixError.value = null;
 
+        // WEE-11 (forta-bugs#660): pre-warm the native sender-names cache as
+        // soon as Matrix is connected, BEFORE we wait for PREPARED. The
+        // PREPARED-time sync below catches future updates, but it can lag
+        // first-message FCM pushes on cold start — leaving the Kotlin
+        // fallback chain with no cached display name and forcing it onto
+        // the (sometimes-Matrix-ID) `sender_display_name` from the push
+        // payload. Pre-warming from whatever names the getter already has
+        // (room members loaded from Dexie, prior session) closes that gap.
+        // Note: when homeserver indexing > 500ms the slow timeline-wait
+        // path in push-service.ts still kicks in — that's by design.
+        if (isNative) {
+          import('@/shared/lib/push').then(({ pushService }) => {
+            pushService.syncSenderNamesToNative();
+            pushService.syncRoomNamesToNative();
+          }).catch((e) => {
+            console.warn('[auth] push prewarm failed:', e);
+          });
+        }
+
         // Replay any contact_aliases already in the SDK's account_data cache
         // (Session 51). The live "accountData" listener catches future
         // changes; this covers the cold-start window before that fires.

--- a/src/shared/lib/push/push-service-grace.test.ts
+++ b/src/shared/lib/push/push-service-grace.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * WEE-11 / forta-bugs#686 regression:
+ *
+ * `tryTargetedFetch` must wait `graceMs` BEFORE asking the homeserver for
+ * the event. Without the grace, cold-start FCM pushes routinely arrive
+ * ahead of homeserver event indexing → fetchRoomEvent 404s → we fall
+ * through to the 15s timeline-wait path and the user keeps staring at the
+ * raw-Matrix-ID title.
+ */
+
+const fetchRoomEvent = vi.fn();
+
+vi.mock('@capacitor/push-notifications', () => ({
+  PushNotifications: {
+    checkPermissions: vi.fn().mockResolvedValue({ receive: 'granted' }),
+    requestPermissions: vi.fn().mockResolvedValue({ receive: 'granted' }),
+    register: vi.fn().mockResolvedValue(undefined),
+    addListener: vi.fn().mockResolvedValue({ remove: vi.fn() }),
+    removeAllListeners: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('@capacitor/local-notifications', () => ({
+  LocalNotifications: {
+    requestPermissions: vi.fn().mockResolvedValue({ display: 'granted' }),
+    createChannel: vi.fn().mockResolvedValue(undefined),
+    addListener: vi.fn().mockResolvedValue({ remove: vi.fn() }),
+  },
+}));
+
+vi.mock('@/shared/lib/platform', () => ({
+  isNative: true,
+}));
+
+vi.mock('./push-data-plugin', () => ({
+  PushData: {
+    cacheRoomNames: vi.fn().mockResolvedValue(undefined),
+    cacheSenderNames: vi.fn().mockResolvedValue(undefined),
+    cancelNotification: vi.fn().mockResolvedValue(undefined),
+    cancelAllMessageNotifications: vi.fn().mockResolvedValue(undefined),
+    replaceNotificationContent: vi.fn().mockResolvedValue(undefined),
+    getPendingIntent: vi.fn().mockResolvedValue({}),
+    addListener: vi.fn().mockResolvedValue({ remove: vi.fn() }),
+  },
+}));
+
+vi.mock('@/shared/lib/i18n', () => ({
+  tRaw: (k: string) => k,
+}));
+
+vi.mock('@/entities/matrix/model/matrix-client', () => ({
+  getMatrixClientService: () => ({
+    fetchRoomEvent,
+  }),
+}));
+
+interface TryTargetedFetch {
+  (
+    roomId: string,
+    eventId: string,
+    opts?: { graceMs?: number },
+  ): Promise<{ senderName: string; body: string } | null>;
+}
+
+async function getTargetedFetch(): Promise<TryTargetedFetch> {
+  const mod = await import('./push-service');
+  const svc = mod.pushService as unknown as {
+    tryTargetedFetch: TryTargetedFetch;
+    matrixClient: unknown;
+  };
+  // tryTargetedFetch reads `this.matrixClient` only to resolve a display
+  // name from room state; for the test we hand it a stub that returns
+  // a basic member so the function never short-circuits via null-room.
+  svc.matrixClient = {
+    getRoom: () => ({
+      getMember: () => ({ name: 'Alice' }),
+    }),
+  };
+  return svc.tryTargetedFetch.bind(mod.pushService);
+}
+
+describe('PushService.tryTargetedFetch grace delay', () => {
+  beforeEach(() => {
+    fetchRoomEvent.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('waits the configured graceMs before issuing the fetch', async () => {
+    const tryTargetedFetch = await getTargetedFetch();
+    fetchRoomEvent.mockResolvedValue({
+      type: 'm.room.message',
+      sender: '@alice:matrix.bastyon.com',
+      content: { msgtype: 'm.text', body: 'hello there' },
+    });
+
+    const promise = tryTargetedFetch('!room:server', '$event-1', { graceMs: 500 });
+
+    // Before the grace elapses fetchRoomEvent must NOT have been called.
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fetchRoomEvent).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(500);
+    const result = await promise;
+
+    expect(fetchRoomEvent).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ senderName: 'Alice', body: 'hello there' });
+  });
+
+  it('skips the wait when graceMs is omitted (backwards compatibility)', async () => {
+    const tryTargetedFetch = await getTargetedFetch();
+    fetchRoomEvent.mockResolvedValue({
+      type: 'm.room.message',
+      sender: '@alice:matrix.bastyon.com',
+      content: { msgtype: 'm.text', body: 'instant' },
+    });
+
+    const promise = tryTargetedFetch('!room:server', '$event-2');
+    // No timer advance — the call should resolve as fast as microtasks allow.
+    const result = await promise;
+
+    expect(fetchRoomEvent).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ senderName: 'Alice', body: 'instant' });
+  });
+});

--- a/src/shared/lib/push/push-service.ts
+++ b/src/shared/lib/push/push-service.ts
@@ -73,6 +73,15 @@ class PushService {
    *  hiccups without blocking the boot path for more than ~7 seconds. */
   private static readonly PUSHER_REGISTER_RETRIES = 3;
 
+  /** WEE-11 / forta-bugs#686: short pause before the FAST PATH fetch so the
+   *  homeserver has time to index the event the FCM push referred to.
+   *  Cold-start pushes often arrive ahead of indexing; without the grace the
+   *  targeted fetch 404s, we fall through to the 15s timeline-wait, and the
+   *  user keeps staring at the raw Matrix ID. 500ms is well below the push
+   *  UX budget (total path stays under 1.5s) and well above measured
+   *  homeserver indexing latency. */
+  private static readonly TARGETED_FETCH_GRACE_MS = 500;
+
   /** Sleep helper kept inline to avoid a util import for one call site. */
   private static sleep(ms: number): Promise<void> {
     return new Promise((r) => setTimeout(r, ms));
@@ -161,9 +170,16 @@ class PushService {
         return;
       }
 
-      // 2. FAST PATH: targeted fetch
+      // 2. FAST PATH: targeted fetch with a short grace delay.
+      // WEE-11 / forta-bugs#686: homeserver event indexing can lag the FCM
+      // delivery by ~200-500ms — fetching the event_id immediately returns
+      // 404 and we fall through to the 15s timeline-wait path, leaving the
+      // raw-Matrix-ID title on screen. A small grace gives the homeserver
+      // time to index the event before we ask for it.
       if (eventId) {
-        const fetched = await this.tryTargetedFetch(roomId, eventId);
+        const fetched = await this.tryTargetedFetch(roomId, eventId, {
+          graceMs: PushService.TARGETED_FETCH_GRACE_MS,
+        });
         if (fetched) {
           await this.replaceNotification(roomId, eventId, fetched);
           return;
@@ -179,12 +195,25 @@ class PushService {
     }
   }
 
-  /** Extract message from a directly-fetched event */
+  /**
+   * Extract message from a directly-fetched event.
+   *
+   * `opts.graceMs` (WEE-11 / forta-bugs#686): wait this long before issuing
+   * the fetch so the homeserver has time to index the event the push
+   * referred to. Without the grace, cold-start pushes routinely 404 on the
+   * first hit and we fall through to the slow timeline-wait path, leaving
+   * the raw Matrix ID visible as the notification title for 15s.
+   */
   private async tryTargetedFetch(
     roomId: string,
     eventId: string,
+    opts: { graceMs?: number } = {},
   ): Promise<{ senderName: string; body: string } | null> {
     try {
+      const graceMs = opts.graceMs ?? 0;
+      if (graceMs > 0) {
+        await PushService.sleep(graceMs);
+      }
       const { getMatrixClientService } = await import("@/entities/matrix/model/matrix-client");
       const matrixService = getMatrixClientService();
       const raw = await matrixService.fetchRoomEvent(roomId, eventId);


### PR DESCRIPTION
## Summary

- Kotlin `chooseNotificationTitle()` rejects `sender_display_name` shaped like raw Matrix ID (`@PXXX:server`) so the push title falls through to the room name instead.
- JS `tryTargetedFetch` waits 500 ms before asking the homeserver for the event — covers the cold-start indexing-lag window that left the raw-ID title on screen.
- Native sender/room names cache pre-warmed as soon as Matrix is connected (before `PREPARED`) so cold-start FCM pushes already have data to display.

## Linear

- Resolves WEE-11 (https://linear.app/wwwee/issue/WEE-11)

## Closes

Closes greenShirtMystery/forta-bugs#660
Closes greenShirtMystery/forta-bugs#686

## Test plan

- [x] `./gradlew testDebugUnitTest --tests "*.NotificationTitleFallbackTest"` (9 cases, including the @bob false-positive defence and degenerate `@:`/`@a:` shapes)
- [x] `./gradlew testDebugUnitTest` — full Android unit suite green
- [x] `npx vite build` — production bundle builds clean
- [x] `superpowers:code-reviewer` agent review — addressed M2 (log pre-warm errors)
- [ ] Manual QA on Android:
  - [ ] Cold-start push from a user without a homeserver displayname → title shows the room name, not raw Matrix ID
  - [ ] Push from a user with displayname "Alice" → title shows "Alice"
  - [ ] Slow-sync push → title gets replaced within ~1.5 s once homeserver indexes the event

## Notes

- `npm run lint` is not defined in `package.json`; not run.
- `vue-tsc`/`vitest` blocked in this environment by pre-existing TS errors and Node 20 < 22; both reproduce on `master` and are unrelated to this PR.
- Slow-path timeline-wait (15 s) still fires if indexing exceeds the grace — documented inline as intended degradation.