### PR TITLE
fix(messaging): web notifier + responsive input + swipe-to-quote + emoji insert (WEE-48)

### DIFF
--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -25,6 +25,8 @@ import { perfMark, perfMeasure, perfCount } from "@/shared/lib/perf-markers";
 import { yieldToMain, yieldEveryN } from "@/shared/lib/yield-to-main";
 import { createPatchScheduler } from "@/shared/lib/patch-scheduler";
 import { isNative } from "@/shared/lib/platform";
+import { notifyNewMessage } from "@/shared/lib/notifications/web-notifier";
+import { tRaw } from "@/shared/lib/i18n";
 
 
 import type { ChatDbKit, ParsedMessage, LocalRoom } from "@/shared/lib/local-db";
@@ -5675,9 +5677,38 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     }
   };
 
+  /**
+   * WEE-48 / forta-bugs#437, #439, #440, #445, #498: web/electron notifier.
+   * Native (Capacitor) ships its own FCM push pipeline via WEE-11, so we
+   * skip this branch there. On web, fire a short beep + tab-title bump +
+   * optional Notification API banner only for new inbound messages in
+   * non-active, non-muted rooms — and only when the tab itself is hidden.
+   * The notifier internally gates on visibility + permission, but we still
+   * filter here to avoid the WebAudio + Notification ctor cost in the common
+   * "active room" case.
+   *
+   * System messages (member changes, room renames, pin events, …) are NOT
+   * surfaced — they ride through `dexieWriteMessage` too but the user
+   * doesn't think of them as "new messages" worth a beep.
+   */
+  const notifyInboundMessageIfBackground = (msg: Message, roomId: string): void => {
+    if (isNative) return;
+    if (msg.type === MessageType.system) return;
+    if (roomId === activeRoomId.value) return;
+    if (mutedRoomIds.value.has(roomId)) return;
+    const myAddr = useAuthStore().address ?? "";
+    if (msg.senderId && myAddr && msg.senderId === myAddr) return;
+    const room = getRoomById(roomId);
+    const title = room?.name || getDisplayName(msg.senderId) || undefined;
+    const fallbackBody = tRaw("notifications.newMessage");
+    const body = msg.content && msg.content !== "[encrypted]" ? msg.content : fallbackBody;
+    notifyNewMessage({ roomId, body, title, fallbackTitle: tRaw("titleBar.appName") });
+  };
+
   /** Dual-write: persist a parsed message to Dexie alongside the in-memory store */
   const dexieWriteMessage = (msg: Message, roomId: string, raw: Record<string, unknown>) => {
     if (!chatDbKitRef.value) return;
+    notifyInboundMessageIfBackground(msg, roomId);
     const isEncrypted = msg.content === "[encrypted]";
     const parsed: ParsedMessage = {
       eventId: raw.event_id as string,

--- a/src/features/messaging/model/__tests__/emoji-insertion.test.ts
+++ b/src/features/messaging/model/__tests__/emoji-insertion.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { insertEmojiAtCursor } from "../emoji-insertion";
+
+describe("insertEmojiAtCursor — WEE-48 / forta-bugs#483, #489", () => {
+  it("inserts at cursor and reports the new caret position", () => {
+    const r = insertEmojiAtCursor({ text: "hello world", selectionStart: 5, selectionEnd: 5, emoji: "😀" });
+    expect(r.text).toBe("hello😀 world");
+    expect(r.cursor).toBe(5 + "😀".length);
+    expect(r.changed).toBe(true);
+  });
+
+  it("replaces the active selection (does not duplicate)", () => {
+    const r = insertEmojiAtCursor({ text: "hello world", selectionStart: 0, selectionEnd: 5, emoji: "👋" });
+    expect(r.text).toBe("👋 world");
+    expect(r.cursor).toBe("👋".length);
+  });
+
+  it("appends to end when selection is at end", () => {
+    const r = insertEmojiAtCursor({ text: "hi", selectionStart: 2, selectionEnd: 2, emoji: "🚀" });
+    expect(r.text).toBe("hi🚀");
+    expect(r.cursor).toBe(2 + "🚀".length);
+  });
+
+  it("is a no-op for an empty emoji (changed=false)", () => {
+    const r = insertEmojiAtCursor({ text: "abc", selectionStart: 1, selectionEnd: 1, emoji: "" });
+    expect(r.changed).toBe(false);
+    expect(r.text).toBe("abc");
+    expect(r.cursor).toBe(1);
+  });
+
+  it("clamps out-of-range selectionStart/End to text length", () => {
+    const r = insertEmojiAtCursor({ text: "abc", selectionStart: 99, selectionEnd: 99, emoji: "✨" });
+    expect(r.text).toBe("abc✨");
+    expect(r.cursor).toBe("abc✨".length);
+  });
+
+  it("handles selectionEnd < selectionStart by ignoring the inversion", () => {
+    const r = insertEmojiAtCursor({ text: "abcdef", selectionStart: 4, selectionEnd: 2, emoji: "⭐" });
+    // start dominates — emit at start, do not delete a backwards range
+    expect(r.text).toBe("abcd⭐ef");
+    expect(r.cursor).toBe(4 + "⭐".length);
+  });
+
+  it("handles NaN selection (e.g. detached textarea) by inserting at start", () => {
+    const r = insertEmojiAtCursor({ text: "abc", selectionStart: Number.NaN, selectionEnd: Number.NaN, emoji: "🎉" });
+    expect(r.text).toBe("🎉abc");
+    expect(r.cursor).toBe("🎉".length);
+  });
+});

--- a/src/features/messaging/model/__tests__/input-layout.test.ts
+++ b/src/features/messaging/model/__tests__/input-layout.test.ts
@@ -2,24 +2,37 @@ import { describe, it, expect } from "vitest";
 import { deriveInputLayout } from "../input-layout";
 
 describe("deriveInputLayout — WEE-48 / forta-bugs#593, #515", () => {
-  it("hides the dedicated PKOIN shortcut on mobile even when donate is supported", () => {
+  it("keeps the PKOIN shortcut visible on mobile while the input is idle", () => {
     const r = deriveInputLayout({ isMobile: true, text: "", showDonate: true });
+    expect(r.showDonateShortcut).toBe(true);
+  });
+
+  it("hides the PKOIN shortcut on mobile as soon as the user starts typing", () => {
+    const r = deriveInputLayout({ isMobile: true, text: "hello", showDonate: true });
     expect(r.showDonateShortcut).toBe(false);
   });
 
-  it("keeps the PKOIN shortcut on desktop when donate is supported", () => {
-    const r = deriveInputLayout({ isMobile: false, text: "", showDonate: true });
-    expect(r.showDonateShortcut).toBe(true);
+  it("keeps the PKOIN shortcut on desktop regardless of text contents", () => {
+    expect(deriveInputLayout({ isMobile: false, text: "", showDonate: true }).showDonateShortcut).toBe(true);
+    expect(deriveInputLayout({ isMobile: false, text: "long message", showDonate: true }).showDonateShortcut).toBe(true);
   });
 
   it("never shows the PKOIN shortcut when the chat does not support donate", () => {
     expect(deriveInputLayout({ isMobile: false, text: "", showDonate: false }).showDonateShortcut).toBe(false);
     expect(deriveInputLayout({ isMobile: true, text: "", showDonate: false }).showDonateShortcut).toBe(false);
+    expect(deriveInputLayout({ isMobile: true, text: "hi", showDonate: false }).showDonateShortcut).toBe(false);
   });
 
-  it("collapses secondary actions on mobile once the textarea has content", () => {
-    expect(deriveInputLayout({ isMobile: true, text: " ", showDonate: true }).showSecondaryActions).toBe(true); // whitespace-only collapses to empty
-    expect(deriveInputLayout({ isMobile: true, text: "hello", showDonate: true }).showSecondaryActions).toBe(false);
+  it("treats whitespace-only text as idle (matches showSecondaryActions semantics)", () => {
+    const r = deriveInputLayout({ isMobile: true, text: "   ", showDonate: true });
+    expect(r.showSecondaryActions).toBe(true);
+    expect(r.showDonateShortcut).toBe(true);
+  });
+
+  it("collapses secondary actions (including PKOIN) on mobile once the user types", () => {
+    const r = deriveInputLayout({ isMobile: true, text: "hello", showDonate: true });
+    expect(r.showSecondaryActions).toBe(false);
+    expect(r.showDonateShortcut).toBe(false);
   });
 
   it("keeps secondary actions on desktop regardless of text", () => {

--- a/src/features/messaging/model/__tests__/input-layout.test.ts
+++ b/src/features/messaging/model/__tests__/input-layout.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { deriveInputLayout } from "../input-layout";
+
+describe("deriveInputLayout — WEE-48 / forta-bugs#593, #515", () => {
+  it("hides the dedicated PKOIN shortcut on mobile even when donate is supported", () => {
+    const r = deriveInputLayout({ isMobile: true, text: "", showDonate: true });
+    expect(r.showDonateShortcut).toBe(false);
+  });
+
+  it("keeps the PKOIN shortcut on desktop when donate is supported", () => {
+    const r = deriveInputLayout({ isMobile: false, text: "", showDonate: true });
+    expect(r.showDonateShortcut).toBe(true);
+  });
+
+  it("never shows the PKOIN shortcut when the chat does not support donate", () => {
+    expect(deriveInputLayout({ isMobile: false, text: "", showDonate: false }).showDonateShortcut).toBe(false);
+    expect(deriveInputLayout({ isMobile: true, text: "", showDonate: false }).showDonateShortcut).toBe(false);
+  });
+
+  it("collapses secondary actions on mobile once the textarea has content", () => {
+    expect(deriveInputLayout({ isMobile: true, text: " ", showDonate: true }).showSecondaryActions).toBe(true); // whitespace-only collapses to empty
+    expect(deriveInputLayout({ isMobile: true, text: "hello", showDonate: true }).showSecondaryActions).toBe(false);
+  });
+
+  it("keeps secondary actions on desktop regardless of text", () => {
+    expect(deriveInputLayout({ isMobile: false, text: "", showDonate: true }).showSecondaryActions).toBe(true);
+    expect(deriveInputLayout({ isMobile: false, text: "long message", showDonate: true }).showSecondaryActions).toBe(true);
+  });
+});

--- a/src/features/messaging/model/emoji-insertion.ts
+++ b/src/features/messaging/model/emoji-insertion.ts
@@ -1,0 +1,43 @@
+/**
+ * Pure emoji-insertion helper extracted from MessageInput for WEE-48 /
+ * forta-bugs#483, #489. The original inline implementation mutated v-model
+ * state but never re-ran the @input pipeline (mention autocomplete, typing
+ * throttle), so the input felt "frozen" after a picker selection and users
+ * had to leave the chat to recover. Keeping the math pure lets us cover
+ * cursor preservation + multi-emoji insertion in isolation.
+ */
+
+export interface InsertEmojiInput {
+  text: string;
+  selectionStart: number;
+  selectionEnd: number;
+  emoji: string;
+}
+
+export interface InsertEmojiResult {
+  text: string;
+  /** New cursor position after insertion — same value for start and end. */
+  cursor: number;
+  /** True when the helper actually mutated the text. False on no-op (empty emoji). */
+  changed: boolean;
+}
+
+/** Insert `emoji` at the current selection and report the new cursor. */
+export const insertEmojiAtCursor = (input: InsertEmojiInput): InsertEmojiResult => {
+  if (!input.emoji) {
+    return { text: input.text, cursor: input.selectionStart, changed: false };
+  }
+  const start = clamp(input.selectionStart, 0, input.text.length);
+  const end = clamp(Math.max(input.selectionEnd, start), 0, input.text.length);
+  const next = input.text.slice(0, start) + input.emoji + input.text.slice(end);
+  return {
+    text: next,
+    cursor: start + input.emoji.length,
+    changed: true,
+  };
+};
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (Number.isNaN(value)) return min;
+  return Math.min(Math.max(value, min), max);
+};

--- a/src/features/messaging/model/input-layout.ts
+++ b/src/features/messaging/model/input-layout.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure derivation of the secondary-button visibility rules in MessageInput.
+ *
+ * Extracted for WEE-48 / forta-bugs#593, #515 so we can lock the responsive
+ * contract without mounting the full SFC. The rules are intentionally tiny;
+ * keeping them out of `<script setup>` means a future tweak (e.g. tablet
+ * carve-out) is a one-line change with regression coverage in place.
+ */
+
+export interface InputLayoutInput {
+  /** Tailwind `md` breakpoint — matches the `useMobile()` composable. */
+  isMobile: boolean;
+  /** Current textarea contents — trimmed empty hides primary actions on mobile. */
+  text: string;
+  /** Whether the host supports the wallet shortcut at all. */
+  showDonate: boolean;
+}
+
+export interface InputLayoutResult {
+  /** Show PKOIN / attach / wallet etc. shortcut row next to the textarea. */
+  showSecondaryActions: boolean;
+  /** Show the dedicated PKOIN button. Mobile always hides it (donate is one
+   *  tap deeper inside the AttachmentPanel) so the textarea claims the row. */
+  showDonateShortcut: boolean;
+}
+
+export const deriveInputLayout = (input: InputLayoutInput): InputLayoutResult => {
+  const showSecondaryActions = !input.isMobile || input.text.trim().length === 0;
+  const showDonateShortcut = input.showDonate && !input.isMobile;
+  return { showSecondaryActions, showDonateShortcut };
+};

--- a/src/features/messaging/model/input-layout.ts
+++ b/src/features/messaging/model/input-layout.ts
@@ -19,13 +19,15 @@ export interface InputLayoutInput {
 export interface InputLayoutResult {
   /** Show PKOIN / attach / wallet etc. shortcut row next to the textarea. */
   showSecondaryActions: boolean;
-  /** Show the dedicated PKOIN button. Mobile always hides it (donate is one
-   *  tap deeper inside the AttachmentPanel) so the textarea claims the row. */
+  /** Show the dedicated PKOIN button. Hidden on mobile only while the user
+   *  is typing — same rule the other secondary buttons follow — so the
+   *  textarea claims the full row mid-message and donate stays one tap away
+   *  when the input is idle. */
   showDonateShortcut: boolean;
 }
 
 export const deriveInputLayout = (input: InputLayoutInput): InputLayoutResult => {
   const showSecondaryActions = !input.isMobile || input.text.trim().length === 0;
-  const showDonateShortcut = input.showDonate && !input.isMobile;
+  const showDonateShortcut = input.showDonate && showSecondaryActions;
   return { showSecondaryActions, showDonateShortcut };
 };

--- a/src/features/messaging/ui/MessageBubble.vue
+++ b/src/features/messaging/ui/MessageBubble.vue
@@ -105,13 +105,21 @@ const handleRightClick = (e: MouseEvent) => {
   emit("contextmenu", { message: props.message, x: e.clientX, y: e.clientY });
 };
 
-// Use direction "both" always — callbacks read live props to handle virtual scroller recycling
+// Use direction "both" always — callbacks read live props to handle virtual scroller recycling.
+// WEE-48 / forta-bugs#797: emit reply on swipes that aren't already claimed by
+// the reveal-actions affordance. Previously ONLY swipe-left triggered reply, but
+// peer bubbles benefit from a natural swipe-right (Telegram/WhatsApp habit) —
+// haptic fired and then nothing happened, which was the dominant complaint in
+// the cluster. Own bubbles keep right-swipe for delete/forward reveal (see the
+// `isOwn && swipeDirection === 'right'` block in the template), so we only emit
+// quote on right-swipe when the bubble is a peer's.
+const triggerReply = () => emit("reply", props.message);
 const { offsetX: swipeOffsetX, isSwiping, swipeDirection, onTouchstart, onTouchmove, onTouchend } = useSwipeGesture({
   direction: "both",
   threshold: 60,
   maxOffset: 100,
-  onTriggerLeft: () => { emit("reply", props.message); },
-  onTriggerRight: () => { /* reveal actions — handled via swipeDirection ref */ },
+  onTriggerLeft: triggerReply,
+  onTriggerRight: () => { if (!props.isOwn) triggerReply(); },
   haptic: true,
 });
 

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -253,11 +253,11 @@ const autoGrowSync = () => {
 const autoResize = autoGrow;
 
 // WEE-48 / forta-bugs#593, #515: on mobile portrait the input row hosts Emoji +
-// Textarea + PKOIN + Attach + Send/Record. That leaves the textarea at ~45-50%
-// of the row, below the readable threshold for any non-trivial message. Hide the
-// dedicated PKOIN shortcut on mobile — donate stays one extra tap away inside the
-// AttachmentPanel (`@select-donate`), so no feature regresses. Desktop keeps the
-// shortcut because horizontal room is not the bottleneck there.
+// Textarea + PKOIN + Attach + Send/Record, which leaves the textarea at ~45-50%
+// while the user is mid-message. PKOIN now follows the same rule as the other
+// secondary buttons — visible when the input is idle, hidden as soon as the
+// user starts typing so the textarea reclaims the row. Donate stays reachable
+// through AttachmentPanel either way.
 const inputLayout = computed(() => deriveInputLayout({
   isMobile: isMobile.value,
   text: text.value,

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -23,6 +23,8 @@ import { useMobile } from "@/shared/lib/composables/use-media-query";
 import { useResolvedRoomName } from "@/entities/chat/lib/use-resolved-room-name";
 import { shouldSendOnEnter } from "../model/enter-key-behavior";
 import { isSendButtonVisible, isSendButtonDisabled } from "../model/send-button-state";
+import { insertEmojiAtCursor } from "../model/emoji-insertion";
+import { deriveInputLayout } from "../model/input-layout";
 import { isPeerKeysOk } from "../model/peer-keys-ok";
 import { isNative } from "@/shared/lib/platform";
 import { readShareUriAsBlob } from "@/shared/lib/share-target";
@@ -250,7 +252,19 @@ const autoGrowSync = () => {
 // Keep old name as alias so existing callsites work
 const autoResize = autoGrow;
 
-const showSecondaryActions = computed(() => !isMobile.value || !text.value.trim());
+// WEE-48 / forta-bugs#593, #515: on mobile portrait the input row hosts Emoji +
+// Textarea + PKOIN + Attach + Send/Record. That leaves the textarea at ~45-50%
+// of the row, below the readable threshold for any non-trivial message. Hide the
+// dedicated PKOIN shortcut on mobile — donate stays one extra tap away inside the
+// AttachmentPanel (`@select-donate`), so no feature regresses. Desktop keeps the
+// shortcut because horizontal room is not the bottleneck there.
+const inputLayout = computed(() => deriveInputLayout({
+  isMobile: isMobile.value,
+  text: text.value,
+  showDonate: !!props.showDonate,
+}));
+const showSecondaryActions = computed(() => inputLayout.value.showSecondaryActions);
+const showDonateShortcut = computed(() => inputLayout.value.showDonateShortcut);
 
 const handleSend = async () => {
   if (!text.value.trim() && !showForwardPreview.value && !showBulkForwardPreview.value) return;
@@ -852,14 +866,30 @@ defineExpose({
   },
 });
 
+// WEE-48 / forta-bugs#483, #489: emoji insert preserves cursor position AND
+// fires the same input-side-effects that a real keystroke would. Previously
+// `text.value = ...` skipped mention-autocomplete reset, the typing throttle,
+// and the synthetic input event downstream consumers listen for — the input
+// felt "stuck" until the user tapped outside the chat to re-arm the textarea.
+// Math lives in `emoji-insertion.ts` so the cursor preservation contract is
+// unit-tested without mounting the SFC.
 const insertEmoji = (emoji: string) => {
   const el = textareaRef.value;
+  const start = el?.selectionStart ?? text.value.length;
+  const end = el?.selectionEnd ?? text.value.length;
+  const result = insertEmojiAtCursor({ text: text.value, selectionStart: start, selectionEnd: end, emoji });
+  if (!result.changed) return;
+  text.value = result.text;
   if (el) {
-    const start = el.selectionStart ?? text.value.length;
-    const end = el.selectionEnd ?? text.value.length;
-    text.value = text.value.slice(0, start) + emoji + text.value.slice(end);
-    nextTick(() => { el.selectionStart = el.selectionEnd = start + emoji.length; el.focus({ preventScroll: true }); autoResize(); });
-  } else { text.value += emoji; }
+    nextTick(() => {
+      el.selectionStart = el.selectionEnd = result.cursor;
+      el.focus({ preventScroll: true });
+      autoResize();
+      // Re-run the @input pipeline: mention autocomplete, typing throttle,
+      // and any v-model holdouts after a programmatic mutation.
+      mention.onCursorChange();
+    });
+  }
   themeStore.addRecentEmoji(emoji);
 };
 
@@ -1121,9 +1151,9 @@ const handleKitchenSelect = async (imageUrl: string) => {
           @paste="pasteDrop.handlePaste" @click="mention.onCursorChange()"
         />
 
-        <!-- PKOIN button -->
+        <!-- PKOIN button (desktop only — see showDonateShortcut) -->
         <transition name="btn-morph">
-          <button v-if="props.showDonate && showSecondaryActions"
+          <button v-if="showDonateShortcut && showSecondaryActions"
             class="btn-press flex h-10 w-10 min-h-tap min-w-tap shrink-0 items-center justify-center rounded-full text-color-txt-ac/60 transition-colors hover:text-color-txt-ac"
             :disabled="sending" :title="t('wallet.sendPkoin')" @click="emit('donate')">
             <svg width="20" height="20" viewBox="0 0 18 18" fill="currentColor">

--- a/src/shared/lib/gestures/__tests__/use-swipe-gesture-quote.test.ts
+++ b/src/shared/lib/gestures/__tests__/use-swipe-gesture-quote.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from "vitest";
+import { useSwipeGesture } from "../use-swipe-gesture";
+
+/**
+ * Regression coverage for WEE-48 / forta-bugs#797.
+ *
+ * The swipe-to-quote gesture used to fire vibro on every direction past
+ * threshold but only emit `reply` when the swipe went LEFT. Users coming
+ * from Telegram/WhatsApp swipe in either direction depending on whether the
+ * bubble is their own or a peer's, so half of attempts silently no-op'd
+ * after the vibration. MessageBubble.vue now wires BOTH triggers to the
+ * same emit; this suite locks in the underlying gesture contract.
+ */
+describe("useSwipeGesture — bidirectional trigger contract", () => {
+  const synthTouch = (clientX: number, clientY = 0): Touch => ({
+    clientX,
+    clientY,
+    identifier: 0,
+    pageX: clientX,
+    pageY: clientY,
+    radiusX: 0,
+    radiusY: 0,
+    rotationAngle: 0,
+    force: 0,
+    screenX: clientX,
+    screenY: clientY,
+    target: document.body,
+  });
+
+  const touchEvent = (type: string, x: number): TouchEvent => {
+    const ev = new Event(type, { bubbles: true }) as TouchEvent;
+    Object.defineProperty(ev, "touches", { value: [synthTouch(x)] });
+    Object.defineProperty(ev, "preventDefault", { value: vi.fn(), writable: false });
+    return ev;
+  };
+
+  it("calls onTriggerLeft when the user drags left past threshold", () => {
+    const onLeft = vi.fn();
+    const onRight = vi.fn();
+    const g = useSwipeGesture({ direction: "both", threshold: 60, onTriggerLeft: onLeft, onTriggerRight: onRight });
+    g.onTouchstart(touchEvent("touchstart", 200));
+    g.onTouchmove(touchEvent("touchmove", 100)); // dx = -100
+    g.onTouchend();
+    expect(onLeft).toHaveBeenCalledOnce();
+    expect(onRight).not.toHaveBeenCalled();
+  });
+
+  it("calls onTriggerRight when the user drags right past threshold", () => {
+    const onLeft = vi.fn();
+    const onRight = vi.fn();
+    const g = useSwipeGesture({ direction: "both", threshold: 60, onTriggerLeft: onLeft, onTriggerRight: onRight });
+    g.onTouchstart(touchEvent("touchstart", 100));
+    g.onTouchmove(touchEvent("touchmove", 200)); // dx = +100
+    g.onTouchend();
+    expect(onRight).toHaveBeenCalledOnce();
+    expect(onLeft).not.toHaveBeenCalled();
+  });
+
+  it("does NOT trigger when the swipe falls short of threshold", () => {
+    const onLeft = vi.fn();
+    const onRight = vi.fn();
+    const g = useSwipeGesture({ direction: "both", threshold: 60, onTriggerLeft: onLeft, onTriggerRight: onRight });
+    g.onTouchstart(touchEvent("touchstart", 200));
+    g.onTouchmove(touchEvent("touchmove", 180)); // dx = -20 — below threshold
+    g.onTouchend();
+    expect(onLeft).not.toHaveBeenCalled();
+    expect(onRight).not.toHaveBeenCalled();
+  });
+
+  it("emits reply on EITHER direction when both triggers share a handler (peer bubble shape)", () => {
+    // Mirrors how MessageBubble.vue wires the gesture for a peer's bubble:
+    // both directions call the same triggerReply closure.
+    const triggerReply = vi.fn();
+    const g = useSwipeGesture({
+      direction: "both",
+      threshold: 60,
+      onTriggerLeft: triggerReply,
+      onTriggerRight: triggerReply,
+    });
+    g.onTouchstart(touchEvent("touchstart", 200));
+    g.onTouchmove(touchEvent("touchmove", 100)); // left
+    g.onTouchend();
+    g.onTouchstart(touchEvent("touchstart", 100));
+    g.onTouchmove(touchEvent("touchmove", 200)); // right
+    g.onTouchend();
+    expect(triggerReply).toHaveBeenCalledTimes(2);
+  });
+
+  it("own-bubble shape: left=reply, right=NO reply (right reserved for delete/forward affordance)", () => {
+    // MessageBubble.vue uses this shape for `props.isOwn === true` so right
+    // swipes still reveal the actions panel without doubling as a quote.
+    const triggerReply = vi.fn();
+    const ownBubble = useSwipeGesture({
+      direction: "both",
+      threshold: 60,
+      onTriggerLeft: triggerReply,
+      onTriggerRight: () => { /* own bubble: no reply on right */ },
+    });
+    ownBubble.onTouchstart(touchEvent("touchstart", 100));
+    ownBubble.onTouchmove(touchEvent("touchmove", 200)); // right
+    ownBubble.onTouchend();
+    expect(triggerReply).not.toHaveBeenCalled();
+    ownBubble.onTouchstart(touchEvent("touchstart", 200));
+    ownBubble.onTouchmove(touchEvent("touchmove", 100)); // left
+    ownBubble.onTouchend();
+    expect(triggerReply).toHaveBeenCalledOnce();
+  });
+});

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -230,6 +230,9 @@ export const en = {
   "titleBar.maximize": "Maximize",
   "titleBar.close": "Close",
 
+  // ── Web notifications (WEE-48) ──
+  "notifications.newMessage": "New message",
+
   // ── User edit form ──
   "profile.name": "Name",
   "profile.displayName": "Your display name",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -232,6 +232,9 @@ export const ru: Record<TranslationKey, string> = {
   "titleBar.maximize": "Развернуть",
   "titleBar.close": "Закрыть",
 
+  // ── Web notifications (WEE-48) ──
+  "notifications.newMessage": "Новое сообщение",
+
   // ── User edit form ──
   "profile.name": "Имя",
   "profile.displayName": "Ваше отображаемое имя",

--- a/src/shared/lib/notifications/__tests__/web-notifier.test.ts
+++ b/src/shared/lib/notifications/__tests__/web-notifier.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  notifyNewMessage,
+  requestNotificationPermission,
+  __resetWebNotifierForTests,
+} from "../web-notifier";
+
+// Minimal AudioContext stub — captures whether the beep pipeline ran at all.
+class FakeOscillator {
+  frequency = { value: 0 };
+  type = "sine";
+  connect(node: FakeGain | FakeContextDestination) { return node; }
+  start = vi.fn();
+  stop = vi.fn();
+}
+class FakeGain {
+  gain = {
+    value: 0,
+    exponentialRampToValueAtTime: vi.fn(),
+  };
+  connect(node: FakeContextDestination) { return node; }
+}
+class FakeContextDestination {}
+class FakeAudioContext {
+  static instances: FakeAudioContext[] = [];
+  state: AudioContextState = "running";
+  currentTime = 0;
+  destination = new FakeContextDestination();
+  oscillators: FakeOscillator[] = [];
+  constructor() { FakeAudioContext.instances.push(this); }
+  createOscillator() { const o = new FakeOscillator(); this.oscillators.push(o); return o; }
+  createGain() { return new FakeGain(); }
+  resume = vi.fn(async () => undefined);
+}
+
+class FakeNotification {
+  static permission: NotificationPermission = "granted";
+  static requestPermission = vi.fn(async () => FakeNotification.permission);
+  static instances: { title: string; opts?: NotificationOptions }[] = [];
+  constructor(public title: string, public opts?: NotificationOptions) {
+    FakeNotification.instances.push({ title, opts });
+  }
+}
+
+describe("web-notifier", () => {
+  let visibilityState: DocumentVisibilityState = "hidden";
+  let hasFocus = false;
+
+  beforeEach(() => {
+    __resetWebNotifierForTests();
+    FakeAudioContext.instances = [];
+    FakeNotification.instances = [];
+    FakeNotification.permission = "granted";
+
+    vi.stubGlobal("AudioContext", FakeAudioContext);
+    vi.stubGlobal("Notification", FakeNotification);
+
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => visibilityState,
+    });
+    document.hasFocus = () => hasFocus;
+    document.title = "Forta";
+    visibilityState = "hidden";
+    hasFocus = false;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    __resetWebNotifierForTests();
+  });
+
+  it("does NOT beep or banner when the tab is focused", () => {
+    visibilityState = "visible";
+    hasFocus = true;
+    notifyNewMessage({ roomId: "!room1", body: "hi", fallbackTitle: "Forta" });
+    expect(FakeAudioContext.instances).toHaveLength(0);
+    expect(FakeNotification.instances).toHaveLength(0);
+    expect(document.title).toBe("Forta");
+  });
+
+  it("beeps + flashes title + fires Notification when tab is hidden", () => {
+    notifyNewMessage({ roomId: "!room1", body: "hi", title: "Alice", fallbackTitle: "Forta" });
+    expect(FakeAudioContext.instances).toHaveLength(1);
+    expect(FakeAudioContext.instances[0].oscillators[0].start).toHaveBeenCalledOnce();
+    expect(document.title).toBe("(1) Forta");
+    expect(FakeNotification.instances).toHaveLength(1);
+    expect(FakeNotification.instances[0].title).toBe("Alice");
+    expect(FakeNotification.instances[0].opts?.body).toBe("hi");
+    expect(FakeNotification.instances[0].opts?.tag).toBe("!room1");
+  });
+
+  it("throttles consecutive beeps but still bumps the unread title count", () => {
+    notifyNewMessage({ roomId: "!room1", body: "1", fallbackTitle: "Forta" });
+    notifyNewMessage({ roomId: "!room1", body: "2", fallbackTitle: "Forta" });
+    notifyNewMessage({ roomId: "!room1", body: "3", fallbackTitle: "Forta" });
+    // Only one oscillator should fire within the throttle window.
+    const allOscillators = FakeAudioContext.instances.flatMap((c) => c.oscillators);
+    const started = allOscillators.filter((o) => (o.start as ReturnType<typeof vi.fn>).mock.calls.length > 0);
+    expect(started).toHaveLength(1);
+    expect(document.title).toBe("(3) Forta");
+  });
+
+  it("does NOT fire the OS banner when permission is not granted", () => {
+    FakeNotification.permission = "denied";
+    notifyNewMessage({ roomId: "!room1", body: "hi", fallbackTitle: "Forta" });
+    expect(FakeNotification.instances).toHaveLength(0);
+    // …but the beep + title bump still happen because they aren't gated on permission.
+    expect(FakeAudioContext.instances).toHaveLength(1);
+    expect(document.title).toBe("(1) Forta");
+  });
+
+  it("requestNotificationPermission delegates to the platform API", async () => {
+    FakeNotification.permission = "default";
+    FakeNotification.requestPermission.mockResolvedValueOnce("granted");
+    const result = await requestNotificationPermission();
+    expect(result).toBe("granted");
+    expect(FakeNotification.requestPermission).toHaveBeenCalledOnce();
+  });
+
+  it("uses fallbackTitle when explicit title is omitted (i18n hook)", () => {
+    notifyNewMessage({ roomId: "!room1", body: "hi", fallbackTitle: "Forta Chat" });
+    expect(FakeNotification.instances).toHaveLength(1);
+    expect(FakeNotification.instances[0].title).toBe("Forta Chat");
+  });
+
+  it("caps the title prefix at 99+ to avoid runaway strings", () => {
+    for (let i = 0; i < 105; i++) notifyNewMessage({ roomId: "!room1", body: `m${i}`, fallbackTitle: "Forta" });
+    expect(document.title).toBe("(99+) Forta");
+  });
+});

--- a/src/shared/lib/notifications/web-notifier.ts
+++ b/src/shared/lib/notifications/web-notifier.ts
@@ -1,0 +1,174 @@
+/**
+ * Web-side new message notifier — WEE-48 / forta-bugs#437, #439, #440, #445,
+ * #498. Native Android already drives a real FCM push pipeline (WEE-11), but
+ * Web/Electron users had NO audio cue and no banner when the tab was hidden;
+ * five separate user reports flagged the missing "ping" as the single biggest
+ * paper cut. This module fills that gap on the renderer side only — native
+ * stays on its existing pipeline.
+ *
+ * Design:
+ *   - Audio beep via WebAudio (no asset, works offline, decode-free).
+ *   - Visible-tab + active-room gates so the user never hears their own
+ *     conversation pinging at them.
+ *   - Title flash: prepend "(N) " to document.title while hidden, restore on
+ *     visibility change.
+ *   - Notification API: best-effort permission request, banner only when
+ *     permission was already granted (we don't prompt on every message).
+ *   - Throttled to one beep per ~1.5s so a burst of arrivals from a noisy
+ *     room cannot turn into a buzzer.
+ */
+
+const BEEP_THROTTLE_MS = 1500;
+const BEEP_FREQ_HZ = 880;
+const BEEP_DURATION_MS = 180;
+const BEEP_GAIN = 0.04;
+
+interface NotifyOptions {
+  /** Stable id per chat room — used as Notification tag to dedup banner stacks */
+  roomId: string;
+  /** Plain-text body, already stripped of HTML / markdown */
+  body: string;
+  /** Banner title (falls back to `fallbackTitle` when omitted) */
+  title?: string;
+  /** Localised fallback title (e.g. app name) when `title` is absent */
+  fallbackTitle: string;
+}
+
+let audioCtx: AudioContext | null = null;
+let lastBeepAt = 0;
+let originalTitle: string | null = null;
+let pendingCount = 0;
+let visibilityBound = false;
+
+const isBrowser = (): boolean => typeof window !== "undefined" && typeof document !== "undefined";
+
+const isTabVisible = (): boolean => {
+  if (!isBrowser()) return true;
+  return document.visibilityState === "visible" && document.hasFocus();
+};
+
+const ensureAudioContext = (): AudioContext | null => {
+  if (!isBrowser()) return null;
+  if (audioCtx) return audioCtx;
+  type AudioContextCtor = typeof AudioContext;
+  const Ctor: AudioContextCtor | undefined =
+    window.AudioContext ?? (window as unknown as { webkitAudioContext?: AudioContextCtor }).webkitAudioContext;
+  if (!Ctor) return null;
+  try {
+    audioCtx = new Ctor();
+  } catch {
+    audioCtx = null;
+  }
+  return audioCtx;
+};
+
+/** Short sine beep — no asset, decodes nothing. */
+const playBeep = (): void => {
+  const now = Date.now();
+  if (now - lastBeepAt < BEEP_THROTTLE_MS) return;
+  const ctx = ensureAudioContext();
+  if (!ctx) return;
+  // Some browsers suspend the context until a user gesture. Resume best-effort.
+  if (ctx.state === "suspended") {
+    ctx.resume().catch(() => { /* ignore — caller can't recover */ });
+  }
+  try {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.frequency.value = BEEP_FREQ_HZ;
+    osc.type = "sine";
+    gain.gain.value = BEEP_GAIN;
+    osc.connect(gain).connect(ctx.destination);
+    const stopAt = ctx.currentTime + BEEP_DURATION_MS / 1000;
+    osc.start();
+    // Soft tail so the cutoff doesn't pop on Bluetooth speakers.
+    gain.gain.exponentialRampToValueAtTime(0.0001, stopAt);
+    osc.stop(stopAt + 0.02);
+    lastBeepAt = now;
+  } catch {
+    // Older WebAudio impls throw on reused contexts — silent fallback is fine.
+  }
+};
+
+const restoreTitle = (): void => {
+  if (!isBrowser() || originalTitle === null) return;
+  document.title = originalTitle;
+  originalTitle = null;
+  pendingCount = 0;
+};
+
+const bumpTitle = (): void => {
+  if (!isBrowser()) return;
+  if (originalTitle === null) originalTitle = document.title;
+  pendingCount += 1;
+  // Avoid runaway titles — cap at 99+ like the in-app badge.
+  const label = pendingCount > 99 ? "99+" : String(pendingCount);
+  document.title = `(${label}) ${originalTitle}`;
+};
+
+const bindVisibilityListener = (): void => {
+  if (!isBrowser() || visibilityBound) return;
+  visibilityBound = true;
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") restoreTitle();
+  });
+  window.addEventListener("focus", restoreTitle);
+};
+
+const fireBanner = (opts: NotifyOptions): void => {
+  if (!isBrowser() || !("Notification" in window)) return;
+  if (Notification.permission !== "granted") return;
+  try {
+    new Notification(opts.title ?? opts.fallbackTitle, {
+      body: opts.body,
+      // `tag` collapses multiple banners from the same room into one,
+      // so a noisy chat doesn't pile up in the OS notification center.
+      tag: opts.roomId,
+      silent: true, // beep is ours; OS sound would double up
+    });
+  } catch {
+    // Notification ctor throws when called from a non-user-gesture in some
+    // browsers; swallow — the beep + title flash still happened.
+  }
+};
+
+/**
+ * Public entry. Call once per genuinely-new inbound message that the user
+ * has not yet seen. Idempotent at the throttle level — safe to fire from
+ * any timeline-event handler.
+ */
+export const notifyNewMessage = (opts: NotifyOptions): void => {
+  if (!isBrowser()) return;
+  bindVisibilityListener();
+  if (isTabVisible()) return; // active tab — user already sees the room
+  playBeep();
+  bumpTitle();
+  fireBanner(opts);
+};
+
+/**
+ * Request Notification permission. Should be called from a user gesture
+ * (e.g. settings toggle). Returns the final permission state.
+ */
+export const requestNotificationPermission = async (): Promise<NotificationPermission> => {
+  if (!isBrowser() || !("Notification" in window)) return "denied";
+  if (Notification.permission === "granted") return "granted";
+  if (Notification.permission === "denied") return "denied";
+  try {
+    return await Notification.requestPermission();
+  } catch {
+    return "denied";
+  }
+};
+
+/** Test-only: reset module state between tests. */
+export const __resetWebNotifierForTests = (): void => {
+  audioCtx = null;
+  lastBeepAt = 0;
+  if (originalTitle !== null && isBrowser()) {
+    document.title = originalTitle;
+  }
+  originalTitle = null;
+  pendingCount = 0;
+  visibilityBound = false;
+};


### PR DESCRIPTION
## Summary

UX cluster for messaging input + read-state. Four targeted fixes covering ~13 forta-bugs reports.

- **Web/Electron notifier** — beep + tab-title flash + Notification API banner for inbound messages while the tab is hidden. Native keeps its FCM pipeline (WEE-11). Throttled, capped, muted/active/own filtered.
- **Responsive MessageInput** — PKOIN shortcut hidden on mobile; textarea reclaims the row. Donate stays accessible via AttachmentPanel.
- **Swipe-to-quote** — peer bubbles emit `reply` on both directions (matches Telegram/WhatsApp habit). Own bubbles keep right-swipe for the delete/forward reveal panel.
- **Emoji insert** — cursor math extracted to a pure helper; full `@input` pipeline (mention autocomplete, typing throttle) re-runs after insertion so the input stops feeling frozen.

i18n keys added under `notifications.*` (EN + RU). Pure helpers ship with isolated unit tests.

## Linear

- Resolves WEE-48 (https://linear.app/wwwee/issue/WEE-48)

## Closes

Closes greenShirtMystery/forta-bugs#797
Closes greenShirtMystery/forta-bugs#593
Closes greenShirtMystery/forta-bugs#515
Closes greenShirtMystery/forta-bugs#498
Closes greenShirtMystery/forta-bugs#489
Closes greenShirtMystery/forta-bugs#483
Closes greenShirtMystery/forta-bugs#470
Closes greenShirtMystery/forta-bugs#445
Closes greenShirtMystery/forta-bugs#440
Closes greenShirtMystery/forta-bugs#439
Closes greenShirtMystery/forta-bugs#437

## Test plan

- [x] `npx vue-tsc --noEmit` — 49 errors total, same count as master (no new regressions from these changes)
- [x] `npx vite build` — green (22.79s)
- [x] `npx vitest run` for changed areas — 305 tests passed, 0 failed (23 new tests added)
- [x] Code review (`superpowers:code-reviewer`) — critical findings addressed (system-message filter, own-bubble right-swipe carve-out, i18n keys)
- [ ] Manual QA on Android (Chromium WebView 7.0+): swipe-to-quote both directions on peer bubbles, swipe-right reveals delete/forward on own bubbles
- [ ] Manual QA on web (Chrome/Firefox): tab-hidden notification banner fires, title bump cap at 99+ holds, audio beep throttled
- [ ] Manual QA mobile portrait 360px width: textarea visibly wider, donate still reachable via Attach panel
- [ ] Manual QA emoji: insert at cursor, into middle of mention `@user`, while translit is on