### PR TITLE
fix(media): voice/file split + upload retry + decrypt UX (WEE-50)

### DIFF
--- a/src/entities/chat/lib/chat-helpers.test.ts
+++ b/src/entities/chat/lib/chat-helpers.test.ts
@@ -11,7 +11,7 @@
  *   A bug here breaks: encrypted file decryption, image/video rendering.
  */
 import { describe, it, expect } from "vitest";
-import { matrixIdToAddress, messageTypeFromMime, normalizeMime, parseFileInfo, looksLikeProperName, resolveSystemText, isUnresolvedName, cleanMatrixIds } from "./chat-helpers";
+import { matrixIdToAddress, messageTypeFromMime, normalizeMime, parseFileInfo, looksLikeProperName, resolveSystemText, isUnresolvedName, cleanMatrixIds, isVoiceAudioContent, MSC3245_VOICE_KEY } from "./chat-helpers";
 import { hexEncode } from "@/shared/lib/matrix/functions";
 import { MessageType } from "../model/types";
 
@@ -293,6 +293,68 @@ describe("parseFileInfo", () => {
     expect(info).toBeDefined();
     expect(info!.duration).toBeUndefined();
     expect(info!.waveform).toBeUndefined();
+  });
+
+  // ─── m.audio voice vs file (WEE-50 / forta-bugs#841) ───────────
+  // The voice player UI must only render for actual voice recordings.
+  // Generic audio attachments (MP3 from gallery, podcasts, …) must be
+  // surfaced as files with a save-to-disk affordance.
+
+  it("flags m.audio with MSC3245 voice marker as a voice recording", () => {
+    const content = {
+      body: "voice.ogg",
+      [MSC3245_VOICE_KEY]: {},
+      info: { mimetype: "audio/ogg", size: 4000, url: "https://url", duration: 5000 },
+    };
+    const info = parseFileInfo(content, "m.audio");
+    expect(info!.isVoice).toBe(true);
+  });
+
+  it("flags m.audio with waveform as a voice recording (legacy fallback)", () => {
+    const content = {
+      body: "voice.ogg",
+      info: { mimetype: "audio/ogg", size: 4000, url: "https://url", duration: 5000, waveform: [100, 200, 300] },
+    };
+    const info = parseFileInfo(content, "m.audio");
+    expect(info!.isVoice).toBe(true);
+  });
+
+  it("does NOT flag plain m.audio MP3 (gallery attachment) as a voice recording", () => {
+    const content = {
+      body: "song.mp3",
+      info: { mimetype: "audio/mpeg", size: 3000, url: "https://url" },
+    };
+    const info = parseFileInfo(content, "m.audio");
+    expect(info!.isVoice).toBe(false);
+  });
+
+  // m.file is never a voice recording — Forta ships gallery picks as m.file
+  // regardless of MIME, so the receiver-side decoder must NOT treat audio
+  // MIME under m.file as a voice message (forta-bugs#841 / WEE-50).
+  it("never flags m.file as voice (pbody path)", () => {
+    const content = {
+      pbody: { name: "song.mp3", type: "audio/mpeg", size: 3000, url: "https://url" },
+    };
+    const info = parseFileInfo(content, "m.file");
+    expect(info!.isVoice).toBe(false);
+  });
+
+  it("never flags m.file as voice (JSON-body path)", () => {
+    const content = {
+      body: JSON.stringify({ name: "track.m4a", type: "audio/mp4", size: 5000, url: "https://url" }),
+    };
+    const info = parseFileInfo(content, "m.file");
+    expect(info!.isVoice).toBe(false);
+  });
+
+  it("never flags m.file as voice (canonical Matrix encrypted-file path)", () => {
+    const content = {
+      body: "podcast.mp3",
+      file: { url: "mxc://server/abc", mimetype: "audio/mpeg" },
+      info: { mimetype: "audio/mpeg", size: 200 },
+    };
+    const info = parseFileInfo(content, "m.file");
+    expect(info!.isVoice).toBe(false);
   });
 
   // ─── m.video ────────────────────────────────────────────────────
@@ -708,5 +770,39 @@ describe("matrixIdToAddress — non-printable character validation", () => {
     const addr = "PPbNqCweFnTePQyXWR21B9jXWCiDJa2yYu";
     const hex = hexEncode(addr).toLowerCase();
     expect(matrixIdToAddress(`@${hex}:server`)).toBe(addr);
+  });
+});
+
+// ─── isVoiceAudioContent — voice recording vs audio file (WEE-50) ───
+//
+// The audio-rendering branch in MessageBubble.vue decides between
+// VoiceMessage and the generic file bubble using this helper. Misclassifying
+// an MP3 picked from the gallery as a voice message (forta-bugs#841) hides
+// the save-to-disk button and presents a player UI with no waveform — so
+// this test set has to lock down both directions of the boundary.
+
+describe("isVoiceAudioContent", () => {
+  it("returns true when the MSC3245 voice marker is on the content", () => {
+    expect(isVoiceAudioContent({ [MSC3245_VOICE_KEY]: {} }, null)).toBe(true);
+  });
+
+  it("returns true when the MSC3245 voice marker is on info", () => {
+    expect(isVoiceAudioContent(null, { [MSC3245_VOICE_KEY]: {} })).toBe(true);
+  });
+
+  it("returns true when info has a non-empty waveform (legacy fallback)", () => {
+    expect(isVoiceAudioContent({}, { waveform: [1, 2, 3] })).toBe(true);
+  });
+
+  it("returns false when neither marker nor waveform present", () => {
+    expect(isVoiceAudioContent({}, { mimetype: "audio/mpeg" })).toBe(false);
+  });
+
+  it("returns false for an empty waveform array (heuristic safety)", () => {
+    expect(isVoiceAudioContent({}, { waveform: [] })).toBe(false);
+  });
+
+  it("returns false when both inputs are null", () => {
+    expect(isVoiceAudioContent(null, null)).toBe(false);
   });
 });

--- a/src/entities/chat/lib/chat-helpers.ts
+++ b/src/entities/chat/lib/chat-helpers.ts
@@ -36,10 +36,45 @@ export function normalizeMime(mime: string | undefined): string {
  */
 export const MSC3245_VIDEO_NOTE_KEY = "org.matrix.msc3245.video_note";
 
+/**
+ * Matrix MSC3245 voice-message marker.
+ * Voice recordings carry this top-level key; regular audio files (mp3
+ * picked from gallery, podcast attachments, etc.) do not. Without it the
+ * UI treats *all* `m.audio` events as voice messages — leaving the user
+ * with a player bubble and no save-to-disk affordance for an MP3 file
+ * (forta-bugs#841 / WEE-50). We also accept the alternative `info.waveform`
+ * marker so legacy bastyon-chat voice notes (which predate MSC3245) keep
+ * rendering as voice bubbles.
+ */
+export const MSC3245_VOICE_KEY = "org.matrix.msc3245.voice";
+
 /** True when an m.video info bag is marked as a video-note (circle). */
 export function isVideoNoteInfo(info: Record<string, unknown> | undefined | null): boolean {
   if (!info) return false;
   return info.videoNote === true || info[MSC3245_VIDEO_NOTE_KEY] === true;
+}
+
+/** True when an `m.audio` event is a voice-message recording.
+ *
+ *  Heuristic, in priority order:
+ *    1. MSC3245 voice marker on the event content (`org.matrix.msc3245.voice`)
+ *       — the canonical Matrix-wide signal used by Element / Cinny / etc.
+ *    2. Same marker mirrored under `content.info` — some clients put it there.
+ *    3. Presence of `info.waveform` — legacy bastyon-chat voice notes
+ *       (pre-MSC3245) only carry the waveform array. Treating waveform as a
+ *       sufficient signal keeps backwards-compat without misclassifying gallery
+ *       MP3s (which never include a waveform).
+ *
+ *  Returns false for everything else — that is the file-bubble path. */
+export function isVoiceAudioContent(
+  content: Record<string, unknown> | undefined | null,
+  info: Record<string, unknown> | undefined | null,
+): boolean {
+  if (!content && !info) return false;
+  if (content && MSC3245_VOICE_KEY in content) return true;
+  if (info && MSC3245_VOICE_KEY in info) return true;
+  if (info && Array.isArray(info.waveform) && info.waveform.length > 0) return true;
+  return false;
 }
 
 /** Determine MessageType from MIME type string */
@@ -104,6 +139,11 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
   const encryptedFile = content.file as any;
   const encryptedUrl: string | undefined = typeof encryptedFile?.url === "string" ? encryptedFile.url : undefined;
 
+  // m.file events never carry a voice recording — voice always rides on
+  // m.audio. Setting `isVoice: false` here lets the UI default-to-voice
+  // safety net (`isVoice ?? true`) keep working for legacy stored rows
+  // without misclassifying audio attachments shipped as m.file.
+  const fileIsVoice = false;
   if (msgtype === "m.file" && pbody) {
     // SyncEngine.processFileSend (sync-engine.ts) ships m.file events with
     // body = JSON({ name, type, size }) and the mxc URL + secrets pinned to
@@ -122,6 +162,7 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
       type: (pbody.type ?? "").replace("encrypted/", ""),
       size: pbody.size ?? 0,
       url: pbody.url ?? encryptedUrl ?? topUrl ?? "",
+      isVoice: fileIsVoice,
       secrets: secrets ? {
         block: secrets.block,
         keys: secrets.keys,
@@ -164,6 +205,10 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
         ? Math.round(info.duration / 1000)
         : undefined,
       waveform: normalizedWaveform,
+      // Detect MSC3245 voice marker so generic mp3/aac attachments (no marker,
+      // no waveform) render as files instead of being forced into the voice
+      // player UI (forta-bugs#841 / WEE-50).
+      isVoice: isVoiceAudioContent(content, info),
       secrets: info.secrets ? {
         block: info.secrets.block,
         keys: info.secrets.keys,
@@ -202,6 +247,7 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
           type: (parsed.type ?? "").replace("encrypted/", ""),
           size: parsed.size ?? 0,
           url: parsed.url,
+          isVoice: fileIsVoice,
           secrets: parsed.secrets ? {
             block: parsed.secrets.block,
             keys: parsed.secrets.keys,
@@ -222,6 +268,7 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
       type: mime.replace("encrypted/", ""),
       size: info?.size ?? 0,
       url: encryptedUrl,
+      isVoice: fileIsVoice,
       // Secrets follow Matrix EncryptedFile shape: { url, key, iv, hashes, v }.
       // We do not surface them here because the bastyon-chat crypto pipeline
       // reads its own pbody.secrets shape; canonical-Matrix decryption is

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -2,7 +2,7 @@ import { getMatrixClientService } from "@/entities/matrix";
 import type { MatrixKit } from "@/entities/matrix";
 import type { Pcrypto, PcryptoRoomInstance } from "@/entities/matrix/model/matrix-crypto";
 import { getmatrixid, hexEncode, hexDecode } from "@/shared/lib/matrix/functions";
-import { matrixIdToAddress, messageTypeFromMime, parseFileInfo, cleanMatrixIds, looksLikeProperName, isVideoNoteInfo } from "../lib/chat-helpers";
+import { matrixIdToAddress, messageTypeFromMime, parseFileInfo, cleanMatrixIds, looksLikeProperName, isVideoNoteInfo, isVoiceAudioContent } from "../lib/chat-helpers";
 import { buildLastMessage, lastMessageFromMessage, resolveLastMessagePreview } from "../lib/last-message-builder";
 import { parseEditBody } from "../lib/parse-edit";
 import { sortMessagesTimelineAsc } from "../lib/message-utils";
@@ -212,8 +212,14 @@ function matrixRoomToChatRoom(room: any, kit: MatrixKit, myUserId: string, nameH
         previewBody = "[photo]";
         previewType = MessageType.image;
       } else if (msgtype === "m.audio") {
-        previewBody = "[voice message]";
-        previewType = MessageType.audio;
+        // Voice recording vs generic audio file (mp3 from gallery, podcast, …):
+        // only the former should preview as "[voice message]". Without the
+        // distinction MP3 attachments preview with the voice-bubble label even
+        // though the bubble below renders them as files (forta-bugs#841 / WEE-50).
+        const info = content.info as Record<string, unknown> | undefined;
+        const isVoice = isVoiceAudioContent(content, info);
+        previewBody = isVoice ? "[voice message]" : (content?.body as string) || "[audio]";
+        previewType = isVoice ? MessageType.audio : MessageType.file;
       } else if (msgtype === "m.video") {
         const info = content.info as Record<string, unknown> | undefined;
         if (isVideoNoteInfo(info)) {
@@ -4706,9 +4712,20 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       fileInfo = parseFileInfo(content, mtype);
       if (fileInfo) {
         if (mtype === "m.image") msgType = MessageType.image;
-        else if (mtype === "m.audio") msgType = MessageType.audio;
+        // m.audio carries either a voice recording (MSC3245 marker / waveform)
+        // or a regular audio file picked from gallery. The latter must render
+        // as a file-bubble with save-to-disk, not as the voice player UI
+        // (forta-bugs#841 / WEE-50).
+        else if (mtype === "m.audio") msgType = fileInfo.isVoice ? MessageType.audio : MessageType.file;
         else if (mtype === "m.video") msgType = fileInfo.videoNote ? MessageType.videoCircle : MessageType.video;
-        else msgType = messageTypeFromMime(fileInfo.type);
+        // m.file: route audio MIME (mp3, m4a, …) to MessageType.file so the
+        // receiver renders a file-bubble with save-to-disk instead of the
+        // voice player UI. Forta ships gallery picks as m.file regardless
+        // of MIME, so without this override the receiver re-introduces the
+        // forta-bugs#841 misclassification.
+        else msgType = fileInfo.type.startsWith("audio/")
+          ? MessageType.file
+          : messageTypeFromMime(fileInfo.type);
         body = fileInfo.name;
       } else {
         if (mtype === "m.image") msgType = MessageType.image;
@@ -6091,9 +6108,12 @@ export const useChatStore = defineStore(NAMESPACE, () => {
         fileInfo = parseFileInfo(content, mtype);
         if (fileInfo) {
           if (mtype === "m.image") msgType = MessageType.image;
-          else if (mtype === "m.audio") msgType = MessageType.audio;
+          // See decryption-path branch above for the voice vs. audio-file split.
+          else if (mtype === "m.audio") msgType = fileInfo.isVoice ? MessageType.audio : MessageType.file;
           else if (mtype === "m.video") msgType = MessageType.video;
-          else msgType = messageTypeFromMime(fileInfo.type);
+          else msgType = fileInfo.type.startsWith("audio/")
+            ? MessageType.file
+            : messageTypeFromMime(fileInfo.type);
           body = fileInfo.name;
         } else {
           if (mtype === "m.image") msgType = MessageType.image;

--- a/src/entities/chat/model/types.ts
+++ b/src/entities/chat/model/types.ts
@@ -51,6 +51,11 @@ export interface FileInfo {
   videoNote?: boolean;
   /** Thumbnail URL for video circles */
   thumbnailUrl?: string;
+  /** True when the m.audio event is a voice-message recording (MSC3245)
+   *  or carries a waveform (legacy bastyon-chat marker). When false, the
+   *  audio is a generic file that should render as a file-bubble with a
+   *  save-to-disk affordance instead of the voice-bubble player. */
+  isVoice?: boolean;
 }
 
 export interface ReplyTo {

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -381,9 +381,15 @@ export function useMessages() {
       return false;
     }
 
-    // Determine message type from MIME (with fallback for HEIC/extension-only files)
+    // Determine message type from MIME (with fallback for HEIC/extension-only files).
+    // Audio MIME deliberately routes to MessageType.file: voice recordings have
+    // their own send path (sendAudio) and audio attachments coming from the
+    // gallery / file picker are *files*, not voice notes. Without this guard
+    // an MP3 picked from the gallery preview-rendered as a voice bubble with
+    // no save-to-disk affordance (forta-bugs#841 / WEE-50).
     const mime = normalizeMime(resolveMime(processedFile));
-    const msgType = messageTypeFromMime(mime);
+    const inferredType = messageTypeFromMime(mime);
+    const msgType = inferredType === MessageType.audio ? MessageType.file : inferredType;
 
     const localBlobUrl = URL.createObjectURL(processedFile);
 
@@ -587,6 +593,10 @@ export function useMessages() {
         url: localBlobUrl,
         duration: options.duration,
         waveform: options.waveform,
+        // Voice recordings created via VoiceRecorder are always voice messages;
+        // recipients without an MSC3245 marker (older app versions) keep the
+        // waveform-presence heuristic as a fallback.
+        isVoice: true,
       },
       forwardedFrom: options.forwardedFrom,
       localBlobUrl,
@@ -619,6 +629,11 @@ export function useMessages() {
           duration: options.duration ? Math.round(options.duration * 1000) : undefined,
           waveform: intWaveform,
         },
+        // MSC3245 voice marker — canonical Matrix signal that this m.audio
+        // event is a voice recording, not a regular audio file. Lets Element /
+        // Cinny / future Forta builds tell the two apart without inspecting
+        // the waveform (forta-bugs#841 / WEE-50).
+        eventExtras: { "org.matrix.msc3245.voice": {} },
         ...(options.forwardedFrom ? { forwardedFrom: options.forwardedFrom } : {}),
       },
       localMsg.clientId,

--- a/src/features/messaging/ui/MessageBubble.vue
+++ b/src/features/messaging/ui/MessageBubble.vue
@@ -194,7 +194,17 @@ const { toast: showToast } = useToast();
 
 const time = computed(() => formatTime(new Date(props.message.timestamp)));
 
-const isFile = computed(() => props.message.type === MessageType.file);
+// Voice recordings render as the voice player; everything else with audio
+// MIME falls through to the file-bubble below (forta-bugs#841 / WEE-50).
+// Default to `true` for backwards compatibility with messages stored before
+// the `isVoice` flag was introduced — they were always treated as voice.
+const isVoiceAudio = computed(() =>
+  props.message.type === MessageType.audio && (props.message.fileInfo?.isVoice ?? true),
+);
+const isFile = computed(() =>
+  props.message.type === MessageType.file ||
+  (props.message.type === MessageType.audio && !isVoiceAudio.value),
+);
 const hasFileInfo = computed(() => !!props.message.fileInfo);
 // Must use the same cache key as download() — _key (stable clientId) when available,
 // otherwise id. Without this, getState and download write to different state entries
@@ -999,9 +1009,10 @@ const replyPreviewSender = computed(() => {
         </div>
       </div>
 
-      <!-- Audio message -->
+      <!-- Audio message (voice recording only — generic audio files fall
+           through to the file branch below) -->
       <div
-        v-else-if="message.type === MessageType.audio && hasFileInfo"
+        v-else-if="isVoiceAudio && hasFileInfo"
         class="min-w-[240px] rounded-bubble px-3 py-2"
         :class="[tailClass, props.isOwn ? 'bg-chat-bubble-own text-text-on-bg-ac-color' : 'bg-chat-bubble-other text-text-color']"
       >
@@ -1027,7 +1038,24 @@ const replyPreviewSender = computed(() => {
             <div class="truncate text-[11px] opacity-70">{{ replyPreviewText }}</div>
           </div>
         </div>
-        <VoiceMessage :message="message" :is-own="props.isOwn" />
+        <!-- Replace the silent voice player with a typed decrypt-error block
+             when the download/decrypt failed (forta-bugs#456 / WEE-50).
+             Without the v-if guard the player would render an empty bar
+             underneath the error UI. -->
+        <VoiceMessage
+          v-if="!(fileState.error && fileState.errorKind === 'crypto')"
+          :message="message"
+          :is-own="props.isOwn"
+        />
+        <div v-if="fileState.error && fileState.errorKind === 'crypto'" class="mt-1 flex flex-col gap-0.5">
+          <p class="text-xs font-medium text-color-bad">{{ t('chat.decryptError.title') }}</p>
+          <p class="text-[11px] opacity-70">{{ isOwn ? t('chat.decryptError.askSelf') : t('chat.decryptError.askResend') }}</p>
+          <div class="mt-0.5 flex items-center gap-3">
+            <button type="button" class="text-xs font-medium text-color-bg-ac" @click.stop="retryDownload">{{ t('chat.decryptError.retry') }}</button>
+            <button type="button" class="text-[11px] opacity-60 underline" @click.stop="reportDownloadProblem">{{ t('chat.decryptError.reportProblem') }}</button>
+          </div>
+        </div>
+        <p v-else-if="fileState.error" class="mt-1 text-xs text-color-bad">{{ fileState.error }}</p>
         <!-- Upload progress with cancel for audio -->
         <div v-if="isUploading" class="mt-1 flex items-center gap-2">
           <button class="relative flex h-8 w-8 shrink-0 items-center justify-center" @click.stop="emit('cancelUpload', message)">

--- a/src/shared/lib/local-db/__tests__/sync-engine-false-failed.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-false-failed.test.ts
@@ -39,6 +39,19 @@ const mockMatrix = {
     async () => undefined,
   ),
   uploadContentMxc: vi.fn<(blob: Blob) => Promise<string>>(async () => "mxc://server/file"),
+  // syncSendFile streams uploads through uploadContent (progress + AbortSignal
+  // path). The false-failed scenario covered below is about the *send-event*
+  // step failing after a successful upload, so we resolve the upload happily
+  // and let `sendEncryptedText` carry the simulated failure. Without this
+  // mock, the WEE-50 in-attempt upload retry would wait through its budget
+  // before the catch branch ever runs and the test would race its timeout.
+  uploadContent: vi.fn<
+    (
+      blob: Blob,
+      progress?: (p: { loaded: number; total: number }) => void,
+      signal?: AbortSignal,
+    ) => Promise<string>
+  >(async () => "https://server/_matrix/media/r0/download/server/file"),
 };
 
 vi.mock("@/entities/matrix", () => ({

--- a/src/shared/lib/local-db/__tests__/sync-engine-upload-retry.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-upload-retry.test.ts
@@ -1,0 +1,276 @@
+/**
+ * SyncEngine in-attempt upload retry (forta-bugs#831 / #725 / #423 / WEE-50).
+ *
+ * Flaky Android cell links drop the first upload POST even when the rest of
+ * the pipeline is healthy. Pre-fix, the whole `send_file` op failed and the
+ * user waited out the queue-level 1-30s backoff before anything happened.
+ * The new in-attempt retry burns through transient errors within ~6 s,
+ * leaving the queue-level retries as a fallback for genuinely persistent
+ * failures.
+ *
+ * These tests pin three behaviours:
+ *   1. A transient first failure must NOT propagate — the upload retries and
+ *      the op completes within the same processTick.
+ *   2. A "too large" error (Matrix repo 413) must short-circuit immediately —
+ *      retrying just delays a deterministic failure.
+ *   3. After exhausting the in-attempt budget, the op falls back to the
+ *      queue's exponential-backoff retry path (delete-on-success once the
+ *      next attempt succeeds).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Dexie from "dexie";
+import "fake-indexeddb/auto";
+import { SyncEngine } from "../sync-engine";
+import type { PendingOperation, LocalMessage, LocalRoom, LocalAttachment } from "../schema";
+
+// --- Mocks -------------------------------------------------------------------
+
+const mockMatrix = {
+  sendEncryptedText: vi.fn<
+    (roomId: string, content: unknown, txnId?: string) => Promise<string>
+  >(async () => "$server_event_id"),
+  sendText: vi.fn<(roomId: string, text: string, txnId?: string) => Promise<string>>(
+    async () => "$server_event_id",
+  ),
+  sendReaction: vi.fn<(roomId: string, eventId: string, emoji: string) => Promise<string>>(
+    async () => "$reaction_id",
+  ),
+  redactEvent: vi.fn<(roomId: string, eventId: string) => Promise<void>>(async () => undefined),
+  sendPollStart: vi.fn<(roomId: string, content: unknown) => Promise<string>>(
+    async () => "$poll_id",
+  ),
+  sendPollResponse: vi.fn<(roomId: string, content: unknown) => Promise<void>>(
+    async () => undefined,
+  ),
+  uploadContent: vi.fn<
+    (
+      blob: Blob,
+      progress?: (p: { loaded: number; total: number }) => void,
+      signal?: AbortSignal,
+    ) => Promise<string>
+  >(),
+  uploadContentMxc: vi.fn<(blob: Blob) => Promise<string>>(async () => "mxc://server/file"),
+};
+
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: () => mockMatrix,
+}));
+
+// --- Test DB -----------------------------------------------------------------
+
+class TestDb extends Dexie {
+  messages!: Dexie.Table<LocalMessage, number>;
+  rooms!: Dexie.Table<LocalRoom, string>;
+  pendingOps!: Dexie.Table<PendingOperation, number>;
+  attachments!: Dexie.Table<LocalAttachment, number>;
+  users!: Dexie.Table<{ address: string }, string>;
+  syncState!: Dexie.Table<{ key: string; value: string | number }, string>;
+  decryptionQueue!: Dexie.Table<{ id?: number; status: string }, number>;
+  listenedMessages!: Dexie.Table<{ messageId: string }, string>;
+
+  constructor(name: string) {
+    super(name, { indexedDB, IDBKeyRange });
+    this.version(1).stores({
+      messages:
+        "++localId, eventId, clientId, [roomId+timestamp], [roomId+status], senderId",
+      rooms: "id, updatedAt, membership, isDeleted",
+      pendingOps:
+        "++id, [roomId+createdAt], status, clientId, [status+nextAttemptAt]",
+      attachments: "++id, messageLocalId, status",
+      users: "address, updatedAt",
+      syncState: "key",
+      decryptionQueue: "++id, status, [status+nextAttemptAt]",
+      listenedMessages: "messageId",
+    });
+  }
+}
+
+interface Harness {
+  db: TestDb;
+  engine: SyncEngine;
+  messageRepo: {
+    confirmSent: ReturnType<typeof vi.fn>;
+    confirmMediaSent: ReturnType<typeof vi.fn>;
+    updateStatus: ReturnType<typeof vi.fn>;
+    getByEventId: ReturnType<typeof vi.fn>;
+    updateReactions: ReturnType<typeof vi.fn>;
+    getByClientId: ReturnType<typeof vi.fn>;
+    updateUploadProgress: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeHarness(name: string): Harness {
+  const db = new TestDb(name);
+  const messageRepo = {
+    confirmSent: vi.fn(async () => undefined),
+    confirmMediaSent: vi.fn(async () => undefined),
+    updateStatus: vi.fn(async () => undefined),
+    getByEventId: vi.fn(async () => undefined),
+    updateReactions: vi.fn(async () => undefined),
+    getByClientId: vi.fn(async () => undefined),
+    updateUploadProgress: vi.fn(async () => undefined),
+  };
+  const roomRepo = { updateRoom: vi.fn(async () => undefined) };
+  const getRoomCrypto = vi.fn(async () => undefined);
+  const engine = new SyncEngine(
+    db as never,
+    messageRepo as never,
+    roomRepo as never,
+    getRoomCrypto as never,
+  );
+  return { db, engine, messageRepo };
+}
+
+async function seedAttachment(db: TestDb): Promise<number> {
+  const blob = new Blob(["x".repeat(100)], { type: "image/jpeg" });
+  return db.attachments.add({
+    messageLocalId: 1,
+    fileName: "photo.jpg",
+    mimeType: "image/jpeg",
+    size: 100,
+    localBlob: blob,
+    status: "local",
+  } as LocalAttachment);
+}
+
+async function seedFileOp(db: TestDb, clientId: string, attachmentId: number): Promise<void> {
+  await db.pendingOps.add({
+    type: "send_file",
+    roomId: "!room:server",
+    payload: {
+      fileName: "photo.jpg",
+      mimeType: "image/jpeg",
+      msgtype: "m.image",
+      attachmentId,
+    },
+    status: "pending",
+    retries: 0,
+    maxRetries: 5,
+    createdAt: Date.now(),
+    clientId,
+    nextAttemptAt: 0,
+  } as PendingOperation);
+}
+
+async function waitForProcessed(db: TestDb, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const remaining = await db.pendingOps.count();
+    if (remaining === 0) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error("pendingOps queue did not drain in time");
+}
+
+describe("SyncEngine.syncSendFile — upload retry (WEE-50)", () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    h?.engine.dispose();
+    await h?.db.delete();
+  });
+
+  it("retries a transient upload failure within the same op", async () => {
+    h = makeHarness(`upload-retry-${Date.now()}-${Math.random()}`);
+    await h.db.open();
+
+    // First attempt drops with a generic "Failed to fetch" — second succeeds.
+    let attempt = 0;
+    mockMatrix.uploadContent.mockImplementation(async () => {
+      attempt += 1;
+      if (attempt === 1) throw new TypeError("Failed to fetch");
+      return "https://server/_matrix/media/r0/download/server/ok";
+    });
+
+    const attachmentId = await seedAttachment(h.db);
+    await seedFileOp(h.db, "cli_blip", attachmentId);
+
+    await h.engine.processQueue();
+    await waitForProcessed(h.db);
+
+    // Two upload attempts, single send_file op succeeded (no queue retry).
+    expect(mockMatrix.uploadContent).toHaveBeenCalledTimes(2);
+    expect(h.messageRepo.confirmMediaSent).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry a 'too large' upload failure", async () => {
+    h = makeHarness(`upload-413-${Date.now()}-${Math.random()}`);
+    await h.db.open();
+
+    mockMatrix.uploadContent.mockImplementation(async () => {
+      throw new Error("413 Payload Too Large");
+    });
+
+    const attachmentId = await seedAttachment(h.db);
+    await seedFileOp(h.db, "cli_too_large", attachmentId);
+
+    await h.engine.processQueue();
+    // Give the queue scheduler a tick to record the failure.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Only one upload attempt — fatal error short-circuits the retry loop.
+    expect(mockMatrix.uploadContent).toHaveBeenCalledTimes(1);
+
+    // Op stays in the queue (failed or scheduled for queue-level retry).
+    // confirmMediaSent must never run for an upload that never succeeded.
+    expect(h.messageRepo.confirmMediaSent).not.toHaveBeenCalled();
+  });
+
+  it("performs the full in-attempt budget before bubbling to queue retry", async () => {
+    h = makeHarness(`upload-exhaust-${Date.now()}-${Math.random()}`);
+    await h.db.open();
+
+    // Always-failing transient error — saturates the in-attempt budget and
+    // then surfaces to the queue-level retry path. Tracked in a closure so
+    // the assertion can verify the exact attempt count.
+    let perOpAttempts = 0;
+    mockMatrix.uploadContent.mockImplementation(async () => {
+      perOpAttempts += 1;
+      throw new TypeError("Failed to fetch");
+    });
+
+    const attachmentId = await seedAttachment(h.db);
+    // maxRetries=0 so the queue does NOT reschedule the op for another execution
+    // after the in-attempt budget is exhausted — keeps the test fast and the
+    // attempt count deterministic.
+    await h.db.pendingOps.add({
+      type: "send_file",
+      roomId: "!room:server",
+      payload: {
+        fileName: "photo.jpg",
+        mimeType: "image/jpeg",
+        msgtype: "m.image",
+        attachmentId,
+      },
+      status: "pending",
+      retries: 0,
+      maxRetries: 0,
+      createdAt: Date.now(),
+      clientId: "cli_exhaust",
+      nextAttemptAt: 0,
+    } as PendingOperation);
+
+    await h.engine.processQueue();
+
+    // Wait until the engine records the op as failed (maxRetries=0 → first
+    // exhausted run marks it failed; no further attempts).
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline) {
+      const op = await h.db.pendingOps
+        .where("clientId")
+        .equals("cli_exhaust")
+        .first();
+      if (op?.status === "failed") break;
+      await new Promise((r) => setTimeout(r, 25));
+    }
+
+    // Initial attempt + 3 retry slots = 4 calls inside one execution. Anything
+    // less would mean the retry loop short-circuited a transient error.
+    expect(perOpAttempts).toBe(4);
+    expect(h.messageRepo.confirmMediaSent).not.toHaveBeenCalled();
+  }, 20_000);
+});

--- a/src/shared/lib/local-db/sync-engine.ts
+++ b/src/shared/lib/local-db/sync-engine.ts
@@ -57,6 +57,84 @@ function computeBackoff(retries: number): number {
   return base + Math.random() * Math.min(base * 0.5, 5_000);
 }
 
+/** Short, in-attempt backoff for the upload sub-step (forta-bugs#831 /
+ *  #725 / #423 / WEE-50). Network blips on flaky Android cell links lose
+ *  the first POST to the media repo even when the rest of the pipeline is
+ *  fine; without an in-line retry the whole op fails and the user waits
+ *  out the engine-level 1-30s backoff. Three quick attempts cover the
+ *  vast majority of single-packet drops within ~6 s before falling back
+ *  to the queue-level retry logic. Delays kept in ms. */
+const UPLOAD_RETRY_DELAYS_MS = [500, 1500, 4000] as const;
+
+/** Errors that the upload retry loop must NOT swallow. Aborts are user
+ *  intent (cancelMediaUpload), and deterministic server-side failures are
+ *  retry-immune — retrying just delays the failure UX. */
+function isUploadFatal(err: unknown): boolean {
+  if (err instanceof DOMException && err.name === "AbortError") return true;
+  if (err instanceof Error) {
+    // Matrix media repo returns 413 (payload too large) and 4xx auth/quota
+    // failures that are not retryable. We don't have typed errors at this
+    // layer, so substring-match the bare message — same approach the
+    // download path takes. Matches only digit groups that look like an
+    // HTTP-status mention (preceded by "status" or by start-of-message /
+    // whitespace + non-digit) so a filename like `meeting_403.mp3` doesn't
+    // poison the heuristic.
+    if (/(?:status\s*|^|\s)(?:413|415|401|403)\b|too large|payload too large/i.test(err.message)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** AbortSignal-aware sleep. Resolves after `ms` or rejects immediately on
+ *  abort — the latter is important so `cancelMediaUpload` can interrupt the
+ *  backoff between attempts instead of forcing the user to wait out the
+ *  4-second tail. */
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException("Upload cancelled", "AbortError"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException("Upload cancelled", "AbortError"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/** Wrap `matrixService.uploadContent` with short in-attempt retries.
+ *  See `UPLOAD_RETRY_DELAYS_MS` for the rationale. Returns the mxc:// URL
+ *  emitted by the final successful attempt. Throws the LAST error if every
+ *  attempt fails so the engine-level retry loop can take over with its
+ *  longer backoff.
+ *
+ *  Total: 1 initial attempt + UPLOAD_RETRY_DELAYS_MS.length retries. */
+async function uploadWithRetry(
+  upload: () => Promise<string>,
+  signal: AbortSignal,
+): Promise<string> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= UPLOAD_RETRY_DELAYS_MS.length; attempt++) {
+    if (signal.aborted) throw new DOMException("Upload cancelled", "AbortError");
+    if (attempt > 0) {
+      await sleep(UPLOAD_RETRY_DELAYS_MS[attempt - 1], signal);
+    }
+    try {
+      return await upload();
+    } catch (e) {
+      lastErr = e;
+      if (isUploadFatal(e)) throw e;
+    }
+  }
+  throw lastErr;
+}
+
 /**
  * SyncEngine processes pending operations (outbound queue).
  *
@@ -607,8 +685,20 @@ export class SyncEngine {
         // fire-and-forget; progress is advisory and must not stall upload
         void this.messageRepo.updateUploadProgress(op.clientId, percent);
       });
+      // The retry loop sits *inside* the timeout so the deadline covers the
+      // whole upload phase (including in-attempt retries) rather than being
+      // reset between attempts — protects against a runaway 4×4-min loop on
+      // a flaky link.
       const url = await withTimeout(
-        matrixService.uploadContent(fileToUpload, onProgress, controller.signal),
+        uploadWithRetry(
+          () =>
+            matrixService.uploadContent(
+              fileToUpload,
+              onProgress,
+              controller.signal,
+            ),
+          controller.signal,
+        ),
         MEDIA_UPLOAD_TIMEOUT_MS,
         "Media upload",
       );


### PR DESCRIPTION
## Summary
- **forta-bugs#841 (MP3 = voice UI):** MP3 attachments now correctly render as file-bubbles with save-to-disk. Voice recordings keep the player UI via MSC3245 (`org.matrix.msc3245.voice`) emission + waveform fallback. Fixed on both the sender's optimistic preview and the receiver's decoder.
- **forta-bugs#831/#830/#725/#715/#423/#370 (photo upload fails):** Added in-attempt upload retry around `uploadContent` (500/1500/4000ms backoff, fatal-error short-circuit for 413/4xx, AbortSignal-aware) so a single network blip no longer requires the user to wait out the 1-30s queue-level retry.
- **forta-bugs#456 ("No room crypto for decryption"):** Voice bubble now surfaces the typed decrypt-error UX with retry/report-problem actions instead of leaving an empty player.

## Linear
- Resolves WEE-50 (https://linear.app/wwwee/issue/WEE-50/media-photo-uploaddownload-failures-audio-mp3-misclassified-kak-voice)

## Closes
Closes greenShirtMystery/forta-bugs#841
Closes greenShirtMystery/forta-bugs#831
Closes greenShirtMystery/forta-bugs#830
Closes greenShirtMystery/forta-bugs#725
Closes greenShirtMystery/forta-bugs#715
Closes greenShirtMystery/forta-bugs#707
Closes greenShirtMystery/forta-bugs#456
Closes greenShirtMystery/forta-bugs#423
Closes greenShirtMystery/forta-bugs#370

## Files changed
- `src/entities/chat/lib/chat-helpers.ts` — `MSC3245_VOICE_KEY`, `isVoiceAudioContent()` helper, `parseFileInfo` writes `isVoice` for m.audio and explicit `false` for m.file paths.
- `src/entities/chat/model/types.ts` — added `FileInfo.isVoice`.
- `src/entities/chat/model/chat-store.ts` — decoder routes m.audio→audio only when isVoice; m.file with audio MIME → file (3 sites).
- `src/features/messaging/model/use-messages.ts` — `sendFile` always uses `MessageType.file`; `sendAudio` emits the MSC3245 voice marker via `eventExtras` and tags local `fileInfo.isVoice = true`.
- `src/shared/lib/local-db/sync-engine.ts` — `uploadWithRetry` with cancellable in-attempt backoff; HTTP-status regex tightened to avoid filename false positives.
- `src/features/messaging/ui/MessageBubble.vue` — `isVoiceAudio` gate, audio branch only renders for voice; decrypt-error UI parity with file branch; legacy `isVoice ?? true` default to preserve old stored rows.
- Tests: 12 new tests in `chat-helpers.test.ts` (voice classification across MSC3245 / waveform / m.file paths); new `sync-engine-upload-retry.test.ts` (3 retry tests); updated `sync-engine-false-failed.test.ts` mock so it doesn't race the retry budget.

## Test plan
- [x] `npm test` — 12 new passing tests, no regressions vs master (same 9 pre-existing fails in unrelated files).
- [x] `vue-tsc --noEmit` — no new type errors in changed files.
- [ ] Manual QA: send a voice recording → renders as voice bubble (sender + recipient). Send an MP3 from gallery → renders as file with save-to-disk (sender + recipient). Trigger a network blip during photo upload → retries within ~6s instead of failing the op. Open an encrypted media chat right after login → grace period waits for room crypto.