### PR TITLE
fix(chat): degrade post-update sync hang instead of infinite preloader (WEE-55)

### DIFF
--- a/src/entities/auth/model/stores.ts
+++ b/src/entities/auth/model/stores.ts
@@ -527,6 +527,11 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
           // Skip event processing before initial sync completes — events will be
           // picked up by fullRoomRefresh reconciliation. Processing them early causes
           // Dexie writes → liveQuery notifications against an incomplete room list.
+          // WEE-55: the degraded watchdog also flips roomsInitialized=true after a
+          // stalled first /sync, so events may be processed before the first full
+          // refresh. That is intentional — degraded mode favours showing live
+          // events over an infinite preloader, and the eventual PREPARED full
+          // refresh reconciles any rooms missed in the meantime.
           if (roomId && chatStore.roomsInitialized) {
             chatStore.handleTimelineEvent(event, roomId);
           }

--- a/src/entities/chat/model/chat-store-initial-sync.test.ts
+++ b/src/entities/chat/model/chat-store-initial-sync.test.ts
@@ -1,0 +1,127 @@
+/**
+ * WEE-55 — post-update Matrix sync hang regression tests.
+ *
+ * Guards the initial-sync lifecycle watchdog: if the first /sync never lands
+ * (invalid sync_token, slow 3G, server stall) the UI must stop showing an
+ * infinite preloader and degrade to the cached/empty state instead.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setActivePinia } from "pinia";
+import { createTestingPinia } from "@pinia/testing";
+
+const mockMatrixService = {
+  isReady: vi.fn(() => true),
+  getUserId: vi.fn(() => "@me:server"),
+  getRooms: vi.fn(() => [] as unknown[]),
+  getRoom: vi.fn(() => ({ selfMembership: "join" })),
+  getIgnoredMatrixUserIds: vi.fn(() => [] as string[]),
+  kit: { client: { getUserId: () => "@me:server" } },
+};
+
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: vi.fn(() => mockMatrixService),
+}));
+
+import { useChatStore } from "./chat-store";
+
+describe("chat-store WEE-55 initial-sync watchdog", () => {
+  let store: ReturnType<typeof useChatStore>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setActivePinia(createTestingPinia({ stubActions: false }));
+    store = useChatStore();
+  });
+
+  afterEach(() => {
+    store.cleanup();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("starts in 'loading' with isSyncing true", () => {
+    expect(store.initialSyncStatus).toBe("loading");
+    expect(store.isSyncing).toBe(true);
+    expect(store.roomsInitialized).toBe(false);
+  });
+
+  it("degrades after the timeout when the first sync never completes", () => {
+    store.startInitialSyncWatch();
+    expect(store.initialSyncStatus).toBe("loading");
+
+    vi.advanceTimersByTime(8000);
+
+    // Stop blocking the UI: surface cached rooms / empty hint, not a spinner.
+    expect(store.initialSyncStatus).toBe("degraded");
+    expect(store.roomsInitialized).toBe(true);
+    expect(store.isSyncing).toBe(false);
+  });
+
+  it("does not degrade before the deadline elapses", () => {
+    store.startInitialSyncWatch();
+    vi.advanceTimersByTime(7999);
+    expect(store.initialSyncStatus).toBe("loading");
+    expect(store.isSyncing).toBe(true);
+  });
+
+  it("reaches 'ready' on a PREPARED sync and cancels the degraded fallback", () => {
+    // setHelpers wires the Matrix client and arms the watchdog.
+    store.setHelpers(mockMatrixService.kit as never, {} as never);
+    expect(store.initialSyncStatus).toBe("loading");
+
+    store.refreshRooms("PREPARED");
+    vi.advanceTimersByTime(150); // debounce window → refreshRoomsImmediate
+
+    expect(store.roomsInitialized).toBe(true);
+    expect(store.initialSyncStatus).toBe("ready");
+    expect(store.isSyncing).toBe(false);
+
+    // The watchdog must have been cleared — staying ready past the deadline.
+    vi.advanceTimersByTime(8000);
+    expect(store.initialSyncStatus).toBe("ready");
+  });
+
+  it("keeps isSyncing true while the connection is lost, even after ready", () => {
+    store.setHelpers(mockMatrixService.kit as never, {} as never);
+    store.refreshRooms("PREPARED");
+    vi.advanceTimersByTime(150);
+    expect(store.isSyncing).toBe(false);
+
+    store.setSyncState("RECONNECTING");
+    expect(store.isSyncing).toBe(true);
+  });
+
+  it("upgrades degraded → ready when a real PREPARED sync arrives late", () => {
+    // Simulate the post-update hang: watchdog armed, sync never lands in time.
+    store.setHelpers(mockMatrixService.kit as never, {} as never);
+    vi.advanceTimersByTime(8000);
+    expect(store.initialSyncStatus).toBe("degraded");
+    expect(store.roomsInitialized).toBe(true);
+    expect(store.isSyncing).toBe(false);
+
+    // The stalled /sync finally completes → first PREPARED arrives.
+    store.refreshRooms("PREPARED");
+    vi.advanceTimersByTime(150); // debounce → refreshRoomsImmediate
+
+    // Status upgrades to ready; roomsInitialized stays true (no flicker back).
+    expect(store.initialSyncStatus).toBe("ready");
+    expect(store.roomsInitialized).toBe(true);
+    expect(store.isSyncing).toBe(false);
+  });
+
+  it("cleanup resets the lifecycle back to 'loading'", () => {
+    store.startInitialSyncWatch();
+    vi.advanceTimersByTime(8000);
+    expect(store.initialSyncStatus).toBe("degraded");
+
+    store.cleanup();
+    expect(store.initialSyncStatus).toBe("loading");
+    expect(store.roomsInitialized).toBe(false);
+
+    // A fresh watchdog can be armed again after cleanup.
+    store.startInitialSyncWatch();
+    vi.advanceTimersByTime(8000);
+    expect(store.initialSyncStatus).toBe("degraded");
+  });
+});

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -465,8 +465,51 @@ export const useChatStore = defineStore(NAMESPACE, () => {
   const namesReady = ref(false);
   /** Current Matrix sync state — updated from onSync callback via refreshRooms */
   const syncState = ref<"PREPARED" | "SYNCING" | "ERROR" | "STOPPED" | "RECONNECTING" | null>(null);
-  /** True during initial sync or when connection is lost */
-  const isSyncing = computed(() => !roomsInitialized.value || syncState.value === "ERROR" || syncState.value === "RECONNECTING");
+
+  // WEE-55: explicit initial-sync lifecycle. A hung post-update Matrix /sync
+  // (invalid sync_token, slow 3G, server stall) used to leave roomsInitialized
+  // false forever → infinite preloader / empty chat list / endless in-room
+  // message skeleton. "degraded" is the escape hatch: stop waiting and fall
+  // back to whatever the Dexie cache holds (or the empty-state hint).
+  const initialSyncStatus = ref<"loading" | "ready" | "degraded">("loading");
+  /** Watchdog deadline before we give up on the first sync and degrade. */
+  const INITIAL_SYNC_TIMEOUT_MS = 8000;
+  let initialSyncTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearInitialSyncTimer = () => {
+    if (initialSyncTimer) {
+      clearTimeout(initialSyncTimer);
+      initialSyncTimer = null;
+    }
+  };
+
+  /**
+   * Start the watchdog that escapes the "loading" state if the first Matrix
+   * sync never completes. Idempotent per login; cleared on `cleanup()` and on
+   * the first successful sync-driven refresh. Local-first: degrading unblocks
+   * the UI to render whatever Dexie already holds instead of spinning forever.
+   */
+  const startInitialSyncWatch = () => {
+    if (initialSyncStatus.value === "ready") return;
+    clearInitialSyncTimer();
+    initialSyncTimer = setTimeout(() => {
+      initialSyncTimer = null;
+      if (initialSyncStatus.value !== "loading") return;
+      initialSyncStatus.value = "degraded";
+      // Release every skeleton/preloader that keys off roomsInitialized so the
+      // cached room list (or the empty-state hint) becomes visible. A later
+      // PREPARED sync still runs a full refresh and upgrades back to "ready".
+      roomsInitialized.value = true;
+    }, INITIAL_SYNC_TIMEOUT_MS);
+  };
+
+  /** True during initial sync or when connection is lost. Degraded mode is
+   *  intentionally NOT syncing — we have stopped blocking the UI. */
+  const isSyncing = computed(() =>
+    initialSyncStatus.value === "loading"
+    || syncState.value === "ERROR"
+    || syncState.value === "RECONNECTING",
+  );
 
   // Cache for decrypted room previews — persists across refreshRooms() rebuilds
   const decryptedPreviewCache = new Map<string, string>();
@@ -1819,6 +1862,9 @@ export const useChatStore = defineStore(NAMESPACE, () => {
   const setHelpers = (kit: MatrixKit, crypto: Pcrypto) => {
     matrixKitRef.value = kit;
     pcryptoRef.value = crypto;
+    // WEE-55: begin the initial-sync watchdog as soon as the Matrix client is
+    // wired up, so a stalled first /sync degrades instead of hanging the UI.
+    startInitialSyncWatch();
   };
 
 
@@ -2800,9 +2846,15 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       incrementalRoomRefresh(kit, myUserId, changed);
     }
 
-    // Mark rooms as initialized (first sync-based refresh complete)
-    if (!roomsInitialized.value) {
-      roomsInitialized.value = true;
+    // Mark rooms as initialized (first sync-based refresh complete).
+    // WEE-55: gate the one-time post-sync side effects on initialSyncStatus
+    // rather than roomsInitialized, because the degraded watchdog may have
+    // already flipped roomsInitialized=true before the first real sync landed.
+    const firstSyncComplete = initialSyncStatus.value !== "ready";
+    if (!roomsInitialized.value) roomsInitialized.value = true;
+    if (firstSyncComplete) {
+      initialSyncStatus.value = "ready";
+      clearInitialSyncTimer();
       // Start background preloading after rooms are built
       // Delay lets the UI render the room list and decrypt previews first
       setTimeout(() => preloadVisibleRooms(), 500);
@@ -6791,6 +6843,9 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     roomsInitialized.value = false;
     namesReady.value = false;
     syncState.value = null;
+    // WEE-55: reset the initial-sync lifecycle for the next login/account.
+    initialSyncStatus.value = "loading";
+    clearInitialSyncTimer();
     editingMessage.value = null;
     deletingMessage.value = null;
     deletingMessages.value = [];
@@ -6920,6 +6975,8 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     removeMessage,
     removeRoom,
     roomsInitialized,
+    initialSyncStatus,
+    startInitialSyncWatch,
     namesReady,
     syncState,
     isSyncing,


### PR DESCRIPTION
## Summary
- Fixes the post-update boot path where a hung first Matrix `/sync` left the chat list on an infinite preloader / empty list and in-room timelines on an endless skeleton.
- Root cause: `chatStore.roomsInitialized` (and the derived `isSyncing`) only flipped to `true` inside `refreshRoomsImmediate()`, which runs solely on Matrix `onSync` PREPARED/SYNCING. If the first sync never completed (invalid `sync_token`, slow 3G, server stall), the flag — and every skeleton/preloader keyed off it — stayed stuck forever, and the empty-state hint never showed.
- Adds an explicit initial-sync lifecycle `loading | ready | degraded` with an 8s watchdog armed in `setHelpers()`. On timeout the status degrades and `roomsInitialized` is released, so cached Dexie rooms (or the empty hint) render instead of a spinner. A late PREPARED sync still runs a full refresh and upgrades back to `ready`, firing the one-time post-sync side effects exactly once. `cleanup()` resets the lifecycle per login.
- Last-message dates (#742) were already locale-aware via `tRaw("date.today/yesterday")`; covered by existing `format.test.ts`.

## Linear
- Resolves WEE-55 (https://linear.app/wwwee/issue/WEE-55)

## Closes
Closes greenShirtMystery/forta-bugs#742
Closes greenShirtMystery/forta-bugs#844
Closes greenShirtMystery/forta-bugs#859
Closes greenShirtMystery/forta-bugs#867
Closes greenShirtMystery/forta-bugs#868

## Changes
- `src/entities/chat/model/chat-store.ts` — `initialSyncStatus` lifecycle + 8s watchdog; `isSyncing` keyed on status; `setHelpers` arms watchdog; `refreshRoomsImmediate` upgrades to ready + gates one-time side effects on status; `cleanup` resets.
- `src/entities/auth/model/stores.ts` — comment documenting the `onTimeline` gate behavior in degraded mode.
- `src/entities/chat/model/chat-store-initial-sync.test.ts` — 7 regression tests (loading→degraded, pre-deadline boundary, PREPARED→ready cancels fallback, degraded→ready late upgrade, RECONNECTING-after-ready, cleanup reset/re-arm).

## Test plan
- [x] `vitest run` watchdog suite — 7/7 pass
- [x] chat-store + format suites — 219/219 pass
- [x] No new `vue-tsc` errors introduced (pre-existing repo errors in unrelated files only)
- [x] Code review (superpowers:code-reviewer) — no CRITICAL/HIGH; MEDIUM/LOW notes addressed
- [ ] Manual QA on Android: post-update restart → chats load <5s; corrupt `sync_token` → recovers; 3G throttling → degraded UI (cached/empty hint) after 8s, not infinite spinner; RU locale yesterday → "Вчера"

> Note: repo's default Node 20.11.1 can't run the current vitest/rolldown (needs `node:util.styleText`); tests verified on Node 22.