### PR TITLE
fix(calls): post-WEE-49 regression cluster — audio, ringtone, cellular, ringback (WEE-54)

### DIFF
--- a/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
@@ -134,6 +134,32 @@ class AudioRouter private constructor(private val context: Context) {
         @androidx.annotation.VisibleForTesting
         internal fun modeReapplyScheduleMs(): List<Long> =
             listOf(500L, 1_500L, 3_500L, 7_500L)
+
+        /**
+         * WEE-54 / forta-bugs#860 — Samsung A15 (Android 15) bidirectional
+         * silence guard.
+         *
+         * When [setDeviceModern] cannot find the requested device in
+         * `availableCommunicationDevices`, the old behaviour was to call
+         * `clearCommunicationDevice()`. For a *removable* device (Bluetooth /
+         * wired headset) that genuinely went away that is correct — fall back
+         * to the system default. But the built-in earpiece and speaker ALWAYS
+         * physically exist; their absence from the freshly-enumerated comm-
+         * device list is a transient timing artifact on Android 15, where the
+         * list can be momentarily empty right after `mode` flips to
+         * MODE_IN_COMMUNICATION. Clearing the communication device in that
+         * window tears down the only routing the call has and leaves both
+         * parties in total silence (#860 on Samsung SM-G991B / A15).
+         *
+         * So: only clear for removable devices; for built-in earpiece/speaker
+         * keep whatever routing the system already chose (default is the
+         * earpiece in communication mode) and let the OEM mode-reapply window
+         * settle the enumeration. Pure predicate so it is covered by a JVM
+         * unit test without a real AudioManager.
+         */
+        @androidx.annotation.VisibleForTesting
+        internal fun shouldClearWhenTargetMissing(device: Device): Boolean =
+            device == Device.BLUETOOTH || device == Device.WIRED_HEADSET
     }
 
     enum class Device(val label: String) {
@@ -607,9 +633,20 @@ class AudioRouter private constructor(private val context: Context) {
         if (target != null) {
             val success = audioManager.setCommunicationDevice(target)
             Log.d(LIFECYCLE_TAG, "setCommunicationDevice(${deviceTypeToString(target.type)}): $success")
-        } else {
-            Log.w(LIFECYCLE_TAG, "Target device $device not found in available communication devices")
+        } else if (shouldClearWhenTargetMissing(device)) {
+            // Removable device (BT / wired) genuinely gone — fall back to the
+            // system default by clearing the explicit communication device.
+            Log.w(LIFECYCLE_TAG, "Removable target $device gone — clearing communication device")
             audioManager.clearCommunicationDevice()
+        } else {
+            // WEE-54 / forta-bugs#860: built-in earpiece/speaker missing from
+            // the enumeration is a transient Android 15 timing artifact — do
+            // NOT clear, or we strand the call in total silence. Keep the
+            // system's current routing; the OEM mode-reapply window settles it.
+            Log.w(
+                LIFECYCLE_TAG,
+                "Built-in target $device not yet enumerated (Android 15 race) — keeping current routing",
+            )
         }
     }
 

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallForegroundService.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallForegroundService.kt
@@ -204,6 +204,44 @@ class CallForegroundService : Service() {
         return START_NOT_STICKY
     }
 
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        // WEE-54 / forta-bugs#839 (reopen): when the user swipes the app out of
+        // Recents during or right after a call, Android delivers onTaskRemoved
+        // but does NOT always call onDestroy promptly — the OS can keep the
+        // service record around (especially on OEM ROMs), so AudioRouter stays
+        // in MODE_IN_COMMUNICATION and the cellular network is blocked until
+        // reboot. WEE-49 only hardened onDestroy(); this swipe-out path slipped
+        // through, which is why #839 reopened on 1.10.31. Mirror the onDestroy
+        // brute-force cleanup here and stopSelf() so teardown is deterministic.
+        runCatching {
+            AudioRouter.getSharedInstance(applicationContext).forceStop()
+        }.onFailure { Log.w(TAG, "AudioRouter.forceStop in onTaskRemoved threw", it) }
+
+        runCatching {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+        }.onFailure { Log.w(TAG, "stopForeground in onTaskRemoved threw", it) }
+
+        hasStarted = false
+        releaseWakeLock()
+        abandonAudioFocus()
+        // Clear liveness NOW, not in the (possibly deferred) onDestroy. The
+        // audio mode has already been torn down above, but `isRunning` is what
+        // the AudioRouter orphan watchdog and CallActivity.onResume consult
+        // before restoring MODE_IN_COMMUNICATION. If we left `instance`
+        // non-null until the OS finally runs onDestroy, a surface waking in
+        // that window would see a "running" call and re-apply comm mode —
+        // re-stranding the audio and re-creating the orphan VoIP-mode bug
+        // (#708 / #462) that this whole cellular-unblock fix targets. Nulling
+        // here keeps liveness consistent with the teardown that just ran;
+        // onDestroy setting it null again is an idempotent no-op.
+        instance = null
+
+        super.onTaskRemoved(rootIntent)
+        // stopSelf so the OS finalises the service (and runs onDestroy) instead
+        // of leaving a zombie service record holding the audio mode.
+        stopSelf()
+    }
+
     override fun onDestroy() {
         // WEE-49: when the OS tears the service down without going through
         // ACTION_STOP (process killed by OEM Doze, swipe-app-out, low-mem

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/CallNotificationConfig.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/CallNotificationConfig.kt
@@ -53,6 +53,40 @@ object CallNotificationConfig {
      */
     val LEGACY_INCOMING_CALL_CHANNEL_IDS: List<String> = listOf("calls")
 
+    /**
+     * Mirror of [android.media.AudioManager.RINGER_MODE_NORMAL] (= 2),
+     * duplicated as a plain constant so [ringVolumeToForce] stays a pure
+     * JVM-unit-testable predicate without the Android framework on the
+     * test classpath (same approach as [AudioRouter]'s companion predicates).
+     */
+    const val RINGER_MODE_NORMAL = 2
+
+    /**
+     * Compute the STREAM_RING volume to force before playing the incoming-call
+     * ringtone, or `null` when no adjustment should be made.
+     *
+     * WEE-54 / forta-bugs#862: on MIUI / HyperOS (Xiaomi) the STREAM_RING
+     * volume is frequently left muted or near-zero by the OEM even though the
+     * phone is in the normal ringer mode, so [android.media.RingtoneManager]
+     * plays inaudibly and the user only feels the vibration ("тихая вибрация
+     * без рингтона"). When the ringer mode is NORMAL but the ring stream sits
+     * below half its range, bump it to half so the ringtone is actually heard.
+     *
+     * Silent and vibrate ringer modes are respected (return `null`): forcing
+     * audio there would override an explicit user choice. The vibration that
+     * accompanies the ringer remains the fallback signal in those modes.
+     *
+     * @return the volume to apply via `setStreamVolume`, or `null` to leave
+     *   the current volume untouched.
+     */
+    fun ringVolumeToForce(ringerMode: Int, currentVolume: Int, maxVolume: Int): Int? {
+        if (ringerMode != RINGER_MODE_NORMAL) return null
+        if (maxVolume <= 0) return null
+        val target = maxVolume / 2
+        if (currentVolume >= target) return null
+        return target
+    }
+
     fun incomingCallChannelSpec(name: String, description: String): IncomingCallChannelSpec =
         IncomingCallChannelSpec(
             id = INCOMING_CALL_CHANNEL_ID,

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/IncomingCallActivity.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/IncomingCallActivity.kt
@@ -421,8 +421,31 @@ class IncomingCallActivity : Activity() {
         }
     }
 
+    /**
+     * WEE-54 / forta-bugs#862: bump STREAM_RING when an OEM (MIUI / HyperOS)
+     * has left it muted while the phone is in normal ringer mode, otherwise
+     * the system ringtone plays inaudibly and only the vibration is felt.
+     * Silent / vibrate ringer modes are respected (no-op) — see
+     * [CallNotificationConfig.ringVolumeToForce]. Best-effort: any failure
+     * (locked stream on hardened ROMs) is swallowed; vibration still fires.
+     */
+    private fun ensureRingerAudible() {
+        try {
+            val am = getSystemService(Context.AUDIO_SERVICE) as? android.media.AudioManager ?: return
+            val target = CallNotificationConfig.ringVolumeToForce(
+                ringerMode = am.ringerMode,
+                currentVolume = am.getStreamVolume(android.media.AudioManager.STREAM_RING),
+                maxVolume = am.getStreamMaxVolume(android.media.AudioManager.STREAM_RING),
+            ) ?: return
+            am.setStreamVolume(android.media.AudioManager.STREAM_RING, target, 0)
+        } catch (e: Exception) {
+            Log.w(TAG, "ensureRingerAudible failed", e)
+        }
+    }
+
     private fun startRingtone() {
         try {
+            ensureRingerAudible()
             val ringtoneUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
             ringtone = RingtoneManager.getRingtone(applicationContext, ringtoneUri)
             ringtone?.audioAttributes = AudioAttributes.Builder()

--- a/android/app/src/test/java/com/forta/chat/plugins/calls/AudioRouterModeReapplyTest.kt
+++ b/android/app/src/test/java/com/forta/chat/plugins/calls/AudioRouterModeReapplyTest.kt
@@ -75,6 +75,46 @@ class AudioRouterModeReapplyTest {
         )
     }
 
+    // -------------------------------------------------------------------------
+    // WEE-54 / forta-bugs#860 — Samsung A15 bidirectional-silence guard.
+    //
+    // setDeviceModern() must only clear the communication device when a
+    // *removable* device (BT / wired) is genuinely gone. Built-in earpiece /
+    // speaker missing from the freshly-enumerated list is a transient Android
+    // 15 timing artifact; clearing routing there leaves both parties silent.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun builtInEarpieceMissing_doesNotClearRouting() {
+        assertFalse(
+            "built-in earpiece absence is a transient A15 enumeration race — " +
+                "clearing would strand the call in silence (#860)",
+            AudioRouter.shouldClearWhenTargetMissing(AudioRouter.Device.EARPIECE),
+        )
+    }
+
+    @Test
+    fun builtInSpeakerMissing_doesNotClearRouting() {
+        assertFalse(
+            AudioRouter.shouldClearWhenTargetMissing(AudioRouter.Device.SPEAKER),
+        )
+    }
+
+    @Test
+    fun removableBluetoothMissing_clearsRouting() {
+        assertTrue(
+            "a Bluetooth device that left must fall back to the system default",
+            AudioRouter.shouldClearWhenTargetMissing(AudioRouter.Device.BLUETOOTH),
+        )
+    }
+
+    @Test
+    fun removableWiredHeadsetMissing_clearsRouting() {
+        assertTrue(
+            AudioRouter.shouldClearWhenTargetMissing(AudioRouter.Device.WIRED_HEADSET),
+        )
+    }
+
     @Test
     fun reapplySchedule_coversExpectedOemResetWindows() {
         // The schedule must include the original 500 ms catch (fast OEMs) and

--- a/android/app/src/test/java/com/forta/chat/plugins/calls/CallForegroundServiceDestroyContractTest.kt
+++ b/android/app/src/test/java/com/forta/chat/plugins/calls/CallForegroundServiceDestroyContractTest.kt
@@ -82,6 +82,68 @@ class CallForegroundServiceDestroyContractTest {
         )
     }
 
+    // -------------------------------------------------------------------------
+    // WEE-54 / forta-bugs#839 (reopen) — swipe-out cellular block.
+    //
+    // onDestroy() hardening (WEE-49) only fired when the OS actually destroyed
+    // the service. On swipe-app-out the OS delivers onTaskRemoved but can defer
+    // onDestroy, leaving AudioRouter in MODE_IN_COMMUNICATION and cellular
+    // blocked. onTaskRemoved must run the same brute-force audio cleanup.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun onTaskRemoved_forceStopsAudioRouter_toUnblockCellularOnSwipeOut() {
+        val block = extractFunctionBody("onTaskRemoved")
+        assertTrue(
+            "onTaskRemoved() must call AudioRouter.forceStop() so a swipe-out " +
+                "during a call cannot leave MODE_IN_COMMUNICATION set and block " +
+                "cellular (WEE-54 / forta-bugs#839 reopen):\n$block",
+            block.contains("AudioRouter.getSharedInstance(") &&
+                block.contains(".forceStop()"),
+        )
+    }
+
+    @Test
+    fun onTaskRemoved_stopsForegroundAndStopsSelf_soNoZombieServiceHoldsAudioMode() {
+        val block = extractFunctionBody("onTaskRemoved")
+        assertTrue(
+            "onTaskRemoved() must stopForeground(STOP_FOREGROUND_REMOVE):\n$block",
+            block.contains("stopForeground(STOP_FOREGROUND_REMOVE)"),
+        )
+        assertTrue(
+            "onTaskRemoved() must stopSelf() so the OS finalises the service " +
+                "instead of leaving a zombie record holding the audio mode:\n$block",
+            block.contains("stopSelf()"),
+        )
+    }
+
+    @Test
+    fun onTaskRemoved_clearsInstance_soStaleIsRunningCannotResurrectVoipMode() {
+        val block = extractFunctionBody("onTaskRemoved")
+        // isRunning == (instance != null) is what the AudioRouter orphan
+        // watchdog / CallActivity.onResume consult before restoring
+        // MODE_IN_COMMUNICATION. onTaskRemoved tears audio down but the OS can
+        // defer onDestroy — if instance stays non-null in that window a waking
+        // surface re-applies comm mode and re-strands audio (#708 / #462).
+        assertTrue(
+            "onTaskRemoved() must set instance = null so isRunning matches the " +
+                "audio teardown that already ran (WEE-54):\n$block",
+            block.contains("instance = null"),
+        )
+    }
+
+    @Test
+    fun onTaskRemoved_wrapsBruteResetInRunCatching_soOneFailureDoesNotSwallowTheNext() {
+        val block = extractFunctionBody("onTaskRemoved")
+        val runCatchingHits = Regex("runCatching\\s*\\{")
+            .findAll(block).count()
+        assertTrue(
+            "onTaskRemoved() must wrap at least two brute-force steps in " +
+                "runCatching (found $runCatchingHits):\n$block",
+            runCatchingHits >= 2,
+        )
+    }
+
     /**
      * Extract the body of a top-level `override fun <name>(...)` block from the
      * Kotlin source. Brace-counts so nested blocks (if/try/runCatching) do not

--- a/android/app/src/test/java/com/forta/chat/plugins/calls/CallNotificationConfigTest.kt
+++ b/android/app/src/test/java/com/forta/chat/plugins/calls/CallNotificationConfigTest.kt
@@ -2,6 +2,7 @@ package com.forta.chat.plugins.calls
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -83,5 +84,95 @@ class CallNotificationConfigTest {
     fun `spec id matches the active channel id constant`() {
         val spec = CallNotificationConfig.incomingCallChannelSpec("Calls", "desc")
         assertEquals(CallNotificationConfig.INCOMING_CALL_CHANNEL_ID, spec.id)
+    }
+
+    // -------------------------------------------------------------------------
+    // WEE-54 / forta-bugs#862 — STREAM_RING volume bump for OEM-muted ringers.
+    //
+    // MIUI / HyperOS leave the ring stream muted while the phone is in normal
+    // ringer mode, so the system ringtone is silent and the user only feels
+    // vibration. ringVolumeToForce decides when to bump the volume, respecting
+    // silent / vibrate ringer modes (an explicit user choice).
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `RINGER_MODE_NORMAL mirrors the AudioManager constant value`() {
+        // AudioManager.RINGER_MODE_NORMAL == 2. If the platform ever changed
+        // this, our call sites that pass am.ringerMode would silently break.
+        assertEquals(2, CallNotificationConfig.RINGER_MODE_NORMAL)
+    }
+
+    @Test
+    fun `bumps muted ring stream to half in normal ringer mode (regression for #862)`() {
+        // Xiaomi: normal mode but stream muted → ringtone silent. Bump to half.
+        assertEquals(
+            Integer.valueOf(7),
+            CallNotificationConfig.ringVolumeToForce(
+                ringerMode = CallNotificationConfig.RINGER_MODE_NORMAL,
+                currentVolume = 0,
+                maxVolume = 15,
+            ),
+        )
+    }
+
+    @Test
+    fun `bumps a near-silent ring stream up to half`() {
+        assertEquals(
+            Integer.valueOf(7),
+            CallNotificationConfig.ringVolumeToForce(
+                ringerMode = CallNotificationConfig.RINGER_MODE_NORMAL,
+                currentVolume = 2,
+                maxVolume = 15,
+            ),
+        )
+    }
+
+    @Test
+    fun `leaves an already-audible ring stream untouched`() {
+        assertNull(
+            "volume already at/above half — no adjustment needed",
+            CallNotificationConfig.ringVolumeToForce(
+                ringerMode = CallNotificationConfig.RINGER_MODE_NORMAL,
+                currentVolume = 10,
+                maxVolume = 15,
+            ),
+        )
+    }
+
+    @Test
+    fun `respects vibrate ringer mode and does not force audio`() {
+        // RINGER_MODE_VIBRATE == 1 — user explicitly chose vibrate-only.
+        assertNull(
+            CallNotificationConfig.ringVolumeToForce(
+                ringerMode = 1,
+                currentVolume = 0,
+                maxVolume = 15,
+            ),
+        )
+    }
+
+    @Test
+    fun `respects silent ringer mode and does not force audio`() {
+        // RINGER_MODE_SILENT == 0 — user explicitly silenced the phone.
+        assertNull(
+            CallNotificationConfig.ringVolumeToForce(
+                ringerMode = 0,
+                currentVolume = 0,
+                maxVolume = 15,
+            ),
+        )
+    }
+
+    @Test
+    fun `returns null when the device reports a zero-range ring stream`() {
+        // Defensive: a maxVolume of 0 must not produce a divide-by-zero or a
+        // bogus target of 0 — leave the stream untouched.
+        assertNull(
+            CallNotificationConfig.ringVolumeToForce(
+                ringerMode = CallNotificationConfig.RINGER_MODE_NORMAL,
+                currentVolume = 0,
+                maxVolume = 0,
+            ),
+        )
     }
 }

--- a/src/features/video-calls/model/call-service.test.ts
+++ b/src/features/video-calls/model/call-service.test.ts
@@ -64,6 +64,7 @@ vi.mock('@/shared/lib/native-calls', () => ({
     wire: vi.fn().mockResolvedValue(undefined),
     startAudioRouting: mockStartAudioRouting,
     stopAudioRouting: mockStopAudioRouting,
+    ensureIncomingCallVisible: vi.fn().mockResolvedValue(undefined),
   },
   consumePendingAnswerCallId: vi.fn().mockResolvedValue(false),
   consumePendingRejectCallId: vi.fn().mockResolvedValue(false),
@@ -376,6 +377,105 @@ describe('call-service permission flow', () => {
       // path or the user would be locked out of dialing until reload.
       await service.startCall('!room:matrix.org', 'voice');
       expect(mockEnsureCallPermissions).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // WEE-54 / forta-bugs#866 — phantom ringback tone.
+  //
+  // The local ringback ("гудки") used to play synchronously inside
+  // startCallInner *before* placeVoiceCall() ran, so it sounded during local
+  // getUserMedia + offer creation, and even when the invite never reached the
+  // homeserver. Users perceived this as ringback "when the peer device was
+  // off". The fix gates the ringback on the SDK's InviteSent state (invite
+  // actually delivered to the server) inside wireCallEvents.
+  // -------------------------------------------------------------------------
+  describe('outgoing ringback gating (#866 / WEE-54)', () => {
+    function captureOnState() {
+      const stateCall = mockOn.mock.calls.find((c: unknown[]) => c[0] === 'State');
+      return stateCall?.[1] as
+        | ((newState: string, oldState: string) => void)
+        | undefined;
+    }
+
+    it('does NOT play the ringback synchronously when the call is dialed', async () => {
+      const { playDialtone } = await import('./call-sounds');
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      await service.startCall('!room:matrix.org', 'voice');
+
+      // The dial tone must not fire just because placeVoiceCall resolved —
+      // only the SDK InviteSent transition is allowed to start it.
+      expect(vi.mocked(playDialtone)).not.toHaveBeenCalled();
+    });
+
+    it('plays the ringback once the SDK reports InviteSent (invite delivered)', async () => {
+      const { playDialtone } = await import('./call-sounds');
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      await service.startCall('!room:matrix.org', 'voice');
+
+      const onState = captureOnState();
+      expect(onState).toBeTruthy();
+
+      // SDK transitions CreateOffer → InviteSent once the invite is sent.
+      onState?.('invite_sent', 'create_offer');
+      expect(vi.mocked(playDialtone)).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT play the ringback during pre-invite states (local media / offer setup)', async () => {
+      const { playDialtone } = await import('./call-sounds');
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      await service.startCall('!room:matrix.org', 'voice');
+
+      const onState = captureOnState();
+      // None of the pre-invite states should trigger the dial tone — this is
+      // exactly the window where the phantom ringback used to play.
+      onState?.('wait_local_media', 'fledgling');
+      onState?.('create_offer', 'wait_local_media');
+      expect(vi.mocked(playDialtone)).not.toHaveBeenCalled();
+    });
+
+    it('starts the ringback at most once even if InviteSent is observed twice', async () => {
+      const { playDialtone } = await import('./call-sounds');
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+      await service.startCall('!room:matrix.org', 'voice');
+
+      const onState = captureOnState();
+      onState?.('invite_sent', 'create_offer');
+      onState?.('invite_sent', 'invite_sent');
+      expect(vi.mocked(playDialtone)).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT play the ringback for an incoming call on InviteSent', async () => {
+      // Defensive: the gate is keyed on direction === "outgoing". An incoming
+      // call must never emit the outgoing dial tone.
+      const { playDialtone } = await import('./call-sounds');
+      const { useCallService } = await import('./call-service');
+      const service = useCallService();
+
+      mockCallStore.matrixCall = {
+        callId: 'incoming-call-id',
+        roomId: '!room:matrix.org',
+        type: 'voice',
+        on: mockOn,
+        off: mockOff,
+        answer: mockAnswer,
+        reject: mockReject,
+        localUsermediaStream: null,
+        localScreensharingStream: null,
+        remoteUsermediaStream: null,
+        remoteScreensharingStream: null,
+        remoteUsermediaFeed: null,
+        getOpponentMember: vi.fn(() => ({ userId: '@peer:matrix.org' })),
+      };
+      await service.handleIncomingCall(mockCallStore.matrixCall as never);
+
+      const onState = captureOnState();
+      onState?.('invite_sent', 'create_offer');
+      expect(vi.mocked(playDialtone)).not.toHaveBeenCalled();
     });
   });
 

--- a/src/features/video-calls/model/call-service.ts
+++ b/src/features/video-calls/model/call-service.ts
@@ -314,9 +314,38 @@ function wireCallEvents(call: MatrixCall, direction: "outgoing" | "incoming") {
 
   const callStore = useCallStore();
 
+  // WEE-54 / forta-bugs#866 — phantom ringback guard.
+  //
+  // Closure-local (reset per call because wireCallEvents runs once per
+  // MatrixCall) one-shot flag so the local ringback tone ("гудки") starts
+  // exactly once, and only after the SDK has actually emitted the invite
+  // to the homeserver (CallState.InviteSent). See the InviteSent branch
+  // below for the full rationale.
+  let ringbackStarted = false;
+
   const onState = ((newState: SDKCallState, _oldState: SDKCallState) => {
     const status = mapSDKState(newState, direction);
     callStore.updateStatus(status);
+
+    // WEE-54 / forta-bugs#866: start the outgoing ringback only once the
+    // invite has actually been sent to the homeserver (InviteSent), not
+    // the instant the user taps dial. Previously playDialtone() ran
+    // synchronously in startCallInner *before* placeVoiceCall(), so the
+    // ringback played during local getUserMedia + offer creation + the
+    // DTLS handshake — and even when the invite never left the device
+    // (e.g. a failed placeCall), which users perceived as "гудки when the
+    // peer was offline" (#866). Matrix 1:1 call signaling has no peer-ack
+    // receipt, so InviteSent (invite delivered to the server) is the
+    // earliest honest "we are now dialing the peer" signal we can gate on.
+    // stopAllSounds() in the connected/ended/error/hangup paths stops it.
+    if (
+      direction === "outgoing" &&
+      newState === SDKCallState.InviteSent &&
+      !ringbackStarted
+    ) {
+      ringbackStarted = true;
+      playDialtone();
+    }
 
     // Any transition out of "connecting" cancels the watchdog — either
     // we connected successfully or the SDK itself decided to end/fail.
@@ -886,7 +915,12 @@ export function useCallService() {
       refreshPeerNameAsync(call.callId, peerAddress);
     }
 
-    playDialtone();
+    // WEE-54 / forta-bugs#866: the local ringback tone is NOT started here.
+    // It used to play synchronously at this point — before placeVoiceCall()
+    // even ran — so "гудки" sounded during local media setup and even when
+    // the invite never reached the server. It is now gated on the SDK's
+    // InviteSent state inside wireCallEvents() so it only plays once we are
+    // actually dialing the peer.
 
     // Register outgoing call with Android ConnectionService + launch native UI
     if (isNative) {


### PR DESCRIPTION
## Summary
Fix-forward for the post-WEE-49 calls regression cluster on 1.10.32-33 (4 independent bugs):

- **#860 Samsung A15 bidirectional silence** — `AudioRouter.setDeviceModern` no longer calls `clearCommunicationDevice()` when a *built-in* earpiece/speaker is transiently missing from the Android 15 communication-device enumeration (race right after `mode = MODE_IN_COMMUNICATION`). Clearing in that window stranded the call in total silence. Only genuinely-removable BT/wired devices still clear. Gated by the pure predicate `shouldClearWhenTargetMissing`.
- **#862 silent ringtone on MIUI/Xiaomi** — `IncomingCallActivity.startRingtone()` now bumps `STREAM_RING` to half-volume when the OEM left it muted while the phone is in normal ringer mode (so the ringtone is actually audible, not just vibration). Silent/vibrate ringer modes are respected. Decision encapsulated in the pure predicate `CallNotificationConfig.ringVolumeToForce`.
- **#839 cellular block after swipe-out (reopen)** — `CallForegroundService.onTaskRemoved` now mirrors `onDestroy`'s brute-force `AudioRouter.forceStop()` + `stopForeground` + `stopSelf`, and clears `instance` so the deferred-`onDestroy` window can't leave `isRunning == true` and resurrect orphan VoIP mode. WEE-49 only hardened `onDestroy`; the swipe-out path slipped through.
- **#866 phantom ringback** — the local ringback ("гудки") now starts on the SDK `InviteSent` state (invite actually delivered to the homeserver) inside `wireCallEvents`, instead of synchronously *before* `placeVoiceCall()`. No more ringback during local media setup / failed dials.

## Linear
- Resolves [WEE-54](https://linear.app/wwwee/issue/WEE-54) (https://linear.app/wwwee/issue/WEE-54)

## Closes
Closes greenShirtMystery/forta-bugs#839
Closes greenShirtMystery/forta-bugs#860
Closes greenShirtMystery/forta-bugs#862
Closes greenShirtMystery/forta-bugs#866

Refs WEE-49.

## Test plan
- [x] `vitest` — `call-service.test.ts` (5 new cases: no sync ringback, InviteSent starts once, pre-invite silence, double-InviteSent idempotency, incoming-direction guard)
- [x] JVM unit tests (`./gradlew :app:testDebugUnitTest`) for the calls package: `ringVolumeToForce` (normal/vibrate/silent/already-audible/zero-range), `shouldClearWhenTargetMissing` (4 device branches), `onTaskRemoved` source contracts (forceStop / stopForeground / stopSelf / instance=null / runCatching)
- [x] `vite build` passes; Kotlin compiles clean (only pre-existing deprecation warnings)
- [ ] Manual QA matrix (no lab devices): Samsung A15 bidirectional audio; Xiaomi/MIUI muted-ring → audible ringtone or vibrate; cellular available immediately after Forta hangup on graceful/swipe-out/ANR paths; outgoing call to offline → no phantom ringback

> Note: this branch carries pre-existing, unrelated `vue-tsc` errors and 9 failing vitest specs (chat-helpers / display-result / open-profile-url / video-embed) that exist on `HEAD` before this change; none are in the call code touched here.