### PR TITLE
fix(calls): self-preview native aspect + proactive legacy-WebView warning (WEE-53)

### DIFF
--- a/src/features/video-calls/model/call-service.ts
+++ b/src/features/video-calls/model/call-service.ts
@@ -23,7 +23,11 @@ import {
 } from "@/shared/lib/native-calls";
 import { ensureCallPermissions, PermissionDeniedError, callPermissionError } from "./permissions";
 import { finalizeCall } from "./finalize-call";
-import { isLegacyWebView, MIN_CHROMIUM_MAJOR_FOR_MODERN_WEBRTC } from "./webview-compatibility";
+import {
+  isLegacyWebView,
+  shouldWarnLegacyWebView,
+  MIN_CHROMIUM_MAJOR_FOR_MODERN_WEBRTC,
+} from "./webview-compatibility";
 import {
   isIncomingCallSeen,
   markIncomingCallSeen,
@@ -39,7 +43,19 @@ import {
 let legacyWebViewToastShown = false;
 
 function maybeWarnLegacyWebView(): void {
-  if (legacyWebViewToastShown) return;
+  // Self-gating so call sites (call start, answer, mid-call restart skip)
+  // can fire-and-forget without each duplicating the native/legacy/one-shot
+  // policy. Native negotiates ICE through bundled libwebrtc, so the UA Chrome
+  // version is meaningless there — never warn on native.
+  if (
+    !shouldWarnLegacyWebView({
+      isNative,
+      isLegacy: isLegacyWebView(),
+      alreadyWarned: legacyWebViewToastShown,
+    })
+  ) {
+    return;
+  }
   legacyWebViewToastShown = true;
   try {
     // The shared toast surface only models info/success/error severities.
@@ -797,6 +813,13 @@ export function useCallService() {
 
     callStore.cancelScheduledClear();
 
+    // forta-bugs#497 / WEE-53: warn up-front when an outdated WebView is about
+    // to drive a call. Previously this only surfaced if a mid-call network
+    // change triggered the restartIce skip — but most legacy-device failures
+    // happen before any handover, so the user never saw the hint. One-shot
+    // guard + native exclusion live inside maybeWarnLegacyWebView.
+    maybeWarnLegacyWebView();
+
     // Preflight: mic (+ camera for video). Throws PermissionDeniedError
     // if the OS denied access, or if getUserMedia returns a stream with
     // empty tracks. If we skip this and let the SDK's getUserMedia fail
@@ -1195,6 +1218,12 @@ export function useCallService() {
     }
 
     answerInProgress = true;
+
+    // forta-bugs#497 / WEE-53: same proactive legacy-WebView hint on the
+    // answer path — an outdated callee should be told why the call may drop
+    // before it connects, not only if a later network change skips restartIce.
+    maybeWarnLegacyWebView();
+
     // Safety net per code-review: if any future edit inserts a throwing
     // synchronous call between here and the manual releases below, the
     // outer try/finally guarantees the lock is cleared on the way out so

--- a/src/features/video-calls/model/pip-size.test.ts
+++ b/src/features/video-calls/model/pip-size.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import {
+  computePipSize,
+  PIP_LONG_EDGE_MOBILE,
+  PIP_LONG_EDGE_DESKTOP,
+  PIP_MIN_ASPECT,
+  PIP_MAX_ASPECT,
+} from "./pip-size";
+
+describe("computePipSize", () => {
+  it("uses the desktop long edge as the width for landscape sources", () => {
+    // 16:9 landscape camera on desktop
+    const size = computePipSize(16 / 9, false);
+    expect(size.w).toBe(PIP_LONG_EDGE_DESKTOP);
+    expect(size.h).toBe(Math.round(PIP_LONG_EDGE_DESKTOP / (16 / 9)));
+    expect(size.w).toBeGreaterThan(size.h);
+  });
+
+  it("uses the long edge as the height for portrait sources (the #433 case)", () => {
+    // 9:16 portrait phone front camera on mobile — must NOT be cropped square
+    const aspect = 9 / 16;
+    const size = computePipSize(aspect, true);
+    expect(size.h).toBe(PIP_LONG_EDGE_MOBILE);
+    expect(size.w).toBe(Math.round(PIP_LONG_EDGE_MOBILE * aspect));
+    expect(size.h).toBeGreaterThan(size.w);
+  });
+
+  it("produces a square when the source is 1:1", () => {
+    const size = computePipSize(1, false);
+    expect(size.w).toBe(size.h);
+    expect(size.w).toBe(PIP_LONG_EDGE_DESKTOP);
+  });
+
+  it("falls back to a 4:3 landscape box when aspect is null", () => {
+    const size = computePipSize(null, false);
+    expect(size.w).toBe(PIP_LONG_EDGE_DESKTOP);
+    expect(size.w).toBeGreaterThan(size.h);
+    // 4:3 → height is three quarters of width
+    expect(size.h).toBe(Math.round(PIP_LONG_EDGE_DESKTOP / (4 / 3)));
+  });
+
+  it("uses the smaller long edge on mobile", () => {
+    const mobile = computePipSize(16 / 9, true);
+    const desktop = computePipSize(16 / 9, false);
+    expect(mobile.w).toBe(PIP_LONG_EDGE_MOBILE);
+    expect(desktop.w).toBe(PIP_LONG_EDGE_DESKTOP);
+    expect(mobile.w).toBeLessThan(desktop.w);
+  });
+
+  it("clamps an ultrawide source so the thumbnail never becomes a sliver", () => {
+    const size = computePipSize(5, false); // 5:1 ultrawide screen share
+    // Clamped to PIP_MAX_ASPECT → height stays above the un-clamped value
+    expect(size.h).toBe(Math.round(PIP_LONG_EDGE_DESKTOP / PIP_MAX_ASPECT));
+  });
+
+  it("clamps an extremely tall source", () => {
+    const size = computePipSize(0.1, true); // 1:10 pathological
+    expect(size.w).toBe(Math.round(PIP_LONG_EDGE_MOBILE * PIP_MIN_ASPECT));
+    expect(size.h).toBe(PIP_LONG_EDGE_MOBILE);
+  });
+
+  it("ignores invalid aspects (NaN, 0, negative) and falls back", () => {
+    const fallback = computePipSize(null, false);
+    expect(computePipSize(Number.NaN, false)).toEqual(fallback);
+    expect(computePipSize(0, false)).toEqual(fallback);
+    expect(computePipSize(-2, false)).toEqual(fallback);
+    expect(computePipSize(Number.POSITIVE_INFINITY, false)).toEqual(fallback);
+  });
+});

--- a/src/features/video-calls/model/pip-size.ts
+++ b/src/features/video-calls/model/pip-size.ts
@@ -1,0 +1,65 @@
+/**
+ * Self-view PiP geometry for the in-call window (forta-bugs#433 / WEE-53).
+ *
+ * The local self-preview used to render inside a fixed ~4:3 landscape box and
+ * fill it with `object-fit: cover`. On a phone held vertically the front
+ * camera produces a portrait stream (≈9:16), so `cover` cropped away the left
+ * and right of the frame — users saw only a square slice of themselves and
+ * could not tell what the peer actually received.
+ *
+ * Instead of hard-coding one aspect, the PiP now follows the *source* aspect
+ * ratio: we keep the long edge fixed and derive the short edge from the
+ * stream's natural ratio. The container then matches the video exactly, so
+ * `cover` no longer crops — the user sees the full frame, same as the peer.
+ *
+ * Pure module (no Vue / DOM) so the geometry is unit-testable in isolation.
+ */
+
+/** Long edge (px) of the PiP thumbnail on mobile (<640px) layouts. */
+export const PIP_LONG_EDGE_MOBILE = 120;
+/** Long edge (px) of the PiP thumbnail on desktop layouts. */
+export const PIP_LONG_EDGE_DESKTOP = 160;
+
+/**
+ * Fallback aspect (width / height) used until the real stream metadata
+ * arrives. 4:3 matches the previous fixed PiP dimensions so there is no
+ * visible size jump on the first frame before `loadedmetadata` fires.
+ */
+export const PIP_DEFAULT_ASPECT = 4 / 3;
+
+/**
+ * Clamp the source aspect into a sane thumbnail range. Without this an
+ * ultrawide screen-share (e.g. 21:9) would render the PiP as a thin sliver,
+ * and a pathological tall source as an unusable column. The bounds comfortably
+ * cover phone portrait (9:16 ≈ 0.5625) and landscape (16:9 ≈ 1.78).
+ */
+export const PIP_MIN_ASPECT = 0.4;
+export const PIP_MAX_ASPECT = 2.4;
+
+export interface PipSize {
+  w: number;
+  h: number;
+}
+
+/**
+ * Compute PiP width/height (px) for a given source aspect ratio.
+ *
+ * @param aspect width/height of the local stream, or `null` before metadata
+ *   is known (falls back to {@link PIP_DEFAULT_ASPECT}).
+ * @param isMobile whether the call window is in its mobile layout.
+ */
+export function computePipSize(aspect: number | null, isMobile: boolean): PipSize {
+  const longEdge = isMobile ? PIP_LONG_EDGE_MOBILE : PIP_LONG_EDGE_DESKTOP;
+
+  const safeAspect =
+    aspect !== null && Number.isFinite(aspect) && aspect > 0
+      ? Math.min(PIP_MAX_ASPECT, Math.max(PIP_MIN_ASPECT, aspect))
+      : PIP_DEFAULT_ASPECT;
+
+  if (safeAspect >= 1) {
+    // Landscape (or square): width is the long edge, height derived.
+    return { w: longEdge, h: Math.round(longEdge / safeAspect) };
+  }
+  // Portrait: height is the long edge, width derived.
+  return { w: Math.round(longEdge * safeAspect), h: longEdge };
+}

--- a/src/features/video-calls/model/webview-compatibility.test.ts
+++ b/src/features/video-calls/model/webview-compatibility.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   getWebViewInfo,
   isLegacyWebView,
+  shouldWarnLegacyWebView,
   MIN_CHROMIUM_MAJOR_FOR_MODERN_WEBRTC,
 } from "./webview-compatibility";
 
@@ -122,5 +123,31 @@ describe("isLegacyWebView", () => {
   it("uses the documented constant for default threshold", () => {
     // Sentinel — if someone bumps the constant we want the test to scream.
     expect(MIN_CHROMIUM_MAJOR_FOR_MODERN_WEBRTC).toBe(100);
+  });
+});
+
+describe("shouldWarnLegacyWebView", () => {
+  it("warns when a legacy WebView drives a call on the web path", () => {
+    expect(
+      shouldWarnLegacyWebView({ isNative: false, isLegacy: true, alreadyWarned: false }),
+    ).toBe(true);
+  });
+
+  it("never warns on native (bundled libwebrtc, UA version irrelevant)", () => {
+    expect(
+      shouldWarnLegacyWebView({ isNative: true, isLegacy: true, alreadyWarned: false }),
+    ).toBe(false);
+  });
+
+  it("does not warn on a modern WebView", () => {
+    expect(
+      shouldWarnLegacyWebView({ isNative: false, isLegacy: false, alreadyWarned: false }),
+    ).toBe(false);
+  });
+
+  it("fires only once per process (one-shot guard)", () => {
+    expect(
+      shouldWarnLegacyWebView({ isNative: false, isLegacy: true, alreadyWarned: true }),
+    ).toBe(false);
   });
 });

--- a/src/features/video-calls/model/webview-compatibility.ts
+++ b/src/features/video-calls/model/webview-compatibility.ts
@@ -88,3 +88,29 @@ export function isLegacyWebView(
   if (info.engine !== "chromium") return false;
   return info.major < threshold;
 }
+
+export interface LegacyWarnContext {
+  /** Capacitor native runtime — UA Chrome version is irrelevant there. */
+  isNative: boolean;
+  /** Result of {@link isLegacyWebView} for the current UA. */
+  isLegacy: boolean;
+  /** Whether the one-shot warning has already fired this process. */
+  alreadyWarned: boolean;
+}
+
+/**
+ * Pure policy for the legacy-WebView user warning (forta-bugs#497 / WEE-53).
+ *
+ * The warning must surface once per process when an outdated WebView drives a
+ * call on the web/Electron path — proactively when the user starts or answers
+ * a call, not only when a mid-call network change happens to trigger the
+ * restartIce skip. Native is excluded because it negotiates ICE through the
+ * bundled libwebrtc, so the WebView Chrome version says nothing about call
+ * health there.
+ *
+ * Extracted as a pure predicate so the gating matrix is unit-testable without
+ * the toast/i18n composables.
+ */
+export function shouldWarnLegacyWebView(ctx: LegacyWarnContext): boolean {
+  return !ctx.isNative && ctx.isLegacy && !ctx.alreadyWarned;
+}

--- a/src/features/video-calls/ui/CallWindow.vue
+++ b/src/features/video-calls/ui/CallWindow.vue
@@ -4,6 +4,7 @@ import { UserAvatar } from "@/entities/user";
 import { formatDuration } from "@/shared/lib/format";
 import { useCallService } from "../model/call-service";
 import { isFrontFacingStream } from "../model/camera-facing";
+import { computePipSize } from "../model/pip-size";
 import CallControls from "./CallControls.vue";
 import VideoTile from "./VideoTile.vue";
 import { useAndroidBackHandler } from "@/shared/lib/composables/use-android-back-handler";
@@ -330,8 +331,22 @@ watch(callContainerRef, (el, _oldEl, onCleanup) => {
   }
 });
 
-const PIP_W = computed(() => isMobile.value ? 110 : 160);
-const PIP_H = computed(() => isMobile.value ? 82 : 120);
+// Self-view PiP follows the local camera's natural aspect ratio so the user
+// sees the full frame the peer receives, not a cropped square (forta-bugs#433
+// / WEE-53). The aspect is reported by the PiP VideoTile via `@aspectchange`
+// once stream metadata is known; until then `computePipSize(null, …)` falls
+// back to the prior 4:3 box so there is no first-frame size jump.
+const localAspect = ref<number | null>(null);
+// Holds the last ratio VideoTile reported. On a stream swap (camera flip,
+// camera→screen-share) the tile does not emit a reset, so this keeps the
+// previous aspect until the new stream's metadata arrives — see the
+// `aspectchange` rationale in VideoTile.vue.
+function onLocalAspect(ratio: number) {
+  localAspect.value = ratio;
+}
+const pipSize = computed(() => computePipSize(localAspect.value, isMobile.value));
+const PIP_W = computed(() => pipSize.value.w);
+const PIP_H = computed(() => pipSize.value.h);
 const PIP_MARGIN = computed(() => isMobile.value ? 12 : 16);
 const PIP_BOTTOM_OFFSET = computed(() => isMobile.value ? 80 : 96);
 
@@ -652,6 +667,7 @@ const isAnyScreenSharing = computed(
                   object-fit="cover"
                   muted
                   class="h-full w-full"
+                  @aspectchange="onLocalAspect"
                 />
               </div>
             </Transition>

--- a/src/features/video-calls/ui/VideoTile.vue
+++ b/src/features/video-calls/ui/VideoTile.vue
@@ -30,6 +30,11 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{
   pin: [tileId: string];
+  // Natural aspect ratio (width / height) of the bound stream, emitted once
+  // metadata is known and again on track resize. Lets a parent size its
+  // container to the source so a `cover` thumbnail no longer crops the frame
+  // (forta-bugs#433 / WEE-53 — self-preview PiP).
+  aspectchange: [ratio: number];
 }>();
 
 const videoRef = ref<HTMLVideoElement | null>(null);
@@ -47,6 +52,13 @@ watch(
     // before the wrapper can reshape. Without this the desktop side kept
     // the previous voice-only aspect after the phone enabled its camera
     // mid-call and the user saw a stretched/dot remote tile (WEE-45).
+    //
+    // We deliberately do NOT re-emit `aspectchange` here. A parent sizing a
+    // container from the ratio (the self-view PiP, WEE-53) keeps the prior
+    // aspect until the new stream's `loadedmetadata` fires a fresh value —
+    // typically within a frame or two. Emitting a reset would force a size
+    // blip to the fallback on every swap, including front↔back camera flips
+    // where the ratio is usually identical; persisting is the calmer choice.
     videoAspect.value = null;
   },
   { flush: "post" },
@@ -76,6 +88,7 @@ function captureAspect() {
   const h = v.videoHeight;
   if (w > 0 && h > 0) {
     videoAspect.value = w / h;
+    emit("aspectchange", w / h);
   }
 }
 

--- a/src/features/video-calls/ui/__tests__/VideoTile.test.ts
+++ b/src/features/video-calls/ui/__tests__/VideoTile.test.ts
@@ -65,4 +65,49 @@ describe('VideoTile', () => {
     const video = wrapper.find('video');
     expect(video.classes()).not.toContain('scale-x-[-1]');
   });
+
+  it('emits aspectchange with the natural ratio on loadedmetadata (WEE-53 self-preview)', async () => {
+    const wrapper = mount(VideoTile, {
+      props: { stream: null, objectFit: 'cover' },
+    });
+    const video = wrapper.find('video');
+    // happy-dom leaves videoWidth/Height at 0; stub a portrait 9:16 source.
+    Object.defineProperty(video.element, 'videoWidth', { value: 720, configurable: true });
+    Object.defineProperty(video.element, 'videoHeight', { value: 1280, configurable: true });
+
+    await video.trigger('loadedmetadata');
+
+    const events = wrapper.emitted('aspectchange');
+    expect(events).toBeTruthy();
+    expect(events?.[0]?.[0]).toBeCloseTo(720 / 1280);
+  });
+
+  it('does not emit aspectchange while dimensions are still zero', async () => {
+    const wrapper = mount(VideoTile, {
+      props: { stream: null, objectFit: 'cover' },
+    });
+    const video = wrapper.find('video');
+    // videoWidth/Height default to 0 in happy-dom — no usable aspect yet.
+    await video.trigger('loadedmetadata');
+    expect(wrapper.emitted('aspectchange')).toBeFalsy();
+  });
+
+  it('does not re-emit on stream swap — prior aspect persists until next loadedmetadata', async () => {
+    // Contract lock (WEE-53 review): swapping the stream must NOT emit a
+    // reset. A parent keeps the last reported ratio until the new stream's
+    // metadata arrives, avoiding a size blip on every camera flip.
+    const wrapper = mount(VideoTile, {
+      props: { stream: new MediaStream(), objectFit: 'cover' },
+    });
+    const video = wrapper.find('video');
+    Object.defineProperty(video.element, 'videoWidth', { value: 1280, configurable: true });
+    Object.defineProperty(video.element, 'videoHeight', { value: 720, configurable: true });
+    await video.trigger('loadedmetadata');
+    expect(wrapper.emitted('aspectchange')).toHaveLength(1);
+
+    // Swap to a different stream — no metadata event yet.
+    await wrapper.setProps({ stream: new MediaStream() });
+    // Still exactly one emit: the swap itself emitted nothing.
+    expect(wrapper.emitted('aspectchange')).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Summary

- **Self-preview native aspect (forta-bugs#433):** the in-call self-view PiP was a fixed ~4:3 landscape box filled with `object-fit: cover`, cropping portrait phone-camera streams into a square — users couldn't see the frame the peer actually received. The PiP now follows the camera's natural aspect ratio via a new pure `computePipSize(aspect, isMobile)` helper. `VideoTile` emits its source ratio (`@aspectchange`) and `CallWindow` sizes the PiP to it, so `cover` no longer crops.
- **Proactive legacy-WebView warning (forta-bugs#497):** the old-WebView call hint only fired when a mid-call network change skipped `restartIce`, so old-device users who failed *before* any handover never saw it. New pure `shouldWarnLegacyWebView()` predicate centralizes the native/legacy/one-shot policy; `maybeWarnLegacyWebView()` is now self-gating and also fires proactively at outgoing `startCall` and incoming `answerCall`.

## Linear
- Resolves [WEE-53](https://linear.app/wwwee/issue/WEE-53) (partial — see Scope below)

## Closes
- Closes greenShirtMystery/forta-bugs#433 — self-preview square instead of native aspect
- Closes greenShirtMystery/forta-bugs#497 — calls on old Android (10/11) WebView

## Scope / deferred
This PR ships **A1 (self-preview aspect)** and **A3 (legacy-WebView warning)** from the WEE-53 plan. Deferred, with rationale:
- **A2 — missed-call retry notification (#429):** Kotlin-side; the `CallNotificationManager.kt` named in the ticket does not exist (notifications live in `IncomingCallActivity` / `CallNotificationConfig` / `FortaFirebaseMessagingService`). Requires an Android gradle build to verify and is not covered by the JS gate. Tracked separately.
- **A4 — Bastyon+Forta dual-app interference (#809):** hard-blocked on WEE-35 (Todo, not merged); it is an explicit post-WEE-35 follow-up.
- Not addressed here: #424, #565 (separate connection-lifecycle symptoms).

## Test plan
- [x] `vite build` passes
- [x] Unit tests added: `pip-size.test.ts` (geometry + clamping + fallback), `webview-compatibility.test.ts` (gating matrix), `VideoTile.test.ts` (aspectchange emit + stream-swap contract) — 151/151 video-calls tests green
- [x] Full suite: 0 new failures introduced (9 pre-existing failures in unrelated chat/shared modules; 49 pre-existing vue-tsc errors — none from this diff)
- [ ] Manual QA on device: portrait phone front-cam → PiP shows full frame (no square crop); old Android System WebView → warning toast on call start