### PR TITLE
fix(wallet): human-readable PKOIN send errors + theme-aware fee tabs

### DIFF
--- a/src/features/wallet/lib/__tests__/extract-error.test.ts
+++ b/src/features/wallet/lib/__tests__/extract-error.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { extractErrorMessage } from "../extract-error";
+
+const FALLBACK = "Operation failed";
+
+describe("extractErrorMessage", () => {
+  it("returns the message of an Error instance", () => {
+    // Arrange
+    const err = new Error("Insufficient balance");
+
+    // Act
+    const result = extractErrorMessage(err, FALLBACK);
+
+    // Assert
+    expect(result).toBe("Insufficient balance");
+    expect(result).not.toContain("[object Object]");
+  });
+
+  it("returns a thrown string as-is", () => {
+    expect(extractErrorMessage("Network unavailable", FALLBACK)).toBe("Network unavailable");
+  });
+
+  it("extracts message from a plain RPC object { code, message }", () => {
+    // Arrange — Pocketnet RPC error shape that previously rendered "[object Object]"
+    const rpcErr = { code: -6, message: "Fee estimation failed" };
+
+    // Act
+    const result = extractErrorMessage(rpcErr, FALLBACK);
+
+    // Assert
+    expect(result).toBe("Fee estimation failed");
+    expect(result).not.toContain("[object Object]");
+  });
+
+  it("extracts message from a nested { error: { message } } shape", () => {
+    const nested = { error: { code: -1, message: "Recipient invalid" } };
+    expect(extractErrorMessage(nested, FALLBACK)).toBe("Recipient invalid");
+  });
+
+  it("extracts a string nested under { error }", () => {
+    expect(extractErrorMessage({ error: "Server down" }, FALLBACK)).toBe("Server down");
+  });
+
+  it("falls back for opaque objects without a message", () => {
+    // Arrange — the exact bug: an object with no readable message
+    const opaque = { code: "X", details: "bad" };
+
+    // Act
+    const result = extractErrorMessage(opaque, FALLBACK);
+
+    // Assert
+    expect(result).toBe(FALLBACK);
+    expect(result).not.toContain("[object Object]");
+  });
+
+  it("falls back for null / undefined", () => {
+    expect(extractErrorMessage(null, FALLBACK)).toBe(FALLBACK);
+    expect(extractErrorMessage(undefined, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("falls back for an Error with an empty message", () => {
+    expect(extractErrorMessage(new Error(""), FALLBACK)).toBe(FALLBACK);
+  });
+});

--- a/src/features/wallet/lib/extract-error.ts
+++ b/src/features/wallet/lib/extract-error.ts
@@ -1,0 +1,33 @@
+/**
+ * Extract a human-readable message from an unknown thrown value.
+ *
+ * Wallet RPC failures (Pocketnet `api.rpc(...)`) can reject with arbitrary
+ * shapes — plain objects like `{ code, message }` or `{ error: { message } }` —
+ * which stringify to the useless `"[object Object]"`. This normalizes those
+ * shapes into a readable string, falling back to a caller-provided message.
+ */
+export function extractErrorMessage(err: unknown, fallback: string): string {
+  if (err instanceof Error) {
+    return err.message || fallback;
+  }
+  if (typeof err === "string") {
+    return err || fallback;
+  }
+  if (err && typeof err === "object") {
+    // Direct { message } shape
+    if ("message" in err) {
+      const msg = (err as { message: unknown }).message;
+      if (typeof msg === "string" && msg) return msg;
+    }
+    // Nested Pocketnet RPC shape: { error: { message } } or { error: "..." }
+    if ("error" in err) {
+      const nested = (err as { error: unknown }).error;
+      if (typeof nested === "string" && nested) return nested;
+      if (nested && typeof nested === "object" && "message" in nested) {
+        const msg = (nested as { message: unknown }).message;
+        if (typeof msg === "string" && msg) return msg;
+      }
+    }
+  }
+  return fallback;
+}

--- a/src/features/wallet/ui/DonateModal.vue
+++ b/src/features/wallet/ui/DonateModal.vue
@@ -4,6 +4,7 @@ import { useAuthStore } from "@/entities/auth";
 import { useWallet } from "../model/use-wallet";
 import { useWalletStore, formatPkoin } from "../model/wallet-store";
 import { useMessages } from "@/features/messaging/model/use-messages";
+import { extractErrorMessage } from "../lib/extract-error";
 import Modal from "@/shared/ui/modal/Modal.vue";
 
 const props = defineProps<{ show: boolean; receiverAddress: string; receiverName: string }>();
@@ -64,7 +65,8 @@ const calculateFees = async () => {
   try {
     fees.value = await estimateFees(props.receiverAddress, numericAmount.value, feeDirection.value);
   } catch (e) {
-    error.value = String(e);
+    console.error("[wallet] calculate fees failed:", e);
+    error.value = extractErrorMessage(e, t("wallet.operationFailed"));
     fees.value = null;
   } finally {
     feesLoading.value = false;
@@ -85,7 +87,8 @@ const handleSend = async () => {
     await sendTransferMessage(txId, numericAmount.value, props.receiverAddress, message.value || undefined);
     resetAndClose();
   } catch (e) {
-    error.value = t("wallet.transactionError");
+    console.error("[wallet] send transfer failed:", e);
+    error.value = extractErrorMessage(e, t("wallet.transactionError"));
   } finally {
     sending.value = false;
   }
@@ -166,14 +169,14 @@ watch(() => props.show, (v) => {
       <div class="flex gap-2">
         <button
           class="flex-1 rounded-xl border-2 px-3 py-2 text-xs font-medium transition-colors"
-          :class="feeDirection === 'exclude' ? 'border-color-bg-ac bg-color-bg-ac/10 text-color-txt-ac' : 'border-neutral-grad-0 text-text-on-main-bg-color hover:bg-neutral-grad-0/50'"
+          :class="feeDirection === 'exclude' ? 'border-color-bg-ac bg-color-bg-ac/10 text-color-bg-ac' : 'border-neutral-grad-0 text-text-on-main-bg-color hover:bg-neutral-grad-0/50'"
           @click="feeDirection = 'exclude'"
         >
           {{ t("wallet.senderPaysFees") }}
         </button>
         <button
           class="flex-1 rounded-xl border-2 px-3 py-2 text-xs font-medium transition-colors"
-          :class="feeDirection === 'include' ? 'border-color-bg-ac bg-color-bg-ac/10 text-color-txt-ac' : 'border-neutral-grad-0 text-text-on-main-bg-color hover:bg-neutral-grad-0/50'"
+          :class="feeDirection === 'include' ? 'border-color-bg-ac bg-color-bg-ac/10 text-color-bg-ac' : 'border-neutral-grad-0 text-text-on-main-bg-color hover:bg-neutral-grad-0/50'"
           @click="feeDirection = 'include'"
         >
           {{ t("wallet.receiverPaysFees") }}

--- a/src/features/wallet/ui/__tests__/DonateModal.test.ts
+++ b/src/features/wallet/ui/__tests__/DonateModal.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+
+// --- i18n: echo a small dict so assertions read real strings ---
+const dict: Record<string, string> = {
+  "wallet.transactionError": "Ошибка транзакции",
+  "wallet.operationFailed": "Не удалось выполнить операцию. Попробуйте позже.",
+  "wallet.senderPaysFees": "Комиссию платит отправитель",
+  "wallet.receiverPaysFees": "Комиссию платит получатель",
+  "wallet.calculateFees": "Рассчитать комиссию",
+  "wallet.send": "Отправить",
+};
+vi.mock("@/shared/lib/i18n", () => ({
+  useI18n: () => ({
+    t: (key: string) => dict[key] ?? key,
+    locale: { value: "ru" },
+  }),
+}));
+
+// --- heavy dependencies stubbed to keep the test focused on rendering ---
+const estimateFees = vi.fn();
+const sendTransfer = vi.fn();
+vi.mock("../../model/use-wallet", () => ({
+  useWallet: () => ({ estimateFees, sendTransfer }),
+}));
+
+vi.mock("../../model/wallet-store", () => ({
+  useWalletStore: () => ({ balance: 11183.38, refresh: vi.fn() }),
+  formatPkoin: (n: number) => n.toFixed(2),
+}));
+
+vi.mock("@/entities/chat", () => ({ useChatStore: () => ({}) }));
+vi.mock("@/entities/auth", () => ({ useAuthStore: () => ({ address: "PSender" }) }));
+vi.mock("@/features/messaging/model/use-messages", () => ({
+  useMessages: () => ({ sendTransferMessage: vi.fn() }),
+}));
+
+// Modal stub: always render its default slot so we can inspect inner UI.
+vi.mock("@/shared/ui/modal/Modal.vue", () => ({
+  default: { name: "ModalStub", template: "<div><slot /></div>" },
+}));
+
+import DonateModal from "../DonateModal.vue";
+
+const mountDialog = () =>
+  mount(DonateModal, {
+    props: { show: true, receiverAddress: "PReceiver", receiverName: "Network_support" },
+  });
+
+describe("DonateModal", () => {
+  beforeEach(() => {
+    estimateFees.mockReset();
+    sendTransfer.mockReset();
+  });
+
+  it("renders the thrown Error message, not '[object Object]'", async () => {
+    // Arrange
+    estimateFees.mockRejectedValue(new Error("Insufficient balance"));
+    const wrapper = mountDialog();
+    await wrapper.find("input[type='number']").setValue("3000");
+
+    // Act — click the "Calculate fees" button
+    const calcBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Рассчитать комиссию"));
+    await calcBtn!.trigger("click");
+    await flushPromises();
+
+    // Assert
+    const text = wrapper.text();
+    expect(text).toContain("Insufficient balance");
+    expect(text).not.toContain("[object Object]");
+  });
+
+  it("renders a readable message for a plain RPC error object", async () => {
+    // Arrange — the exact failure mode from the bug report
+    estimateFees.mockRejectedValue({ code: -6, message: "Fee estimation failed" });
+    const wrapper = mountDialog();
+    await wrapper.find("input[type='number']").setValue("3000");
+
+    // Act
+    const calcBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Рассчитать комиссию"));
+    await calcBtn!.trigger("click");
+    await flushPromises();
+
+    // Assert
+    const text = wrapper.text();
+    expect(text).toContain("Fee estimation failed");
+    expect(text).not.toContain("[object Object]");
+  });
+
+  it("styles fee-payer tabs with theme accent tokens, not hardcoded blue", () => {
+    // Arrange / Act
+    const wrapper = mountDialog();
+    const tabs = wrapper
+      .findAll("button")
+      .filter((b) => b.text().includes("Комиссию платит"));
+
+    // Assert — selected (sender) tab uses the accent token that follows the
+    // user's chosen palette; no hardcoded Tailwind blue anywhere on the tabs.
+    expect(tabs.length).toBe(2);
+    const senderTab = tabs[0];
+    const cls = senderTab.classes().join(" ");
+    expect(cls).toContain("text-color-bg-ac");
+    expect(cls).not.toContain("text-color-txt-ac");
+    for (const tab of tabs) {
+      const c = tab.classes().join(" ");
+      expect(c).not.toMatch(/blue/);
+    }
+  });
+});

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -588,6 +588,7 @@ export const en = {
   "wallet.balance": "Balance",
   "wallet.insufficientBalance": "Insufficient balance",
   "wallet.transactionError": "Transaction failed",
+  "wallet.operationFailed": "Operation failed. Please try again.",
   "wallet.senderPaysFees": "Sender pays fees",
   "wallet.receiverPaysFees": "Receiver pays fees",
   "wallet.sent": "Sent {amount} PKOIN",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -590,6 +590,7 @@ export const ru: Record<TranslationKey, string> = {
   "wallet.balance": "Баланс",
   "wallet.insufficientBalance": "Недостаточно средств",
   "wallet.transactionError": "Ошибка транзакции",
+  "wallet.operationFailed": "Не удалось выполнить операцию. Попробуйте позже.",
   "wallet.senderPaysFees": "Комиссию платит отправитель",
   "wallet.receiverPaysFees": "Комиссию платит получатель",
   "wallet.sent": "Отправлено {amount} PKOIN",


### PR DESCRIPTION
## Summary
- **Bug 1 — `[object Object]` error:** `DonateModal.vue` rendered `String(e)` on RPC failure. Pocketnet `api.rpc(...)` rejects with plain `{ code, message }` objects, which stringify to `[object Object]`. Added `extractErrorMessage(err, fallback)` util (handles `Error` / string / `{message}` / `{error:{message}}` / `{error:"..."}`) and use it in both `calculateFees` and `handleSend` catches.
- **Bug 2 — fee tabs always blue:** selected fee-payer tab used `text-color-txt-ac` for its text. `applyAccentColor()` (theme store) updates only `--color-bg-ac`, never `--color-txt-ac`, so the text stayed blue regardless of the user's accent palette. Switched selected tab text to `text-color-bg-ac` so it follows the chosen accent (border/bg already did).
- Added `wallet.operationFailed` i18n key (ru/en).

## Linear
- Resolves [WEE-58](https://linear.app/wwwee/issue/WEE-58)

## Test plan
- [x] `vite build` passed locally (pre-existing unrelated `vue-tsc` errors in other files only)
- [x] Unit tests added: `extract-error.test.ts` (8) + `DonateModal.test.ts` (3 regression) — all green
- [x] Full suite: 9 pre-existing failures confirmed unrelated (stash-verified); no new failures
- [ ] Manual QA on device: force RPC error → readable message (not `[object Object]`); change Settings → accent palette → reopen dialog → selected tab text follows accent; verify light + dark theme contrast

> Note: test runner requires Node ≥ 20.12 (worktree default is 20.11.1; run under Node 22).