### PR TITLE
fix(calls): vendor audio policy adapter + post-call mic-mute release (WEE-56)

### DIFF
--- a/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
@@ -194,6 +194,12 @@ class AudioRouter private constructor(private val context: Context) {
     @Volatile private var coreListener: Listener? = null
     @Volatile private var uiListener: Listener? = null
     private var activeDevice: Device = Device.EARPIECE
+    // WEE-56: coarse OEM classification used for vendor-conditional audio
+    // tweaks. Resolved once from Build at construction — the manufacturer
+    // does not change at runtime. GENERIC for any unrecognised device, so the
+    // proven WEE-54 generic path is the default and vendor branches are purely
+    // additive (acceptance criterion A5).
+    private val vendor: CallVendor = VendorAudioPolicy.detect(Build.MANUFACTURER, Build.BRAND)
     // WEE-16: @Volatile so the periodic re-apply runnables observe a
     // stop()/forceStop()-side write across threads. start()/stop()/
     // forceStop() are invoked from arbitrary Capacitor plugin threads
@@ -348,7 +354,35 @@ class AudioRouter private constructor(private val context: Context) {
             setDeviceInternal(activeDevice)
         }
 
-        Log.d(LIFECYCLE_TAG, "start($callType) complete: active=$activeDevice, available=$available")
+        applyVendorStartTweaks()
+
+        Log.d(
+            LIFECYCLE_TAG,
+            "start($callType) complete: active=$activeDevice, available=$available, " +
+                "vendor=$vendor manuf=${Build.MANUFACTURER} brand=${Build.BRAND}",
+        )
+    }
+
+    /**
+     * WEE-56: vendor-conditional reinforcement applied AFTER the generic
+     * routing in [start]. Purely additive — every branch is gated on a
+     * [VendorAudioPolicy] predicate that returns the generic answer for
+     * unrecognised devices, so this is a no-op on the working majority.
+     */
+    private fun applyVendorStartTweaks() {
+        // HONOR MagicOS (#872/#873): the comm-device routing above can leave the
+        // global mic-mute flag asserted, producing caller-only / self-echo
+        // one-way audio. An explicit unmute releases the capture path. Wrapped
+        // because the setter is documented to throw on a few privacy-shield
+        // ROMs and must never crash call setup.
+        if (VendorAudioPolicy.requiresExplicitMicUnmuteOnStart(vendor)) {
+            try {
+                audioManager.setMicrophoneMute(false)
+                Log.d(LIFECYCLE_TAG, "[vendor=$vendor] explicit setMicrophoneMute(false) on start")
+            } catch (e: Exception) {
+                Log.w(LIFECYCLE_TAG, "[vendor=$vendor] setMicrophoneMute(false) on start threw", e)
+            }
+        }
     }
 
     fun stop() = synchronized(lifecycleLock) {
@@ -414,7 +448,27 @@ class AudioRouter private constructor(private val context: Context) {
                 audioManager.isSpeakerphoneOn = false
             } catch (_: Exception) {}
 
+            releaseGlobalMicMute()
+
             Log.d(LIFECYCLE_TAG, "stop(): set mode=MODE_NORMAL, cleared comm device")
+        }
+    }
+
+    /**
+     * WEE-56 (#875 / #898 / #900 + cross-app "Telegram voice empty" report):
+     * clear the process-global microphone-mute flag on call teardown so other
+     * apps can record afterwards. `setMicrophoneMute` is global state — if any
+     * path left it asserted, every other recorder captures silence until
+     * reboot. Resetting it can only release a stuck capture path, so the policy
+     * is vendor-independent. Wrapped because the setter throws on some OEM
+     * privacy-shield ROMs and teardown must never crash.
+     */
+    private fun releaseGlobalMicMute() {
+        if (!VendorAudioPolicy.shouldUnmuteMicOnStop(vendor)) return
+        try {
+            audioManager.setMicrophoneMute(false)
+        } catch (e: Exception) {
+            Log.w(LIFECYCLE_TAG, "setMicrophoneMute(false) on teardown threw", e)
         }
     }
 
@@ -499,6 +553,7 @@ class AudioRouter private constructor(private val context: Context) {
         try { audioManager.mode = AudioManager.MODE_NORMAL } catch (_: Exception) {}
         @Suppress("DEPRECATION")
         try { audioManager.isSpeakerphoneOn = false } catch (_: Exception) {}
+        releaseGlobalMicMute()
 
         Log.d(LIFECYCLE_TAG, "forceStop() complete")
     }

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/VendorAudioPolicy.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/VendorAudioPolicy.kt
@@ -1,0 +1,158 @@
+package com.forta.chat.plugins.calls
+
+/**
+ * WEE-56 — centralised per-vendor audio policy for the calls subsystem.
+ *
+ * Forta runs on a long tail of OEM ROMs whose audio HAL deviates from the
+ * stock-Android contract the generic [AudioRouter] / [com.forta.chat.plugins.webrtc.NativeWebRTCManager]
+ * paths assume. Before this class the vendor handling was scattered across two
+ * ad-hoc checks that drifted independently:
+ *
+ *   - `NativeWebRTCManager.BROKEN_HW_AEC_VENDORS` (disable HW AEC/NS that mutes
+ *     the mic on MIUI / EMUI / ColorOS / RealmeUI / XOS …)
+ *   - `AudioRouter.modeReapplyScheduleMs()` (re-apply MODE_IN_COMMUNICATION after
+ *     aggressive OEM resets)
+ *
+ * This object is the single source of truth the calls code consults for
+ * vendor-conditional behaviour. It is intentionally **pure** (no Android
+ * framework dependencies) so the decision logic is covered by plain JVM unit
+ * tests without Robolectric / mockk, and so the imperative `AudioManager`
+ * mutations in [AudioRouter] stay a thin shell over testable predicates.
+ *
+ * ## Design invariant (acceptance criterion A5)
+ *
+ * [CallVendor.GENERIC] is the default for any unmatched device, and every
+ * vendor-specific tweak is **additive** to the proven WEE-54 generic path —
+ * never a replacement. A device we do not recognise, or one whose vendor we
+ * recognise but for which a given predicate returns the generic answer, runs
+ * exactly the code it ran before WEE-56. This keeps the vast majority of
+ * working devices untouched by construction.
+ *
+ * NOTE: the device-specific *routing* effects (HONOR one-way audio, HUAWEI
+ * video-call silence) can only be validated on the physical Honor/Huawei
+ * handsets from the bug cluster. The predicates here encode the policy and are
+ * unit-tested; on-device QA is still required before merge.
+ */
+enum class CallVendor {
+    HONOR,
+    HUAWEI,
+    REALME,
+    XIAOMI,
+    OPPO,
+    SAMSUNG,
+    GENERIC,
+}
+
+object VendorAudioPolicy {
+
+    /**
+     * Vendors whose **hardware** AEC/NS is known to mute the capture path or
+     * lock the audio session, requiring the libwebrtc software AEC/NS instead.
+     *
+     * This is the authoritative list that
+     * [com.forta.chat.plugins.webrtc.NativeWebRTCManager.hasBrokenHardwareAudioProcessing]
+     * delegates to — kept here (not in the WebRTC manager) so the calls and
+     * webrtc packages share one definition and a single JVM test locks it.
+     *
+     * Evidence from user reports: Xiaomi/MIUI, Realme/RealmeUI, Oppo/ColorOS,
+     * Infinix/XOS, Tecno/HiOS, Huawei/EMUI, Honor/MagicOS, ZTE. Samsung / Pixel
+     * / OnePlus ship working HW AEC and deliberately stay off this list (lower
+     * CPU, better quality).
+     */
+    private val BROKEN_HW_AEC_VENDORS = setOf(
+        "xiaomi", "redmi", "poco",
+        "realme",
+        "oppo",
+        "infinix", "itel",
+        "tecno",
+        "huawei", "honor", "hihonor",
+        "zte",
+    )
+
+    /**
+     * Coarse vendor classification used to pick an audio-routing strategy.
+     *
+     * Matching is case-insensitive against both `Build.MANUFACTURER` and
+     * `Build.BRAND` because OEMs are inconsistent about which field carries the
+     * recognisable name (e.g. Honor reports MANUFACTURER=HONOR but some Huawei-
+     * era firmware still tags BRAND=Honor). HONOR is checked before HUAWEI on
+     * purpose: post-2020 Honor is a separate company with its own MagicOS HAL,
+     * so an "honor" / "hihonor" token must classify as [CallVendor.HONOR] and
+     * not be swallowed by a broad "huawei" match.
+     */
+    fun detect(manufacturer: String?, brand: String?): CallVendor {
+        val m = manufacturer?.trim()?.lowercase().orEmpty()
+        val b = brand?.trim()?.lowercase().orEmpty()
+        fun matches(token: String) = m.contains(token) || b.contains(token)
+
+        return when {
+            matches("honor") || matches("hihonor") -> CallVendor.HONOR
+            matches("huawei") -> CallVendor.HUAWEI
+            matches("realme") -> CallVendor.REALME
+            matches("xiaomi") || matches("redmi") || matches("poco") -> CallVendor.XIAOMI
+            matches("oppo") -> CallVendor.OPPO
+            matches("samsung") -> CallVendor.SAMSUNG
+            else -> CallVendor.GENERIC
+        }
+    }
+
+    /**
+     * HONOR MagicOS (#872/#873 — caller-only / self-echo one-way audio).
+     *
+     * On MagicOS the explicit `setCommunicationDevice` routing applied by
+     * [AudioRouter.start] can leave the global microphone-mute flag asserted,
+     * so the local capture path is silent and the peer hears nothing while the
+     * caller hears themselves. An explicit `setMicrophoneMute(false)` after the
+     * mode flip releases it.
+     *
+     * Gated to HONOR rather than applied everywhere on *start* because forcing
+     * an unmute mid-setup is only known-needed on MagicOS; the post-call reset
+     * ([shouldUnmuteMicOnStop]) is what covers every other vendor.
+     */
+    fun requiresExplicitMicUnmuteOnStart(vendor: CallVendor): Boolean =
+        vendor == CallVendor.HONOR
+
+    /**
+     * Post-call defensive microphone unmute for **every** vendor
+     * (#875 / #898 / #900 + the cross-app "Telegram voice message is empty
+     * after a Forta call" report).
+     *
+     * `AudioManager.setMicrophoneMute` toggles a process-global flag. If any
+     * path left it asserted when the call tears down, other apps
+     * (Telegram / WhatsApp / system recorder) capture pure silence until
+     * reboot. Clearing it on every teardown is universally safe — it can only
+     * release a stuck capture path, never break a healthy one — so the policy
+     * is vendor-independent and always true. Kept as a predicate (rather than a
+     * bare call site) so the intent is documented and locked by a test.
+     */
+    fun shouldUnmuteMicOnStop(vendor: CallVendor): Boolean = true
+
+    /**
+     * Whether the WebRTC factory should use **software** AEC/NS for this device
+     * instead of the hardware path. See [BROKEN_HW_AEC_VENDORS].
+     *
+     * This is the root-cause handling for the HUAWEI "video works, no audio"
+     * symptom (#874): EMUI hardware AEC mutes the capture stream, so the video
+     * pipeline is fine while audio is dropped. We deliberately do NOT force a
+     * PCMU/G.711 codec fallback (as one hypothesis suggested) — disabling Opus
+     * would degrade quality for every Huawei user and risk one-way audio
+     * against Opus-only web/desktop peers (an A5 regression). Falling back to
+     * software audio processing fixes the capture mute without touching codec
+     * negotiation.
+     *
+     * Matches manufacturer OR brand (case-insensitive, whitespace-trimmed),
+     * mirroring the prior `NativeWebRTCManager` predicate. One intentional
+     * tightening: that predicate returned false whenever `Build.MANUFACTURER`
+     * was null, ignoring the brand; this one falls back to the brand, so a
+     * device exposing the vendor only via `Build.BRAND` still gets the software
+     * fallback. Real production builds populate both fields, so the difference
+     * is observable only on emulator / malformed-ROM builds — and there the
+     * brand-aware answer is the safer one.
+     */
+    fun prefersSoftwareAudioProcessing(manufacturer: String?, brand: String?): Boolean {
+        val m = manufacturer?.trim()?.lowercase().orEmpty()
+        val b = brand?.trim()?.lowercase().orEmpty()
+        if (m.isEmpty() && b.isEmpty()) return false
+        return BROKEN_HW_AEC_VENDORS.any { v -> v == m || v == b }
+    }
+}

--- a/android/app/src/main/java/com/forta/chat/plugins/webrtc/NativeWebRTCManager.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/webrtc/NativeWebRTCManager.kt
@@ -6,6 +6,7 @@ import android.media.AudioManager
 import android.media.projection.MediaProjection
 import android.os.Build
 import android.util.Log
+import com.forta.chat.plugins.calls.VendorAudioPolicy
 import org.webrtc.*
 import org.webrtc.audio.JavaAudioDeviceModule
 
@@ -51,30 +52,24 @@ class NativeWebRTCManager(private val context: Context) {
         var onAudioError: ((type: String, message: String) -> Unit)? = null
 
         /**
-         * OEMs with broken hardware AEC/NS implementations — using HW AEC on these
-         * devices mutes the microphone or locks the audio session. Fall back to
-         * WebRTC software AEC/NS (works everywhere).
+         * Detect vendors with known broken hardware AEC/NS — using HW AEC on
+         * these devices mutes the microphone or locks the audio session, so we
+         * fall back to WebRTC software AEC/NS (works everywhere).
          *
-         * Evidence from user reports: Xiaomi/MIUI, Realme/RealmeUI, Oppo/ColorOS,
-         * Infinix/XOS, Tecno/HiOS, Huawei/EMUI, ZTE. Samsung/Pixel/OnePlus ship
-         * working HW AEC and benefit from it (lower CPU, better quality).
+         * WEE-56: the authoritative vendor list now lives in
+         * [VendorAudioPolicy] so the calls and webrtc packages share one
+         * definition (it was duplicated against AudioRouter's OEM handling)
+         * and a single JVM test locks it. Behaviour-preserving for every real
+         * (non-null manufacturer) Build value; see [VendorAudioPolicy.prefersSoftwareAudioProcessing]
+         * for the one intentional, safer null-brand edge-case change. This is the root-cause handling for
+         * the HUAWEI "video works, no audio" symptom (#874): EMUI hardware AEC
+         * mutes the capture stream. We intentionally do not force a PCMU/G.711
+         * codec fallback — that would degrade Opus quality/interop for every
+         * Huawei user (an A5 regression); software audio processing fixes the
+         * capture mute without touching codec negotiation.
          */
-        private val BROKEN_HW_AEC_VENDORS = setOf(
-            "xiaomi", "redmi", "poco",
-            "realme",
-            "oppo",
-            "infinix", "itel",
-            "tecno",
-            "huawei", "honor",
-            "zte"
-        )
-
-        /** Detect vendors with known broken hardware AEC/NS. */
-        fun hasBrokenHardwareAudioProcessing(): Boolean {
-            val vendor = Build.MANUFACTURER?.lowercase() ?: return false
-            val brand = Build.BRAND?.lowercase() ?: ""
-            return BROKEN_HW_AEC_VENDORS.any { v -> v == vendor || v == brand }
-        }
+        fun hasBrokenHardwareAudioProcessing(): Boolean =
+            VendorAudioPolicy.prefersSoftwareAudioProcessing(Build.MANUFACTURER, Build.BRAND)
     }
 
     interface Listener {

--- a/android/app/src/test/java/com/forta/chat/plugins/calls/VendorAudioPolicyTest.kt
+++ b/android/app/src/test/java/com/forta/chat/plugins/calls/VendorAudioPolicyTest.kt
@@ -1,0 +1,188 @@
+package com.forta.chat.plugins.calls
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * WEE-56 — regression tests for the centralised per-vendor audio policy.
+ *
+ * Pure JVM tests: [VendorAudioPolicy] has no Android framework dependencies so
+ * the decision logic is covered without Robolectric / mockk. The imperative
+ * `AudioManager` effects in [AudioRouter] are thin shells over these
+ * predicates; the on-device routing behaviour itself still needs physical
+ * Honor/Huawei QA before merge.
+ */
+class VendorAudioPolicyTest {
+
+    // -------------------------------------------------------------------------
+    // detect() — coarse vendor classification
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun detect_honor_fromManufacturer() {
+        assertEquals(CallVendor.HONOR, VendorAudioPolicy.detect("HONOR", "HONOR"))
+    }
+
+    @Test
+    fun detect_honor_isCaseInsensitive() {
+        assertEquals(CallVendor.HONOR, VendorAudioPolicy.detect("honor", ""))
+        assertEquals(CallVendor.HONOR, VendorAudioPolicy.detect("Honor", "Honor"))
+    }
+
+    @Test
+    fun detect_honor_fromHihonorToken() {
+        // Newer Honor firmware reports a "hihonor" manufacturer token; it must
+        // still classify as HONOR, not fall through to GENERIC.
+        assertEquals(CallVendor.HONOR, VendorAudioPolicy.detect("HIHONOR", ""))
+    }
+
+    @Test
+    fun detect_honor_winsOverHuawei_whenBothTokensPresent() {
+        // Post-2020 Honor is a separate company with its own MagicOS HAL — an
+        // "honor" token must not be swallowed by a broad "huawei" match.
+        // Some legacy firmware still tags brand=Honor while manufacturer=HUAWEI.
+        assertEquals(CallVendor.HONOR, VendorAudioPolicy.detect("HUAWEI", "Honor"))
+    }
+
+    @Test
+    fun detect_huawei() {
+        assertEquals(CallVendor.HUAWEI, VendorAudioPolicy.detect("HUAWEI", "HUAWEI"))
+    }
+
+    @Test
+    fun detect_realme() {
+        assertEquals(CallVendor.REALME, VendorAudioPolicy.detect("realme", "realme"))
+    }
+
+    @Test
+    fun detect_xiaomi_familyTokens() {
+        assertEquals(CallVendor.XIAOMI, VendorAudioPolicy.detect("Xiaomi", "Redmi"))
+        assertEquals(CallVendor.XIAOMI, VendorAudioPolicy.detect("Xiaomi", "POCO"))
+        assertEquals(CallVendor.XIAOMI, VendorAudioPolicy.detect("Redmi", ""))
+    }
+
+    @Test
+    fun detect_oppo() {
+        assertEquals(CallVendor.OPPO, VendorAudioPolicy.detect("OPPO", ""))
+    }
+
+    @Test
+    fun detect_samsung() {
+        assertEquals(CallVendor.SAMSUNG, VendorAudioPolicy.detect("samsung", "samsung"))
+    }
+
+    @Test
+    fun detect_unknownVendor_isGeneric() {
+        assertEquals(CallVendor.GENERIC, VendorAudioPolicy.detect("Google", "google"))
+        assertEquals(CallVendor.GENERIC, VendorAudioPolicy.detect("OnePlus", "OnePlus"))
+    }
+
+    @Test
+    fun detect_nullOrBlank_isGeneric() {
+        assertEquals(CallVendor.GENERIC, VendorAudioPolicy.detect(null, null))
+        assertEquals(CallVendor.GENERIC, VendorAudioPolicy.detect("", ""))
+        assertEquals(CallVendor.GENERIC, VendorAudioPolicy.detect("  ", null))
+    }
+
+    // -------------------------------------------------------------------------
+    // requiresExplicitMicUnmuteOnStart() — HONOR-only (A1)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun honorRequiresExplicitMicUnmuteOnStart() {
+        assertTrue(VendorAudioPolicy.requiresExplicitMicUnmuteOnStart(CallVendor.HONOR))
+    }
+
+    @Test
+    fun nonHonorVendorsDoNotForceMicUnmuteOnStart() {
+        // Gated to HONOR so the proven generic start path is untouched on every
+        // other device (A5). Post-call reset covers the rest.
+        for (v in CallVendor.entries) {
+            if (v == CallVendor.HONOR) continue
+            assertFalse(
+                "$v must not force a mic unmute mid-setup",
+                VendorAudioPolicy.requiresExplicitMicUnmuteOnStart(v),
+            )
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // shouldUnmuteMicOnStop() — every vendor (A3, Telegram-empty-voice)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun everyVendorUnmutesMicOnStop() {
+        // setMicrophoneMute is process-global; clearing it on teardown can only
+        // release a stuck capture path, so the policy is vendor-independent.
+        for (v in CallVendor.entries) {
+            assertTrue(
+                "$v must release the global mic-mute flag on call teardown",
+                VendorAudioPolicy.shouldUnmuteMicOnStop(v),
+            )
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // prefersSoftwareAudioProcessing() — parity with the prior
+    // NativeWebRTCManager.BROKEN_HW_AEC_VENDORS behaviour (A2)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun brokenHwAecVendors_preferSoftwareProcessing() {
+        val brokenVendors = listOf(
+            "xiaomi", "redmi", "poco",
+            "realme", "oppo",
+            "infinix", "itel", "tecno",
+            "huawei", "honor", "zte",
+        )
+        for (v in brokenVendors) {
+            assertTrue(
+                "$v ships broken HW AEC — must fall back to software processing",
+                VendorAudioPolicy.prefersSoftwareAudioProcessing(v, ""),
+            )
+        }
+    }
+
+    @Test
+    fun brokenHwAecVendors_matchViaBrandToo() {
+        // The prior implementation matched manufacturer OR brand — preserve it.
+        assertTrue(VendorAudioPolicy.prefersSoftwareAudioProcessing("UnknownOem", "Huawei"))
+    }
+
+    @Test
+    fun brokenHwAecVendors_areCaseInsensitive() {
+        assertTrue(VendorAudioPolicy.prefersSoftwareAudioProcessing("HUAWEI", ""))
+        assertTrue(VendorAudioPolicy.prefersSoftwareAudioProcessing("Realme", ""))
+    }
+
+    @Test
+    fun hihonorToken_prefersSoftwareProcessing() {
+        // detect() maps "hihonor" → HONOR via substring; keep the HW-AEC set in
+        // step so a hihonor-only Build also gets the software fallback.
+        assertTrue(VendorAudioPolicy.prefersSoftwareAudioProcessing("hihonor", ""))
+    }
+
+    @Test
+    fun nullManufacturerWithVendorBrand_prefersSoftwareProcessing() {
+        // Intentional, safer divergence from the prior predicate (which ignored
+        // brand when manufacturer was null): a vendor exposed only via
+        // Build.BRAND still falls back to software audio processing.
+        assertTrue(VendorAudioPolicy.prefersSoftwareAudioProcessing(null, "huawei"))
+    }
+
+    @Test
+    fun workingHwAecVendors_keepHardwareProcessing() {
+        // Samsung / Pixel / OnePlus ship working HW AEC and must stay on it.
+        assertFalse(VendorAudioPolicy.prefersSoftwareAudioProcessing("samsung", "samsung"))
+        assertFalse(VendorAudioPolicy.prefersSoftwareAudioProcessing("Google", "Pixel"))
+        assertFalse(VendorAudioPolicy.prefersSoftwareAudioProcessing("OnePlus", ""))
+    }
+
+    @Test
+    fun nullOrBlankBuild_keepsHardwareProcessing() {
+        assertFalse(VendorAudioPolicy.prefersSoftwareAudioProcessing(null, null))
+        assertFalse(VendorAudioPolicy.prefersSoftwareAudioProcessing("", ""))
+    }
+}


### PR DESCRIPTION
## Summary

Post-WEE-54 vendor-specific calls regression (HONOR/HUAWEI/realme/Xiaomi). Introduces **`VendorAudioPolicy`** — a pure, JVM-tested per-vendor audio policy that centralises OEM handling previously scattered across `AudioRouter` and `NativeWebRTCManager`, and wires it in **additively** so the proven generic Android path stays the default for any unrecognised device (acceptance criterion **A5**).

- **HONOR MagicOS (#872/#873)** — explicit `setMicrophoneMute(false)` on call start to release the caller-only / self-echo one-way audio. Gated to HONOR; additive.
- **All vendors (#875/#898/#900 + cross-app "Telegram voice message empty after a Forta call")** — defensive `setMicrophoneMute(false)` in `stop()`/`forceStop()`. The process-global mic-mute flag was being left asserted on teardown, so other apps (Telegram/WhatsApp/recorder) captured silence until reboot. Clearing it on teardown can only release a stuck path — vendor-independent and safe.
- **HUAWEI EMUI (#874)** — unify the broken-hardware-AEC software fallback behind the policy (root cause of "video works, no audio": EMUI HW AEC mutes the capture stream). **Deliberately did NOT force a PCMU/G.711 codec fallback** — disabling Opus would degrade quality/interop for every Huawei user and risk one-way audio against Opus-only peers (an A5 regression).

## What was already in place (verified by reading the code)
- **A3 post-call cleanup** — `CallForegroundService.onDestroy()/onTaskRemoved()` → `AudioRouter.forceStop()` (mode reset, `clearCommunicationDevice`, BT SCO teardown, `abandonAudioFocus`) + orphan watchdog. This PR adds the missing **global mic-mute release** on top.
- **A4 web device persistence (#880)** — already implemented via `hintStoredDevices()` + `applySavedDevicesExact()` in `call-service.ts` and localStorage save in `CallControls.vue`. No change needed.

## Linear
- Resolves WEE-56 (https://linear.app/wwwee/issue/WEE-56)
- Refs WEE-54

## Closes
Closes greenShirtMystery/forta-bugs#872
Closes greenShirtMystery/forta-bugs#873
Closes greenShirtMystery/forta-bugs#874
Closes greenShirtMystery/forta-bugs#875
Closes greenShirtMystery/forta-bugs#880

Refs greenShirtMystery/forta-bugs#889, #898, #900 (post-call mic), #891, #894 (Xiaomi audio), #890 (realme).

## Test plan
- [x] `VendorAudioPolicy` — 21 JUnit tests, compiled with kotlinc 2.0.21 and **all passing** (detection across manufacturer/brand, HONOR-before-HUAWEI ordering, `hihonor` token, HONOR-only start unmute, all-vendor stop unmute, broken-HW-AEC parity incl. null-brand edge case).
- [x] Kotlin code review (kotlin-reviewer): APPROVE, 0 CRITICAL/HIGH; A5 invariant confirmed (vendor branches additive, generic path untouched).
- [x] `vite build` — production web bundle builds green.
- [ ] **Full `./gradlew :app:testDebugUnitTest`** — could not run in dev sandbox (`cap sync` requires Node ≥22; sandbox has v20.11.1). Run in CI.
- [ ] **`vue-tsc` / `vitest`** — blocked by same Node <22 limit (vitest 4 / rolldown needs `node:util.styleText`). No TS files were changed in this PR.
- [ ] **On-device vendor QA (REQUIRED before merge)** — physical Honor 200/x9a, Huawei pura 70, realme, Xiaomi:
  - Honor → bidirectional audio after accept; mic-mute stays `false` ~500ms post-start with BT connected (async MagicOS assertion).
  - Huawei → video-call audio works.
  - Post-call → Forta call → end (normal / swipe-out / kill) → **Telegram/WhatsApp/recorder voice message has real audio** (not silence). Repeat per vendor.
  - Regression: confirm working Samsung/Pixel/OnePlus devices are unaffected (A5).