### PR TITLE
fix(invite): hash-route invite/join links so they stop 404ing (WEE-27)

### DIFF
--- a/src/features/chat-info/ui/ChatInfoPanel.vue
+++ b/src/features/chat-info/ui/ChatInfoPanel.vue
@@ -4,7 +4,8 @@ import type { Message } from "@/entities/chat";
 import { UserAvatar } from "@/entities/user";
 import { useAuthStore } from "@/entities/auth";
 import { hexEncode, hexDecode } from "@/shared/lib/matrix/functions";
-import { MATRIX_SERVER, APP_PUBLIC_URL } from "@/shared/config";
+import { MATRIX_SERVER } from "@/shared/config";
+import { buildJoinUrl } from "@/shared/lib/invite-link";
 import { useContacts } from "@/features/contacts/model/use-contacts";
 import { matrixIdToAddress, isUnresolvedName } from "@/entities/chat/lib/chat-helpers";
 import { useFileDownload } from "@/features/messaging/model/use-file-download";
@@ -88,14 +89,15 @@ const roomShareable = computed(() => {
   return chatStore.isRoomShareableByLink(room.value.id);
 });
 
-// Path-based URL (NOT hash-based) — AndroidManifest pathPrefix="/join"
-// matches path, not fragment. Using a hash URL means the Android App Link
-// intent-filter never fires and the link opens in the browser.
+// Hash-routing URL via the shared builder. A bare-path `/join?room=...` 404s
+// on the static host (no such file under hash routing), which is the WEE-27
+// onboarding blocker — see invite-link.ts. Native deep-linking still works:
+// legacy bare-path links and `forta://` are accepted by parse-invite-url.ts.
 const inviteLink = computed(() => {
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
   stateMarker.value;
   if (!room.value) return "";
-  return `${APP_PUBLIC_URL}/join?room=${encodeURIComponent(room.value.id)}`;
+  return buildJoinUrl(room.value.id);
 });
 
 // Subscribe to RoomState.events so toggles by *other* admins appear

--- a/src/features/invite/ui/InviteModal.vue
+++ b/src/features/invite/ui/InviteModal.vue
@@ -3,7 +3,7 @@ import Modal from "@/shared/ui/modal/Modal.vue";
 import { useAuthStore } from "@/entities/auth";
 import { useNativeShare } from "@/shared/lib/composables/use-native-share";
 import { isNative } from "@/shared/lib/platform";
-import { APP_PUBLIC_URL } from "@/shared/config";
+import { buildInviteUrl } from "@/shared/lib/invite-link";
 
 const props = defineProps<{ show: boolean }>();
 const emit = defineEmits<{ close: [] }>();
@@ -17,9 +17,7 @@ const { share } = useNativeShare({
 
 const copied = ref(false);
 
-const inviteLink = computed(() => {
-  return `${APP_PUBLIC_URL}/#/invite?ref=${authStore.address}`;
-});
+const inviteLink = computed(() => buildInviteUrl(authStore.address ?? ""));
 
 const copyLink = async () => {
   try {

--- a/src/shared/lib/invite-link.test.ts
+++ b/src/shared/lib/invite-link.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+
+import { buildInviteUrl, buildJoinUrl } from "./invite-link";
+import { parseInviteUrl, parseJoinUrl } from "./parse-invite-url";
+
+const ADDR = "PABCdefGHIjklMNOpqrSTUvwx12";
+const ROOM_ID = "!abc123:matrix.bastyon.com";
+
+describe("buildInviteUrl", () => {
+  it("emits the hash-routing path so the static host never 404s", () => {
+    const url = buildInviteUrl(ADDR);
+    expect(url).toContain("#/invite");
+    // The bug we are fixing: a bare `forta.chat/invite` path has no file on
+    // the static host and returns 404. Assert we never regress to it.
+    expect(url).not.toMatch(/forta\.chat\/invite/);
+  });
+
+  it("carries the referral address", () => {
+    expect(buildInviteUrl(ADDR)).toContain(`ref=${ADDR}`);
+  });
+
+  it("round-trips through parseInviteUrl", () => {
+    expect(parseInviteUrl(buildInviteUrl(ADDR))).toEqual({ address: ADDR });
+  });
+});
+
+describe("buildJoinUrl", () => {
+  it("emits the hash-routing path so the static host never 404s", () => {
+    const url = buildJoinUrl(ROOM_ID);
+    expect(url).toContain("#/join");
+    // Confirmed root cause of WEE-27 (forta-bugs#435/#29): the bare
+    // `forta.chat/join?room=...` link 404s under hash routing.
+    expect(url).not.toMatch(/forta\.chat\/join/);
+  });
+
+  it("URL-encodes the room id separator", () => {
+    // encodeURIComponent keeps `!` literal but escapes the `:` to %3A — the
+    // raw colon must never reach the query string (it would break the param
+    // split on some parsers / share targets).
+    const url = buildJoinUrl(ROOM_ID);
+    expect(url).toContain("room=!abc123%3Amatrix.bastyon.com");
+    expect(url).not.toContain(":matrix.bastyon.com");
+  });
+
+  it("round-trips through parseJoinUrl", () => {
+    expect(parseJoinUrl(buildJoinUrl(ROOM_ID))).toEqual({ roomId: ROOM_ID });
+  });
+
+  it("round-trips a room id carrying an explicit server port", () => {
+    // The parser grammar allows `!local:server:port`; encoding both colons to
+    // %3A must survive the URLSearchParams decode on the way back.
+    const withPort = "!abc:matrix.bastyon.com:8448";
+    const url = buildJoinUrl(withPort);
+    expect(url).toContain("matrix.bastyon.com%3A8448");
+    expect(parseJoinUrl(url)).toEqual({ roomId: withPort });
+  });
+});

--- a/src/shared/lib/invite-link.ts
+++ b/src/shared/lib/invite-link.ts
@@ -1,0 +1,30 @@
+/**
+ * Invite / join deep-link *generation* — the write-side counterpart to
+ * `parse-invite-url.ts` (the read-side). They live together on purpose: the
+ * link shapes we emit and the shapes we accept must never drift apart.
+ *
+ * Forta's SPA uses hash routing (`createWebHashHistory`). A bare-path link
+ * such as `https://forta.chat/join?room=...` has no corresponding file on the
+ * static host, so tapping it in a browser — a recipient without the app, or a
+ * device where Android App Link verification never took — returns a 404. That
+ * is the onboarding blocker reported in forta-bugs#435 / #29 (WEE-27).
+ *
+ * Emitting the hash form `https://forta.chat/#/join?room=...` always resolves
+ * through `index.html` + the client-side router, so the link works everywhere
+ * the recipient lands. Native deep-linking is unaffected: legacy bare-path
+ * links and the `forta://` custom scheme are still accepted by
+ * `parse-invite-url.ts` when delivered through Capacitor's `appUrlOpen`.
+ */
+
+import { APP_PUBLIC_URL } from "@/shared/config";
+
+/** Personal invite: opens the welcome screen and pre-fills the inviter's
+ *  Bastyon address so accepting creates a 1:1 chat. */
+export function buildInviteUrl(address: string): string {
+  return `${APP_PUBLIC_URL}/#/invite?ref=${encodeURIComponent(address)}`;
+}
+
+/** Group / room join: opens the welcome screen primed to join `roomId`. */
+export function buildJoinUrl(roomId: string): string {
+  return `${APP_PUBLIC_URL}/#/join?room=${encodeURIComponent(roomId)}`;
+}


### PR DESCRIPTION
## Summary
- Group invite links were generated as a **bare path** (`forta.chat/join?room=...`). The app uses `createWebHashHistory`, so the static host has no `/join` file and the link **404s** when tapped in a browser — the onboarding blocker reported in forta-bugs#435 / #29.
- Consolidated invite/join URL generation into a shared `buildInviteUrl` / `buildJoinUrl` utility (`src/shared/lib/invite-link.ts`, the write-side counterpart to the existing `parse-invite-url.ts` read-side). Both now emit the **hash form** (`#/invite`, `#/join`) which always resolves through `index.html` + the client router.
- Routed `ChatInfoPanel.vue` (group link) and `InviteModal.vue` (personal link) through the shared builder, removing two divergent inline string builders.

## Linear
- Resolves WEE-27 (https://linear.app/wwwee/issue/WEE-27)

## Closes
Closes greenShirtMystery/forta-bugs#435
Closes greenShirtMystery/forta-bugs#29

## Tradeoff (please ack)
Android App Links match on URL **path** (`pathPrefix="/join"|"/invite"`), not the `#` fragment. Switching generated links to the hash form means our own links no longer auto-launch the installed app via App Links — they open the web app in the browser (which then resolves the join via `localStorage`). This is accepted because a link that **works everywhere** beats an App Link that 404s for users without verified App Links — the 404 was the actual user complaint. Native delivery is unchanged: legacy bare-path links and the `forta://` scheme are still parsed by `parse-invite-url.ts` via Capacitor `appUrlOpen`. A future server-side `/join` → `#/join` 302 redirect could restore native auto-open without re-introducing the 404 (follow-up, out of scope).

## Test plan
- [x] Added `src/shared/lib/invite-link.test.ts` (7 tests): hash present, bare-path regression guard, colon/port encoding, round-trip through `parseInviteUrl`/`parseJoinUrl`.
- [x] Existing `parse-invite-url` + `deep-link-handler` + `share-link` suites green.
- [x] `vite build` passes.
- [ ] Manual QA: copy a group invite link → open in a fresh browser → should load the join screen (not 404). Personal invite link unchanged.

### Notes
- `vue-tsc --noEmit` has 49 **pre-existing** errors across unrelated files (test globals, VideoTile, DownloadPage, etc.); this change adds **zero** (verified base=49, with-fix=49). Full `vitest run` has 9 pre-existing failures in 4 unrelated files (video-embed, open-profile-url, chat-helpers, display-result), identical on the base branch.
- Tests require Node ≥20.12 (env Node v20.11.1 trips a rolldown/`styleText` startup error); ran on Node v22.