### PR TITLE
fix(chat-list): show pending invites in "All" tab (WEE-59)

### DIFF
--- a/src/entities/chat/lib/room-visibility.test.ts
+++ b/src/entities/chat/lib/room-visibility.test.ts
@@ -62,17 +62,31 @@ describe("filterRoomsForTab", () => {
 
   const all: ChatRoom[] = [joined1, joined2, joinedEmpty, invite1, inviteEmpty];
 
-  it('"all" tab hides invites and empty rooms', () => {
+  // WEE-59: pending invites must surface in the "all" tab alongside joined rooms
+  // so the user does not miss them. Only empty placeholder rooms stay hidden.
+  it('"all" tab shows joined rooms AND pending invites, hides only empty placeholders', () => {
     const filtered = filterRoomsForTab(all, "all");
-    expect(filtered.map(r => r.id)).toEqual(["!j1:s", "!j2:s"]);
+    expect(filtered.map(r => r.id)).toEqual(["!j1:s", "!j2:s", "!i1:s"]);
   });
 
-  it('"personal" tab hides groups, invites, and empty rooms', () => {
+  it('"all" tab still drops un-hydrated empty invites (no blank stripes)', () => {
+    const filtered = filterRoomsForTab(all, "all");
+    expect(filtered.map(r => r.id)).not.toContain("!ie:s");
+  });
+
+  it('"all" tab shows both DM and group invites (WEE-59 A6)', () => {
+    const dmInvite = makeRoom({ id: "!dm:s", membership: "invite", isGroup: false, name: "DM Invite", lastMessage: undefined, updatedAt: 1000 });
+    const groupInvite = makeRoom({ id: "!gi:s", membership: "invite", isGroup: true, name: "Group Invite", lastMessage: undefined, updatedAt: 2000 });
+    const filtered = filterRoomsForTab([joined1, dmInvite, groupInvite], "all");
+    expect(filtered.map(r => r.id)).toEqual(["!j1:s", "!dm:s", "!gi:s"]);
+  });
+
+  it('"personal" tab keeps joined membership only (invites live in "all" + Invites tab)', () => {
     const filtered = filterRoomsForTab(all, "personal");
     expect(filtered.map(r => r.id)).toEqual(["!j1:s"]);
   });
 
-  it('"groups" tab hides non-groups, invites, and empty rooms', () => {
+  it('"groups" tab keeps joined groups only (invites excluded)', () => {
     const filtered = filterRoomsForTab(all, "groups");
     expect(filtered.map(r => r.id)).toEqual(["!j2:s"]);
   });

--- a/src/entities/chat/lib/room-visibility.ts
+++ b/src/entities/chat/lib/room-visibility.ts
@@ -29,9 +29,14 @@ export function hasDisplayableContent(room: ChatRoom): boolean {
  * Filter `rooms` for a given sidebar tab.
  *
  * Rules:
- *   - "all": hide invites (they live on the dedicated Invites tab) and hide
- *     empty placeholder rooms. This removes the blank stripes between chats.
+ *   - "all": joined rooms AND pending invites together (WEE-59). Invites must
+ *     surface here so the user does not miss them; they render with a distinct
+ *     badge and are mixed in by activity (the list is sorted upstream). Only
+ *     empty placeholder rooms (incl. un-hydrated invites) are dropped, to avoid
+ *     blank stripes between chats.
  *   - "personal": 1:1 chats, joined membership only, displayable content.
+ *     Invites are not split across personal/groups — they live in "all" and on
+ *     the dedicated Invites tab.
  *   - "groups": group chats, joined membership only, displayable content.
  *   - "invites": ALL invites (even empty ones — the user still needs to
  *     accept/decline them). No displayability filter.
@@ -44,8 +49,10 @@ export function filterRoomsForTab(rooms: ChatRoom[], tab: ContactListTab): ChatR
   if (tab === "channels") {
     return [];
   }
+  if (tab === "all") {
+    return rooms.filter(hasDisplayableContent);
+  }
   const base = rooms.filter(r => r.membership !== "invite" && hasDisplayableContent(r));
   if (tab === "personal") return base.filter(r => !r.isGroup);
-  if (tab === "groups") return base.filter(r => r.isGroup);
-  return base;
+  return base.filter(r => r.isGroup);
 }

--- a/src/features/contacts/ui/ContactList.vue
+++ b/src/features/contacts/ui/ContactList.vue
@@ -455,9 +455,11 @@ const allFilteredRooms = computed<UnifiedItem[]>(() => {
 
   // "all": merge-sort rooms + channels (both already sorted by time desc).
   // O(n+m) instead of O((n+m) log(n+m)).
-  // Invites and empty placeholder rooms are filtered out here to prevent
-  // blank stripes in RecycleScroller (each slot reserves ITEM_HEIGHT even
-  // when its content is empty). Invites live on the dedicated Invites tab.
+  // Joined rooms AND pending invites are shown here (WEE-59), interleaved by
+  // activity — their relative order comes from the upstream sortedRooms sort
+  // (membershipRank below only tie-breaks room-vs-channel at equal timestamps).
+  // Only empty placeholder rooms are filtered out to prevent blank stripes in
+  // RecycleScroller (each slot reserves ITEM_HEIGHT even when its content is empty).
   const roomItems: UnifiedItem[] = filterRoomsForTab(rooms, "all").map(toItem);
   const channelItems: UnifiedItem[] = channelStore.channels
     .map(c => ({ ...c, _key: `ch:${c.address}` }))


### PR DESCRIPTION
## Summary
- Pending room invites (`membership === "invite"`) were missing from the **"All"/"Все"** tab — `filterRoomsForTab(rooms, "all")` explicitly excluded them, so users only saw joined rooms and silently missed invitations.
- Fix: include invites in the "all" tab (interleaved with joined rooms by activity); only empty placeholder rooms stay hidden to avoid blank stripes. `personal`/`groups` sub-tabs remain joined-only.
- Deliberately scoped to the one filter — all other invite infrastructure already exists and is reused: invite badge + italic preview (ContactList), dedicated Invites tab + counter, ChatWindow invite-preview with accept/decline wired to `chatStore.acceptInvite`/`declineInvite`, and the merge-sort `membershipRank` that already ranks invites.

## Root cause
`src/entities/chat/lib/room-visibility.ts` → `filterRoomsForTab` had `r.membership !== "invite"` in the "all"-tab predicate. The data layer (`RoomRepository.getAllRooms` querying `["join","invite"]`) and the rendering layer were already invite-ready; only this filter dropped them.

## Linear
- Resolves WEE-59 (https://linear.app/wwwee/issue/WEE-59)

## Test plan
- [x] `vite build` passes; `vue-tsc` clean for changed files (repo has 49 pre-existing unrelated TS errors — unchanged)
- [x] Unit tests added/updated in `room-visibility.test.ts` (16/16 pass): invites shown in "all", empty invites still dropped, DM + group invites both shown, personal/groups stay joined-only, invites tab unchanged
- [x] Pre-existing test failures (9 in 4 unrelated files) confirmed present on baseline — not introduced here
- [ ] Manual QA: invite from a second account → appears in "All" with badge "Приглашение"; tap → ChatWindow preview → Принять (`joinRoom`) / Отклонить (`leave`); works for DM and group invites

> Note: test/build tooling requires Node ≥ 20.12 (vitest 4 / rolldown needs `node:util.styleText`); ran under Node 22. Confirm CI Node version.