### PR TITLE
fix(chat): prevent chat data loss after update — cleanup guard + cache key (WEE-61)

### DIFF
--- a/src/entities/chat/model/__tests__/load-cached-rooms-key.test.ts
+++ b/src/entities/chat/model/__tests__/load-cached-rooms-key.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { resolveCachedRoomsAddress } from "../cached-rooms-address";
+
+const ACTIVE_KEY = "forta-chat:activeAccount";
+const LEGACY_KEY = "forta-chat:auth";
+
+describe("resolveCachedRoomsAddress (WEE-61 / forta-bugs#892)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("reads forta-chat:activeAccount, not the migration-removed forta-chat:auth", () => {
+    // Post-migration state: legacy key gone, address under activeAccount.
+    localStorage.removeItem(LEGACY_KEY);
+    localStorage.setItem(ACTIVE_KEY, JSON.stringify("addr1"));
+
+    expect(resolveCachedRoomsAddress()).toBe("addr1");
+  });
+
+  it("falls back to legacy forta-chat:auth when activeAccount is absent (pre-migration)", () => {
+    // loadCachedRooms can run before SessionManager.migrate() — still resolve.
+    localStorage.setItem(LEGACY_KEY, JSON.stringify({ address: "legacyAddr", privateKey: "pk" }));
+
+    expect(resolveCachedRoomsAddress()).toBe("legacyAddr");
+  });
+
+  it("prefers activeAccount over legacy when both exist", () => {
+    localStorage.setItem(ACTIVE_KEY, JSON.stringify("activeAddr"));
+    localStorage.setItem(LEGACY_KEY, JSON.stringify({ address: "legacyAddr", privateKey: "pk" }));
+
+    expect(resolveCachedRoomsAddress()).toBe("activeAddr");
+  });
+
+  it("returns null when nothing is stored", () => {
+    expect(resolveCachedRoomsAddress()).toBeNull();
+  });
+
+  it("returns null on malformed activeAccount with no legacy fallback", () => {
+    localStorage.setItem(ACTIVE_KEY, "{not-json");
+
+    expect(resolveCachedRoomsAddress()).toBeNull();
+  });
+
+  it("ignores a null-address legacy payload", () => {
+    localStorage.setItem(LEGACY_KEY, JSON.stringify({ address: null, privateKey: "pk" }));
+
+    expect(resolveCachedRoomsAddress()).toBeNull();
+  });
+});

--- a/src/entities/chat/model/__tests__/room-cleanup-guard.test.ts
+++ b/src/entities/chat/model/__tests__/room-cleanup-guard.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { cleanupStaleRooms, type CleanupContext, ORPHAN_SYNC_SAFETY_MS } from "../room-cleanup";
+import type { LocalRoom } from "@/shared/lib/local-db";
+
+function makeLocalRoom(overrides: Partial<LocalRoom> = {}): LocalRoom {
+  return {
+    id: overrides.id ?? "!r:s",
+    name: "Room",
+    isGroup: false,
+    members: [],
+    membership: overrides.membership ?? "join",
+    unreadCount: 0,
+    lastReadInboundTs: 0,
+    lastReadOutboundTs: 0,
+    updatedAt: overrides.updatedAt ?? Date.now(),
+    lastMessageTimestamp: overrides.lastMessageTimestamp,
+    syncedAt: overrides.syncedAt ?? Date.now(),
+    hasMoreHistory: true,
+    isDeleted: overrides.isDeleted ?? false,
+    deletedAt: overrides.deletedAt ?? null,
+    deleteReason: overrides.deleteReason ?? null,
+    ...overrides,
+  };
+}
+
+function makeContext(rooms: LocalRoom[], sdkRoomIds: Set<string>): CleanupContext & { _deletedIds: string[] } {
+  const deletedIds: string[] = [];
+  return {
+    getAllRooms: () => Promise.resolve(rooms),
+    deleteRooms: async (ids) => {
+      deletedIds.push(...ids);
+    },
+    isRoomInSdk: (id) => sdkRoomIds.has(id),
+    getRoomHistoryVisibility: () => null,
+    _deletedIds: deletedIds,
+  } as CleanupContext & { _deletedIds: string[] };
+}
+
+describe("cleanupStaleRooms — data-loss guard (WEE-61 / forta-bugs#892)", () => {
+  it("does NOT delete a freshly-synced room even when isRoomInSdk=false", async () => {
+    // The SDK has not materialized this room into memory yet (slow cold-start
+    // after update), but it was synced 5s ago — it is valid, not orphaned.
+    const rooms = [makeLocalRoom({ id: "!fresh:s", syncedAt: Date.now() - 5_000 })];
+    const ctx = makeContext(rooms, new Set()); // empty SDK
+
+    const count = await cleanupStaleRooms(ctx);
+
+    expect(count).toBe(0);
+    expect(ctx._deletedIds).toEqual([]);
+  });
+
+  it("deletes a genuinely orphaned room not synced for longer than the safety window", async () => {
+    const rooms = [
+      makeLocalRoom({ id: "!orphan:s", syncedAt: Date.now() - ORPHAN_SYNC_SAFETY_MS - 60_000 }),
+    ];
+    const ctx = makeContext(rooms, new Set());
+
+    const count = await cleanupStaleRooms(ctx);
+
+    expect(count).toBe(1);
+    expect(ctx._deletedIds).toEqual(["!orphan:s"]);
+  });
+
+  it("treats a room exactly at the safety boundary as still fresh (keeps it)", async () => {
+    const rooms = [
+      makeLocalRoom({ id: "!boundary:s", syncedAt: Date.now() - ORPHAN_SYNC_SAFETY_MS + 1_000 }),
+    ];
+    const ctx = makeContext(rooms, new Set());
+
+    const count = await cleanupStaleRooms(ctx);
+
+    expect(count).toBe(0);
+    expect(ctx._deletedIds).toEqual([]);
+  });
+
+  it("still removes membership=leave rooms regardless of fresh syncedAt", async () => {
+    // The leave branch is authoritative (server told us we left) — unaffected by the guard.
+    const rooms = [makeLocalRoom({ id: "!left:s", membership: "leave", syncedAt: Date.now() })];
+    const ctx = makeContext(rooms, new Set());
+
+    const count = await cleanupStaleRooms(ctx);
+
+    expect(count).toBe(1);
+    expect(ctx._deletedIds).toEqual(["!left:s"]);
+  });
+
+  it("protects 50+ freshly-synced rooms on a slow cold-start (the #892 scenario)", async () => {
+    const rooms = Array.from({ length: 60 }, (_, i) =>
+      makeLocalRoom({ id: `!room${i}:s`, syncedAt: Date.now() - 10_000 }),
+    );
+    const ctx = makeContext(rooms, new Set()); // SDK loaded none yet
+
+    const count = await cleanupStaleRooms(ctx);
+
+    expect(count).toBe(0);
+    expect(ctx._deletedIds).toEqual([]);
+  });
+});

--- a/src/entities/chat/model/__tests__/room-cleanup.test.ts
+++ b/src/entities/chat/model/__tests__/room-cleanup.test.ts
@@ -57,8 +57,10 @@ describe("cleanupStaleRooms", () => {
     expect(ctx._deletedIds).toEqual(["!left:s"]);
   });
 
-  it("removes orphaned rooms not in SDK", async () => {
-    const rooms = [makeLocalRoom({ id: "!orphan:s" })];
+  it("removes orphaned rooms not in SDK (synced long ago — genuinely gone)", async () => {
+    // WEE-61: only an orphan synced outside the safety window is removed.
+    // Fresh-synced rooms are protected (see room-cleanup-guard.test.ts).
+    const rooms = [makeLocalRoom({ id: "!orphan:s", syncedAt: FOUR_DAYS_AGO })];
     const sdkRoomIds = new Set<string>(); // empty — room not in SDK
     const ctx = makeContext(rooms, sdkRoomIds) as CleanupContext & { _deletedIds: string[] };
 
@@ -112,7 +114,7 @@ describe("cleanupStaleRooms", () => {
     const rooms = [
       makeLocalRoom({ id: "!keep:s", membership: "join" }),
       makeLocalRoom({ id: "!left:s", membership: "leave" }),
-      makeLocalRoom({ id: "!orphan:s", membership: "join" }),
+      makeLocalRoom({ id: "!orphan:s", membership: "join", syncedAt: FOUR_DAYS_AGO }),
       makeLocalRoom({ id: "!stale-stream:s", membership: "join", lastMessageTimestamp: FOUR_DAYS_AGO }),
       makeLocalRoom({ id: "!fresh-stream:s", membership: "join", lastMessageTimestamp: ONE_HOUR_AGO }),
     ];

--- a/src/entities/chat/model/cached-rooms-address.ts
+++ b/src/entities/chat/model/cached-rooms-address.ts
@@ -1,0 +1,39 @@
+const ACTIVE_ACCOUNT_KEY = "forta-chat:activeAccount";
+const LEGACY_AUTH_KEY = "forta-chat:auth";
+
+/**
+ * Resolve the cached user address used by `loadCachedRooms` to open Dexie
+ * before the full auth/Matrix flow runs (instant sidebar first-paint).
+ *
+ * WEE-61 / forta-bugs#892: after the multi-account migration the singleton
+ * `forta-chat:auth` key is removed (`SessionManager.migrate`) and the address
+ * lives under `forta-chat:activeAccount` as a JSON string. Reading the dead
+ * `forta-chat:auth` key always returned null → empty sidebar until PREPARED.
+ *
+ * We read `activeAccount` first and fall back to the legacy key so the cache
+ * paints regardless of migration timing (e.g. loadCachedRooms running before
+ * `migrate()`).
+ */
+export function resolveCachedRoomsAddress(): string | null {
+  try {
+    const active = localStorage.getItem(ACTIVE_ACCOUNT_KEY);
+    if (active) {
+      const parsed: unknown = JSON.parse(active);
+      if (typeof parsed === "string" && parsed) return parsed;
+    }
+  } catch {
+    // malformed activeAccount — fall through to legacy key
+  }
+
+  try {
+    const legacy = localStorage.getItem(LEGACY_AUTH_KEY);
+    if (legacy) {
+      const addr: unknown = (JSON.parse(legacy) as { address?: unknown })?.address;
+      if (typeof addr === "string" && addr) return addr;
+    }
+  } catch {
+    // malformed legacy auth — give up
+  }
+
+  return null;
+}

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -35,6 +35,7 @@ import type { RoomChange } from "@/shared/lib/local-db";
 import { ChatDatabase, useLiveQuery, localToMessages, localStatusToMessageStatus, deriveOutboundStatus } from "@/shared/lib/local-db";
 import type { ChatRoom, FileInfo, ForwardingMessage, LinkPreview, Message, PeerKeysStatus, PollInfo, ReplyTo, TransferInfo } from "./types";
 import { MessageStatus, MessageType } from "./types";
+import { resolveCachedRoomsAddress } from "./cached-rooms-address";
 
 const NAMESPACE = "chat";
 
@@ -1636,10 +1637,18 @@ export const useChatStore = defineStore(NAMESPACE, () => {
   const runRoomCleanup = async () => {
     if (!chatDbKitRef.value) return;
     const matrixService = getMatrixClientService();
+    // DATA-LOSS GUARD (WEE-61): only run orphan cleanup once the SDK has reached
+    // steady-state incremental sync ("SYNCING"). Right after "PREPARED" the SDK
+    // may not have materialized all rooms into memory yet (slow WebView / 50+
+    // rooms), so isRoomInSdk() reports false for valid rooms. If we're not there
+    // yet, skip this tick — the 30-minute interval will retry safely.
+    if (matrixService.getSyncState() !== "SYNCING") return;
     const { cleanupStaleRooms } = await import("./room-cleanup");
     await cleanupStaleRooms({
       getAllRooms: () => chatDbKitRef.value!.rooms.getAllRooms(),
-      deleteRooms: (ids) => chatDbKitRef.value!.rooms.bulkRemoveRooms(ids).catch(() => {}),
+      // Soft-delete (tombstone) instead of hard-delete: a mistaken orphan is
+      // recoverable (revived on next sync, GC'd after 30 days) — no data loss.
+      deleteRooms: (ids) => chatDbKitRef.value!.rooms.bulkTombstoneRooms(ids, "removed").catch(() => {}),
       isRoomInSdk: (id) => !!matrixService.getRoom(id),
       getRoomHistoryVisibility: (id) => {
         try {
@@ -6737,9 +6746,11 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     if (rooms.value.length > 0) return; // already have rooms
 
     try {
-      // Read address from localStorage without going through auth store init
-      const raw = localStorage.getItem("forta-chat:auth");
-      const address = raw ? JSON.parse(raw)?.address : null;
+      // Read address from localStorage without going through auth store init.
+      // WEE-61: the singleton `forta-chat:auth` key is removed by the
+      // multi-account migration — read `forta-chat:activeAccount` (with a
+      // legacy fallback) so the cached sidebar paints post-migration.
+      const address = resolveCachedRoomsAddress();
       if (!address) return;
 
       // Open Dexie DB directly — ChatDatabase constructor is synchronous,

--- a/src/entities/chat/model/room-cleanup.ts
+++ b/src/entities/chat/model/room-cleanup.ts
@@ -2,6 +2,18 @@ import type { LocalRoom } from "@/shared/lib/local-db";
 
 const THREE_DAYS_MS = 3 * 24 * 60 * 60 * 1000;
 
+/**
+ * Safety window for orphan removal (WEE-61 / forta-bugs#892 — DATA LOSS).
+ *
+ * `isRoomInSdk` returning false is NOT reliable evidence of an orphan shortly
+ * after a cold-start/update: matrix-js-sdk lazily materializes Room objects, so
+ * on slow WebView / 50+ rooms `getRoom()` returns null for rooms that are still
+ * valid and just haven't loaded yet. A room synced within this window is
+ * therefore kept even if absent from SDK memory. Genuinely-left rooms come
+ * through the `membership === "leave"` branch and are unaffected.
+ */
+export const ORPHAN_SYNC_SAFETY_MS = 24 * 60 * 60 * 1000;
+
 /** Dependency injection interface for testability */
 export interface CleanupContext {
   getAllRooms: () => Promise<LocalRoom[]>;
@@ -29,6 +41,13 @@ export async function cleanupStaleRooms(ctx: CleanupContext): Promise<number> {
       continue;
     }
     if (!ctx.isRoomInSdk(room.id)) {
+      // DATA-LOSS GUARD (WEE-61): a recently-synced room may simply not be
+      // materialized into SDK memory yet on a slow cold-start. Only treat it as
+      // a genuine orphan if it hasn't synced for longer than the safety window.
+      const syncedAt = room.syncedAt ?? 0;
+      if (now - syncedAt < ORPHAN_SYNC_SAFETY_MS) {
+        continue; // fresh — keep, SDK just hasn't loaded it yet
+      }
       toRemove.push(room.id);
       continue;
     }

--- a/src/entities/matrix/model/matrix-client.ts
+++ b/src/entities/matrix/model/matrix-client.ts
@@ -643,6 +643,15 @@ export class MatrixClientService {
     return this.client?.getRoom(roomId);
   }
 
+  /** Current Matrix /sync state, or null if the client is not initialized.
+   *  "SYNCING" means initial sync finished and the client is doing incremental
+   *  syncs — at that point all rooms are materialized into SDK memory (WEE-61).
+   *  Returns the underlying `SyncState` string enum value ("PREPARED" | "SYNCING"
+   *  | "ERROR" | "STOPPED" | "RECONNECTING" | "CATCHUP") widened to string. */
+  getSyncState(): string | null {
+    return this.client?.getSyncState() ?? null;
+  }
+
   /** Create a room */
   async createRoom(opts: Record<string, unknown>): Promise<{ room_id: string }> {
     if (!this.client) throw new Error("Client not initialized");

--- a/src/shared/lib/local-db/__tests__/bulk-tombstone-rooms.test.ts
+++ b/src/shared/lib/local-db/__tests__/bulk-tombstone-rooms.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "fake-indexeddb/auto";
+import { ChatDatabase } from "../schema";
+import type { LocalMessage, LocalRoom } from "../schema";
+import { MessageRepository } from "../message-repository";
+import { RoomRepository } from "../room-repository";
+import { MessageType } from "@/entities/chat/model/types";
+
+let db: ChatDatabase;
+let msgRepo: MessageRepository;
+let roomRepo: RoomRepository;
+
+function makeMsg(roomId: string, overrides: Partial<LocalMessage> = {}): LocalMessage {
+  return {
+    eventId: overrides.eventId ?? `$evt_${Math.random().toString(36).slice(2)}`,
+    clientId: overrides.clientId ?? `cli_${Math.random().toString(36).slice(2)}`,
+    roomId,
+    senderId: "user1",
+    content: "hello",
+    timestamp: overrides.timestamp ?? Date.now(),
+    type: MessageType.text,
+    status: "synced",
+    version: 1,
+    softDeleted: false,
+    ...overrides,
+  } as LocalMessage;
+}
+
+function makeRoom(id: string, overrides: Partial<LocalRoom> = {}): LocalRoom {
+  return {
+    id,
+    name: "Room",
+    isGroup: false,
+    members: ["user1", "user2"],
+    membership: "join",
+    unreadCount: 0,
+    lastReadInboundTs: 0,
+    lastReadOutboundTs: 0,
+    updatedAt: Date.now(),
+    syncedAt: Date.now(),
+    hasMoreHistory: true,
+    isDeleted: false,
+    deletedAt: null,
+    deleteReason: null,
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  const name = `test-tombstone-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  db = new ChatDatabase(name);
+  await db.open();
+  msgRepo = new MessageRepository(db);
+  roomRepo = new RoomRepository(db);
+});
+
+afterEach(async () => {
+  await db.delete();
+});
+
+describe("bulkTombstoneRooms (WEE-61 / forta-bugs#892)", () => {
+  it("soft-deletes rooms and PRESERVES their messages (no data loss)", async () => {
+    await db.rooms.bulkAdd([makeRoom("!a:s"), makeRoom("!b:s")]);
+    await db.messages.bulkAdd([makeMsg("!a:s"), makeMsg("!a:s"), makeMsg("!b:s")]);
+
+    await roomRepo.bulkTombstoneRooms(["!a:s", "!b:s"], "removed");
+
+    // Rooms still exist in Dexie (recoverable), just hidden.
+    expect(await db.rooms.count()).toBe(2);
+    // Messages are untouched — the whole point of the fix.
+    expect(await db.messages.count()).toBe(3);
+
+    const a = await db.rooms.get("!a:s");
+    expect(a?.isDeleted).toBe(true);
+    expect(a?.deleteReason).toBe("removed");
+    expect(a?.membership).toBe("leave");
+    expect(typeof a?.deletedAt).toBe("number");
+  });
+
+  it("tombstoned rooms are excluded from getAllRooms but revivable", async () => {
+    await db.rooms.bulkAdd([makeRoom("!a:s")]);
+    await roomRepo.bulkTombstoneRooms(["!a:s"], "removed");
+
+    expect(await roomRepo.getAllRooms()).toHaveLength(0);
+    expect(await roomRepo.isTombstoned("!a:s")).toBe(true);
+
+    await roomRepo.reviveRoom("!a:s");
+    expect(await roomRepo.isTombstoned("!a:s")).toBe(false);
+  });
+
+  it("is a no-op for an empty id list", async () => {
+    await db.rooms.bulkAdd([makeRoom("!a:s")]);
+    await roomRepo.bulkTombstoneRooms([], "removed");
+
+    expect(await roomRepo.isTombstoned("!a:s")).toBe(false);
+  });
+});

--- a/src/shared/lib/local-db/room-repository.ts
+++ b/src/shared/lib/local-db/room-repository.ts
@@ -465,6 +465,29 @@ export class RoomRepository {
     });
   }
 
+  /** Bulk soft-delete (tombstone) rooms in a single transaction.
+   *  WEE-61: the background cleanup path uses this instead of `bulkRemoveRooms`
+   *  so a false-positive orphan never destroys data — messages are preserved,
+   *  the room is hidden from UI, revived on the next sync upsert, and physically
+   *  GC'd only after the tombstone TTL (`garbageCollectTombstones`, 30 days). */
+  async bulkTombstoneRooms(
+    roomIds: string[],
+    reason: "left" | "kicked" | "banned" | "removed" = "removed",
+  ): Promise<void> {
+    if (roomIds.length === 0) return;
+    const now = Date.now();
+    await this.db.transaction("rw", [this.db.rooms], async () => {
+      for (const id of roomIds) {
+        await this.db.rooms.update(id, {
+          isDeleted: true,
+          deletedAt: now,
+          deleteReason: reason,
+          membership: "leave" as const,
+        });
+      }
+    });
+  }
+
   // ---------------------------------------------------------------------------
   // Optimistic update from push notification
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **H1** — `loadCachedRooms` read the migration-removed `forta-chat:auth` key → empty sidebar after update. Now resolves the address via `resolveCachedRoomsAddress()` (`forta-chat:activeAccount` with a legacy fallback) so the cached sidebar paints instantly post-migration.
- **H2 (DATA LOSS)** — `cleanupStaleRooms` hard-deleted valid rooms + their messages 30s after `PREPARED` because matrix-js-sdk hadn't materialized all rooms into memory yet on slow WebViews (`isRoomInSdk()` false-positive). Fixed with defense-in-depth: (a) keep any orphan synced within `ORPHAN_SYNC_SAFETY_MS` (24h), (b) gate `runRoomCleanup` on `getSyncState() === "SYNCING"`, (c) replace hard-delete (`bulkRemoveRooms`) with soft-delete (`bulkTombstoneRooms`) — recoverable, revived on next sync, GC'd after 30 days.
- **H3** — fixed transitively by H1 (the degraded watchdog no longer shows an empty sidebar).
- User-initiated "delete chat" / `clearHistory` are untouched (separate path via `tombstoneRoom`/`clearHistory`).

## Linear
- Resolves WEE-61 (https://linear.app/wwwee/issue/WEE-61)

## Closes
Closes greenShirtMystery/forta-bugs#892
Closes greenShirtMystery/forta-bugs#887
Closes greenShirtMystery/forta-bugs#908
Closes greenShirtMystery/forta-bugs#533
Closes greenShirtMystery/forta-bugs#173
Closes greenShirtMystery/forta-bugs#465
Closes greenShirtMystery/forta-bugs#159
Closes greenShirtMystery/forta-bugs#420

## Test plan
- [x] Targeted unit + regression tests added and green (22 tests):
  - `load-cached-rooms-key.test.ts` — H1 cache-key resolution + fallback/edge cases
  - `room-cleanup-guard.test.ts` — `syncedAt` guard, 50+ fresh rooms protected (the #892 scenario), boundary, leave-branch unaffected
  - `bulk-tombstone-rooms.test.ts` — soft-delete preserves messages, revivable, excluded from `getAllRooms`
  - updated `room-cleanup.test.ts` — orphan removal now requires stale `syncedAt`
- [x] No new `vue-tsc` errors introduced (49 pre-existing on master, 49 with this change — all in unrelated files)
- [x] No new test failures (16 pre-existing failures on master in unrelated files, identical with/without this change)
- [x] Architectural code review (superpowers:code-reviewer) — APPROVE, 1 MEDIUM addressed (removed `any` from `getSyncState`)
- [ ] Manual QA: simulate update with 50+ rooms on a throttled slow device → verify no rooms disappear 30s after PREPARED; verify account add/switch (#887) keeps chats

## Notes
- ⚠️ H2 is irreversible for already-affected users (local data already hard-deleted; only a Matrix resync from homeserver recovers rooms, losing read-watermarks/pending). This PR **stops further loss**.
- Pre-existing latent issue noted: `garbageCollectTombstones` queries `isDeleted == 1` but IndexedDB cannot index booleans — likely a no-op in practice. Out of scope for this ticket (same path is used by existing user-delete); recovery here relies primarily on revive-on-sync, not the 30-day GC.