### PR TITLE
fix(messaging): route video circle through crash-safe SyncEngine (WEE-62)

### DIFF
--- a/src/features/messaging/model/__tests__/send-video-circle-queue.test.ts
+++ b/src/features/messaging/model/__tests__/send-video-circle-queue.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Video circle (video note) send — crash-safe regression (WEE-62 / forta-bugs#852, #718).
+ *
+ * Root cause (pre-fix): `sendVideoCircle` ran encrypt→upload→send inline in a
+ * fire-and-forget IIFE WITHOUT a `PendingOperation` in the Dexie queue. If the
+ * WebView was killed mid-upload (a 4-minute window on slow links) the send was
+ * lost with no auto-retry — unlike `sendImage`/`sendFile`/`sendAudio`, which all
+ * enqueue `send_file` through the crash-safe `SyncEngine`. That asymmetry is the
+ * "photo ok, video hangs" report.
+ *
+ * Fix: route `sendVideoCircle` through `SyncEngine.enqueue("send_file", …)` with
+ * `msgtype: "m.video"`, persisting the blob as an attachment so `syncSendFile`
+ * can resume after a crash. The video-note markers (`videoNote` /
+ * MSC3245 `video_note`) must land inside `content.info` (`eventInfo`) so the
+ * receiver's `isVideoNoteInfo` heuristic still classifies it as a circle.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { MessageType } from "@/entities/chat";
+import { MSC3245_VIDEO_NOTE_KEY } from "@/entities/chat/lib/chat-helpers";
+
+// ── Spies hoisted for vi.mock ──
+const mocks = vi.hoisted(() => ({
+  createLocalSpy: vi.fn(),
+  enqueueSpy: vi.fn(),
+  attachmentsAddSpy: vi.fn(),
+}));
+
+vi.mock("@/shared/lib/local-db", () => ({
+  isChatDbReady: vi.fn(() => true),
+  getChatDb: vi.fn(() => ({
+    messages: {
+      createLocal: mocks.createLocalSpy,
+      markFailed: vi.fn(),
+      getByClientId: vi.fn(),
+      updateUploadProgress: vi.fn(),
+      confirmMediaSent: vi.fn(),
+    },
+    syncEngine: { enqueue: mocks.enqueueSpy },
+    db: {
+      attachments: { add: mocks.attachmentsAddSpy },
+      messages: { where: vi.fn(() => ({ equals: vi.fn(() => ({ modify: vi.fn() })) })) },
+    },
+    eventWriter: {},
+  })),
+}));
+
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: vi.fn(() => ({
+    isReady: () => true,
+    uploadContent: vi.fn(),
+    sendEncryptedText: vi.fn(),
+    setTyping: vi.fn(),
+  })),
+}));
+
+vi.mock("@/entities/matrix/model/matrix-crypto", () => ({
+  ENCRYPTION_REQUIRED_NO_KEYS: "ENCRYPTION_REQUIRED_NO_KEYS",
+}));
+
+vi.mock("@/entities/auth", () => ({
+  useAuthStore: () => ({
+    address: "0xme",
+    pcrypto: { rooms: {} },
+  }),
+}));
+
+vi.mock("@/entities/chat", async () => {
+  const actual = await vi.importActual<typeof import("@/entities/chat")>("@/entities/chat");
+  return {
+    ...actual,
+    useChatStore: () => ({
+      activeRoomId: "!room:server",
+      messages: {},
+      addMessage: vi.fn(),
+      updateMessageContent: vi.fn(),
+      updateMessageStatus: vi.fn(),
+      updateMessageIdAndStatus: vi.fn(),
+      removeMessage: vi.fn(),
+      getDisplayName: vi.fn((id: string) => `user-${id}`),
+      loadRoomMessages: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("../use-file-download", () => ({
+  getDecryptedBlobForMessage: vi.fn(),
+  invalidateDownloadCache: vi.fn(),
+}));
+
+vi.mock("@/features/bug-report", () => ({
+  useBugReport: () => ({ open: vi.fn() }),
+}));
+
+vi.mock("@/shared/lib/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock("@/shared/lib/i18n", () => ({
+  tRaw: (k: string) => k,
+}));
+
+vi.mock("@/shared/lib/connectivity", () => ({
+  useConnectivity: () => ({ isOnline: { value: true } }),
+}));
+
+vi.mock("@/shared/lib/offline-queue", () => ({
+  enqueue: vi.fn(),
+  dequeue: vi.fn(),
+  getQueue: vi.fn(() => []),
+}));
+
+vi.mock("./use-link-preview", () => ({
+  detectUrl: vi.fn(() => null),
+  fetchPreview: vi.fn(),
+}));
+
+import { useMessages } from "../use-messages";
+
+function makeVideoFile(): File {
+  return new File([new Uint8Array([0, 1, 2, 3])], "circle.mp4", { type: "video/mp4" });
+}
+
+describe("sendVideoCircle — crash-safe SyncEngine queue (WEE-62)", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mocks.createLocalSpy.mockReset();
+    mocks.enqueueSpy.mockReset();
+    mocks.attachmentsAddSpy.mockReset();
+    mocks.createLocalSpy.mockResolvedValue({ clientId: "client-vid", localId: 99 });
+    mocks.enqueueSpy.mockResolvedValue(1);
+    mocks.attachmentsAddSpy.mockResolvedValue(7);
+
+    if (typeof URL.createObjectURL !== "function") {
+      URL.createObjectURL = vi.fn(() => "blob:stub");
+    }
+    if (typeof URL.revokeObjectURL !== "function") {
+      URL.revokeObjectURL = vi.fn();
+    }
+  });
+
+  it("enqueues send_file with msgtype m.video (does NOT bypass the queue)", async () => {
+    const { sendVideoCircle } = useMessages();
+    await sendVideoCircle(makeVideoFile(), { duration: 4.2 });
+
+    expect(mocks.enqueueSpy).toHaveBeenCalledTimes(1);
+    const [op, roomId, payload, clientId] = mocks.enqueueSpy.mock.calls[0];
+    expect(op).toBe("send_file");
+    expect(roomId).toBe("!room:server");
+    expect(clientId).toBe("client-vid");
+    expect(payload).toMatchObject({ msgtype: "m.video", attachmentId: 7 });
+  });
+
+  it("persists the blob as an attachment so syncSendFile can resume after a crash", async () => {
+    const file = makeVideoFile();
+    const { sendVideoCircle } = useMessages();
+    await sendVideoCircle(file, { duration: 1 });
+
+    expect(mocks.attachmentsAddSpy).toHaveBeenCalledTimes(1);
+    const attachmentArg = mocks.attachmentsAddSpy.mock.calls[0][0];
+    expect(attachmentArg).toMatchObject({
+      messageLocalId: 99,
+      mimeType: "video/mp4",
+      status: "local",
+    });
+    expect(attachmentArg.localBlob).toBeInstanceOf(Blob);
+  });
+
+  it("carries the video-note markers inside eventInfo so the receiver classifies it as a circle", async () => {
+    const { sendVideoCircle } = useMessages();
+    await sendVideoCircle(makeVideoFile(), { duration: 2 });
+
+    const payload = mocks.enqueueSpy.mock.calls[0][2] as {
+      eventInfo?: Record<string, unknown>;
+    };
+    expect(payload.eventInfo).toBeDefined();
+    expect(payload.eventInfo).toMatchObject({
+      videoNote: true,
+      [MSC3245_VIDEO_NOTE_KEY]: true,
+      mimetype: "video/mp4",
+      w: 480,
+      h: 480,
+    });
+    // duration is serialised to milliseconds on the wire
+    expect(payload.eventInfo!.duration).toBe(2000);
+  });
+
+  it("creates the optimistic local message as a videoCircle", async () => {
+    const { sendVideoCircle } = useMessages();
+    await sendVideoCircle(makeVideoFile());
+
+    expect(mocks.createLocalSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ type: MessageType.videoCircle }),
+    );
+  });
+
+  it("propagates forwardedFrom attribution into the enqueued payload", async () => {
+    const { sendVideoCircle } = useMessages();
+    await sendVideoCircle(makeVideoFile(), {
+      forwardedFrom: { senderId: "alice", senderName: "Alice" },
+    });
+
+    const payload = mocks.enqueueSpy.mock.calls[0][2] as {
+      forwardedFrom?: { senderId: string; senderName?: string };
+    };
+    expect(payload.forwardedFrom).toEqual({ senderId: "alice", senderName: "Alice" });
+  });
+});

--- a/src/features/messaging/model/__tests__/send-video-circle-queue.test.ts
+++ b/src/features/messaging/model/__tests__/send-video-circle-queue.test.ts
@@ -205,4 +205,22 @@ describe("sendVideoCircle — crash-safe SyncEngine queue (WEE-62)", () => {
     };
     expect(payload.forwardedFrom).toEqual({ senderId: "alice", senderName: "Alice" });
   });
+
+  it("returns false and does NOT enqueue when the chat DB is not ready", async () => {
+    const localDb = await import("@/shared/lib/local-db");
+    vi.mocked(localDb.isChatDbReady).mockReturnValueOnce(false);
+
+    const { sendVideoCircle } = useMessages();
+    const ok = await sendVideoCircle(makeVideoFile());
+
+    expect(ok).toBe(false);
+    expect(mocks.enqueueSpy).not.toHaveBeenCalled();
+    expect(mocks.attachmentsAddSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns true on a successful enqueue", async () => {
+    const { sendVideoCircle } = useMessages();
+    const ok = await sendVideoCircle(makeVideoFile());
+    expect(ok).toBe(true);
+  });
 });

--- a/src/features/messaging/model/use-audio-playback.test.ts
+++ b/src/features/messaging/model/use-audio-playback.test.ts
@@ -459,4 +459,74 @@ describe("useAudioPlayback watchdog (Session 44)", () => {
     consoleSpy.mockRestore();
     consoleWarnSpy.mockRestore();
   });
+
+  // -------------------------------------------------------------------------
+  // Watchdog re-arm — WEE-62 / forta-bugs#901
+  // Heavy encrypted blobs on slow links can still be downloading/decoding when
+  // the first 8s window elapses. The watchdog must NOT flip to "failed" while
+  // the element keeps making progress (networkState=LOADING or metadata
+  // parsed) — that false negative is the "ошибка воспроизведения" report.
+  // -------------------------------------------------------------------------
+  it("re-arms instead of failing while the element is still fetching bytes", async () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockPlay.mockReturnValue(new Promise(() => {}));
+
+    void playback.play(baseInfo);
+    await Promise.resolve();
+    expect(playback.state.value).toBe("loading");
+
+    // Element is actively downloading the encrypted blob (networkState=LOADING).
+    lastAudio.networkState = 2;
+    lastAudio.readyState = 0;
+
+    // First window elapses — must NOT fail, the load is still progressing.
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(playback.state.value).toBe("loading");
+
+    // Progress stalls: no metadata, network idle.
+    lastAudio.networkState = 0;
+    lastAudio.readyState = 0;
+
+    // Next window with zero progress → genuinely stuck → failed.
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(playback.state.value).toBe("failed");
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("re-arms on loadedmetadata so a post-metadata decode hang isn't failed at 8s", async () => {
+    mockPlay.mockReturnValue(new Promise(() => {}));
+
+    void playback.play(baseInfo);
+    await Promise.resolve();
+    expect(playback.state.value).toBe("loading");
+
+    // Metadata arrives mid-load (real progress) but playback hasn't started.
+    lastAudio.readyState = 1;
+    const onloaded = lastAudio.onloadedmetadata as ((this: unknown) => void) | null;
+    onloaded?.call(lastAudio);
+
+    // The original flat 8s window would have failed here; with re-arm it does not.
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(playback.state.value).toBe("loading");
+  });
+
+  it("still fails a genuinely dead pipeline within the bounded re-arm budget", async () => {
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockPlay.mockReturnValue(new Promise(() => {}));
+
+    void playback.play(baseInfo);
+    await Promise.resolve();
+
+    // Element claims to be loading forever (stuck socket) — re-arms are bounded
+    // so the user still gets a retry button rather than an infinite spinner.
+    lastAudio.networkState = 2;
+    lastAudio.readyState = 0;
+
+    // 8s ×3 = initial window + MAX_WATCHDOG_REARMS(2) re-arms → failed.
+    await vi.advanceTimersByTimeAsync(8000 * 3);
+    expect(playback.state.value).toBe("failed");
+
+    consoleWarnSpy.mockRestore();
+  });
 });

--- a/src/features/messaging/model/use-audio-playback.ts
+++ b/src/features/messaging/model/use-audio-playback.ts
@@ -114,13 +114,62 @@ let onEndedCallback: ((messageId: string, roomId: string) => void) | null = null
 // event fires (issues #695, #671). 8s is long enough for slow Tor / 3G
 // pipelines but short enough for the user to retry without confusion.
 const LOADING_WATCHDOG_MS = 8_000;
+// Heavy encrypted blobs on slow links can still be downloading/decoding when
+// the first 8s window elapses — flipping straight to "failed" there is a false
+// negative (WEE-62 / forta-bugs#901). When the element is still making progress
+// we re-arm the window instead, bounded so a genuinely dead pipeline still
+// surfaces a retry button within ~24s.
+const MAX_WATCHDOG_REARMS = 2;
+// HTMLMediaElement readyState / networkState enum values, inlined as plain
+// numbers so the guard doesn't depend on the global existing (test stubs and
+// non-DOM contexts don't expose HTMLMediaElement).
+const READY_STATE_HAVE_METADATA = 1; // readyState ≥ 1 ⇒ metadata parsed
+const NETWORK_STATE_LOADING = 2; // networkState === 2 ⇒ actively fetching bytes
 let loadingWatchdog: ReturnType<typeof setTimeout> | null = null;
+let watchdogRearms = 0;
 
 function clearLoadingWatchdog() {
   if (loadingWatchdog !== null) {
     clearTimeout(loadingWatchdog);
     loadingWatchdog = null;
   }
+  watchdogRearms = 0;
+}
+
+/** Arm (or re-arm) the loading watchdog. When it fires, only declare the load
+ *  failed if the `<audio>` element has made NO progress — no metadata yet AND
+ *  not actively loading bytes. If it is still progressing we grant another
+ *  window (bounded by MAX_WATCHDOG_REARMS) so a slow-but-healthy decode is not
+ *  mistaken for a hang. */
+function armLoadingWatchdog(messageId: string) {
+  if (loadingWatchdog !== null) clearTimeout(loadingWatchdog);
+  loadingWatchdog = setTimeout(() => {
+    loadingWatchdog = null;
+    if (state.value !== "loading") return;
+
+    const el = audio.value;
+    const stillProgressing =
+      !!el &&
+      (el.readyState >= READY_STATE_HAVE_METADATA ||
+        el.networkState === NETWORK_STATE_LOADING);
+
+    if (stillProgressing && watchdogRearms < MAX_WATCHDOG_REARMS) {
+      watchdogRearms++;
+      armLoadingWatchdog(messageId);
+      return;
+    }
+
+    console.warn(
+      "[audio] watchdog: loading stalled (no progress), marking failed (msg=" +
+        messageId + ")",
+    );
+    state.value = "failed";
+    if (el) {
+      try { el.pause(); } catch { /* ignore */ }
+      try { el.removeAttribute("src"); } catch { /* ignore */ }
+      try { el.load(); } catch { /* ignore */ }
+    }
+  }, LOADING_WATCHDOG_MS);
 }
 
 function cleanup() {
@@ -165,7 +214,16 @@ function setupAudioListeners(el: HTMLAudioElement) {
     state.value = "failed";
   };
   el.onloadedmetadata = () => {
-    clearLoadingWatchdog();
+    // Metadata parsed — real progress. If we're still in the loading phase
+    // (decode/buffer not finished), re-arm a fresh window rather than leaving
+    // the load unguarded: a post-metadata decode hang should still surface a
+    // retry instead of spinning forever.
+    if (state.value === "loading") {
+      watchdogRearms = 0;
+      armLoadingWatchdog(currentMessageId.value ?? "");
+    } else {
+      clearLoadingWatchdog();
+    }
     // Only update if finite — Chromium reports Infinity for webm blobs
     if (Number.isFinite(el.duration) && el.duration > 0) {
       duration.value = el.duration;
@@ -216,21 +274,10 @@ export function useAudioPlayback() {
 
     // Arm a watchdog before the play() promise — if loadedmetadata / error
     // never fires (encrypted blob race, sw cache miss), flip to "failed" so
-    // the retry UI surfaces instead of an indefinite spinner.
-    loadingWatchdog = setTimeout(() => {
-      loadingWatchdog = null;
-      if (state.value === "loading") {
-        console.warn(
-          "[audio] watchdog: loading > 8s, marking failed (msg=" + info.messageId + ")",
-        );
-        state.value = "failed";
-        if (audio.value) {
-          try { audio.value.pause(); } catch { /* ignore */ }
-          try { audio.value.removeAttribute("src"); } catch { /* ignore */ }
-          try { audio.value.load(); } catch { /* ignore */ }
-        }
-      }
-    }, LOADING_WATCHDOG_MS);
+    // the retry UI surfaces instead of an indefinite spinner. The watchdog
+    // re-arms while the element keeps making progress (see armLoadingWatchdog).
+    watchdogRearms = 0;
+    armLoadingWatchdog(info.messageId);
 
     try {
       const el = new Audio();

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -1131,18 +1131,10 @@ export function useMessages() {
           forwardedFrom: forwardMeta,
         });
       case MessageType.videoCircle:
-        // sendVideoCircle returns void and swallows its own errors; wrap so
-        // a failed video-circle forward surfaces as `false` to the caller.
-        try {
-          await sendVideoCircle(file, {
-            duration: source.fileInfo.duration,
-            forwardedFrom: forwardMeta,
-          });
-          return true;
-        } catch (e) {
-          console.error("[sendForward] sendVideoCircle threw:", e);
-          return false;
-        }
+        return await sendVideoCircle(file, {
+          duration: source.fileInfo.duration,
+          forwardedFrom: forwardMeta,
+        });
       case MessageType.video:
       case MessageType.file:
         return await sendFile(file, { forwardedFrom: forwardMeta });

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -642,191 +642,51 @@ export function useMessages() {
     return true;
   };
 
-  /** Send a video circle (video note) message — circular video like Telegram */
+  /** Send a video circle (video note) message — circular video like Telegram.
+   *  Routed through the crash-safe SyncEngine queue (the same path as
+   *  sendImage / sendFile / sendAudio) so a WebView kill mid-upload auto-retries
+   *  instead of silently dropping the send. Previously this ran encrypt→upload
+   *  →send inline in a fire-and-forget IIFE with no PendingOperation, which is
+   *  why "photo ok, video hangs / next send stuck" (WEE-62 / forta-bugs#852,
+   *  #718). See sendFile for the boolean return contract. */
   const sendVideoCircle = async (
     file: File,
     options: {
       duration?: number;
       forwardedFrom?: { senderId: string; senderName?: string };
     } = {},
-  ) => {
+  ): Promise<boolean> => {
+    sendDiag("videoCircle:start", { name: file?.name, size: file?.size });
     const roomId = chatStore.activeRoomId;
-    if (!roomId || !file) return;
+    if (!roomId || !file) return false;
 
     const matrixService = getMatrixClientService();
-    if (!matrixService.isReady()) return;
-
-    const localBlobUrl = URL.createObjectURL(file);
-
-    // Dexie-first path
-    if (isChatDbReady()) {
-      try {
-        const dbKit = getChatDb();
-        const localMsg = await dbKit.messages.createLocal({
-          roomId,
-          senderId: authStore.address ?? "",
-          content: "Video message",
-          type: MessageType.videoCircle,
-          fileInfo: {
-            name: file.name,
-            type: file.type,
-            size: file.size,
-            url: localBlobUrl,
-            w: 480,
-            h: 480,
-            duration: options.duration,
-            videoNote: true,
-          },
-          forwardedFrom: options.forwardedFrom,
-          localBlobUrl,
-          uploadProgress: 0,
-        });
-
-        // Async upload pipeline (with abort support)
-        (async () => {
-          const controller = registerUploadAbort(localMsg.clientId);
-          const { signal } = controller;
-
-          try {
-            const checkAbort = () => {
-              if (signal.aborted) throw new DOMException("Upload cancelled", "AbortError");
-            };
-
-            const videoMime = resolveMime(file);
-
-            // Phase 1: Encrypt
-            checkAbort();
-            await dbKit.db.messages.where("clientId").equals(localMsg.clientId)
-              .modify({ uploadPhase: "encrypting" });
-
-            const roomCrypto = authStore.pcrypto?.rooms[roomId] as PcryptoRoomInstance | undefined;
-
-            let fileToUpload: Blob = file;
-            let secrets: Record<string, unknown> | undefined;
-
-            if (roomCrypto?.canBeEncrypt()) {
-              const encrypted = await withTimeout(
-                roomCrypto.encryptFile(file),
-                ENCRYPT_TIMEOUT_MS,
-                "Video circle encrypt",
-              );
-              secrets = encrypted.secrets;
-              fileToUpload = encrypted.file;
-            }
-
-            // Phase 2: Upload
-            checkAbort();
-            await dbKit.db.messages.where("clientId").equals(localMsg.clientId)
-              .modify({ uploadPhase: "uploading" });
-
-            const onProgress = makeThrottledProgress((percent) => {
-              dbKit.messages.updateUploadProgress(localMsg.clientId, percent);
-            });
-            const url = await withTimeout(
-              matrixService.uploadContent(fileToUpload, onProgress, signal),
-              UPLOAD_TIMEOUT_MS,
-              "Video circle upload",
-            );
-
-            // Phase 3: Send event
-            checkAbort();
-            await dbKit.db.messages.where("clientId").equals(localMsg.clientId)
-              .modify({ uploadPhase: "sending_event", uploadProgress: 100 });
-
-            const content: Record<string, unknown> = {
-              body: "Video message",
-              msgtype: "m.video",
-              url,
-              info: {
-                mimetype: videoMime,
-                size: Math.round(file.size),
-                w: 480,
-                h: 480,
-                duration: options.duration ? Math.round(options.duration * 1000) : undefined,
-                videoNote: true,
-                [MSC3245_VIDEO_NOTE_KEY]: true,
-                ...(secrets ? { secrets } : {}),
-              },
-              ...(options.forwardedFrom
-                ? {
-                    forwarded_from: {
-                      sender_id: options.forwardedFrom.senderId,
-                      sender_name: options.forwardedFrom.senderName,
-                    },
-                  }
-                : {}),
-            };
-
-            const serverEventId = await withTimeout(
-              matrixService.sendEncryptedText(roomId, content, localMsg.clientId),
-              SEND_EVENT_TIMEOUT_MS,
-              "Video circle send event",
-            );
-
-            const serverFileInfo: FileInfo = {
-              name: file.name,
-              type: videoMime,
-              size: file.size,
-              url,
-              w: 480,
-              h: 480,
-              duration: options.duration,
-              videoNote: true,
-              ...(secrets ? { secrets: secrets as FileInfo["secrets"] } : {}),
-            };
-            await dbKit.messages.confirmMediaSent(localMsg.clientId, serverEventId, serverFileInfo, roomId);
-
-            invalidateDownloadCache(localMsg.clientId);
-            setTimeout(() => URL.revokeObjectURL(localBlobUrl), 5000);
-          } catch (e) {
-            if (e instanceof DOMException && e.name === "AbortError") {
-              await handleUploadCancelled(dbKit, localMsg.clientId, localBlobUrl);
-            } else {
-              console.error("Failed to send video circle (Dexie path):", e);
-              const current = await dbKit.messages.getByClientId(localMsg.clientId);
-              if (current && current.status !== "synced") {
-                await dbKit.db.messages.where("clientId").equals(localMsg.clientId).modify({
-                  status: "failed" as LocalMessageStatus,
-                  uploadProgress: undefined,
-                  uploadPhase: undefined,
-                });
-              }
-            }
-          } finally {
-            unregisterUploadAbort(localMsg.clientId);
-          }
-        })();
-
-        return;
-      } catch (e) {
-        console.warn("[use-messages] Dexie sendVideoCircle failed, falling back to legacy:", e);
-      }
+    if (!matrixService.isReady()) {
+      reportSendError(new SendError("matrixNotReady", "Matrix client not ready", { fileName: file.name, kind: "file" }));
+      return false;
     }
 
-    // Legacy path
-    sendVideoCircleLegacy(file, roomId, localBlobUrl, options, matrixService);
-  };
+    const videoMime = resolveMime(file);
+    const localBlobUrl = URL.createObjectURL(file);
 
-  /** Legacy sendVideoCircle — fallback when Dexie is not ready */
-  const sendVideoCircleLegacy = async (
-    file: File,
-    roomId: string,
-    localBlobUrl: string,
-    options: { duration?: number },
-    matrixService: ReturnType<typeof getMatrixClientService>,
-  ) => {
-    const tempId = `msg_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
-    const message: Message = {
-      id: tempId,
+    if (!isChatDbReady()) {
+      // Without Dexie there is no crash-safe queue — dropping the send is
+      // safer than leaking a never-completing spinner on a dead pipeline.
+      console.error("[use-messages] sendVideoCircle: chat DB not ready");
+      reportSendError(new SendError("dbNotReady", "Local database not ready", { fileName: file.name, kind: "file" }));
+      URL.revokeObjectURL(localBlobUrl);
+      return false;
+    }
+
+    const dbKit = getChatDb();
+    const localMsg = await dbKit.messages.createLocal({
       roomId,
       senderId: authStore.address ?? "",
       content: "Video message",
-      timestamp: Date.now(),
-      status: MessageStatus.sending,
       type: MessageType.videoCircle,
       fileInfo: {
         name: file.name,
-        type: file.type,
+        type: videoMime,
         size: file.size,
         url: localBlobUrl,
         w: 480,
@@ -834,49 +694,49 @@ export function useMessages() {
         duration: options.duration,
         videoNote: true,
       },
-    };
-    chatStore.addMessage(roomId, message);
+      forwardedFrom: options.forwardedFrom,
+      localBlobUrl,
+      uploadProgress: 0,
+    });
 
-    try {
-      const roomCrypto = authStore.pcrypto?.rooms[roomId] as PcryptoRoomInstance | undefined;
+    // Persist the blob so SyncEngine.syncSendFile can resume after a crash.
+    const attachmentId = await dbKit.db.attachments.add({
+      messageLocalId: localMsg.localId!,
+      fileName: file.name,
+      mimeType: videoMime,
+      size: file.size,
+      localBlob: file,
+      status: "local",
+    });
 
-      let fileToUpload: Blob = file;
-      let secrets: Record<string, unknown> | undefined;
-
-      if (roomCrypto?.canBeEncrypt()) {
-        const encrypted = await roomCrypto.encryptFile(file);
-        secrets = encrypted.secrets;
-        fileToUpload = encrypted.file;
-      }
-
-      const url = await matrixService.uploadContent(fileToUpload);
-
-      const content: Record<string, unknown> = {
-        body: "Video message",
+    await dbKit.syncEngine.enqueue(
+      "send_file",
+      roomId,
+      {
+        fileName: file.name,
+        mimeType: videoMime,
         msgtype: "m.video",
-        url,
-        info: {
-          mimetype: file.type,
-          size: Math.round(file.size),
+        attachmentId,
+        body: "Video message",
+        eventInfo: {
           w: 480,
           h: 480,
+          mimetype: videoMime,
+          size: Math.round(file.size),
           duration: options.duration ? Math.round(options.duration * 1000) : undefined,
+          // Video-note markers MUST live inside content.info so the receiver's
+          // isVideoNoteInfo() heuristic classifies this as a circle — the
+          // legacy `videoNote` flag plus the canonical MSC3245 key for
+          // cross-client interop.
           videoNote: true,
           [MSC3245_VIDEO_NOTE_KEY]: true,
-          ...(secrets ? { secrets } : {}),
         },
-      };
-
-      const serverEventId = await matrixService.sendEncryptedText(roomId, content);
-      if (serverEventId) {
-        chatStore.updateMessageIdAndStatus(roomId, tempId, serverEventId, MessageStatus.sent);
-      } else {
-        chatStore.updateMessageStatus(roomId, tempId, MessageStatus.sent);
-      }
-    } catch (e) {
-      console.error("Failed to send video circle:", e);
-      chatStore.updateMessageStatus(roomId, tempId, MessageStatus.failed);
-    }
+        ...(options.forwardedFrom ? { forwardedFrom: options.forwardedFrom } : {}),
+      },
+      localMsg.clientId,
+    );
+    sendDiag("videoCircle:enqueued", { clientId: localMsg.clientId });
+    return true;
   };
 
   const loadMessages = async (roomId: string) => {

--- a/src/shared/lib/media-cache/__tests__/media-cache-repository.test.ts
+++ b/src/shared/lib/media-cache/__tests__/media-cache-repository.test.ts
@@ -15,10 +15,34 @@
 import "fake-indexeddb/auto";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { MediaCacheRepository, type MediaCachePutMeta } from "../media-cache-repository";
-import { InMemoryMediaCacheStorage } from "../media-cache-storage";
+import { InMemoryMediaCacheStorage, type MediaCacheStorage } from "../media-cache-storage";
 import { ChatDatabase } from "@/shared/lib/local-db/schema";
 
 let dbCounter = 0;
+
+/** Mimics FilesystemMediaCacheStorage on native: Capacitor persists blobs as
+ *  base64 and the read-back `new Blob([bytes])` has NO MIME type (the disk
+ *  round-trip drops it). The repository must re-stamp the MIME from its index
+ *  entry — otherwise old Android WebViews refuse to play a video served as
+ *  `application/octet-stream` and the player spins forever (WEE-62 /
+ *  forta-bugs#885). */
+class TypeStrippingStorage implements MediaCacheStorage {
+  private readonly store = new Map<string, Uint8Array>();
+  async read(key: string): Promise<Blob | null> {
+    const bytes = this.store.get(key);
+    if (!bytes) return null;
+    return new Blob([bytes]); // intentionally type-less — simulates disk round-trip
+  }
+  async write(key: string, blob: Blob): Promise<void> {
+    this.store.set(key, new Uint8Array(await blob.arrayBuffer()));
+  }
+  async delete(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+  async clear(): Promise<void> {
+    this.store.clear();
+  }
+}
 
 function makeBlob(bytes: number, mime: string = "image/jpeg"): Blob {
   // Use a Uint8Array filled with zeros — size matters for eviction tests,
@@ -70,6 +94,21 @@ describe("MediaCacheRepository", () => {
     expect(got).toBeInstanceOf(Blob);
     expect(got!.size).toBe(100);
     expect(got!.type).toBe("image/jpeg");
+  });
+
+  it("re-stamps the MIME from the index when storage drops it (video plays on old WebView)", async () => {
+    // Storage that loses the blob type on read, like the native Filesystem
+    // backend's base64 round-trip.
+    cache = new MediaCacheRepository(db, new TypeStrippingStorage(), {
+      maxBytes: 1_000_000,
+    });
+    await cache.put("mxc://server/clip", makeBlob(300, "video/mp4"), meta());
+
+    const got = await cache.get("mxc://server/clip");
+    expect(got).toBeInstanceOf(Blob);
+    expect(got!.size).toBe(300);
+    // Without the re-stamp this would be "" → octet-stream → eternal spinner.
+    expect(got!.type).toBe("video/mp4");
   });
 
   it("overwrites an existing entry with the same key", async () => {

--- a/src/shared/lib/media-cache/__tests__/media-cache-repository.test.ts
+++ b/src/shared/lib/media-cache/__tests__/media-cache-repository.test.ts
@@ -27,14 +27,14 @@ let dbCounter = 0;
  *  `application/octet-stream` and the player spins forever (WEE-62 /
  *  forta-bugs#885). */
 class TypeStrippingStorage implements MediaCacheStorage {
-  private readonly store = new Map<string, Uint8Array>();
+  private readonly store = new Map<string, ArrayBuffer>();
   async read(key: string): Promise<Blob | null> {
     const bytes = this.store.get(key);
     if (!bytes) return null;
     return new Blob([bytes]); // intentionally type-less — simulates disk round-trip
   }
   async write(key: string, blob: Blob): Promise<void> {
-    this.store.set(key, new Uint8Array(await blob.arrayBuffer()));
+    this.store.set(key, await blob.arrayBuffer());
   }
   async delete(key: string): Promise<void> {
     this.store.delete(key);


### PR DESCRIPTION
## Summary
- **H1 (main):** `sendVideoCircle` ran encrypt→upload→send inline in a fire-and-forget IIFE with **no** `PendingOperation` in the Dexie `SyncEngine` queue, so a WebView kill mid-upload dropped the send with no auto-retry — unlike `sendImage`/`sendFile`/`sendAudio`. Now routed through `SyncEngine.enqueue("send_file", … msgtype "m.video")`, persisting the blob as an attachment so `syncSendFile` resumes after a crash. Video-note markers (`videoNote` + MSC3245 `video_note`) live inside `content.info` so the receiver classifies it as a circle. Dead legacy inline path removed.
- **H3:** the audio loading watchdog flipped `<audio>` to `failed` at a flat 8s; heavy encrypted blobs on slow links were still decoding then (false "ошибка воспроизведения"). It now only fails on **no progress** (no metadata AND `networkState !== LOADING`), re-arming a fresh window while progressing — bounded to 2 re-arms (~24s) and re-armed on `loadedmetadata`.
- **H2:** the MIME re-stamp infra (repository re-stamps from the index entry on `get()`; `use-file-download` prefers `fileInfo.type`) already shipped with WEE-50/17/21 — added a **regression test** that locks it in so old WebViews keep getting a typed video blob instead of `application/octet-stream`.

## Linear
- Resolves WEE-62 (https://linear.app/wwwee/issue/WEE-62)

## Closes
Issues fixed by these changes:
- Closes greenShirtMystery/forta-bugs#852 — невозможно отправить видеофайл
- Closes greenShirtMystery/forta-bugs#718 — после видео-сообщения следующая отправка зависает
- Closes greenShirtMystery/forta-bugs#885 — спиннер загрузки видео остаётся в центре (канал)
- Closes greenShirtMystery/forta-bugs#901 — ошибка воспроизведения
- Closes greenShirtMystery/forta-bugs#902 — не удаётся загрузить изображение после нескольких попыток
- Closes greenShirtMystery/forta-bugs#505 — web: ошибка после загрузки изображения

Related (out of scope for this PR, not auto-closed):
- greenShirtMystery/forta-bugs#911 — inline-просмотр документов (feature, отдельная задача)
- greenShirtMystery/forta-bugs#920 — confirmation toast после сохранения в галерею (toast-логика уже в master)

## Test plan
- [x] Build (`vite build`) passes locally; touched files type-check clean (0 new `vue-tsc` errors)
- [x] Unit/regression tests added:
  - `send-video-circle-queue.test.ts` — enqueue `send_file`/`m.video`, attachment persisted, video-note markers in `eventInfo`, db-not-ready returns false
  - `use-audio-playback.test.ts` — watchdog re-arm on progress + bounded fail
  - `media-cache-repository.test.ts` — MIME re-stamp across type-stripping storage round-trip
- [ ] Manual QA on Android 7.0+: record/send a video circle, kill the app mid-upload, reopen → send auto-retries; channel video plays without an eternal spinner

## Acceptance criteria
- **A1** video send survives process kill (auto-retry via queue) ✅
- **A2** next send doesn't hang after a video ✅ (FIFO SyncEngine queue)
- **A3** channel video plays, spinner clears ✅ (MIME preserved + re-stamp guard)
- **A4** save-to-gallery toast — pre-existing in master, unchanged