### PR TITLE
fix(calls): audio routing — native speaker toggle + vendor AEC + OEM mic re-unmute (WEE-60)

### DIFF
--- a/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
@@ -136,6 +136,36 @@ class AudioRouter private constructor(private val context: Context) {
             listOf(500L, 1_500L, 3_500L, 7_500L)
 
         /**
+         * WEE-60: pure predicate for re-applying the vendor mic-unmute inside
+         * the OEM re-apply window.
+         *
+         * [applyVendorStartTweaks] clears the global mic-mute flag once at t=0
+         * for vendors that need it (HONOR MagicOS), but MIUI/MagicOS can
+         * re-assert that flag in the same async window they reset the audio
+         * mode (the [modeReapplyScheduleMs] ticks). When that happens the
+         * one-time unmute is clobbered and the peer hears one-way silence.
+         *
+         * Returns true only when ALL of:
+         *   - the vendor required the explicit start-time unmute, AND
+         *   - routing is still active (don't fight a fresh call after stop), AND
+         *   - the mic is actually muted right now (no-op otherwise).
+         *
+         * Re-applying `setMicrophoneMute(false)` is safe even on intentional
+         * user mutes: the in-call Mute button toggles the WebRTC track
+         * (`MatrixCall.setMicrophoneMuted` → `track.enabled`), never this
+         * process-global AudioManager flag, so clearing it can only release an
+         * OEM-stuck capture path.
+         *
+         * Companion-scope so a JVM-only test covers it without AudioManager.
+         */
+        @androidx.annotation.VisibleForTesting
+        internal fun shouldReapplyMicUnmute(
+            requiresUnmute: Boolean,
+            isActive: Boolean,
+            isMicMuted: Boolean,
+        ): Boolean = requiresUnmute && isActive && isMicMuted
+
+        /**
          * WEE-54 / forta-bugs#860 — Samsung A15 (Android 15) bidirectional
          * silence guard.
          *
@@ -300,6 +330,24 @@ class AudioRouter private constructor(private val context: Context) {
                             "Audio mode reset detected at +${delayMs}ms — re-applying MODE_IN_COMMUNICATION",
                         )
                         audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+                    }
+                    // WEE-60: the OEM that resets the audio mode in this window
+                    // can also re-assert the global mic-mute flag, clobbering the
+                    // t=0 applyVendorStartTweaks() unmute and leaving the peer with
+                    // one-way silence. Re-release it on every tick for vendors that
+                    // need it (gated + mic-actually-muted guard → no-op otherwise).
+                    if (
+                        shouldReapplyMicUnmute(
+                            VendorAudioPolicy.requiresExplicitMicUnmuteOnStart(vendor),
+                            isActive,
+                            audioManager.isMicrophoneMute,
+                        )
+                    ) {
+                        audioManager.setMicrophoneMute(false)
+                        Log.w(
+                            LIFECYCLE_TAG,
+                            "[vendor=$vendor] OEM re-muted mic at +${delayMs}ms — releasing",
+                        )
                     }
                 } catch (e: Exception) {
                     Log.w(LIFECYCLE_TAG, "Re-apply tick at +${delayMs}ms threw", e)

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/VendorAudioPolicy.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/VendorAudioPolicy.kt
@@ -153,6 +153,12 @@ object VendorAudioPolicy {
         val m = manufacturer?.trim()?.lowercase().orEmpty()
         val b = brand?.trim()?.lowercase().orEmpty()
         if (m.isEmpty() && b.isEmpty()) return false
-        return BROKEN_HW_AEC_VENDORS.any { v -> v == m || v == b }
+        // WEE-60: substring match, not strict equality. detect() above already
+        // uses contains(); this predicate lagged behind with `==`, so OEMs that
+        // report a multi-word Build.MANUFACTURER/BRAND (e.g. "Infinix Mobility
+        // Limited", "TECNO MOBILE LIMITED", brand "Itel it2163") never matched
+        // and kept the broken hardware AEC — muting the capture path into
+        // one-way audio (#894 Xiaomi 12X, #921 Pixel-adjacent reports).
+        return BROKEN_HW_AEC_VENDORS.any { v -> m.contains(v) || b.contains(v) }
     }
 }

--- a/android/app/src/test/java/com/forta/chat/plugins/calls/AudioRouterModeReapplyTest.kt
+++ b/android/app/src/test/java/com/forta/chat/plugins/calls/AudioRouterModeReapplyTest.kt
@@ -115,6 +115,64 @@ class AudioRouterModeReapplyTest {
         )
     }
 
+    // -------------------------------------------------------------------------
+    // WEE-60 — re-apply vendor mic-unmute inside the OEM re-apply window.
+    //
+    // The t=0 applyVendorStartTweaks() unmute is clobbered when the OEM
+    // re-asserts the global mic-mute flag in the same async window it resets the
+    // audio mode, leaving the peer with one-way silence. shouldReapplyMicUnmute
+    // gates the re-release: vendor needs it AND routing active AND mic muted.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun micRemutedByOem_whileActive_triggersReapply() {
+        assertTrue(
+            "vendor-needs-unmute + active + mic muted → must re-release the mic",
+            AudioRouter.shouldReapplyMicUnmute(
+                requiresUnmute = true,
+                isActive = true,
+                isMicMuted = true,
+            ),
+        )
+    }
+
+    @Test
+    fun micNotMuted_doesNotReapply() {
+        assertFalse(
+            "mic already open → re-applying is a pointless framework call",
+            AudioRouter.shouldReapplyMicUnmute(
+                requiresUnmute = true,
+                isActive = true,
+                isMicMuted = false,
+            ),
+        )
+    }
+
+    @Test
+    fun vendorDoesNotRequireUnmute_doesNotReapply() {
+        assertFalse(
+            "gated to vendors with the known start-time mute quirk (A5 — leave " +
+                "the proven generic path untouched on every other device)",
+            AudioRouter.shouldReapplyMicUnmute(
+                requiresUnmute = false,
+                isActive = true,
+                isMicMuted = true,
+            ),
+        )
+    }
+
+    @Test
+    fun inactiveRouter_doesNotReapplyMicUnmute() {
+        assertFalse(
+            "router stopped → must not fight a fresh call's mic state",
+            AudioRouter.shouldReapplyMicUnmute(
+                requiresUnmute = true,
+                isActive = false,
+                isMicMuted = true,
+            ),
+        )
+    }
+
     @Test
     fun reapplySchedule_coversExpectedOemResetWindows() {
         // The schedule must include the original 500 ms catch (fast OEMs) and

--- a/android/app/src/test/java/com/forta/chat/plugins/calls/VendorAudioPolicyTest.kt
+++ b/android/app/src/test/java/com/forta/chat/plugins/calls/VendorAudioPolicyTest.kt
@@ -173,6 +173,28 @@ class VendorAudioPolicyTest {
     }
 
     @Test
+    fun brokenHwAecVendors_matchMultiWordBuildStrings() {
+        // WEE-60 regression: real OEM Build fields are rarely the bare token.
+        // Infinix/Tecno/Itel ship multi-word MANUFACTURER/BRAND strings; the
+        // old strict `==` predicate missed them and left the broken hardware
+        // AEC active, producing one-way audio. Substring match fixes it.
+        assertTrue(
+            "multi-word Infinix manufacturer must still prefer software AEC",
+            VendorAudioPolicy.prefersSoftwareAudioProcessing("Infinix Mobility Limited", "Infinix X6525"),
+        )
+        assertTrue(
+            VendorAudioPolicy.prefersSoftwareAudioProcessing("TECNO MOBILE LIMITED", "TECNO KI5k"),
+        )
+        assertTrue(
+            VendorAudioPolicy.prefersSoftwareAudioProcessing("itel", "Itel it2163"),
+        )
+        assertTrue(
+            "Xiaomi marketing brand strings carry the token mid-word",
+            VendorAudioPolicy.prefersSoftwareAudioProcessing("Xiaomi", "Redmi Note 12"),
+        )
+    }
+
+    @Test
     fun workingHwAecVendors_keepHardwareProcessing() {
         // Samsung / Pixel / OnePlus ship working HW AEC and must stay on it.
         assertFalse(VendorAudioPolicy.prefersSoftwareAudioProcessing("samsung", "samsung"))

--- a/src/features/video-calls/ui/CallControls.vue
+++ b/src/features/video-calls/ui/CallControls.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { useCallStore, CallStatus } from "@/entities/call";
+import { isNative } from "@/shared/lib/platform";
+import { nativeCallBridge } from "@/shared/lib/native-calls/native-call-bridge";
+import type { NativeAudioDeviceType } from "@/shared/lib/native-calls/native-call-bridge";
 import { useCallService } from "../model/call-service";
 import { useMediaDevices } from "../model/use-media-devices";
 
@@ -75,11 +78,84 @@ const selectVideo = async (deviceId: string) => {
   }
 };
 
-const selectOutput = (deviceId: string) => {
+// WEE-60 H1: map a (possibly normalised) audiooutput label to the native
+// AudioRouter device type. Android's enumerateDevices rarely yields audiooutput
+// entries at all, so this only fires on the few ROMs that do expose them; the
+// standalone toggle below is the primary native control.
+const mapOutputLabelToNativeType = (label: string): NativeAudioDeviceType => {
+  const key = label.trim().toLowerCase();
+  if (key.includes("bluetooth") || key.includes("блютуз")) return "bluetooth";
+  if (
+    key.includes("headset") || key.includes("headphone") ||
+    key.includes("wired") || key.includes("usb") ||
+    key.includes("гарнитур") || key.includes("наушник")
+  ) {
+    return "wired_headset";
+  }
+  if (key.includes("speaker") || key.includes("динамик") || key.includes("громк")) {
+    // "Динамик телефона" (earpiece) also contains "динамик" — disambiguate.
+    if (key.includes("телефон") || key.includes("phone") || key.includes("ухо")) {
+      return "earpiece";
+    }
+    return "speaker";
+  }
+  return "earpiece";
+};
+
+const selectOutput = async (deviceId: string) => {
   selectedOutputId.value = deviceId;
   saveDeviceChoice(STORAGE_KEY_OUTPUT, deviceId);
+  // Web: CallWindow watches audioOutputId and applies setSinkId on the remote
+  // element. Native: setSinkId is a no-op in the Android WebView, so route
+  // through the native AudioRouter instead.
   callStore.audioOutputId = deviceId;
+  if (!isNative) return;
+  const dev = audioOutputDevices.value.find(d => d.deviceId === deviceId);
+  const type = mapOutputLabelToNativeType(dev?.label ?? "");
+  speakerOn.value = type === "speaker";
+  await nativeCallBridge.setAudioDevice({ type });
 };
+
+// WEE-60 H1: standalone speaker toggle wired straight to the native
+// AudioRouter, independent of enumerateDevices (which is empty on Android, so
+// the gear-menu speaker list never appears — leaving users with no way to
+// switch earpiece↔speaker). Initial guess mirrors AudioRouter.start() (video
+// opens on speaker, voice on earpiece) and is corrected from the real native
+// route on mount + on every audioDevicesChanged event below.
+const speakerOn = ref(callStore.activeCall?.type === "video");
+
+const toggleSpeaker = async () => {
+  const next = !speakerOn.value;
+  speakerOn.value = next;
+  // The native AudioRouter echoes back an audioDevicesChanged event, which
+  // re-syncs speakerOn — so the optimistic flip above self-corrects if the
+  // route ends up elsewhere (e.g. forced to BT).
+  await nativeCallBridge.setAudioDevice({ type: next ? "speaker" : "earpiece" });
+};
+
+// Keep the toggle in sync with the real native output. enumerateDevices is
+// empty on Android, so the only reliable source of truth is the AudioRouter.
+// Re-seeding on mount also fixes drift after minimize→restore (this component
+// is v-if-mounted, so it remounts on restore).
+let unsubscribeAudioDevices: (() => void) | null = null;
+
+const syncSpeakerFromNative = (active: string) => {
+  if (active) speakerOn.value = active.toLowerCase() === "speaker";
+};
+
+onMounted(async () => {
+  if (!isNative) return;
+  const state = await nativeCallBridge.getAudioDevices();
+  syncSpeakerFromNative(state.active);
+  unsubscribeAudioDevices = await nativeCallBridge.onAudioDevicesChanged(
+    (s) => syncSpeakerFromNative(s.active),
+  );
+});
+
+onUnmounted(() => {
+  unsubscribeAudioDevices?.();
+  unsubscribeAudioDevices = null;
+});
 
 // Close device menu when call ends
 watch(
@@ -250,6 +326,31 @@ watch(
           <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
           <line x1="8" y1="21" x2="16" y2="21" />
           <line x1="12" y1="17" x2="12" y2="21" />
+        </svg>
+      </button>
+
+      <!-- Speaker toggle (native) — standalone, independent of enumerateDevices -->
+      <button
+        v-if="isNative"
+        class="ctrl-btn"
+        :class="[
+          speakerOn ? 'ctrl-btn--screen-active' : 'ctrl-btn--default',
+          compact && 'ctrl-btn--compact',
+        ]"
+        :title="speakerOn ? t('call.speakerOn') : t('call.speakerOff')"
+        data-testid="speaker-toggle"
+        @click="toggleSpeaker()"
+      >
+        <!-- Speaker on (loud) -->
+        <svg v-if="speakerOn" :width="compact ? 18 : 20" :height="compact ? 18 : 20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+          <path d="M19.07 4.93a10 10 0 010 14.14M15.54 8.46a5 5 0 010 7.07" />
+        </svg>
+        <!-- Speaker off (earpiece) -->
+        <svg v-else :width="compact ? 18 : 20" :height="compact ? 18 : 20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+          <line x1="23" y1="9" x2="17" y2="15" />
+          <line x1="17" y1="9" x2="23" y2="15" />
         </svg>
       </button>
 

--- a/src/features/video-calls/ui/__tests__/call-controls-speaker.test.ts
+++ b/src/features/video-calls/ui/__tests__/call-controls-speaker.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ref, nextTick } from "vue";
+import { mount, flushPromises } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import { useCallStore } from "@/entities/call";
+import { CallStatus } from "@/entities/call";
+import type { CallInfo, CallType } from "@/entities/call/model/types";
+
+/**
+ * WEE-60 — regression tests for the native speaker toggle.
+ *
+ * Root cause H1: on Android the in-call speaker button only wrote to
+ * `callStore.audioOutputId`. The store→setSinkId path (CallWindow) is a no-op
+ * on the native WebView, and `enumerateDevices()` returns no `audiooutput`
+ * entries, so the gear-menu speaker section was hidden and the user had no way
+ * to reach `AudioRouter.setDevice()`. These tests lock the fix: a standalone
+ * speaker toggle, present on native regardless of enumerateDevices (A4), wired
+ * straight to `nativeCallBridge.setAudioDevice({ type })` (A1).
+ */
+
+// Mutable platform flag — flipped per test before mount.
+const platformMock = { isNative: true };
+vi.mock("@/shared/lib/platform", () => ({
+  get isNative() {
+    return platformMock.isNative;
+  },
+}));
+
+const setAudioDevice = vi.fn().mockResolvedValue(undefined);
+// Native AudioRouter snapshot the mocked bridge reports on mount, plus the
+// captured audioDevicesChanged callback so tests can simulate hot-swaps.
+const nativeState = { active: "" };
+let audioDevicesCb: ((s: { active: string; devices: never[] }) => void) | null = null;
+vi.mock("@/shared/lib/native-calls/native-call-bridge", () => ({
+  nativeCallBridge: {
+    setAudioDevice: (opts: { type: string }) => setAudioDevice(opts),
+    getAudioDevices: () =>
+      Promise.resolve({ active: nativeState.active, devices: [] }),
+    onAudioDevicesChanged: (cb: (s: { active: string; devices: never[] }) => void) => {
+      audioDevicesCb = cb;
+      return Promise.resolve(() => {
+        audioDevicesCb = null;
+      });
+    },
+  },
+}));
+
+vi.mock("../model/call-service", () => ({
+  useCallService: () => ({
+    toggleMute: vi.fn(),
+    toggleCamera: vi.fn(),
+    toggleScreenShare: vi.fn(),
+    hangup: vi.fn(),
+    setAudioDevice: vi.fn(),
+    setVideoDevice: vi.fn(),
+  }),
+}));
+
+// Default: empty device lists — mirrors Android, where enumerateDevices()
+// yields no audiooutput entries. Individual tests can override.
+const mediaDevicesState = {
+  audioDevices: ref<unknown[]>([]),
+  videoDevices: ref<unknown[]>([]),
+  audioOutputDevices: ref<{ deviceId: string; label: string; kind: string }[]>([]),
+};
+vi.mock("../model/use-media-devices", () => ({
+  useMediaDevices: () => ({
+    audioDevices: mediaDevicesState.audioDevices,
+    videoDevices: mediaDevicesState.videoDevices,
+    audioOutputDevices: mediaDevicesState.audioOutputDevices,
+    enumerateDevices: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let CallControls: any;
+
+function makeCall(type: CallType): CallInfo {
+  return {
+    callId: "c1",
+    roomId: "r1",
+    peerId: "p1",
+    peerAddress: "addr",
+    peerName: "Peer",
+    type,
+    direction: "outgoing",
+    status: CallStatus.connected,
+    startedAt: 0,
+    endedAt: null,
+  };
+}
+
+describe("CallControls — native speaker toggle (WEE-60)", () => {
+  beforeEach(async () => {
+    setActivePinia(createPinia());
+    platformMock.isNative = true;
+    mediaDevicesState.audioOutputDevices.value = [];
+    setAudioDevice.mockClear();
+    nativeState.active = "";
+    audioDevicesCb = null;
+    vi.stubGlobal("useI18n", () => ({ t: (k: string) => k }));
+    CallControls = (await import("../CallControls.vue")).default;
+  });
+
+  it("renders a standalone speaker toggle on native even with no enumerated audiooutput (A4)", () => {
+    const store = useCallStore();
+    store.setActiveCall(makeCall("voice"));
+    const wrapper = mount(CallControls);
+    expect(wrapper.find('[data-testid="speaker-toggle"]').exists()).toBe(true);
+  });
+
+  it("voice call: first tap routes to speaker, second tap back to earpiece (A1)", async () => {
+    const store = useCallStore();
+    store.setActiveCall(makeCall("voice"));
+    const wrapper = mount(CallControls);
+
+    const btn = wrapper.find('[data-testid="speaker-toggle"]');
+    await btn.trigger("click");
+    expect(setAudioDevice).toHaveBeenLastCalledWith({ type: "speaker" });
+
+    await btn.trigger("click");
+    expect(setAudioDevice).toHaveBeenLastCalledWith({ type: "earpiece" });
+  });
+
+  it("video call opens on speaker, so first tap drops to earpiece", async () => {
+    const store = useCallStore();
+    store.setActiveCall(makeCall("video"));
+    const wrapper = mount(CallControls);
+
+    await wrapper.find('[data-testid="speaker-toggle"]').trigger("click");
+    expect(setAudioDevice).toHaveBeenLastCalledWith({ type: "earpiece" });
+  });
+
+  it("seeds the toggle from the native active route on mount (survives minimize/restore)", async () => {
+    // Voice call → initial guess is earpiece (off). But the native router
+    // already reports speaker (e.g. user had it on before a minimize/restore).
+    nativeState.active = "speaker";
+    const store = useCallStore();
+    store.setActiveCall(makeCall("voice"));
+    const wrapper = mount(CallControls);
+    await flushPromises();
+
+    // Toggle now reflects speaker=on, so the next tap drops to earpiece.
+    await wrapper.find('[data-testid="speaker-toggle"]').trigger("click");
+    expect(setAudioDevice).toHaveBeenLastCalledWith({ type: "earpiece" });
+  });
+
+  it("re-syncs the toggle when the native route changes (BT/headset hot-swap)", async () => {
+    // Video call → initial speaker=on.
+    const store = useCallStore();
+    store.setActiveCall(makeCall("video"));
+    const wrapper = mount(CallControls);
+    await flushPromises();
+
+    // Native reports the route moved off the loudspeaker (e.g. BT connected).
+    audioDevicesCb?.({ active: "earpiece", devices: [] });
+    await nextTick();
+
+    // speakerOn is now false → next tap routes back to speaker.
+    await wrapper.find('[data-testid="speaker-toggle"]').trigger("click");
+    expect(setAudioDevice).toHaveBeenLastCalledWith({ type: "speaker" });
+  });
+
+  it("does not render the native toggle on web, and selectOutput stays store-only", async () => {
+    // `isNative` is a live getter on the mocked platform module, so flipping
+    // the flag before mount is enough — no module reset needed.
+    platformMock.isNative = false;
+
+    const store = useCallStore();
+    store.setActiveCall(makeCall("voice"));
+    const wrapper = mount(CallControls);
+
+    expect(wrapper.find('[data-testid="speaker-toggle"]').exists()).toBe(false);
+    expect(setAudioDevice).not.toHaveBeenCalled();
+  });
+});

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -530,6 +530,8 @@ export const en = {
   "call.microphone": "Microphone",
   "call.camera": "Camera",
   "call.speaker": "Speaker",
+  "call.speakerOn": "Speaker on",
+  "call.speakerOff": "Speaker off",
   "call.devices": "Devices",
   "call.deviceLabel.earpiece": "Earpiece",
   "call.deviceLabel.speakerphone": "Speakerphone",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -532,6 +532,8 @@ export const ru: Record<TranslationKey, string> = {
   "call.microphone": "Микрофон",
   "call.camera": "Камера",
   "call.speaker": "Динамик",
+  "call.speakerOn": "Громкая связь вкл.",
+  "call.speakerOff": "Громкая связь выкл.",
   "call.devices": "Устройства",
   "call.deviceLabel.earpiece": "Разговорный (в ухо)",
   "call.deviceLabel.speakerphone": "Громкая связь",

--- a/src/shared/lib/native-calls/native-call-bridge.ts
+++ b/src/shared/lib/native-calls/native-call-bridge.ts
@@ -41,6 +41,16 @@ export interface InviteThrottleSnapshot {
   records: InviteThrottleRecord[];
 }
 
+/** Native AudioRouter device identifiers (see `CallPlugin.setAudioDevice`). */
+export type NativeAudioDeviceType = 'speaker' | 'earpiece' | 'bluetooth' | 'wired_headset';
+
+/** Snapshot of the native AudioRouter routing state. */
+export interface NativeAudioDevicesState {
+  /** Active device type, lowercased (e.g. 'speaker'). Empty when unknown. */
+  active: string;
+  devices: Array<{ type: string; name: string }>;
+}
+
 interface NativeCallNativePlugin {
   reportIncomingCall(options: {
     callId: string;
@@ -98,7 +108,7 @@ interface NativeCallNativePlugin {
     active: string;
     devices: Array<{ type: string; name: string }>;
   }>;
-  setAudioDevice(options: { type: string }): Promise<void>;
+  setAudioDevice(options: { type: NativeAudioDeviceType }): Promise<void>;
   startAudioRouting(options: { callType: string }): Promise<void>;
   stopAudioRouting(): Promise<void>;
   /**
@@ -693,6 +703,75 @@ class NativeCallBridge {
         '[NativeCallBridge] startAudioRouting recovered on attempt',
         result.attempts,
       );
+    }
+  }
+
+  /**
+   * WEE-60: route in-call audio to a specific output through the native
+   * AudioRouter. `type` is one of 'speaker' | 'earpiece' | 'bluetooth' |
+   * 'wired_headset' (see `CallPlugin.setAudioDevice` → `AudioRouter.setDevice`).
+   *
+   * No-op on web: the WebView has no AudioManager, and web output selection is
+   * handled by `setSinkId` on the remote element in CallWindow. Surfaced here so
+   * the Vue speaker toggle has a typed entry point instead of reaching into the
+   * raw Capacitor plugin.
+   */
+  async setAudioDevice(options: { type: NativeAudioDeviceType }): Promise<void> {
+    if (!isNative) return;
+    try {
+      await NativeCall.setAudioDevice(options);
+    } catch (e) {
+      console.warn('[NativeCallBridge] setAudioDevice failed:', e);
+    }
+  }
+
+  /**
+   * WEE-60: read the native AudioRouter's current routing snapshot. Used to
+   * seed the in-call speaker-toggle state on mount so it reflects the real
+   * output (the call may have opened on speaker for video, or BT may already
+   * be connected). Safe default on web / older native builds.
+   */
+  async getAudioDevices(): Promise<NativeAudioDevicesState> {
+    if (!isNative) return { active: '', devices: [] };
+    try {
+      const res = await NativeCall.getAudioDevices();
+      return {
+        active: typeof res?.active === 'string' ? res.active : '',
+        devices: Array.isArray(res?.devices) ? res.devices : [],
+      };
+    } catch (e) {
+      console.warn('[NativeCallBridge] getAudioDevices unavailable:', e);
+      return { active: '', devices: [] };
+    }
+  }
+
+  /**
+   * WEE-60: subscribe to native AudioRouter routing changes (BT/wired hot-swap,
+   * OEM auto-routing). Keeps the speaker toggle in sync with the actual output
+   * instead of drifting after minimize/restore or a headset connect. Returns an
+   * unsubscribe function; no-op on web / older native builds.
+   */
+  async onAudioDevicesChanged(
+    cb: (state: NativeAudioDevicesState) => void,
+  ): Promise<() => void> {
+    if (!isNative) return () => {};
+    try {
+      const handle = await NativeCall.addListener('audioDevicesChanged', (data) => {
+        cb({
+          active: typeof data?.active === 'string' ? data.active : '',
+          devices: Array.isArray(data?.devices) ? data.devices : [],
+        });
+      });
+      return () => {
+        try {
+          handle.remove();
+        } catch {
+          /* listener already detached */
+        }
+      };
+    } catch (e) {
+      console.warn('[NativeCallBridge] onAudioDevicesChanged unavailable:', e);
+      return () => {};
     }
   }
 


### PR DESCRIPTION
## Summary
P0 fix for persistent call-audio failures on 1.10.35 (post WEE-56/54/49). Three independent root-cause defects across JS + Kotlin:

- **H1 (JS)** — In-call speaker button only wrote `callStore.audioOutputId`; on Android `setSinkId` is a no-op and `enumerateDevices()` returns no `audiooutput`, so the speaker section stayed hidden and never reached the native `AudioRouter`. Added a **standalone speaker toggle** (native-only, independent of `enumerateDevices`) wired to a new typed `nativeCallBridge.setAudioDevice()`, seeded from and kept in sync with the real native route via `getAudioDevices()` + `audioDevicesChanged` (survives minimize/restore and BT/headset hot-swap). Web path unchanged.
- **H2 (Kotlin)** — `VendorAudioPolicy.prefersSoftwareAudioProcessing` used strict `==` while `detect()` uses `contains()`; multi-word `Build.MANUFACTURER`/`BRAND` (Infinix/Tecno/Itel) never matched → broken HW AEC muted capture → one-way audio. Switched to substring match (A5-safe — no broken token is a substring of samsung/google/pixel/oneplus).
- **H3 (Kotlin)** — HONOR mic-unmute ran only at t=0; OEM ROMs re-assert the global mic-mute flag in the same async window they reset the audio mode. Re-apply `setMicrophoneMute(false)` inside the existing scheduled re-apply ticks via the new `shouldReapplyMicUnmute` predicate (gated + mic-actually-muted guard → no-op on healthy devices).

## Linear
- Resolves [WEE-60](https://linear.app/wwwee/issue/WEE-60)

## Closes
Closes greenShirtMystery/forta-bugs#905
Closes greenShirtMystery/forta-bugs#900
Closes greenShirtMystery/forta-bugs#894
Closes greenShirtMystery/forta-bugs#891
Closes greenShirtMystery/forta-bugs#921
Closes greenShirtMystery/forta-bugs#833
Closes greenShirtMystery/forta-bugs#909
Closes greenShirtMystery/forta-bugs#890
Closes greenShirtMystery/forta-bugs#898
Closes greenShirtMystery/forta-bugs#889
Closes greenShirtMystery/forta-bugs#565
Closes greenShirtMystery/forta-bugs#854
Closes greenShirtMystery/forta-bugs#458
Closes greenShirtMystery/forta-bugs#429
Closes greenShirtMystery/forta-bugs#424
Closes greenShirtMystery/forta-bugs#525
Closes greenShirtMystery/forta-bugs#589
Closes greenShirtMystery/forta-bugs#661
Closes greenShirtMystery/forta-bugs#662

## Test plan
- [x] `npx vitest run call-controls-speaker` — 6/6 (A1 speaker route, A4 toggle present without enumerate, native-route seed on mount, BT/headset re-sync, web no-op)
- [x] `./gradlew testDebugUnitTest` — VendorAudioPolicy (multi-word match) + AudioRouter (`shouldReapplyMicUnmute` predicate) green
- [x] `vite build` clean; changed files type-check clean (pre-existing repo-wide vue-tsc/test baseline unchanged)
- [ ] **Manual QA (no lab devices)** — real Xiaomi (MIUI), Pixel 6a, and an Infinix/Tecno if available: bidirectional audio, speaker toggle actually switches earpiece↔speaker, and mic works in a 3rd-party app (Telegram voice) immediately after hangup. Verify Samsung regression-free (A5).

## Out of scope
WebRTC stack replacement, duplicate incoming-call dialog, external providers (WEE-57).