### PR TITLE
fix(messaging): chat-list preview reflects failed/sending send status (WEE-64)

### DIFF
--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -2079,6 +2079,9 @@ export function useMessages() {
       status: "pending" as import("@/shared/lib/local-db/schema").LocalMessageStatus,
       uploadProgress: 0,
     });
+    // WEE-64: mirror the reset onto the chat-list preview (still-last guard
+    // inside the repository) so the sidebar shows "отправляется" during retry.
+    await dbKit.rooms.syncLastMessageLocalStatus(roomId, localMsg.timestamp, "pending");
 
     // Re-run upload pipeline (with abort support)
     const controller = registerUploadAbort(localMsg.clientId);
@@ -2205,6 +2208,9 @@ export function useMessages() {
             uploadProgress: undefined,
             uploadPhase: undefined,
           });
+          // WEE-64: the media retry pipeline bypasses SyncEngine, so mirror the
+          // failed badge onto the chat-list preview (still-last guard in the repo).
+          await dbKit.rooms.syncLastMessageLocalStatus(roomId, localMsg.timestamp, "failed");
         }
       }
     } finally {
@@ -2230,11 +2236,18 @@ export function useMessages() {
 
     // Reset status to pending
     await dbKit.messages.updateStatus({ clientId: mKey }, "pending");
+    // WEE-64: mirror the reset onto the chat-list preview so the sidebar shows
+    // "отправляется" (not a stale error) while the retry is in flight. Guarded
+    // to the still-last-message case inside the repository.
+    await dbKit.rooms.syncLastMessageLocalStatus(roomId, localMsg.timestamp, "pending");
 
     const matrixService = getMatrixClientService();
     if (!matrixService.isReady()) {
       console.error("[retryMessage] Matrix client still not ready", { roomId, clientId: mKey });
       await dbKit.messages.markFailed(mKey);
+      // WEE-64: this retry never reaches SyncEngine.markMessageFailed, so mirror
+      // the failed badge onto the preview here (still-last guard in the repo).
+      await dbKit.rooms.syncLastMessageLocalStatus(roomId, localMsg.timestamp, "failed");
       return;
     }
 
@@ -2262,6 +2275,9 @@ export function useMessages() {
     } catch (e) {
       console.error("[retryMessage] Failed to enqueue:", e);
       await dbKit.messages.markFailed(mKey);
+      // WEE-64: enqueue failed before SyncEngine took over — keep the preview
+      // consistent with the failed message (still-last guard in the repo).
+      await dbKit.rooms.syncLastMessageLocalStatus(roomId, localMsg.timestamp, "failed");
     }
   };
 

--- a/src/shared/lib/local-db/__tests__/sync-engine-failed-room-status.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-failed-room-status.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Dexie from "dexie";
+import "fake-indexeddb/auto";
+import { SyncEngine } from "../sync-engine";
+import { MessageRepository } from "../message-repository";
+import { RoomRepository } from "../room-repository";
+import type { PendingOperation, LocalMessage, LocalRoom } from "../schema";
+
+/**
+ * Regression coverage for WEE-64: the chat-list preview must reflect the real
+ * transport status of the last outbound message, the same way the open chat
+ * does. The bug: `SyncEngine.markMessageFailed` only flipped the per-message
+ * `LocalMessage.status` to "failed" and never touched the denormalised
+ * `LocalRoom.lastMessageLocalStatus` that drives the sidebar preview — so the
+ * preview stayed stuck on "sending" (часики) after a failed send.
+ *
+ * The fix mirrors the success path (`sync-engine.ts:607-610`) but guards the
+ * write twice:
+ *   (a) only outbound send-ops (send_message/send_file/send_transfer/send_poll)
+ *       — an edit/reaction failure must not corrupt the preview badge;
+ *   (b) only when the failed message is STILL the room's last message — a newer
+ *       message (ours or the peer's) already advanced the preview.
+ * On retry the preview must return to "pending" (sending) symmetrically.
+ */
+
+const mockMatrix = {
+  sendEncryptedText: vi.fn<
+    (roomId: string, content: unknown, clientId?: string) => Promise<string>
+  >(async () => "$server_event_id"),
+  sendText: vi.fn<(roomId: string, body: unknown, clientId?: string) => Promise<string>>(
+    async () => "$server_event_id",
+  ),
+  sendReaction: vi.fn<(roomId: string, eventId: string, emoji: string) => Promise<string>>(
+    async () => "$reaction_id",
+  ),
+  redactEvent: vi.fn<(roomId: string, eventId: string) => Promise<void>>(async () => undefined),
+  sendPollStart: vi.fn<(roomId: string, content: unknown) => Promise<string>>(
+    async () => "$poll_id",
+  ),
+  sendPollResponse: vi.fn<(roomId: string, content: unknown) => Promise<void>>(
+    async () => undefined,
+  ),
+};
+
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: () => mockMatrix,
+}));
+
+class TestDb extends Dexie {
+  messages!: Dexie.Table<LocalMessage, number>;
+  rooms!: Dexie.Table<LocalRoom, string>;
+  pendingOps!: Dexie.Table<PendingOperation, number>;
+  attachments!: Dexie.Table<{ id?: number; localBlob?: Blob; size?: number; status?: string }, number>;
+  users!: Dexie.Table<{ address: string }, string>;
+  syncState!: Dexie.Table<{ key: string; value: string | number }, string>;
+  decryptionQueue!: Dexie.Table<{ id?: number; status: string }, number>;
+  listenedMessages!: Dexie.Table<{ messageId: string }, string>;
+
+  constructor(name: string) {
+    super(name, { indexedDB, IDBKeyRange });
+    this.version(1).stores({
+      messages:
+        "++localId, eventId, clientId, [roomId+timestamp], [roomId+status], senderId",
+      rooms: "id, updatedAt, membership, isDeleted",
+      pendingOps:
+        "++id, [roomId+createdAt], status, clientId, [status+nextAttemptAt]",
+      attachments: "++id, messageLocalId, status",
+      users: "address, updatedAt",
+      syncState: "key",
+      decryptionQueue: "++id, status, [status+nextAttemptAt]",
+      listenedMessages: "messageId",
+    });
+  }
+}
+
+interface Harness {
+  db: TestDb;
+  engine: SyncEngine;
+  messages: MessageRepository;
+  rooms: RoomRepository;
+}
+
+const ROOM_ID = "!room:server";
+
+function makeHarness(name: string): Harness {
+  const db = new TestDb(name);
+  const messages = new MessageRepository(db as never);
+  const rooms = new RoomRepository(db as never);
+  const getRoomCrypto = vi.fn(async () => undefined);
+  const engine = new SyncEngine(db as never, messages as never, rooms as never, getRoomCrypto);
+  return { db, engine, messages, rooms };
+}
+
+function seedRoom(db: TestDb, overrides: Partial<LocalRoom> = {}): Promise<string> {
+  const room: LocalRoom = {
+    id: ROOM_ID,
+    name: "Test Room",
+    isGroup: false,
+    members: ["@me:server"],
+    membership: "join",
+    unreadCount: 0,
+    lastReadInboundTs: 0,
+    lastReadOutboundTs: 0,
+    updatedAt: 1,
+    isDeleted: false,
+    deletedAt: null,
+    deleteReason: null,
+    syncedAt: 0,
+    hasMoreHistory: true,
+    ...overrides,
+  };
+  return db.rooms.put(room).then(() => room.id);
+}
+
+async function seedOp(
+  db: TestDb,
+  overrides: Partial<PendingOperation> = {},
+): Promise<number> {
+  return db.pendingOps.add({
+    type: "send_message",
+    roomId: ROOM_ID,
+    payload: { content: "hello" },
+    status: "pending",
+    retries: 0,
+    maxRetries: 1,
+    createdAt: Date.now(),
+    clientId: `cli_${Math.random().toString(36).slice(2)}`,
+    nextAttemptAt: 0,
+    ...overrides,
+  } as PendingOperation);
+}
+
+/** A genuinely-failed send leaves its op row in the table with status "failed"
+ *  (it is only deleted when an echo already confirmed it). Wait for that. */
+async function waitOpFailed(db: TestDb, clientId: string): Promise<void> {
+  await vi.waitFor(
+    async () => {
+      const op = await db.pendingOps.where("clientId").equals(clientId).first();
+      expect(op?.status).toBe("failed");
+    },
+    { timeout: 2000, interval: 10 },
+  );
+}
+
+describe("SyncEngine — WEE-64: chat-list preview reflects failed/retried send", () => {
+  let h: Harness;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockMatrix.sendEncryptedText.mockImplementation(async () => "$server_event_id");
+    h = makeHarness(`sync-engine-failed-room-status-${Date.now()}-${Math.random()}`);
+    await h.db.open();
+  });
+
+  afterEach(async () => {
+    h.engine.dispose();
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    await h.db.delete();
+  });
+
+  it("markMessageFailed sets room.lastMessageLocalStatus='failed' for the last message", async () => {
+    await seedRoom(h.db);
+    const msg = await h.messages.createLocal({
+      roomId: ROOM_ID,
+      senderId: "@me:server",
+      content: "boom",
+    });
+    // Preconditions: writeOutbound primed the preview to "pending".
+    expect((await h.db.rooms.get(ROOM_ID))?.lastMessageLocalStatus).toBe("pending");
+
+    mockMatrix.sendEncryptedText.mockImplementation(async () => {
+      throw new Error("permanent network failure");
+    });
+
+    await seedOp(h.db, { clientId: msg.clientId, maxRetries: 1 });
+    h.engine.processQueue();
+    await waitOpFailed(h.db, msg.clientId);
+
+    const message = await h.messages.getByClientId(msg.clientId);
+    const room = await h.db.rooms.get(ROOM_ID);
+    expect(message?.status).toBe("failed");
+    expect(room?.lastMessageLocalStatus).toBe("failed");
+  });
+
+  it("does NOT touch room status when the failed message is not the room's last", async () => {
+    await seedRoom(h.db);
+    const stale = await h.messages.createLocal({
+      roomId: ROOM_ID,
+      senderId: "@me:server",
+      content: "stale",
+    });
+    // Simulate a newer message having advanced the preview to a later timestamp
+    // and a delivered (synced) status.
+    await h.db.rooms.update(ROOM_ID, {
+      lastMessageTimestamp: stale.timestamp + 10_000,
+      lastMessageLocalStatus: "synced",
+    });
+
+    mockMatrix.sendEncryptedText.mockImplementation(async () => {
+      throw new Error("permanent network failure");
+    });
+
+    await seedOp(h.db, { clientId: stale.clientId, maxRetries: 1 });
+    h.engine.processQueue();
+    await waitOpFailed(h.db, stale.clientId);
+
+    const message = await h.messages.getByClientId(stale.clientId);
+    const room = await h.db.rooms.get(ROOM_ID);
+    // The message itself is failed, but the preview belongs to a newer message.
+    expect(message?.status).toBe("failed");
+    expect(room?.lastMessageLocalStatus).toBe("synced");
+  });
+
+  it("edit/reaction failure does NOT corrupt lastMessageLocalStatus", async () => {
+    await seedRoom(h.db, {
+      lastMessageTimestamp: 5000,
+      lastMessageLocalStatus: "synced",
+    });
+
+    mockMatrix.sendEncryptedText.mockImplementation(async () => {
+      throw new Error("edit send failed");
+    });
+    mockMatrix.sendReaction.mockImplementation(async () => {
+      throw new Error("reaction send failed");
+    });
+
+    await seedOp(h.db, {
+      type: "edit_message",
+      clientId: "edit_cli",
+      payload: { eventId: "$evt", content: "edited" },
+      maxRetries: 1,
+    });
+    h.engine.processQueue();
+    await waitOpFailed(h.db, "edit_cli");
+
+    const room = await h.db.rooms.get(ROOM_ID);
+    expect(room?.lastMessageLocalStatus).toBe("synced");
+  });
+
+  it("retryAllFailed resets a failed last-message preview back to 'pending'", async () => {
+    await seedRoom(h.db);
+    const msg = await h.messages.createLocal({
+      roomId: ROOM_ID,
+      senderId: "@me:server",
+      content: "retry me",
+    });
+    // Simulate the parked failed end-state: per-message status + preview both
+    // "failed", op left in the queue as "failed" (as after retry exhaustion).
+    await h.messages.updateStatus({ clientId: msg.clientId }, "failed");
+    await h.rooms.updateRoom(ROOM_ID, { lastMessageLocalStatus: "failed" });
+    await seedOp(h.db, { clientId: msg.clientId, status: "failed", retries: 1, maxRetries: 1 });
+
+    // Hang the in-flight retry send so we can observe the reset-to-pending
+    // transition deterministically, without the op immediately re-failing.
+    mockMatrix.sendEncryptedText.mockImplementation(() => new Promise<string>(() => {}));
+
+    await h.engine.retryAllFailed();
+
+    const room = await h.db.rooms.get(ROOM_ID);
+    expect(room?.lastMessageLocalStatus).toBe("pending");
+  });
+
+  it("RoomRepository.syncLastMessageLocalStatus only writes when timestamp matches", async () => {
+    await seedRoom(h.db, { lastMessageTimestamp: 1000, lastMessageLocalStatus: "synced" });
+
+    // Non-matching timestamp → no-op.
+    await h.rooms.syncLastMessageLocalStatus(ROOM_ID, 999, "failed");
+    expect((await h.db.rooms.get(ROOM_ID))?.lastMessageLocalStatus).toBe("synced");
+
+    // Matching timestamp → writes.
+    await h.rooms.syncLastMessageLocalStatus(ROOM_ID, 1000, "failed");
+    expect((await h.db.rooms.get(ROOM_ID))?.lastMessageLocalStatus).toBe("failed");
+
+    // Unknown room → no throw.
+    await expect(
+      h.rooms.syncLastMessageLocalStatus("!nope:server", 1000, "failed"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/shared/lib/local-db/__tests__/sync-engine-false-failed.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-false-failed.test.ts
@@ -97,7 +97,7 @@ interface Harness {
   db: TestDb;
   engine: SyncEngine;
   messageRepo: MessageRepoStub;
-  roomRepo: { updateRoom: ReturnType<typeof vi.fn> };
+  roomRepo: { updateRoom: ReturnType<typeof vi.fn>; syncLastMessageLocalStatus: ReturnType<typeof vi.fn> };
   /** Backing store the messageRepo stub reads from. Tests mutate this to
    *  simulate Matrix /sync echoes arriving mid-flight. */
   rows: Map<string, Partial<LocalMessage>>;
@@ -121,7 +121,7 @@ function makeHarness(name: string): Harness {
     updateReactions: vi.fn(async () => undefined),
     getByClientId: vi.fn(async (clientId: string) => rows.get(clientId)),
   };
-  const roomRepo = { updateRoom: vi.fn(async () => undefined) };
+  const roomRepo = { updateRoom: vi.fn(async () => undefined), syncLastMessageLocalStatus: vi.fn(async () => undefined) };
   const getRoomCrypto = vi.fn(async () => undefined);
   const engine = new SyncEngine(
     db as never,

--- a/src/shared/lib/local-db/__tests__/sync-engine-media.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-media.test.ts
@@ -106,7 +106,7 @@ interface Harness {
     getByClientId: ReturnType<typeof vi.fn>;
     updateUploadProgress: ReturnType<typeof vi.fn>;
   };
-  roomRepo: { updateRoom: ReturnType<typeof vi.fn> };
+  roomRepo: { updateRoom: ReturnType<typeof vi.fn>; syncLastMessageLocalStatus: ReturnType<typeof vi.fn> };
   getRoomCrypto: ReturnType<typeof vi.fn>;
 }
 
@@ -125,7 +125,7 @@ function makeHarness(
     getByClientId: vi.fn(async (..._args: unknown[]) => opts.existingMsg as LocalMessage | undefined),
     updateUploadProgress: vi.fn(async () => undefined),
   };
-  const roomRepo = { updateRoom: vi.fn(async () => undefined) };
+  const roomRepo = { updateRoom: vi.fn(async () => undefined), syncLastMessageLocalStatus: vi.fn(async () => undefined) };
   const roomCrypto = encrypted
     ? {
         canBeEncrypt: () => true,

--- a/src/shared/lib/local-db/__tests__/sync-engine-txnid.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-txnid.test.ts
@@ -98,7 +98,7 @@ interface Harness {
     getByClientId: ReturnType<typeof vi.fn>;
     updateUploadProgress: ReturnType<typeof vi.fn>;
   };
-  roomRepo: { updateRoom: ReturnType<typeof vi.fn> };
+  roomRepo: { updateRoom: ReturnType<typeof vi.fn>; syncLastMessageLocalStatus: ReturnType<typeof vi.fn> };
   getRoomCrypto: ReturnType<typeof vi.fn>;
 }
 
@@ -113,7 +113,7 @@ function makeHarness(name: string, opts: { encrypted: boolean }): Harness {
     getByClientId: vi.fn(async () => undefined),
     updateUploadProgress: vi.fn(async () => undefined),
   };
-  const roomRepo = { updateRoom: vi.fn(async () => undefined) };
+  const roomRepo = { updateRoom: vi.fn(async () => undefined), syncLastMessageLocalStatus: vi.fn(async () => undefined) };
   const roomCrypto = opts.encrypted
     ? {
         canBeEncrypt: () => true,

--- a/src/shared/lib/local-db/__tests__/sync-engine-upload-retry.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-upload-retry.test.ts
@@ -110,7 +110,7 @@ function makeHarness(name: string): Harness {
     getByClientId: vi.fn(async () => undefined),
     updateUploadProgress: vi.fn(async () => undefined),
   };
-  const roomRepo = { updateRoom: vi.fn(async () => undefined) };
+  const roomRepo = { updateRoom: vi.fn(async () => undefined), syncLastMessageLocalStatus: vi.fn(async () => undefined) };
   const getRoomCrypto = vi.fn(async () => undefined);
   const engine = new SyncEngine(
     db as never,

--- a/src/shared/lib/local-db/__tests__/sync-engine-watchdog.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-watchdog.test.ts
@@ -92,7 +92,7 @@ function makeHarness(name: string): Harness {
     getByClientId: vi.fn(async () => undefined),
     updateUploadProgress: vi.fn(async () => undefined),
   };
-  const roomRepo = { updateRoom: vi.fn(async () => undefined) };
+  const roomRepo = { updateRoom: vi.fn(async () => undefined), syncLastMessageLocalStatus: vi.fn(async () => undefined) };
   const engine = new SyncEngine(
     db as never,
     messageRepo as never,

--- a/src/shared/lib/local-db/__tests__/sync-engine.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine.test.ts
@@ -67,7 +67,7 @@ interface Harness {
   db: TestDb;
   engine: SyncEngine;
   messageRepo: { confirmSent: ReturnType<typeof vi.fn>; updateStatus: ReturnType<typeof vi.fn>; getByEventId: ReturnType<typeof vi.fn>; updateReactions: ReturnType<typeof vi.fn>; getByClientId: ReturnType<typeof vi.fn> };
-  roomRepo: { updateRoom: ReturnType<typeof vi.fn> };
+  roomRepo: { updateRoom: ReturnType<typeof vi.fn>; syncLastMessageLocalStatus: ReturnType<typeof vi.fn> };
   getRoomCrypto: ReturnType<typeof vi.fn>;
 }
 
@@ -82,6 +82,7 @@ function makeHarness(name: string): Harness {
   };
   const roomRepo = {
     updateRoom: vi.fn(async () => undefined),
+    syncLastMessageLocalStatus: vi.fn(async () => undefined),
   };
   const getRoomCrypto = vi.fn(async () => undefined); // plain-text path by default
   const engine = new SyncEngine(

--- a/src/shared/lib/local-db/room-repository.ts
+++ b/src/shared/lib/local-db/room-repository.ts
@@ -245,6 +245,27 @@ export class RoomRepository {
     await this.db.rooms.update(roomId, changes);
   }
 
+  /** Keep the chat-list preview transport status in sync with the room's last
+   *  outbound message (WEE-64). Writes `lastMessageLocalStatus` ONLY when
+   *  `messageTimestamp` still matches the room's current `lastMessageTimestamp`
+   *  — i.e. the given message is still the one rendered in the preview. A newer
+   *  message (ours or the peer's) advances `lastMessageTimestamp`, so a stale
+   *  failed/retried send must never overwrite the badge of a later message.
+   *
+   *  Mirrors the SyncEngine success path which stamps `lastMessageLocalStatus:
+   *  "synced"`; used by the failure path (→ "failed") and the retry path
+   *  (→ "pending") so the sidebar matches the open chat. */
+  async syncLastMessageLocalStatus(
+    roomId: string,
+    messageTimestamp: number,
+    status: LocalMessageStatus,
+  ): Promise<void> {
+    const room = await this.db.rooms.get(roomId);
+    if (!room) return;
+    if (room.lastMessageTimestamp !== messageTimestamp) return;
+    await this.db.rooms.update(roomId, { lastMessageLocalStatus: status });
+  }
+
   /** Update the last message preview for a room.
    *  Monotonic: skips the update if the existing preview is already newer,
    *  preventing stale server data from overwriting fresher local-first writes.

--- a/src/shared/lib/local-db/sync-engine-online.test.ts
+++ b/src/shared/lib/local-db/sync-engine-online.test.ts
@@ -83,6 +83,7 @@ describe("SyncEngine.setOnline — retryAllFailed on transition to online", () =
     };
     const roomRepo = {
       updateRoom: vi.fn(),
+      syncLastMessageLocalStatus: vi.fn(),
     };
 
     engine = new SyncEngine(

--- a/src/shared/lib/local-db/sync-engine-queue-health.test.ts
+++ b/src/shared/lib/local-db/sync-engine-queue-health.test.ts
@@ -34,7 +34,7 @@ function buildEngine(db: TestDb): SyncEngine {
     updateReactions: vi.fn(),
     getByClientId: vi.fn(),
   };
-  const roomRepo = { updateRoom: vi.fn() };
+  const roomRepo = { updateRoom: vi.fn(), syncLastMessageLocalStatus: vi.fn() };
   return new SyncEngine(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     db as any,

--- a/src/shared/lib/local-db/sync-engine.ts
+++ b/src/shared/lib/local-db/sync-engine.ts
@@ -11,6 +11,17 @@ type OnChangeCallback = (roomId: string) => void;
 const MAX_BACKOFF_MS = 30_000;
 const MIN_BACKOFF_MS = 1_000;
 
+/** Outbound message-creating ops whose transport status is mirrored onto the
+ *  room's `lastMessageLocalStatus` (chat-list preview, WEE-64). Edit/reaction/
+ *  delete/vote ops mutate an existing message and must never overwrite the
+ *  preview badge. */
+const SEND_OPS: ReadonlySet<PendingOperation["type"]> = new Set([
+  "send_message",
+  "send_file",
+  "send_transfer",
+  "send_poll",
+]);
+
 /** Watchdog tick interval. The watchdog is a safety net for cases where the
  *  connectivity layer fails to deliver a "back online" signal — most commonly
  *  Android WebView after device sleep+wake, where `window.online` may never
@@ -986,6 +997,24 @@ export class SyncEngine {
       { clientId: op.clientId },
       "failed",
     );
+
+    // WEE-64: mirror the success-path room write (:607-610) so the chat-list
+    // preview shows the same failed badge the open chat does. Guarded twice:
+    //   (a) only outbound send-ops — an edit/reaction/delete failure must not
+    //       corrupt the preview badge of an unrelated last message;
+    //   (b) only when this message is still the room's last message
+    //       (RoomRepository.syncLastMessageLocalStatus enforces the timestamp
+    //       check) — a newer message already advanced the preview.
+    if (SEND_OPS.has(op.type)) {
+      const failedMsg = await this.messageRepo.getByClientId(op.clientId);
+      if (failedMsg) {
+        await this.roomRepo.syncLastMessageLocalStatus(
+          op.roomId,
+          failedMsg.timestamp,
+          "failed",
+        );
+      }
+    }
   }
 
   /** Returns true when the local message row for `clientId` already has a
@@ -1042,10 +1071,26 @@ export class SyncEngine {
 
   /** Retry all failed operations */
   async retryAllFailed(): Promise<void> {
+    // Snapshot the failed ops BEFORE resetting them so we can mirror the
+    // reset onto each room's preview status (WEE-64).
+    const failedOps = await this.db.pendingOps.where("status").equals("failed").toArray();
     await this.db.pendingOps
       .where("status")
       .equals("failed")
       .modify({ status: "pending", retries: 0, errorMessage: undefined, nextAttemptAt: 0 });
+
+    // WEE-64: a failed send returning to the queue must reset its chat-list
+    // preview from "failed" back to "pending" (отправляется), symmetric to
+    // markMessageFailed — otherwise the sidebar shows a stale error while the
+    // retry is in flight. Same send-op + still-last-message guards apply.
+    for (const op of failedOps) {
+      if (!op.clientId || !SEND_OPS.has(op.type)) continue;
+      const msg = await this.messageRepo.getByClientId(op.clientId);
+      if (msg) {
+        await this.roomRepo.syncLastMessageLocalStatus(op.roomId, msg.timestamp, "pending");
+      }
+    }
+
     this.processQueue();
   }
 


### PR DESCRIPTION
## Summary
- Chat-list preview showed «отправляется» (часики) forever after a send failed, while the open chat correctly showed the error. Root cause: two status stores — per-message `LocalMessage.status` (open chat, correct) and denormalized `LocalRoom.lastMessageLocalStatus` (sidebar). The success path wrote `"synced"` to the room field; the failure path (`SyncEngine.markMessageFailed`) never did.
- **Fix:** `markMessageFailed` now mirrors the success-path room write, guarded twice — (a) only outbound send-ops (`send_message`/`send_file`/`send_transfer`/`send_poll`), (b) only when the failed message is still the room's last (timestamp match, via new `RoomRepository.syncLastMessageLocalStatus`).
- **Symmetric reset:** `retryAllFailed` (reconnect) and the manual UI retries (`retryMessage`/`retryMediaUpload`) return the preview to «отправляется»; manual-retry failure branches that bypass SyncEngine (matrix-not-ready, enqueue error, media re-fail) also keep the preview consistent.

## Linear
- Resolves WEE-64 (https://linear.app/wwwee/issue/WEE-64)

## Acceptance criteria
- **A1** failed send → error badge in preview ✅
- **A2** survives leave/reopen + app restart (persisted in Dexie) ✅
- **A3** retry → «отправляется» → delivered ✅
- **A4** preview always consistent with open chat (incl. manual-retry re-failure paths) ✅
- **A5** edit/reaction fail and non-last-message fail do NOT corrupt the preview ✅

## Test plan
- [x] New regression tests `sync-engine-failed-room-status.test.ts` (5 cases: failed→failed, not-last no-op, edit/reaction guard, retry→pending, helper timestamp-match) — pass
- [x] Full `src/shared/lib/local-db` suite (230) + `use-messages` (38) pass
- [x] `vite build` passes; no new `vue-tsc` errors in changed files
- [ ] Manual QA on Android: send while offline → preview shows error badge; retry → часики → ✓

> Note: repo baseline (master) already has ~49 `vue-tsc` errors and ~16 failing tests in unrelated files (test-runner globals, VideoTile, DownloadPage, etc.) + no `lint` npm script — all pre-existing, unaffected by this PR. Tests require Node 22 (vitest 4 / rolldown).