### PR TITLE
perf(media): thumbnail-first + concurrency-pool for DM media (WEE-71)

### DIFF
--- a/src/entities/matrix/model/__tests__/mxc-thumbnail.test.ts
+++ b/src/entities/matrix/model/__tests__/mxc-thumbnail.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MatrixClientService } from "../matrix-client";
+
+/**
+ * WEE-71 (H1) — feed previews should pull a light server-side `/thumbnail`
+ * instead of the full-size original for UNENCRYPTED images. `mxcToThumbnail`
+ * forwards width/height/method to the SDK's `mxcUrlToHttp` with
+ * `allowDirectLinks = true` so the homeserver downscales and re-encodes.
+ */
+describe("MatrixClientService.mxcToThumbnail", () => {
+  let service: MatrixClientService;
+
+  beforeEach(() => {
+    service = new MatrixClientService("test.invalid");
+  });
+
+  it("returns a /thumbnail URL forwarding width/height/method", () => {
+    const mxcUrlToHttp = vi.fn(
+      (mxc: string, w: number, h: number, method: string) =>
+        `https://hs.example/_matrix/media/v3/thumbnail/${mxc.slice(6)}?width=${w}&height=${h}&method=${method}`,
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).client = { mxcUrlToHttp };
+
+    const url = service.mxcToThumbnail("mxc://server/abc", 400, 400, "scale");
+
+    expect(url).toContain("/thumbnail/");
+    expect(url).toContain("width=400");
+    expect(url).toContain("height=400");
+    expect(url).toContain("method=scale");
+  });
+
+  it("requests a thumbnail (allowDirectLinks=true) with the given args", () => {
+    const mxcUrlToHttp = vi.fn(() => "https://hs.example/thumb");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).client = { mxcUrlToHttp };
+
+    service.mxcToThumbnail("mxc://server/abc", 320, 240, "crop");
+
+    expect(mxcUrlToHttp).toHaveBeenCalledWith("mxc://server/abc", 320, 240, "crop", true);
+  });
+
+  it("defaults the resize method to scale", () => {
+    const mxcUrlToHttp = vi.fn(() => "https://hs.example/thumb");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).client = { mxcUrlToHttp };
+
+    service.mxcToThumbnail("mxc://server/abc", 400, 400);
+
+    expect(mxcUrlToHttp).toHaveBeenCalledWith("mxc://server/abc", 400, 400, "scale", true);
+  });
+
+  it("returns null when the client is not initialized", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).client = null;
+
+    expect(service.mxcToThumbnail("mxc://server/abc", 400, 400)).toBeNull();
+  });
+
+  it("returns null when the SDK cannot resolve the URI", () => {
+    const mxcUrlToHttp = vi.fn(() => null);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (service as any).client = { mxcUrlToHttp };
+
+    expect(service.mxcToThumbnail("mxc://server/abc", 400, 400)).toBeNull();
+  });
+});

--- a/src/entities/matrix/model/matrix-client.ts
+++ b/src/entities/matrix/model/matrix-client.ts
@@ -606,6 +606,25 @@ export class MatrixClientService {
     return this.client.mxcUrlToHttp(mxcUrl) ?? null;
   }
 
+  /** Convert an mxc:// URI to a server-side thumbnail HTTP URL
+   *  (`/_matrix/media/.../thumbnail`). The homeserver downscales and
+   *  re-encodes, so the feed can show a light preview almost instantly
+   *  instead of pulling the full-size original (WEE-71, H1).
+   *
+   *  Only valid for UNENCRYPTED media: an E2E attachment is ciphertext on
+   *  the server, so a server-side thumbnail would be undecryptable garbage —
+   *  those must be downscaled client-side after decrypt. Returns null when
+   *  the client is missing or the URI cannot be resolved. */
+  mxcToThumbnail(
+    mxcUrl: string,
+    w: number,
+    h: number,
+    method: "scale" | "crop" = "scale",
+  ): string | null {
+    if (!this.client) return null;
+    return this.client.mxcUrlToHttp(mxcUrl, w, h, method, true) ?? null;
+  }
+
   /** Fetch URL preview (Open Graph metadata) from Matrix server */
   async getUrlPreview(url: string): Promise<{
     siteName?: string;

--- a/src/features/messaging/model/use-file-download.test.ts
+++ b/src/features/messaging/model/use-file-download.test.ts
@@ -109,6 +109,7 @@ const {
   appendCacheBust,
   wrapTransientError,
   _resetToastDedupForTests,
+  _mediaGateActiveForTests,
 } = await import("./use-file-download");
 const { MediaUnavailableError, NetworkBlockedError } = await import(
   "@/shared/lib/network/typed-network-errors"
@@ -1151,6 +1152,87 @@ describe("useFileDownload", () => {
       });
       scope.stop();
     });
+  });
+
+  // -------------------------------------------------------------------------
+  // WEE-71 (H2): concurrency-pool — opening a DM full of photos must not fire
+  // every full-size fetch at once (channel flooding + UI freeze on low-end
+  // Android). The shared semaphore caps simultaneous network downloads to 3.
+  // -------------------------------------------------------------------------
+  describe("download — concurrency pool (WEE-71)", () => {
+    it("never runs more than 3 media downloads concurrently", async () => {
+      const originalFetch = global.fetch;
+
+      let activeFetches = 0;
+      let peakFetches = 0;
+      let releaseFetches: () => void = () => {};
+      const fetchGate = new Promise<void>((resolve) => {
+        releaseFetches = resolve;
+      });
+
+      // Each fetch parks on the shared gate so several can be in flight at once
+      // — letting us observe how many the semaphore actually admits.
+      global.fetch = vi.fn(async () => {
+        activeFetches++;
+        peakFetches = Math.max(peakFetches, activeFetches);
+        await fetchGate;
+        activeFetches--;
+        return {
+          ok: true,
+          status: 200,
+          blob: () => Promise.resolve(new Blob([new Uint8Array([1, 2, 3])], { type: "image/jpeg" })),
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any;
+
+      const scope = effectScope();
+      try {
+        await scope.run(async () => {
+          const { download } = useFileDownload();
+          // 6 distinct encrypted-less images — all want the network at once.
+          const downloads = Array.from({ length: 6 }, (_, i) =>
+            download({
+              id: `$evt_pool_${i}`,
+              _key: `client_pool_${i}`,
+              roomId: "!room:server",
+              senderId: "@u:server",
+              content: "photo.jpg",
+              timestamp: Date.now(),
+              status: "sent",
+              type: "image",
+              fileInfo: {
+                name: "photo.jpg",
+                type: "image/jpeg",
+                size: 1024,
+                url: `https://example.com/photo_${i}.jpg`,
+              },
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any),
+          );
+
+          // Let the admitted downloads reach their fetch() and park on the gate.
+          await new Promise((r) => setTimeout(r, 0));
+
+          // At most 3 in flight; the rest queue on the semaphore.
+          expect(_mediaGateActiveForTests()).toBeLessThanOrEqual(3);
+          expect(peakFetches).toBeLessThanOrEqual(3);
+          expect(activeFetches).toBe(3);
+
+          // Drain: release the gate, let every download complete.
+          releaseFetches();
+          await Promise.all(downloads);
+
+          // Pool fully turned over — no leaked permits, and the 6th still ran.
+          expect(_mediaGateActiveForTests()).toBe(0);
+          expect(peakFetches).toBeLessThanOrEqual(3);
+          expect((global.fetch as Mock).mock.calls.length).toBe(6);
+        });
+      } finally {
+        scope.stop();
+        global.fetch = originalFetch;
+      }
+    }, 15_000);
   });
 
   // -------------------------------------------------------------------------

--- a/src/features/messaging/model/use-file-download.ts
+++ b/src/features/messaging/model/use-file-download.ts
@@ -18,6 +18,7 @@ import {
 } from "@/shared/lib/network/typed-network-errors";
 import { waitForRoomCrypto } from "@/entities/matrix/model/wait-for-crypto";
 import { enqueueDecrypt } from "./decrypt-queue";
+import { createSemaphore } from "@/shared/lib/semaphore";
 import { getMediaCache, type MediaCacheCategory } from "@/shared/lib/media-cache";
 import { MessageType, MessageStatus } from "@/entities/chat";
 import { getChatDb, isChatDbReady } from "@/shared/lib/local-db";
@@ -310,6 +311,21 @@ export async function tryHealStaleBlobFileInfo(
     console.warn("[use-file-download] heal: fetchRoomEvent failed:", e);
     return null;
   }
+}
+
+/** Max concurrent media network downloads (fetch + decrypt). Opening a DM
+ *  with N photos used to fire N full-size `fetch` at once: they competed for
+ *  the channel while the serialized decrypt made the last image wait on every
+ *  prior one, and the burst froze the UI on low-end Android. A small pool lets
+ *  the visible media load a few at a time instead of all-at-once (WEE-71, H2).
+ *  Shared module-wide so the cap holds across every `useFileDownload()`
+ *  instance (feed bubbles, MediaGrid, MediaViewer). */
+const MEDIA_FETCH_CONCURRENCY = 3;
+const mediaDownloadGate = createSemaphore(MEDIA_FETCH_CONCURRENCY);
+
+/** TEST-ONLY: expose in-flight count for the concurrency-pool regression. */
+export function _mediaGateActiveForTests(): number {
+  return mediaDownloadGate.active;
 }
 
 /** Cache of already-decrypted file object URLs: eventId → objectUrl */
@@ -916,13 +932,24 @@ export function useFileDownload() {
     }
 
     try {
-      const blob = await downloadAndDecrypt(
-        effectiveFileInfo,
-        message.roomId,
-        message.senderId,
-        message.timestamp,
-        signal,
-      );
+      // Concurrency-pool: cap simultaneous network downloads so a chat full of
+      // media doesn't flood the channel / freeze the UI (WEE-71, H2). The
+      // permit covers only fetch + decrypt — released before the cache-write
+      // and objectUrl plumbing so the pool turns over as fast as possible.
+      // Cache hits returned above never reach here, so they bypass the gate.
+      await mediaDownloadGate.acquire();
+      let blob: Blob;
+      try {
+        blob = await downloadAndDecrypt(
+          effectiveFileInfo,
+          message.roomId,
+          message.senderId,
+          message.timestamp,
+          signal,
+        );
+      } finally {
+        mediaDownloadGate.release();
+      }
       const mimeType = effectiveFileInfo.type || "application/octet-stream";
       const typedBlob = new Blob([blob], { type: mimeType });
       const url = URL.createObjectURL(typedBlob);

--- a/src/features/messaging/ui/MessageBubble.vue
+++ b/src/features/messaging/ui/MessageBubble.vue
@@ -4,6 +4,8 @@ import { useChatStore, MessageStatus, MessageType } from "@/entities/chat";
 import { formatTime } from "@/shared/lib/format";
 import { stripMentionAddresses, stripBastyonLinks } from "@/shared/lib/message-format";
 import { useFileDownload } from "../model/use-file-download";
+import { getMatrixClientService } from "@/entities/matrix";
+import { useLazyLoad } from "@/shared/lib/use-lazy-load";
 import { isMessageFailedForRetry } from "../model/message-failed-state";
 import { useBugReport } from "@/features/bug-report";
 import { tRaw } from "@/shared/lib/i18n";
@@ -481,20 +483,93 @@ const fileIcon = computed(() => {
   return "file";
 });
 
-// Download image immediately — virtual scroller already handles lazy rendering
-onMounted(() => {
-  if (props.message.type === MessageType.image && props.message.fileInfo) {
-    download(props.message);
+// ── Thumbnail-first + lazy-by-visibility for feed images (WEE-71) ──
+// An UNENCRYPTED image renders a light server-side thumbnail directly — no
+// eager full-size fetch. Full-size loads on tap, inside MediaViewer. An
+// ENCRYPTED image (the common DM case) has no usable server thumbnail, so it
+// still goes through the full download/decrypt path — but gated by visibility
+// (download only when the bubble nears the viewport) and capped by the
+// concurrency-pool inside useFileDownload.
+const imageContainerRef = ref<HTMLElement>();
+const { isVisible: imageInViewport } = useLazyLoad(imageContainerRef, "400px");
+
+// Set when a server thumbnail fails to load — falls back to the full-size
+// download so an unencrypted image never regresses to a broken-image state.
+const thumbnailFetchFailed = ref(false);
+
+/** True for an unencrypted image whose URL points at the homeserver — the
+ *  only case where a server `/thumbnail` is meaningful. Encrypted media,
+ *  optimistic `blob:`/`data:` placeholders and non-image types are excluded. */
+const isUnencryptedFeedImage = computed(() => {
+  const fi = props.message.fileInfo;
+  if (props.message.type !== MessageType.image || !fi) return false;
+  if (fi.secrets?.keys) return false;
+  const u = fi.url ?? "";
+  return u.startsWith("mxc://") || u.startsWith("http://") || u.startsWith("https://");
+});
+
+/** Light preview source for the feed `<img>`: a server thumbnail for mxc://
+ *  media, the plain URL for already-http images, or null once it has failed. */
+const feedThumbnailSrc = computed<string | null>(() => {
+  if (thumbnailFetchFailed.value || !isUnencryptedFeedImage.value) return null;
+  const u = props.message.fileInfo!.url;
+  if (!u.startsWith("mxc://")) return u;
+  try {
+    return getMatrixClientService().mxcToThumbnail(u, 400, 400, "scale");
+  } catch {
+    return null;
   }
 });
 
-// Re-download if message changes (virtual scroller recycling)
-watch(() => props.message.id, () => {
-  if (props.message.type === MessageType.image && props.message.fileInfo) {
+/** What the feed image actually shows: the light thumbnail when available,
+ *  otherwise the decrypted/full object URL from the download pipeline. */
+const feedImageSrc = computed<string | null>(
+  () => feedThumbnailSrc.value ?? fileState.value.objectUrl,
+);
+
+/** Kick off the full download for an image only when there is no light
+ *  preview to show: encrypted media (no usable server thumbnail) or an
+ *  unencrypted image whose thumbnail URL couldn't be resolved — e.g. the
+ *  Matrix client wasn't ready yet at cold start. Without this fallback such
+ *  an image would be stuck on the spinner (the download is otherwise skipped
+ *  for the unencrypted/thumbnail path). */
+const triggerImageDownload = () => {
+  if (
+    props.message.type === MessageType.image &&
+    props.message.fileInfo &&
+    !feedThumbnailSrc.value
+  ) {
     download(props.message);
   }
+};
+
+// Gate the encrypted-image download on viewport visibility. `useLazyLoad`
+// latches `isVisible` to true on first intersection (and stays true), so a
+// recycled bubble that is already on screen re-downloads via the id-watch.
+watch(imageInViewport, (visible) => {
+  if (visible) triggerImageDownload();
+}, { immediate: true });
+
+// Re-download / reset preview state if the message changes (virtual scroller
+// recycling reuses the same component instance for a different message).
+watch(() => props.message.id, () => {
   imageDecodeFailed.value = false;
+  thumbnailFetchFailed.value = false;
+  if (imageInViewport.value) triggerImageDownload();
 });
+
+/** A server thumbnail failed to load. For an unencrypted image with no
+ *  full-size objectUrl yet, recover by fetching the full original instead of
+ *  showing the broken-image placeholder. Otherwise it's a genuine decode
+ *  failure (e.g. HEIC) — keep the existing fallback UI. */
+const onFeedImageError = () => {
+  if (feedThumbnailSrc.value && !fileState.value.objectUrl) {
+    thumbnailFetchFailed.value = true;
+    download(props.message);
+    return;
+  }
+  imageDecodeFailed.value = true;
+};
 
 // `imageDecodeFailed` is for images the WebView refuses to decode (typically
 // HEIC/HEIF from senders on other clients that didn't transcode). Without
@@ -509,7 +584,15 @@ const isLikelyHeic = computed(() => {
 });
 
 const handleMediaClick = () => {
-  if ((props.message.type === MessageType.image || props.message.type === MessageType.video) && fileState.value.objectUrl) {
+  if (props.message.type === MessageType.image) {
+    // Open the viewer when we have either the full object URL or a thumbnail
+    // preview (unencrypted path); MediaViewer fetches the full-size on open.
+    if (fileState.value.objectUrl || feedThumbnailSrc.value) {
+      emit("openMedia", props.message);
+    }
+    return;
+  }
+  if (props.message.type === MessageType.video && fileState.value.objectUrl) {
     emit("openMedia", props.message);
   }
 };
@@ -732,9 +815,9 @@ const replyPreviewSender = computed(() => {
             <div class="truncate text-[11px] opacity-70">{{ replyPreviewText }}</div>
           </div>
         </div>
-        <div class="relative cursor-pointer" @click="handleMediaClick">
+        <div ref="imageContainerRef" class="relative cursor-pointer" @click="handleMediaClick">
           <div
-            v-if="fileState.loading || (!fileState.objectUrl && !fileState.error)"
+            v-if="!feedImageSrc && (fileState.loading || (!fileState.objectUrl && !fileState.error))"
             class="flex items-center justify-center bg-neutral-grad-0"
             :style="imagePlaceholderStyle"
           >
@@ -774,7 +857,7 @@ const replyPreviewSender = computed(() => {
             <span class="truncate max-w-full font-medium">{{ message.fileInfo?.name }}</span>
             <span v-if="isLikelyHeic" class="text-[10px] opacity-70">{{ t('message.heicNotSupported') }}</span>
           </div>
-          <img v-else-if="fileState.objectUrl" :src="fileState.objectUrl" :alt="message.fileInfo?.name" class="block max-h-[460px] max-w-full object-cover" :style="imageStyle" @load="emit('resize')" @error="imageDecodeFailed = true" />
+          <img v-else-if="feedImageSrc" :src="feedImageSrc" :alt="message.fileInfo?.name" class="block max-h-[460px] max-w-full object-cover" :style="imageStyle" @load="emit('resize')" @error="onFeedImageError" />
           <!-- Upload progress overlay -->
           <div v-if="isUploading" class="absolute inset-0 flex items-center justify-center bg-black/30">
             <button class="relative flex h-14 w-14 items-center justify-center" @click.stop="emit('cancelUpload', message)">

--- a/src/features/messaging/ui/__tests__/MessageBubble-heic-fallback.test.ts
+++ b/src/features/messaging/ui/__tests__/MessageBubble-heic-fallback.test.ts
@@ -23,8 +23,11 @@ describe("MessageBubble — HEIC / broken-image fallback (WEE-51)", () => {
     expect(source).toMatch(/const imageDecodeFailed = ref\(false\)/);
   });
 
-  it("wires <img>'s @error to flip the fallback flag", () => {
-    expect(source).toMatch(/@error="imageDecodeFailed = true"/);
+  it("wires <img>'s @error to the fallback handler that flips the flag", () => {
+    // WEE-71 routed @error through onFeedImageError (thumbnail-first recovery),
+    // but a genuine decode failure still flips imageDecodeFailed inside it.
+    expect(source).toMatch(/@error="onFeedImageError"/);
+    expect(source).toMatch(/imageDecodeFailed\.value = true/);
   });
 
   it("resets the fallback flag when the bubble is recycled for a different message", () => {

--- a/src/shared/lib/semaphore.test.ts
+++ b/src/shared/lib/semaphore.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { createSemaphore } from "./semaphore";
+
+/** Drain the microtask queue so queued `acquire()` resolutions settle. */
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("createSemaphore", () => {
+  it("rejects a non-positive or non-integer max", () => {
+    expect(() => createSemaphore(0)).toThrow();
+    expect(() => createSemaphore(-1)).toThrow();
+    expect(() => createSemaphore(1.5)).toThrow();
+  });
+
+  it("resolves immediately while slots are free", async () => {
+    const sem = createSemaphore(2);
+    await sem.acquire();
+    await sem.acquire();
+    expect(sem.active).toBe(2);
+    expect(sem.pending).toBe(0);
+  });
+
+  it("queues acquisitions beyond the limit and resolves them on release", async () => {
+    const sem = createSemaphore(2);
+    await sem.acquire();
+    await sem.acquire();
+
+    let thirdResolved = false;
+    const third = sem.acquire().then(() => {
+      thirdResolved = true;
+    });
+
+    await flush();
+    expect(thirdResolved).toBe(false);
+    expect(sem.pending).toBe(1);
+    expect(sem.active).toBe(2);
+
+    sem.release();
+    await third;
+    expect(thirdResolved).toBe(true);
+    expect(sem.active).toBe(2); // slot handed off, still full
+    expect(sem.pending).toBe(0);
+  });
+
+  it("never lets more than `max` operations run concurrently", async () => {
+    const LIMIT = 3;
+    const TASKS = 12;
+    const sem = createSemaphore(LIMIT);
+    let inFlight = 0;
+    let peak = 0;
+
+    const run = async (): Promise<void> => {
+      await sem.acquire();
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      try {
+        await flush(); // simulate async work
+      } finally {
+        inFlight--;
+        sem.release();
+      }
+    };
+
+    await Promise.all(Array.from({ length: TASKS }, run));
+
+    expect(peak).toBeLessThanOrEqual(LIMIT);
+    expect(sem.active).toBe(0);
+    expect(sem.pending).toBe(0);
+  });
+
+  it("preserves FIFO order for queued waiters", async () => {
+    const sem = createSemaphore(1);
+    await sem.acquire();
+
+    const order: number[] = [];
+    const w1 = sem.acquire().then(() => order.push(1));
+    const w2 = sem.acquire().then(() => order.push(2));
+    const w3 = sem.acquire().then(() => order.push(3));
+
+    sem.release();
+    await w1;
+    sem.release();
+    await w2;
+    sem.release();
+    await w3;
+
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it("ignores a stray release() when nothing is held", () => {
+    const sem = createSemaphore(2);
+    sem.release();
+    sem.release();
+    expect(sem.active).toBe(0);
+  });
+});

--- a/src/shared/lib/semaphore.ts
+++ b/src/shared/lib/semaphore.ts
@@ -1,0 +1,68 @@
+/**
+ * Counting semaphore — ограничивает число одновременно выполняемых
+ * асинхронных операций.
+ *
+ * Зачем: на слабых Android одновременный `fetch` + decrypt нескольких
+ * полноразмерных фото в личном чате забивает сетевой канал и сатурирует CPU,
+ * из-за чего последняя картинка ждёт декрипт всех предыдущих, а UI фризит.
+ * Семафор держит не более `max` операций в полёте, остальные ждут в FIFO-
+ * очереди (WEE-71, H2 concurrency-pool).
+ *
+ * Контракт: каждый успешный `acquire()` ОБЯЗАН быть закрыт ровно одним
+ * `release()` (обычно в `finally`). Лишние `release()` без захвата
+ * игнорируются, чтобы случайный двойной вызов не «раздул» пул выше `max`.
+ */
+export interface Semaphore {
+  /** Захватить разрешение. Резолвится сразу при свободном слоте, иначе
+   *  встаёт в FIFO-очередь и резолвится при следующем `release()`. */
+  acquire(): Promise<void>;
+  /** Освободить разрешение: пропускает первого ожидающего из очереди, а если
+   *  очередь пуста — уменьшает счётчик активных. */
+  release(): void;
+  /** Число операций в полёте (для тестов/диагностики). */
+  readonly active: number;
+  /** Число ожидающих в очереди (для тестов/диагностики). */
+  readonly pending: number;
+}
+
+export function createSemaphore(max: number): Semaphore {
+  if (!Number.isInteger(max) || max < 1) {
+    throw new Error(`createSemaphore: max must be a positive integer, got ${String(max)}`);
+  }
+
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  const acquire = (): Promise<void> => {
+    if (active < max) {
+      active++;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      queue.push(resolve);
+    });
+  };
+
+  const release = (): void => {
+    const next = queue.shift();
+    if (next) {
+      // Слот передаётся следующему ожидающему: `active` не меняется — место
+      // освободившейся операции занимает разбуженный из очереди.
+      next();
+      return;
+    }
+    // Очередь пуста — реально освобождаем слот. Guard от лишнего release().
+    if (active > 0) active--;
+  };
+
+  return {
+    acquire,
+    release,
+    get active() {
+      return active;
+    },
+    get pending() {
+      return queue.length;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- **Concurrency-pool (H2):** new `createSemaphore()` util + module-level pool caps simultaneous media network downloads to **3** (`use-file-download.ts`). Cache hits bypass the gate; permit released around fetch+decrypt only.
- **Thumbnail-first for unencrypted (H1):** new `mxcToThumbnail()` (`matrix-client.ts`) resolves the homeserver `/thumbnail` for unencrypted images; the feed renders a light preview instead of the full-size original, with an `@error` → full-download fallback so images never regress to a broken state.
- **Lazy-by-visibility:** `MessageBubble.vue` replaces the eager `onMounted → download()` with an `IntersectionObserver` gate (`useLazyLoad`), so offscreen overscan bubbles don't download until they near the viewport.
- **Encrypted DM path is byte-identical** to before — now additionally gated by visibility + the concurrency pool.

Worker-decrypt (H3), encrypted client-side downscale, and base64-free native cache (H4) are deferred to a follow-up PR, as the ticket permits (H1+H2 as a standalone first PR).

## Linear
- Resolves [WEE-71](https://linear.app/wwwee/issue/WEE-71) (media: фото/видео в личных чатах грузятся очень долго)

## Closes
_No linked forta-bugs issues — reported directly by a user; no `forta-bugs#NNN` references in the ticket._

## Test plan
- [x] `createSemaphore` unit tests (limit, FIFO, no-leak, peak ≤ max) — `semaphore.test.ts`
- [x] `mxcToThumbnail` unit tests (forwards w/h/method, allowDirectLinks, null paths) — `mxc-thumbnail.test.ts`
- [x] Concurrency-pool regression: ≤3 in-flight, full turnover, all 6 run — `use-file-download.test.ts`
- [x] HEIC fallback source test updated for the new `@error` handler
- [x] `vue-tsc --noEmit`: 0 new type errors (49 total = pre-existing master baseline)
- [x] `vite build` succeeds
- [x] Full suite: 2461 pass; 18 fail are all pre-existing baseline failures in unrelated files (chat-helpers, video-embed, ChatWindow useLiveQuery mock, etc.)
- [ ] Manual QA on Android: open a DM with ~10 photos — visible previews appear fast, ≤3 concurrent network loads, full-size opens on tap, no UI freeze
- [ ] Regression: media send/receive/download still works (WEE-17/50/62)

> Note: `npm run build` is red only because its `vue-tsc` gate hits the pre-existing 49-error master baseline — none from this change. `vite build` (bundling) passes.