### PR TITLE
fix(channels): channel video — no eternal spinner + bounded post skeleton (WEE-70)

### DIFF
--- a/src/features/post-player/ui/PostCard.vue
+++ b/src/features/post-player/ui/PostCard.vue
@@ -10,8 +10,14 @@ import VideoPlayer from "./VideoPlayer.vue";
 import StarRating from "./StarRating.vue";
 import PostPlayerModal from "./PostPlayerModal.vue";
 import { renderArticleText } from "@/shared/lib/article-blocks";
+import { withTimeout } from "@/shared/lib/with-timeout";
 import { useChatStore } from "@/entities/chat";
 import DonateModal from "@/features/wallet/ui/DonateModal.vue";
+
+// Bound the skeleton: on slow networks (Tor) loadPost can hang indefinitely and
+// the skeleton reads as an eternal spinner (WEE-70). After this many ms we drop
+// to an error state with a retry button instead.
+const POST_LOAD_TIMEOUT_MS = 15_000;
 
 interface Props {
   txid: string;
@@ -121,11 +127,13 @@ function onAuthorClick() {
   }
 }
 
-onMounted(async () => {
+async function loadPostData() {
+  loading.value = true;
+  error.value = false;
   try {
     let data = post.value;
     if (!data) {
-      data = await authStore.loadPost(props.txid);
+      data = await withTimeout(authStore.loadPost(props.txid), POST_LOAD_TIMEOUT_MS, "loadPost");
       if (!data) { error.value = true; return; }
       post.value = data;
     }
@@ -136,7 +144,13 @@ onMounted(async () => {
   } finally {
     loading.value = false;
   }
-});
+}
+
+function onRetry() {
+  loadPostData();
+}
+
+onMounted(loadPostData);
 </script>
 
 <template>
@@ -176,14 +190,19 @@ onMounted(async () => {
   </div>
 
   <!-- Error -->
-  <a
-    v-else-if="error"
-    :href="postUrl"
-    target="_blank"
-    rel="noopener noreferrer"
-    class="text-color-txt-ac underline hover:no-underline"
-    @click.stop
-  >{{ t("post.notFound") }}</a>
+  <div v-else-if="error" class="flex items-center gap-3 py-1">
+    <a
+      :href="postUrl"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="text-color-txt-ac underline hover:no-underline"
+      @click.stop
+    >{{ t("post.notFound") }}</a>
+    <button
+      class="rounded-lg border border-neutral-grad-1/50 px-2.5 py-1 text-xs font-medium text-text-color transition-colors hover:bg-neutral-grad-0"
+      @click.stop="onRetry"
+    >{{ t("post.retry") }}</button>
+  </div>
 
   <!-- Post card -->
   <div

--- a/src/features/post-player/ui/VideoPlayer.vue
+++ b/src/features/post-player/ui/VideoPlayer.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { parseVideoUrl, fetchPeerTubeThumb } from "@/shared/lib/video-embed";
 import { useAndroidBackHandler } from "@/shared/lib/composables/use-android-back-handler";
+import { isNative } from "@/shared/lib/platform";
+import { openExternalUrl } from "@/shared/lib/open-external-url";
 
 interface Props {
   url: string;
@@ -12,10 +14,42 @@ const props = withDefaults(defineProps<Props>(), { inline: false });
 const videoInfo = computed(() => parseVideoUrl(props.url));
 const playing = ref(false);
 const error = ref(false);
+const iframeLoaded = ref(false);
+const spinnerTimedOut = ref(false);
 const peertubeThumb = ref("");
 const isFullscreen = ref(false);
 
+// Belt-and-suspenders for old Android WebViews where iframe @load may never
+// fire: stop showing our overlay spinner after this long so it can't become
+// the very "eternal spinner" this fix removes. The "Open externally" fallback
+// stays available regardless.
+const SPINNER_TIMEOUT_MS = 10_000;
+let spinnerTimer: ReturnType<typeof setTimeout> | null = null;
+
+const clearSpinnerTimer = () => {
+  if (spinnerTimer !== null) {
+    clearTimeout(spinnerTimer);
+    spinnerTimer = null;
+  }
+};
+
 const thumbUrl = computed(() => peertubeThumb.value || videoInfo.value?.thumbUrl || "");
+
+// Android WebView blocks autoplay for cross-origin sandboxed iframes, so the
+// embed silently never starts and its own spinner spins forever (WEE-70). On
+// native we drop ?autoplay=1 and let the user tap play inside the embed; on
+// web/desktop autoplay works as before.
+const embedSrc = computed(() => {
+  const base = videoInfo.value?.embedUrl ?? "";
+  return isNative ? base : `${base}?autoplay=1`;
+});
+
+// Our own overlay spinner is only shown while the iframe is still fetching.
+// Once @load fires we hide it; if it never loads, the "Open externally"
+// fallback is available from the first tap as a safety net.
+const showSpinner = computed(
+  () => playing.value && !iframeLoaded.value && !error.value && !spinnerTimedOut.value,
+);
 
 const onFullscreenChange = () => {
   isFullscreen.value = !!document.fullscreenElement;
@@ -32,6 +66,7 @@ onMounted(async () => {
 
 onUnmounted(() => {
   document.removeEventListener("fullscreenchange", onFullscreenChange);
+  clearSpinnerTimer();
 });
 
 // Android back: exit iframe fullscreen instead of closing the post.
@@ -46,11 +81,29 @@ useAndroidBackHandler("post-video-fullscreen", 100, () => {
 
 const play = () => {
   playing.value = true;
+  spinnerTimedOut.value = false;
+  clearSpinnerTimer();
+  spinnerTimer = setTimeout(() => {
+    spinnerTimedOut.value = true;
+    spinnerTimer = null;
+  }, SPINNER_TIMEOUT_MS);
+};
+
+const onIframeLoad = () => {
+  iframeLoaded.value = true;
+  clearSpinnerTimer();
 };
 
 const onIframeError = () => {
   error.value = true;
   playing.value = false;
+  clearSpinnerTimer();
+};
+
+// Route through openExternalUrl: on native a plain <a target="_blank"> is a
+// no-op inside Capacitor's WebView, so we launch a Custom Tab instead.
+const openExternal = () => {
+  void openExternalUrl(props.url);
 };
 </script>
 
@@ -62,16 +115,39 @@ const onIframeError = () => {
   >
     <iframe
       v-if="playing && !error"
-      :src="videoInfo.embedUrl + '?autoplay=1'"
+      :src="embedSrc"
       class="absolute inset-0 h-full w-full"
       frameborder="0"
       sandbox="allow-same-origin allow-scripts allow-presentation allow-forms allow-popups"
       allow="autoplay; picture-in-picture; fullscreen"
       allowfullscreen
+      @load="onIframeLoad"
       @error="onIframeError"
     />
 
-    <template v-else>
+    <!-- Loading overlay while the iframe is fetching; hidden once @load fires -->
+    <div
+      v-if="showSpinner"
+      data-testid="video-loading"
+      class="pointer-events-none absolute inset-0 flex items-center justify-center bg-black/60"
+    >
+      <svg class="animate-spin" width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" opacity="0.85">
+        <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+      </svg>
+    </div>
+
+    <!-- External fallback available from the first tap (not only on error) -->
+    <a
+      v-if="playing && !error"
+      data-testid="video-external"
+      :href="url"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="absolute bottom-2 right-2 z-10 rounded bg-black/60 px-2 py-1 text-xs text-white underline"
+      @click.stop.prevent="openExternal"
+    >Open externally</a>
+
+    <template v-if="!playing && !error">
       <img
         v-if="thumbUrl"
         :src="thumbUrl"
@@ -104,7 +180,7 @@ const onIframeError = () => {
         target="_blank"
         rel="noopener noreferrer"
         class="text-sm text-color-txt-ac underline"
-        @click.stop
+        @click.stop.prevent="openExternal"
       >Open video externally</a>
     </div>
   </div>

--- a/src/features/post-player/ui/__tests__/PostCard.test.ts
+++ b/src/features/post-player/ui/__tests__/PostCard.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+
+// Stub composables/stores BEFORE component import (vi.mock is hoisted).
+const loadPost = vi.fn();
+const getCachedPost = vi.fn(() => null);
+vi.mock("@/entities/auth", () => ({
+  useAuthStore: () => ({
+    address: "myaddr",
+    getCachedPost,
+    loadPost,
+    loadUsersInfo: vi.fn().mockResolvedValue(undefined),
+    getBastyonUserData: () => null,
+  }),
+}));
+vi.mock("@/entities/chat", () => ({
+  useChatStore: () => ({ initPostForward: vi.fn() }),
+}));
+vi.mock("../model/use-post-scores", () => ({
+  usePostScores: () => ({
+    myScore: { value: null },
+    averageScore: { value: 0 },
+    totalVotes: { value: 0 },
+    hasVoted: { value: false },
+    submitting: { value: false },
+    load: vi.fn().mockResolvedValue(undefined),
+    submitVote: vi.fn(),
+  }),
+}));
+vi.mock("../model/use-post-boost", () => ({
+  usePostBoost: () => ({
+    showDonateModal: { value: false },
+    boostAddress: { value: "" },
+    openBoost: vi.fn(),
+    closeBoost: vi.fn(),
+  }),
+}));
+vi.mock("@/shared/lib/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+vi.mock("@/shared/lib/video-embed", () => ({
+  parseVideoUrl: () => null,
+}));
+vi.mock("@/shared/lib/image-url", () => ({
+  normalizePocketnetImageUrl: (x: string) => x,
+}));
+
+vi.stubGlobal("useI18n", () => ({ t: (k: string) => k }));
+
+import PostCard from "../PostCard.vue";
+
+const POST_LOAD_TIMEOUT_MS = 15_000;
+
+const stubs = {
+  VideoPlayer: true,
+  StarRating: true,
+  PostPlayerModal: true,
+  DonateModal: true,
+  PostCard: true,
+};
+
+function mountCard() {
+  return mount(PostCard, {
+    props: { txid: "tx123", isOwn: false },
+    global: { stubs },
+  });
+}
+
+describe("PostCard bounded skeleton + retry (WEE-70)", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+    loadPost.mockReset();
+    getCachedPost.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("показывает skeleton пока loadPost в полёте", async () => {
+    loadPost.mockReturnValue(new Promise(() => {})); // never resolves
+    const w = mountCard();
+    await flushPromises();
+
+    // Skeleton present, no interactive error/retry controls yet.
+    expect(w.find(".animate-pulse").exists()).toBe(true);
+    expect(w.find("button").exists()).toBe(false);
+  });
+
+  it("при таймауте loadPost показывает ошибку + retry, а не вечный skeleton", async () => {
+    loadPost.mockReturnValue(new Promise(() => {})); // hangs forever
+    const w = mountCard();
+
+    await vi.advanceTimersByTimeAsync(POST_LOAD_TIMEOUT_MS + 1);
+    await flushPromises();
+
+    // Skeleton is gone; error state with a not-found link + retry button shows.
+    expect(w.find(".animate-pulse").exists()).toBe(false);
+    expect(w.find("a").exists()).toBe(true);
+    expect(w.find("button").exists()).toBe(true);
+  });
+
+  it("retry повторно вызывает loadPost", async () => {
+    loadPost.mockReturnValue(new Promise(() => {}));
+    const w = mountCard();
+
+    await vi.advanceTimersByTimeAsync(POST_LOAD_TIMEOUT_MS + 1);
+    await flushPromises();
+    expect(loadPost).toHaveBeenCalledTimes(1);
+
+    await w.find("button").trigger("click");
+    await flushPromises();
+    expect(loadPost).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/features/post-player/ui/__tests__/VideoPlayer.test.ts
+++ b/src/features/post-player/ui/__tests__/VideoPlayer.test.ts
@@ -1,11 +1,37 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount, flushPromises } from "@vue/test-utils";
+
+// Mutable platform mock — `mock` prefix lets the hoisted factory reference it.
+let mockIsNative = false;
+vi.mock("@/shared/lib/platform", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/lib/platform")>();
+  return {
+    ...actual,
+    get isNative() {
+      return mockIsNative;
+    },
+  };
+});
+
+// Browser fallback must never be a real no-op `window.open` on native; spy on it.
+const openExternalUrl = vi.fn();
+vi.mock("@/shared/lib/open-external-url", () => ({
+  openExternalUrl: (url: string) => openExternalUrl(url),
+}));
+
 import VideoPlayer from "../VideoPlayer.vue";
+
+const YT_URL = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+
+beforeEach(() => {
+  mockIsNative = false;
+  openExternalUrl.mockClear();
+});
 
 describe("VideoPlayer iframe security", () => {
   it("renders iframe with sandbox attribute set after play is clicked", async () => {
     const wrapper = mount(VideoPlayer, {
-      props: { url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ" },
+      props: { url: YT_URL },
     });
 
     expect(wrapper.find("iframe").exists()).toBe(false);
@@ -20,5 +46,86 @@ describe("VideoPlayer iframe security", () => {
     expect(sandbox).toContain("allow-scripts");
     expect(sandbox).toContain("allow-same-origin");
     expect(sandbox).toContain("allow-presentation");
+  });
+});
+
+describe("VideoPlayer channel spinner (WEE-70)", () => {
+  it("после @load iframe скрывает loading-overlay", async () => {
+    const wrapper = mount(VideoPlayer, { props: { url: YT_URL } });
+
+    await wrapper.find("button").trigger("click");
+    await flushPromises();
+
+    // Spinner shown while the iframe is still loading.
+    expect(wrapper.find("[data-testid='video-loading']").exists()).toBe(true);
+
+    await wrapper.find("iframe").trigger("load");
+    await flushPromises();
+
+    // Spinner disappears once the iframe reports load.
+    expect(wrapper.find("[data-testid='video-loading']").exists()).toBe(false);
+  });
+
+  it("на native не добавляет ?autoplay=1 в iframe src", async () => {
+    mockIsNative = true;
+    const wrapper = mount(VideoPlayer, { props: { url: YT_URL } });
+
+    await wrapper.find("button").trigger("click");
+    await flushPromises();
+
+    const src = wrapper.find("iframe").attributes("src") ?? "";
+    expect(src).not.toContain("autoplay");
+    expect(src).toBe("https://www.youtube.com/embed/dQw4w9WgXcQ");
+  });
+
+  it("на web сохраняет ?autoplay=1 в iframe src", async () => {
+    const wrapper = mount(VideoPlayer, { props: { url: YT_URL } });
+
+    await wrapper.find("button").trigger("click");
+    await flushPromises();
+
+    const src = wrapper.find("iframe").attributes("src") ?? "";
+    expect(src).toContain("autoplay=1");
+  });
+
+  it("показывает «открыть внешне» сразу после тапа play (не только по error)", async () => {
+    const wrapper = mount(VideoPlayer, { props: { url: YT_URL } });
+
+    await wrapper.find("button").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.find("[data-testid='video-external']").exists()).toBe(true);
+  });
+
+  it("прячет overlay-спиннер по таймауту, даже если @load не сработал", async () => {
+    vi.useFakeTimers();
+    try {
+      const wrapper = mount(VideoPlayer, { props: { url: YT_URL } });
+
+      await wrapper.find("button").trigger("click");
+      await flushPromises();
+      expect(wrapper.find("[data-testid='video-loading']").exists()).toBe(true);
+
+      // No @load ever fires — spinner must still go away after the timeout.
+      await vi.advanceTimersByTimeAsync(10_001);
+      await flushPromises();
+
+      expect(wrapper.find("[data-testid='video-loading']").exists()).toBe(false);
+      // External fallback remains reachable.
+      expect(wrapper.find("[data-testid='video-external']").exists()).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("на native «открыть внешне» уходит через openExternalUrl, а не window.open", async () => {
+    mockIsNative = true;
+    const wrapper = mount(VideoPlayer, { props: { url: YT_URL } });
+
+    await wrapper.find("button").trigger("click");
+    await flushPromises();
+
+    await wrapper.find("[data-testid='video-external']").trigger("click");
+    expect(openExternalUrl).toHaveBeenCalledWith(YT_URL);
   });
 });

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -637,6 +637,7 @@ export const en = {
   // ── Post embeds ──
   "post.loading": "Loading post...",
   "post.notFound": "Post not found",
+  "post.retry": "Retry",
   "post.readMore": "Read more",
   "post.video": "Video",
   "post.article": "Article",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -639,6 +639,7 @@ export const ru: Record<TranslationKey, string> = {
   // ── Post embeds ──
   "post.loading": "Загрузка поста...",
   "post.notFound": "Пост не найден",
+  "post.retry": "Повторить",
   "post.readMore": "Читать далее",
   "post.video": "Видео",
   "post.article": "Статья",


### PR DESCRIPTION
## Summary
- **Channel video spinner (Android):** channel video uses iframe-embed (`VideoPlayer.vue`), a different path than chat video (WEE-62). Android WebView silently blocks `?autoplay=1` on cross-origin sandboxed iframes → the embed's own spinner spins forever. Fix: drop `?autoplay=1` on native, add `@load` overlay gated by `showSpinner` (+10s timeout safety for old WebViews), and expose "Open externally" from the first tap (routed through `openExternalUrl` since `target=_blank` is a no-op in Capacitor WebView).
- **Bounded post skeleton:** `PostCard.vue` `loadPost` wrapped in `withTimeout(15s)` + retry button, so a slow (Tor) load no longer reads as an eternal spinner.
- **i18n:** added `post.retry` (en/ru).
- **Tests:** `VideoPlayer.test.ts` (+6) and new `PostCard.test.ts` (+3) regression coverage.

## Linear
- Resolves WEE-70 (https://linear.app/wwwee/issue/WEE-70)

## Closes
Closes greenShirtMystery/forta-bugs#925
Closes greenShirtMystery/forta-bugs#930

## Refs (out of scope — background playback is a separate feature)
Refs greenShirtMystery/forta-bugs#915
Refs greenShirtMystery/forta-bugs#933

> Background playback (#915/#933) is intentionally NOT in this PR — it needs `FOREGROUND_SERVICE_MEDIA_PLAYBACK` + a native service + migrating channel video off iframe to `<video>`. Documented as a separate feature with an estimate.

## Test plan
- [x] `vite build` passes (production bundle)
- [x] `vue-tsc --noEmit`: 0 new errors in changed files (49 = pre-existing master baseline)
- [x] Unit tests added (`VideoPlayer.test.ts`, `PostCard.test.ts`) — 10 pass
- [ ] Manual QA on Android: tap channel video → poster + load overlay clears (or "Open externally" works), no eternal spinner; slow post → skeleton times out with retry
- [x] Chat-video path (WEE-62) untouched

> Note: no `lint` script in this project; build = `vue-tsc && vite build`.