### PR TITLE
fix(providers): enable save for valid Meet URL + Android safe-area padding (WEE-68)

### DIFF
--- a/src/features/user-management/ui/CallProviderDialog.vue
+++ b/src/features/user-management/ui/CallProviderDialog.vue
@@ -41,19 +41,23 @@ function onSave(): void {
     </h3>
 
     <!-- Label -->
-    <label class="mb-1.5 block text-xs font-medium text-text-on-main-bg-color">{{ t("settings.callProviders.label") }}</label>
+    <label class="mb-1.5 block text-xs font-medium text-text-on-main-bg-color">
+      {{ t("settings.callProviders.label") }} <span class="text-color-bad">*</span>
+    </label>
     <input
       v-model="label"
       type="text"
       :placeholder="t('settings.callProviders.labelPlaceholder')"
-      class="mb-4 w-full rounded-xl border border-neutral-grad-2 bg-transparent px-3.5 py-2.5 text-sm text-text-color outline-none transition-colors focus:border-color-bg-ac"
+      class="w-full rounded-xl border bg-transparent px-3.5 py-2.5 text-sm text-text-color outline-none transition-colors focus:border-color-bg-ac"
+      :class="showError && !trimmedLabel.length ? 'border-color-bad' : 'border-neutral-grad-2'"
     />
+    <p v-if="showError && !trimmedLabel.length" class="mt-1.5 text-xs text-color-bad">{{ t("settings.callProviders.labelRequired") }}</p>
 
     <!-- URL -->
-    <label class="mb-1.5 block text-xs font-medium text-text-on-main-bg-color">{{ t("settings.callProviders.url") }}</label>
+    <label class="mb-1.5 mt-4 block text-xs font-medium text-text-on-main-bg-color">{{ t("settings.callProviders.url") }}</label>
     <input
       v-model="url"
-      type="url"
+      type="text"
       inputmode="url"
       autocapitalize="off"
       autocomplete="off"

--- a/src/features/user-management/ui/__tests__/call-provider-dialog.test.ts
+++ b/src/features/user-management/ui/__tests__/call-provider-dialog.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+
+// ───────────────── Mocks ─────────────────
+vi.mock("@/shared/lib/i18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+// Modal renders its default slot inline so we can query the form fields.
+vi.mock("@/shared/ui/modal/Modal.vue", () => ({
+  default: {
+    name: "Modal",
+    props: ["show", "ariaLabel"],
+    template: "<div class='modal-stub'><slot /></div>",
+  },
+}));
+
+import CallProviderDialog from "../CallProviderDialog.vue";
+
+function mountDialog() {
+  return mount(CallProviderDialog, { props: { show: true } });
+}
+
+describe("CallProviderDialog", () => {
+  const MEET_URL = "https://meet.google.com/abc-defg-hij";
+
+  it("Сохранить активна при валидной Google Meet ссылке и заполненном label", async () => {
+    const wrapper = mountDialog();
+    const saveBtn = wrapper.findAll("button").find((b) => b.text() === "settings.callProviders.save")!;
+    expect(saveBtn.attributes("disabled")).toBeDefined();
+
+    await wrapper.find('input[type="text"]').setValue("Meet");
+    await wrapper.find('input[inputmode="url"]').setValue(MEET_URL);
+
+    expect(saveBtn.attributes("disabled")).toBeUndefined();
+
+    await saveBtn.trigger("click");
+    const saved = wrapper.emitted("save");
+    expect(saved).toBeTruthy();
+    expect(saved![0][0]).toEqual({ label: "Meet", urlTemplate: MEET_URL });
+  });
+
+  it("url-поле использует type=text (без type=url deferral на Android OEM)", () => {
+    const wrapper = mountDialog();
+    const urlInput = wrapper.find('input[inputmode="url"]');
+    // type=url откладывает input-событие до blur на части Android OEM WebView.
+    expect(urlInput.attributes("type")).toBe("text");
+    expect(urlInput.attributes("inputmode")).toBe("url");
+    expect(urlInput.attributes("autocapitalize")).toBe("off");
+  });
+
+  it("label показывает индикатор обязательности (*) и Сохранить остаётся disabled при валидном url, но пустом label", async () => {
+    const wrapper = mountDialog();
+    // Индикатор обязательности виден всегда — это и есть UX-фикс (#918): пользователь понимает, почему Сохранить неактивна.
+    expect(wrapper.find("label").text()).toContain("*");
+
+    // url валиден и обновляется немедленно (type=text), но label пуст → Сохранить disabled.
+    await wrapper.find('input[inputmode="url"]').setValue(MEET_URL);
+    const saveBtn = wrapper.findAll("button").find((b) => b.text() === "settings.callProviders.save")!;
+    expect(saveBtn.attributes("disabled")).toBeDefined();
+    expect(wrapper.emitted("save")).toBeFalsy();
+  });
+
+  it("сохранение существующего провайдера (Zoom/Jitsi) по-прежнему работает — регрессия WEE-57", async () => {
+    const wrapper = mount(CallProviderDialog, {
+      props: {
+        show: true,
+        provider: { id: 1, label: "Zoom", urlTemplate: "https://zoom.us/j/123" },
+      },
+    });
+    const saveBtn = wrapper.findAll("button").find((b) => b.text() === "settings.callProviders.save")!;
+    expect(saveBtn.attributes("disabled")).toBeUndefined();
+
+    await saveBtn.trigger("click");
+    const saved = wrapper.emitted("save");
+    expect(saved).toBeTruthy();
+    expect(saved![0]).toEqual([{ label: "Zoom", urlTemplate: "https://zoom.us/j/123" }, 1]);
+  });
+});

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -581,6 +581,7 @@ export const en = {
   "settings.callProviders.addTitle": "New call method",
   "settings.callProviders.editTitle": "Edit call method",
   "settings.callProviders.invalidUrl": "Enter a valid link (https://…)",
+  "settings.callProviders.labelRequired": "Enter a name for this method",
 
   // ── Auth / Login ──
   "auth.signIn": "Sign In",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -583,6 +583,7 @@ export const ru: Record<TranslationKey, string> = {
   "settings.callProviders.addTitle": "Новый способ связи",
   "settings.callProviders.editTitle": "Изменить способ связи",
   "settings.callProviders.invalidUrl": "Введите корректную ссылку (https://…)",
+  "settings.callProviders.labelRequired": "Введите название способа связи",
 
   // ── Auth / Login ──
   "auth.signIn": "Войти",

--- a/src/widgets/sidebar/ui/SettingsContentPanel.vue
+++ b/src/widgets/sidebar/ui/SettingsContentPanel.vue
@@ -190,7 +190,7 @@ const title = computed(() => {
     </div>
 
     <!-- ════════ Video call methods (WEE-57) ════════ -->
-    <div v-else-if="settingsSubView === 'callMethods'" class="flex-1 overflow-y-auto">
+    <div v-else-if="settingsSubView === 'callMethods'" class="flex-1 overflow-y-auto pb-safe">
       <div class="mx-auto max-w-2xl p-6">
         <CallProvidersSection />
       </div>


### PR DESCRIPTION
## Summary
- Fix Save staying disabled for a valid Google Meet link: `type="url"` deferred the `input` event until blur on some Android OEM WebViews, so `v-model url` never updated while the keyboard was open. Switched to `type="text"` (kept `inputmode="url"`, `autocapitalize="off"`).
- Added a visible required indicator (`*`) + inline error on the label field so the user understands why Save is disabled.
- Added `pb-safe` to the `callMethods` settings container so the Add button clears Android gesture navigation (`pb-safe` = `var(--safe-area-inset-bottom, 0px)`, 0px on web).

## Linear
- Resolves [WEE-68](https://linear.app/wwwee/issue/WEE-68)

## Closes
Closes greenShirtMystery/forta-bugs#918
Closes greenShirtMystery/forta-bugs#917

## Test plan
- [x] `vue-tsc --noEmit` — no new errors (49 baseline, 0 in changed files)
- [x] `vite build` — passes
- [x] Unit tests added (`call-provider-dialog.test.ts`, 4 passing): valid Meet URL + label enables Save; url input uses `type=text`; required indicator + disabled-on-empty-label; WEE-57 Zoom/Jitsi edit-mode save still works
- [ ] Manual QA on Android: paste Meet link with keyboard open → Save enables without blur; Add button fully visible above gesture nav