### PR TITLE
fix(ui): localize relative dates, Android Back filter tabs, displayName guard (WEE-67)

### DIFF
--- a/src/entities/chat/model/__tests__/get-display-name-alias.test.ts
+++ b/src/entities/chat/model/__tests__/get-display-name-alias.test.ts
@@ -48,6 +48,33 @@ describe("getDisplayName — local alias priority", () => {
     expect(result.length).toBeLessThan(longAddr.length);
   });
 
+  it("does not surface a raw Matrix ID stored as a profile name (forta-bugs#363/#165)", async () => {
+    const { useUserStore } = await import("@/entities/user/model");
+    const userStore = useUserStore();
+    const addr = "PRawMatrixId";
+    // A profile may carry a raw @id:domain when no human name was ever set.
+    userStore.setUser(addr, { address: addr, name: "@abc123def:matrix.org", about: "", image: "", site: "", language: "" });
+    const result = store.getDisplayName(addr);
+    expect(result).not.toBe("@abc123def:matrix.org");
+    expect(result).not.toContain("@");
+  });
+
+  it("does not surface a long hex blob stored as a profile name (forta-bugs#363/#165)", async () => {
+    const { useUserStore } = await import("@/entities/user/model");
+    const userStore = useUserStore();
+    const addr = "PHexBlob";
+    userStore.setUser(addr, { address: addr, name: "0123456789abcdef0123456789abcdef", about: "", image: "", site: "", language: "" });
+    expect(store.getDisplayName(addr)).not.toBe("0123456789abcdef0123456789abcdef");
+  });
+
+  it("still surfaces short hex-like usernames (no false positives)", async () => {
+    const { useUserStore } = await import("@/entities/user/model");
+    const userStore = useUserStore();
+    const addr = "PCafe";
+    userStore.setUser(addr, { address: addr, name: "cafe", about: "", image: "", site: "", language: "" });
+    expect(store.getDisplayName(addr)).toBe("cafe");
+  });
+
   it("hex-encoded address resolves to alias stored under raw address", async () => {
     const raw = "PAddr1";
     const hex = hexEncode(raw);

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -39,6 +39,18 @@ import { resolveCachedRoomsAddress } from "./cached-rooms-address";
 
 const NAMESPACE = "chat";
 
+/** A cached value is usable as a display name only if it is not a raw
+ *  identifier: a full Matrix ID (`@localpart:domain`) or a long hex blob
+ *  (≥20 chars, e.g. an undecoded hex user ID). Short hex-like usernames
+ *  ("cafe", "abc123") and handle-style names ("@nickname" without a domain)
+ *  are intentionally allowed — only unambiguous machine IDs are rejected so
+ *  they fall through to the truncated-address fallback (forta-bugs#363/#165).
+ *  Note: the local-alias branch in getDisplayName is deliberately NOT guarded
+ *  — an alias is explicit human input and must always win (Session 51). */
+function isDisplayableName(value: string): boolean {
+  return !!value && !/^@[^:]+:.+/.test(value) && !/^[a-f0-9]{20,}$/i.test(value);
+}
+
 /** Extract raw event data from a MatrixEvent object */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getRawEvent(matrixEvent: any): Record<string, unknown> | null {
@@ -616,17 +628,20 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     //    normalized above, so a single lookup is enough.
     const alias = localAliases.value[resolvedAddr];
     if (alias) return alias;
-    // 2) Matrix displayName cache — direct (raw) lookup, then decoded
+    // 2) Matrix displayName cache — direct (raw) lookup, then decoded.
+    //    Guard against raw identifiers (full Matrix IDs or long hex blobs)
+    //    leaking into the UI as a "name" — they must fall through to the
+    //    address fallback instead (forta-bugs#363/#165).
     const cached = userDisplayNames.value[address];
-    if (cached) return cached;
+    if (cached && isDisplayableName(cached)) return cached;
     if (resolvedAddr !== address) {
       const decodedCached = userDisplayNames.value[resolvedAddr];
-      if (decodedCached) return decodedCached;
+      if (decodedCached && isDisplayableName(decodedCached)) return decodedCached;
     }
     // 3) Check user store (synchronously restored from localStorage — available before Matrix sync)
     const uStore = useUserStore();
     const userProfile = uStore.users[resolvedAddr];
-    if (userProfile?.name) return userProfile.name;
+    if (userProfile?.name && isDisplayableName(userProfile.name)) return userProfile.name;
     // Fallback: truncated address
     if (address.length > 16) return address.slice(0, 8) + "\u2026" + address.slice(-4);
     return address;

--- a/src/features/contacts/ui/ContactList.vue
+++ b/src/features/contacts/ui/ContactList.vue
@@ -36,7 +36,7 @@ const chatStore = useChatStore();
 const authStore = useAuthStore();
 const channelStore = useChannelStore();
 const userStore = useUserStore();
-const { t } = useI18n();
+const { t, locale } = useI18n();
 const { formatPreview } = useFormatPreview();
 const selectionStore = useSelectionStore();
 const emit = defineEmits<{ selectRoom: [roomId: string]; selectChannel: [address: string] }>();
@@ -869,7 +869,7 @@ const onRoomContextMenu = (e: MouseEvent, room: ChatRoom) => {
                 v-if="(item as Channel).lastContent"
                 class="flex shrink-0 items-center gap-0.5 text-xs text-text-on-main-bg-color"
               >
-                {{ formatRelativeTime(new Date((item as Channel).lastContent!.time * 1000)) }}
+                {{ formatRelativeTime(new Date((item as Channel).lastContent!.time * 1000), locale) }}
               </span>
             </div>
             <!-- Preview row -->
@@ -966,7 +966,7 @@ const onRoomContextMenu = (e: MouseEvent, room: ChatRoom) => {
                   v-if="(item as ChatRoom).lastMessage?.senderId === authStore.address && (item as ChatRoom).lastMessage!.type !== MessageType.system && (item as ChatRoom).lastMessage!.content !== ''"
                   :status="(item as ChatRoom).lastMessage!.status"
                 />
-                {{ formatRelativeTime(new Date(getRoomTimestamp(item as ChatRoom)!)) }}
+                {{ formatRelativeTime(new Date(getRoomTimestamp(item as ChatRoom)!), locale) }}
               </span>
             </div>
 

--- a/src/features/messaging/ui/MessageBubble.vue
+++ b/src/features/messaging/ui/MessageBubble.vue
@@ -1053,7 +1053,7 @@ const replyPreviewSender = computed(() => {
         <!-- Forwarded indicator -->
         <div v-if="message.forwardedFrom" class="mb-1 truncate text-[11px] italic"
           :class="props.isOwn ? 'text-white/70' : 'text-color-bg-ac'">
-          Forwarded from {{ message.forwardedFrom.senderName || chatStore.getDisplayName(message.forwardedFrom.senderId) }}
+          {{ t('message.forwardedFrom', { name: forwardedFromName }) }}
         </div>
         <!-- Reply preview -->
         <div
@@ -1127,7 +1127,7 @@ const replyPreviewSender = computed(() => {
         <!-- Forwarded indicator -->
         <div v-if="message.forwardedFrom" class="mb-1 truncate text-[11px] italic"
           :class="props.isOwn ? 'text-white/70' : 'text-color-bg-ac'">
-          Forwarded from {{ message.forwardedFrom.senderName || chatStore.getDisplayName(message.forwardedFrom.senderId) }}
+          {{ t('message.forwardedFrom', { name: forwardedFromName }) }}
         </div>
         <!-- Reply preview -->
         <div
@@ -1303,7 +1303,7 @@ const replyPreviewSender = computed(() => {
         <!-- Forwarded indicator -->
         <div v-if="message.forwardedFrom" class="mb-0.5 truncate text-[11px] italic"
           :class="props.isOwn ? 'text-white/70' : 'text-color-bg-ac'">
-          Forwarded from {{ message.forwardedFrom.senderName || chatStore.getDisplayName(message.forwardedFrom.senderId) }}
+          {{ t('message.forwardedFrom', { name: forwardedFromName }) }}
         </div>
 
         <!-- Reply preview -->
@@ -1333,7 +1333,7 @@ const replyPreviewSender = computed(() => {
             class="relative -bottom-[3px] ml-2 inline-flex items-center gap-0.5 whitespace-nowrap align-bottom text-[10px]"
             :class="props.isOwn ? 'text-white/60' : 'text-text-on-main-bg-color'"
           >
-            <span v-if="message.edited" class="italic">edited</span>
+            <span v-if="message.edited" class="italic">{{ t('message.edited') }}</span>
             {{ time }}
             <MessageStatusIcon v-if="props.isOwn" :status="msgStatus" />
           </span>

--- a/src/features/messaging/ui/MessageList.vue
+++ b/src/features/messaging/ui/MessageList.vue
@@ -34,7 +34,7 @@ const themeStore = useThemeStore();
 const { loadMessages, toggleReaction, deleteMessage, deleteMessages, votePoll, endPoll, retryMediaUpload, retryMessage, cancelMediaUpload } = useMessages();
 const { getState: getFileState, download: downloadFile, saveFile } = useFileDownload();
 const { toast } = useToast();
-const { t } = useI18n();
+const { t, locale } = useI18n();
 
 const { bannerState, freezeBanner, dismissBanner, forceDismiss, hasBanner } = useUnreadBanner();
 
@@ -1171,10 +1171,10 @@ const getDateLabel = (
   prevTimestamp?: number,
 ): string | null => {
   const date = new Date(timestamp);
-  if (!prevTimestamp) return formatDate(date);
+  if (!prevTimestamp) return formatDate(date, locale.value);
   const prevDate = new Date(prevTimestamp);
   if (date.toDateString() !== prevDate.toDateString()) {
-    return formatDate(date);
+    return formatDate(date, locale.value);
   }
   return null;
 };

--- a/src/shared/lib/__tests__/format-locale.test.ts
+++ b/src/shared/lib/__tests__/format-locale.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { formatDate, formatRelativeTime } from "@/shared/lib/format";
+
+/**
+ * Regression (WEE-67 / forta-bugs#903): relative date labels must be
+ * localized and recompute when the active locale changes. Previously
+ * formatDate/formatRelativeTime read the locale once from localStorage
+ * via tRaw() and never reacted to in-session language switches.
+ */
+describe("format date localization (WEE-67)", () => {
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  it("formatDate('today', 'ru') returns 'Сегодня'", () => {
+    expect(formatDate(today, "ru")).toBe("Сегодня");
+  });
+
+  it("formatDate('today', 'en') returns 'Today'", () => {
+    expect(formatDate(today, "en")).toBe("Today");
+  });
+
+  it("formatDate('yesterday', 'ru') returns 'Вчера'", () => {
+    expect(formatDate(yesterday, "ru")).toBe("Вчера");
+  });
+
+  it("recomputes label when locale switches ru -> en", () => {
+    const ruLabel = formatDate(today, "ru");
+    const enLabel = formatDate(today, "en");
+    expect(ruLabel).toBe("Сегодня");
+    expect(enLabel).toBe("Today");
+    expect(ruLabel).not.toBe(enLabel);
+  });
+
+  it("formatRelativeTime('yesterday', 'ru') returns 'Вчера'", () => {
+    expect(formatRelativeTime(yesterday, "ru")).toBe("Вчера");
+  });
+
+  it("formatRelativeTime('yesterday', 'en') returns 'Yesterday'", () => {
+    expect(formatRelativeTime(yesterday, "en")).toBe("Yesterday");
+  });
+
+  it("falls back gracefully when no locale is passed (non-Vue contexts)", () => {
+    // Must still return a non-empty string (reads localStorage via tRaw).
+    expect(formatDate(today)).toBeTruthy();
+    expect(formatRelativeTime(yesterday)).toBeTruthy();
+  });
+});

--- a/src/shared/lib/format.ts
+++ b/src/shared/lib/format.ts
@@ -1,18 +1,46 @@
-import { tRaw } from "@/shared/lib/i18n";
+import { tRaw, type TranslationKey } from "@/shared/lib/i18n";
+import { en } from "@/shared/lib/i18n/locales/en";
+import { ru } from "@/shared/lib/i18n/locales/ru";
+
+const dicts = { en, ru } as const;
+type SupportedLocale = keyof typeof dicts;
+
+function isSupportedLocale(locale?: string): locale is SupportedLocale {
+  return locale === "en" || locale === "ru";
+}
+
+/**
+ * Resolve a date label for the given locale. When `locale` is provided the
+ * lookup is reactive — callers that read a reactive `locale.value` and pass it
+ * in re-render on language switches (WEE-67 / forta-bugs#903). When omitted
+ * (non-Vue contexts: services, workers) it falls back to `tRaw()`, which reads
+ * the persisted locale from localStorage.
+ */
+function dateLabel(key: TranslationKey, locale?: string): string {
+  if (isSupportedLocale(locale)) {
+    return dicts[locale][key] ?? dicts.en[key] ?? tRaw(key);
+  }
+  return tRaw(key);
+}
+
+/** BCP-47 locale tag for Intl APIs, or `undefined` to use the runtime default. */
+function intlLocale(locale?: string): string | undefined {
+  return isSupportedLocale(locale) ? locale : undefined;
+}
 
 export function formatTime(date: Date): string {
   return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
-export function formatDate(date: Date): string {
+export function formatDate(date: Date, locale?: string): string {
   const today = new Date();
   const yesterday = new Date(today);
   yesterday.setDate(yesterday.getDate() - 1);
 
-  if (isSameDay(date, today)) return tRaw("date.today");
-  if (isSameDay(date, yesterday)) return tRaw("date.yesterday");
+  if (isSameDay(date, today)) return dateLabel("date.today", locale);
+  if (isSameDay(date, yesterday)) return dateLabel("date.yesterday", locale);
 
-  return date.toLocaleDateString([], {
+  return date.toLocaleDateString(intlLocale(locale), {
     day: "numeric",
     month: "short",
     year: date.getFullYear() !== today.getFullYear() ? "numeric" : undefined
@@ -34,7 +62,7 @@ export function formatDuration(seconds: number): string {
 }
 
 /** Telegram-style relative time for sidebar: "12:34", "Mon", "Jan 5" etc. */
-export function formatRelativeTime(date: Date): string {
+export function formatRelativeTime(date: Date, locale?: string): string {
   const now = new Date();
   if (isSameDay(date, now)) {
     return formatTime(date);
@@ -42,16 +70,16 @@ export function formatRelativeTime(date: Date): string {
 
   const yesterday = new Date(now);
   yesterday.setDate(yesterday.getDate() - 1);
-  if (isSameDay(date, yesterday)) return tRaw("date.yesterday");
+  if (isSameDay(date, yesterday)) return dateLabel("date.yesterday", locale);
 
   // Within same week: day name
   const diffMs = now.getTime() - date.getTime();
   if (diffMs < 7 * 24 * 60 * 60 * 1000) {
-    return date.toLocaleDateString([], { weekday: "short" });
+    return date.toLocaleDateString(intlLocale(locale), { weekday: "short" });
   }
 
   // Older: date
-  return date.toLocaleDateString([], {
+  return date.toLocaleDateString(intlLocale(locale), {
     day: "numeric",
     month: "short",
     year: date.getFullYear() !== now.getFullYear() ? "numeric" : undefined,

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -309,6 +309,7 @@ export const en = {
 
   // ── Message bubble ──
   "message.forwardedFrom": "Forwarded from {name}",
+  "message.edited": "edited",
 
   // ── Voice recorder ──
   "voice.slideToCancel": "< Slide to cancel",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -311,6 +311,7 @@ export const ru: Record<TranslationKey, string> = {
 
   // ── Message bubble ──
   "message.forwardedFrom": "Переслано от {name}",
+  "message.edited": "изменено",
 
   // ── Voice recorder ──
   "voice.slideToCancel": "< Сдвиньте для отмены",

--- a/src/widgets/sidebar/ChatSidebar.vue
+++ b/src/widgets/sidebar/ChatSidebar.vue
@@ -15,6 +15,7 @@ import ContactsPanel from "./ui/ContactsPanel.vue";
 import SettingsPanel from "./ui/SettingsPanel.vue";
 import { useSidebarTab } from "./model/use-sidebar-tab";
 import type { SidebarTab } from "./model/use-sidebar-tab";
+import { shouldClearSearch, shouldResetFilter } from "./model/chat-back-actions";
 
 const emit = defineEmits<{ selectRoom: []; newGroup: [] }>();
 const chatStore = useChatStore();
@@ -51,6 +52,30 @@ const searchPlaceholder = computed(() => {
   return `${t("contactSearch.placeholderShort")} (${shortcut})`;
 });
 const activeFilter = ref<"all" | "personal" | "groups" | "invites" | "channels">("all");
+
+// Android Back inside the Chats tab cascades before the app is allowed to
+// minimize (forta-bugs#877): clear an active search first, then collapse a
+// non-default filter tab back to "all". Both fire only on the Chats tab —
+// the sidebar-tab handler (ChatPage, prio 55) already returns to Chats from
+// Contacts/Settings, so a non-default filter sits just below it (prio 54),
+// with search clearing taking precedence (prio 56).
+const backState = () => ({
+  activeTab: activeTab.value,
+  searchQuery: sidebarSearchQuery.value,
+  activeFilter: activeFilter.value,
+});
+
+useAndroidBackHandler("chat-search-clear", 56, () => {
+  if (!shouldClearSearch(backState())) return false;
+  sidebarSearchQuery.value = "";
+  return true;
+});
+
+useAndroidBackHandler("chat-filter-to-all", 54, () => {
+  if (!shouldResetFilter(backState())) return false;
+  activeFilter.value = "all";
+  return true;
+});
 
 const bulkDeleteConfirm = ref(false);
 

--- a/src/widgets/sidebar/model/__tests__/chat-back-actions.test.ts
+++ b/src/widgets/sidebar/model/__tests__/chat-back-actions.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { shouldClearSearch, shouldResetFilter } from "../chat-back-actions";
+
+/**
+ * Regression (WEE-67 / forta-bugs#877): Android Back from a non-default filter
+ * tab ("Личные"/"Группы") must collapse back to "Все" instead of falling
+ * through to App.minimizeApp(). Search clearing takes precedence over the
+ * filter reset.
+ */
+describe("chat back actions (WEE-67)", () => {
+  describe("shouldResetFilter", () => {
+    it("collapses a non-default filter on the Chats tab", () => {
+      expect(
+        shouldResetFilter({ activeTab: "chats", searchQuery: "", activeFilter: "personal" }),
+      ).toBe(true);
+      expect(
+        shouldResetFilter({ activeTab: "chats", searchQuery: "", activeFilter: "groups" }),
+      ).toBe(true);
+    });
+
+    it("passes through when already on the 'all' filter", () => {
+      expect(
+        shouldResetFilter({ activeTab: "chats", searchQuery: "", activeFilter: "all" }),
+      ).toBe(false);
+    });
+
+    it("does not fire outside the Chats tab", () => {
+      expect(
+        shouldResetFilter({ activeTab: "contacts", searchQuery: "", activeFilter: "personal" }),
+      ).toBe(false);
+      expect(
+        shouldResetFilter({ activeTab: "settings", searchQuery: "", activeFilter: "groups" }),
+      ).toBe(false);
+    });
+  });
+
+  describe("shouldClearSearch", () => {
+    it("clears an active search on the Chats tab", () => {
+      expect(
+        shouldClearSearch({ activeTab: "chats", searchQuery: "alice", activeFilter: "all" }),
+      ).toBe(true);
+    });
+
+    it("passes through when search is empty", () => {
+      expect(
+        shouldClearSearch({ activeTab: "chats", searchQuery: "", activeFilter: "personal" }),
+      ).toBe(false);
+    });
+
+    it("does not fire outside the Chats tab", () => {
+      expect(
+        shouldClearSearch({ activeTab: "contacts", searchQuery: "alice", activeFilter: "all" }),
+      ).toBe(false);
+    });
+
+    it("takes precedence: search clears before filter resets", () => {
+      const state = { activeTab: "chats", searchQuery: "bob", activeFilter: "groups" };
+      // Both conditions are true; the higher-priority (56) search handler runs
+      // first and consumes Back, so the filter (54) is not yet touched.
+      expect(shouldClearSearch(state)).toBe(true);
+      expect(shouldResetFilter(state)).toBe(true);
+    });
+  });
+});

--- a/src/widgets/sidebar/model/chat-back-actions.ts
+++ b/src/widgets/sidebar/model/chat-back-actions.ts
@@ -1,0 +1,28 @@
+/**
+ * Pure decision helpers for the Chats-tab Android Back cascade
+ * (forta-bugs#877). Kept side-effect-free so the priority contract can be
+ * unit-tested without mounting the full sidebar.
+ *
+ * Cascade order (higher priority fires first):
+ *   56 — clear an active search
+ *   55 — sidebar tab → Chats (owned by ChatPage)
+ *   54 — collapse a non-default filter tab → "all"
+ */
+export interface ChatBackState {
+  /** Active sidebar tab ("chats" | "contacts" | "settings"). */
+  activeTab: string;
+  /** Current sidebar search query (empty string when inactive). */
+  searchQuery: string;
+  /** Active filter tab ("all" | "personal" | "groups" | "invites" | "channels"). */
+  activeFilter: string;
+}
+
+/** True when Android Back should clear the active search on the Chats tab. */
+export function shouldClearSearch(state: ChatBackState): boolean {
+  return state.activeTab === "chats" && state.searchQuery.length > 0;
+}
+
+/** True when Android Back should collapse a non-default filter tab to "all". */
+export function shouldResetFilter(state: ChatBackState): boolean {
+  return state.activeTab === "chats" && state.activeFilter !== "all";
+}


### PR DESCRIPTION
## Summary
- **Relative dates (#903):** «Сегодня»/«Вчера» now localized and reactive to in-session language switches. `formatDate`/`formatRelativeTime` take an optional `locale`; `ContactList`/`MessageList` pass the reactive locale so labels recompute on switch (month/weekday names also localized via Intl).
- **Android Back from filter tab (#877):** Back from a non-default filter («Личные»/«Группы») collapses to «Все» instead of minimizing the app; an active search clears first. Logic lives in pure, unit-tested helpers (`chat-back-actions.ts`).
- **Timestamp row localization (#857):** localized hardcoded `"edited"` / `"Forwarded from"` strings in `MessageBubble`.
- **displayName guard (#363/#165):** `getDisplayName` no longer surfaces raw Matrix IDs (`@localpart:domain`) or long hex blobs as a name — they fall through to the truncated-address fallback. Short hex-like usernames and `@handle` names are preserved.

## Scope note
This PR covers the high-confidence **localized bugs** from the WEE-67 package. Two feature-gaps from the cluster are intentionally deferred to follow-up tickets:
- **#802** (scroll-restore on chat re-entry) — feature-gap (column-reverse anchor logic).
- **#934** (cross-platform alias sync) + full eager-profile-load for #363/#165 — needs Matrix `account_data` work.

Out of scope per ticket: **#878** (presence — product/privacy decision), **#362** (Bastyon dual-pusher — interop, has warning banner).

## Linear
- Resolves WEE-67 — https://linear.app/wwwee/issue/WEE-67

## Closes
Closes greenShirtMystery/forta-bugs#903
Closes greenShirtMystery/forta-bugs#877
Closes greenShirtMystery/forta-bugs#857
Closes greenShirtMystery/forta-bugs#363
Closes greenShirtMystery/forta-bugs#165

Refs greenShirtMystery/forta-bugs#878 (presence — feature-gap)
Refs greenShirtMystery/forta-bugs#362 (Bastyon dual-pusher — interop)
Refs greenShirtMystery/forta-bugs#802 (scroll-restore — deferred)
Refs greenShirtMystery/forta-bugs#914 (push name — timing, partial)
Refs greenShirtMystery/forta-bugs#934 (alias cross-sync — deferred)

## Test plan
- [x] `npx vue-tsc --noEmit` — 0 new type errors (49 pre-existing baseline untouched)
- [x] Unit tests added: `format-locale.test.ts` (7), `chat-back-actions.test.ts` (7), `getDisplayName` guard regressions (3)
- [x] Full suite: 2467 pass; 17 fail are all pre-existing baseline (verified via stash parity, none in changed files)
- [ ] Manual QA (Android): switch ru↔en → date separators/«шапка чата» update without restart
- [ ] Manual QA (Android): on «Личные» filter, Back → «Все» (not app minimize)
- [ ] Manual QA: contact with no profile name shows truncated address, not a hex/MXID blob