### PR TITLE
fix(channels): channel video no longer locks feed scroll/pause on Android (WEE-74)

### DIFF
--- a/src/features/post-player/ui/PostCard.vue
+++ b/src/features/post-player/ui/PostCard.vue
@@ -249,8 +249,9 @@ onMounted(loadPostData);
       </div>
     </div>
 
-    <!-- Inline video -->
-    <VideoPlayer v-if="videoInfo" :url="post.url" inline />
+    <!-- Inline video — on native, tapping play opens the post modal instead of
+         embedding the iframe in the feed, which would lock feed scroll (WEE-74). -->
+    <VideoPlayer v-if="videoInfo" :url="post.url" inline @expand="showModal = true" />
 
     <!-- Image -->
     <img

--- a/src/features/post-player/ui/VideoPlayer.vue
+++ b/src/features/post-player/ui/VideoPlayer.vue
@@ -11,6 +11,10 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), { inline: false });
 
+// Inline (channel feed) playback asks the host to open the post instead of
+// embedding the iframe in the feed — see `play()` for why (WEE-74).
+const emit = defineEmits<{ expand: [] }>();
+
 const videoInfo = computed(() => parseVideoUrl(props.url));
 const playing = ref(false);
 const error = ref(false);
@@ -80,6 +84,19 @@ useAndroidBackHandler("post-video-fullscreen", 100, () => {
 });
 
 const play = () => {
+  // WEE-74: a playing cross-origin sandboxed iframe captures Android WebView
+  // touch gestures over its area, so inside the channel feed the feed stops
+  // scrolling and tap-to-pause never reaches the embed (regression surfaced
+  // once WEE-70 made the embed actually reach a playing state). Native inline
+  // playback also needs a tap *inside* the iframe to start (no autoplay), which
+  // is exactly what locks the gesture. Route feed playback to the post modal,
+  // where the iframe lives in its own scroll context and can't lock the feed.
+  // Web/desktop (mouse) keeps inline playback as before.
+  if (props.inline && isNative) {
+    emit("expand");
+    return;
+  }
+
   playing.value = true;
   spinnerTimedOut.value = false;
   clearSpinnerTimer();

--- a/src/features/post-player/ui/__tests__/PostCard.test.ts
+++ b/src/features/post-player/ui/__tests__/PostCard.test.ts
@@ -39,8 +39,10 @@ vi.mock("../model/use-post-boost", () => ({
 vi.mock("@/shared/lib/use-toast", () => ({
   useToast: () => ({ toast: vi.fn() }),
 }));
+// Mutable so a test can simulate a post that carries a recognized video URL.
+let mockVideoInfo: unknown = null;
 vi.mock("@/shared/lib/video-embed", () => ({
-  parseVideoUrl: () => null,
+  parseVideoUrl: () => mockVideoInfo,
 }));
 vi.mock("@/shared/lib/image-url", () => ({
   normalizePocketnetImageUrl: (x: string) => x,
@@ -49,8 +51,21 @@ vi.mock("@/shared/lib/image-url", () => ({
 vi.stubGlobal("useI18n", () => ({ t: (k: string) => k }));
 
 import PostCard from "../PostCard.vue";
+import type { BastyonPostData } from "@/app/providers/initializers";
 
 const POST_LOAD_TIMEOUT_MS = 15_000;
+
+const videoPost: BastyonPostData = {
+  txid: "tx123",
+  address: "author",
+  caption: "clip",
+  message: "",
+  images: [],
+  url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+  tags: [],
+  settings: {},
+  time: 1_700_000_000,
+};
 
 const stubs = {
   VideoPlayer: true,
@@ -113,5 +128,33 @@ describe("PostCard bounded skeleton + retry (WEE-70)", () => {
     await w.find("button").trigger("click");
     await flushPromises();
     expect(loadPost).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("PostCard channel feed video expand (WEE-74)", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    getCachedPost.mockReturnValue(videoPost);
+    mockVideoInfo = { type: "youtube", embedUrl: "https://www.youtube.com/embed/dQw4w9WgXcQ" };
+  });
+
+  afterEach(() => {
+    mockVideoInfo = null;
+  });
+
+  it("expand от inline-видео открывает пост-модалку (а не лочит ленту)", async () => {
+    const w = mountCard();
+    await flushPromises();
+
+    // Cached post renders straight to the card with the inline VideoPlayer.
+    const player = w.findComponent({ name: "VideoPlayer" });
+    expect(player.exists()).toBe(true);
+    expect(w.findComponent({ name: "PostPlayerModal" }).exists()).toBe(false);
+
+    player.vm.$emit("expand");
+    await flushPromises();
+
+    // Playback is routed to the modal instead of embedding in the feed.
+    expect(w.findComponent({ name: "PostPlayerModal" }).exists()).toBe(true);
   });
 });

--- a/src/features/post-player/ui/__tests__/VideoPlayer.test.ts
+++ b/src/features/post-player/ui/__tests__/VideoPlayer.test.ts
@@ -129,3 +129,41 @@ describe("VideoPlayer channel spinner (WEE-70)", () => {
     expect(openExternalUrl).toHaveBeenCalledWith(YT_URL);
   });
 });
+
+describe("VideoPlayer channel feed touch/scroll lock (WEE-74)", () => {
+  it("inline на native не встраивает iframe в ленту, а эмитит expand", async () => {
+    mockIsNative = true;
+    const wrapper = mount(VideoPlayer, { props: { url: YT_URL, inline: true } });
+
+    await wrapper.find("button").trigger("click");
+    await flushPromises();
+
+    // No iframe is mounted in the feed — so it can't capture touch/scroll.
+    expect(wrapper.find("iframe").exists()).toBe(false);
+    // The host is asked to open the post modal instead.
+    expect(wrapper.emitted("expand")).toHaveLength(1);
+  });
+
+  it("inline на web сохраняет встроенное воспроизведение (мышь, не Android WebView)", async () => {
+    const wrapper = mount(VideoPlayer, { props: { url: YT_URL, inline: true } });
+
+    await wrapper.find("button").trigger("click");
+    await flushPromises();
+
+    // Desktop has no touch gesture-lock, so inline playback stays.
+    expect(wrapper.find("iframe").exists()).toBe(true);
+    expect(wrapper.emitted("expand")).toBeUndefined();
+  });
+
+  it("в модалке (inline=false) на native играет встроенно, не эмитит expand", async () => {
+    mockIsNative = true;
+    const wrapper = mount(VideoPlayer, { props: { url: YT_URL } });
+
+    await wrapper.find("button").trigger("click");
+    await flushPromises();
+
+    // Modal context: the iframe is fine here — it doesn't lock the channel feed.
+    expect(wrapper.find("iframe").exists()).toBe(true);
+    expect(wrapper.emitted("expand")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Channel feed videos render via a cross-origin sandboxed `<iframe>` (`VideoPlayer.vue`) inline in `PostCard.vue`. After WEE-70 fixed the eternal spinner, the embed now actually reaches a **playing** state — and on Android WebView a playing cross-origin iframe captures all touch gestures over its `absolute inset-0` area, so the channel feed stops scrolling and tap-to-pause never reaches the embed (P1 regression, forta-bugs#937).
- Native inline playback also can't autoplay (WEE-70 dropped `?autoplay=1` on native), so it requires a tap *inside* the iframe to start — exactly what locks the gesture.
- **Fix:** in `VideoPlayer.vue`, when `inline && isNative`, `play()` emits a new `expand` event instead of mounting the inline iframe; `PostCard.vue` routes it to the existing post modal (`PostPlayerModal`), where the iframe lives in its own scroll context and can't lock the channel feed. Web/desktop (mouse, no touch gesture-lock) keep inline playback unchanged; modal usage (`inline=false`) is unaffected.

## Linear
- Resolves WEE-74 (https://linear.app/wwwee/issue/WEE-74)
- Refs WEE-70 (regression source)

## Closes
Closes greenShirtMystery/forta-bugs#937

## Test plan
- [x] `npx vue-tsc --noEmit` — 0 errors (clean in changed files)
- [x] `vite build` — succeeds
- [x] Unit tests added (`VideoPlayer.test.ts` +3, `PostCard.test.ts` +1) — all post-player tests pass
- [x] No lint script in repo (N/A)
- [ ] Manual QA on Android (realme / Android 11): open a channel, tap a video in the feed → post opens in modal; **feed scrolls freely during/after**; tap pauses in modal. Verify WEE-70 not reintroduced (no eternal spinner; poster + "Open externally" intact).

## QA note
On **native**, tapping a feed video now opens the post modal (one extra tap to start playback inside the modal) instead of embedding inline — this is the intended trade-off to keep the feed scrollable. Web/desktop behaviour is unchanged.