### PR TITLE
fix(messaging): delete-for-all, placeholder, multi-select, landscape edit, copy (WEE-66)

### DIFF
--- a/src/entities/chat/model/chat-store.test.ts
+++ b/src/entities/chat/model/chat-store.test.ts
@@ -297,6 +297,18 @@ describe("chat-store", () => {
       expect(store.selectionMode).toBe(false);
       expect(store.selectedMessageIds.size).toBe(0);
     });
+
+    // WEE-66 / #863, #924 — multi-select must accumulate beyond the seed
+    // message so users can delete/forward several DM messages or images at once.
+    it("accumulates multiple selections via repeated toggles", () => {
+      store.enterSelectionMode("msg1");
+      store.toggleSelection("msg2");
+      store.toggleSelection("msg3");
+      expect(store.selectedMessageIds.size).toBe(3);
+      expect(store.selectedMessageIds.has("msg1")).toBe(true);
+      expect(store.selectedMessageIds.has("msg2")).toBe(true);
+      expect(store.selectedMessageIds.has("msg3")).toBe(true);
+    });
   });
 
   // ─── togglePinRoom / toggleMuteRoom ───────────────────────────

--- a/src/features/messaging/model/__tests__/delete-message.test.ts
+++ b/src/features/messaging/model/__tests__/delete-message.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "fake-indexeddb/auto";
+import { ChatDatabase } from "@/shared/lib/local-db/schema";
+import type { LocalMessage, LocalRoom } from "@/shared/lib/local-db/schema";
+import { MessageRepository } from "@/shared/lib/local-db/message-repository";
+import { RoomRepository } from "@/shared/lib/local-db/room-repository";
+import { UserRepository } from "@/shared/lib/local-db/user-repository";
+import { EventWriter } from "@/shared/lib/local-db/event-writer";
+import { MessageType } from "@/entities/chat/model/types";
+import { isServerEventId } from "../redact-target";
+
+/**
+ * WEE-66 / forta-bugs#773, #864 — "delete for all" must work for pending
+ * messages that only have a clientId (no server $eventId yet).
+ *
+ * Root cause (H1): deleteMessage redacted by `message.id` = eventId ?? clientId.
+ * For a not-yet-confirmed message that is the clientId, which the server has
+ * never seen — softDelete (eventId-only) found nothing and SyncEngine queued a
+ * redact for a clientId that silently failed server-side.
+ */
+
+let db: ChatDatabase;
+let msgRepo: MessageRepository;
+let roomRepo: RoomRepository;
+let userRepo: UserRepository;
+let eventWriter: EventWriter;
+
+const ROOM_ID = "!room:server";
+
+function makeMsg(overrides: Partial<LocalMessage> = {}): LocalMessage {
+  return {
+    eventId: overrides.eventId ?? `$evt_${Math.random().toString(36).slice(2)}`,
+    clientId: overrides.clientId ?? `cli_${Math.random().toString(36).slice(2)}`,
+    roomId: overrides.roomId ?? ROOM_ID,
+    senderId: overrides.senderId ?? "user1",
+    content: overrides.content ?? "hello",
+    timestamp: overrides.timestamp ?? Date.now(),
+    type: overrides.type ?? MessageType.text,
+    status: overrides.status ?? "synced",
+    version: 1,
+    softDeleted: false,
+    ...overrides,
+  } as LocalMessage;
+}
+
+function makeRoom(overrides: Partial<LocalRoom> = {}): LocalRoom {
+  return {
+    id: overrides.id ?? ROOM_ID,
+    name: "Test Room",
+    isGroup: false,
+    members: ["user1", "user2"],
+    membership: "join",
+    unreadCount: 0,
+    lastReadInboundTs: 0,
+    lastReadOutboundTs: 0,
+    updatedAt: Date.now(),
+    syncedAt: Date.now(),
+    hasMoreHistory: true,
+    isDeleted: false,
+    deletedAt: null,
+    deleteReason: null,
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  const name = `test-delete-message-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  db = new ChatDatabase(name);
+  await db.open();
+  msgRepo = new MessageRepository(db);
+  roomRepo = new RoomRepository(db);
+  userRepo = new UserRepository(db);
+  eventWriter = new EventWriter(db, msgRepo, roomRepo, userRepo);
+});
+
+afterEach(async () => {
+  await db.delete();
+});
+
+describe("isServerEventId — only $-prefixed ids are known to the server", () => {
+  it("returns true for a Matrix event id", () => {
+    expect(isServerEventId("$abc:server")).toBe(true);
+  });
+
+  it("returns false for a local clientId (UUID, pending message)", () => {
+    expect(isServerEventId("3f9a1c2e-1111-2222-3333-444455556666")).toBe(false);
+    expect(isServerEventId("cli_xyz")).toBe(false);
+  });
+
+  it("returns false for empty / non-string input", () => {
+    expect(isServerEventId("")).toBe(false);
+    // @ts-expect-error — runtime guard against bad callers
+    expect(isServerEventId(undefined)).toBe(false);
+  });
+});
+
+describe("MessageRepository.softDelete — matches eventId OR clientId", () => {
+  it("soft-deletes a synced message by its eventId (regression)", async () => {
+    await db.messages.add(makeMsg({ eventId: "$msg1", clientId: "cli1" }));
+
+    await msgRepo.softDelete("$msg1");
+
+    const row = await db.messages.where("clientId").equals("cli1").first();
+    expect(row!.softDeleted).toBe(true);
+    expect(row!.deletedAt).toBeGreaterThan(0);
+  });
+
+  it("soft-deletes a pending message by its clientId when eventId is null", async () => {
+    await db.messages.add(
+      makeMsg({ eventId: null, clientId: "pending-1", status: "pending" }),
+    );
+
+    // deleteMessage passes message.id = eventId ?? clientId = "pending-1"
+    await msgRepo.softDelete("pending-1");
+
+    const row = await db.messages.where("clientId").equals("pending-1").first();
+    expect(row!.softDeleted).toBe(true);
+  });
+});
+
+describe("EventWriter.writeRedaction — pending message (clientId) deletes locally", () => {
+  it("soft-deletes a pending message identified only by clientId", async () => {
+    await db.rooms.add(makeRoom());
+    await db.messages.add(
+      makeMsg({ eventId: null, clientId: "pending-2", status: "pending", content: "draft" }),
+    );
+
+    await eventWriter.writeRedaction({ redactedEventId: "pending-2", roomId: ROOM_ID });
+
+    const row = await db.messages.where("clientId").equals("pending-2").first();
+    expect(row!.softDeleted).toBe(true);
+  });
+
+  it("does NOT queue a server-side redact for a pending (clientId) message", () => {
+    // The enqueue guard in use-messages.deleteMessage relies on this predicate:
+    // a clientId is not a server identity, so "delete for all" stays local.
+    expect(isServerEventId("pending-2")).toBe(false);
+  });
+});

--- a/src/features/messaging/model/__tests__/input-layout.test.ts
+++ b/src/features/messaging/model/__tests__/input-layout.test.ts
@@ -39,4 +39,26 @@ describe("deriveInputLayout — WEE-48 / forta-bugs#593, #515", () => {
     expect(deriveInputLayout({ isMobile: false, text: "", showDonate: true }).showSecondaryActions).toBe(true);
     expect(deriveInputLayout({ isMobile: false, text: "long message", showDonate: true }).showSecondaryActions).toBe(true);
   });
+
+  // WEE-66 / #829 — a landscape phone is wider than the md breakpoint, so
+  // isMobile is false; it must still collapse secondary actions while typing so
+  // the edit row stays usable.
+  describe("landscape phone (#829)", () => {
+    it("treats a landscape phone as mobile: collapses secondary actions while typing", () => {
+      const r = deriveInputLayout({ isMobile: false, isLandscapePhone: true, text: "hello", showDonate: true });
+      expect(r.showSecondaryActions).toBe(false);
+      expect(r.showDonateShortcut).toBe(false);
+    });
+
+    it("keeps secondary actions on a landscape phone while the input is idle", () => {
+      const r = deriveInputLayout({ isMobile: false, isLandscapePhone: true, text: "", showDonate: true });
+      expect(r.showSecondaryActions).toBe(true);
+      expect(r.showDonateShortcut).toBe(true);
+    });
+
+    it("defaults isLandscapePhone to false (desktop keeps actions while typing)", () => {
+      const r = deriveInputLayout({ isMobile: false, text: "hello", showDonate: true });
+      expect(r.showSecondaryActions).toBe(true);
+    });
+  });
 });

--- a/src/features/messaging/model/input-layout.ts
+++ b/src/features/messaging/model/input-layout.ts
@@ -10,6 +10,11 @@
 export interface InputLayoutInput {
   /** Tailwind `md` breakpoint — matches the `useMobile()` composable. */
   isMobile: boolean;
+  /** A phone held in landscape. Width-based `md` detection reports such
+   *  devices as desktop (a landscape phone is wider than 768px), which kept
+   *  the secondary-action row pinned open and broke the edit layout (#829).
+   *  Treated as mobile-like here. Optional — defaults to false. */
+  isLandscapePhone?: boolean;
   /** Current textarea contents — trimmed empty hides primary actions on mobile. */
   text: string;
   /** Whether the host supports the wallet shortcut at all. */
@@ -27,7 +32,8 @@ export interface InputLayoutResult {
 }
 
 export const deriveInputLayout = (input: InputLayoutInput): InputLayoutResult => {
-  const showSecondaryActions = !input.isMobile || input.text.trim().length === 0;
+  const mobileLike = input.isMobile || input.isLandscapePhone === true;
+  const showSecondaryActions = !mobileLike || input.text.trim().length === 0;
   const showDonateShortcut = input.showDonate && showSecondaryActions;
   return { showSecondaryActions, showDonateShortcut };
 };

--- a/src/features/messaging/model/redact-target.ts
+++ b/src/features/messaging/model/redact-target.ts
@@ -1,0 +1,12 @@
+/**
+ * Pure guard for the "delete for all" redact path (WEE-66 / forta-bugs#773).
+ *
+ * A Matrix server event id always starts with "$". A message that hasn't been
+ * confirmed by the server yet is identified only by its local `clientId` (a
+ * UUID the server has never seen). Queuing a redact for a clientId silently
+ * fails server-side — so we only enqueue a server-side redact for ids the
+ * server actually knows; pending messages are deleted locally only.
+ */
+export function isServerEventId(id: string): boolean {
+  return typeof id === "string" && id.startsWith("$");
+}

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -18,6 +18,7 @@ import type { LocalMessageStatus } from "@/shared/lib/local-db/schema";
 import { useBugReport } from "@/features/bug-report";
 import { tRaw } from "@/shared/lib/i18n";
 import { useToast } from "@/shared/lib/use-toast";
+import { isServerEventId } from "./redact-target";
 import { SendError, sendDiag } from "./send-errors";
 import { reportSendError } from "./send-error-bus";
 
@@ -1234,7 +1235,11 @@ export function useMessages() {
           redactedEventId: messageId,
           roomId,
         });
-        if (forEveryone) {
+        // Only redact on the server when the message actually has a server
+        // identity. A pending message is identified by its clientId, which the
+        // server has never seen — queuing a redact for it silently fails
+        // (WEE-66 / #773). Such messages are deleted locally only.
+        if (forEveryone && isServerEventId(messageId)) {
           await dbKit.syncEngine.enqueue(
             "delete_message",
             roomId,
@@ -1432,7 +1437,9 @@ export function useMessages() {
               redactedEventId: id,
               roomId,
             });
-            if (forEveryone) {
+            // Pending messages (clientId, no server identity) delete locally
+            // only — a server redact for a clientId silently fails (WEE-66).
+            if (forEveryone && isServerEventId(id)) {
               await dbKit.syncEngine.enqueue(
                 "delete_message",
                 roomId,

--- a/src/features/messaging/ui/MessageBubble.vue
+++ b/src/features/messaging/ui/MessageBubble.vue
@@ -103,18 +103,27 @@ const forwardedFromName = computed(() => {
 const longPressTriggered = ref(false);
 const { onPointerdown: lpPointerdown, onPointermove, onPointerup: lpPointerup, onPointerleave: lpPointerleave } = useLongPress({
   onTrigger: (e) => {
+    // Guard emission (not the timer cleanup) — re-opening the context menu
+    // mid-multiselect would steal the tap (WEE-66 / #863, #924).
+    if (chatStore.selectionMode) return;
     longPressTriggered.value = true;
     emit("contextmenu", { message: props.message, x: e.clientX, y: e.clientY });
   },
 });
 const onPointerdown = (e: PointerEvent) => {
+  // In selection mode a tap toggles selection (see handleBubbleClick) — don't
+  // arm long-press at all.
+  if (chatStore.selectionMode) return;
   longPressTriggered.value = false;
   lpPointerdown(e);
 };
+// Always run cleanup so a timer armed just before selection mode flipped on
+// can't survive to fire.
 const onPointerup = () => { lpPointerup(); };
 const onPointerleave = () => { lpPointerleave(); };
 
 const handleRightClick = (e: MouseEvent) => {
+  if (chatStore.selectionMode) return;
   // .prevent modifier already calls preventDefault
   emit("contextmenu", { message: props.message, x: e.clientX, y: e.clientY });
 };
@@ -128,7 +137,7 @@ const handleRightClick = (e: MouseEvent) => {
 // `isOwn && swipeDirection === 'right'` block in the template), so we only emit
 // quote on right-swipe when the bubble is a peer's.
 const triggerReply = () => emit("reply", props.message);
-const { offsetX: swipeOffsetX, isSwiping, swipeDirection, onTouchstart, onTouchmove, onTouchend } = useSwipeGesture({
+const { offsetX: swipeOffsetX, isSwiping, swipeDirection, onTouchstart: swipeTouchstart, onTouchmove: swipeTouchmove, onTouchend: swipeTouchend } = useSwipeGesture({
   direction: "both",
   threshold: 60,
   maxOffset: 100,
@@ -145,6 +154,12 @@ const swipeStyle = computed(() => {
     transition: isSwiping.value ? "none" : "transform 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94)",
   };
 });
+
+// Swipe-to-reply is disabled while selecting so a horizontal drag across
+// bubbles toggles selection cleanly instead of firing reply gestures.
+const onTouchstart = (e: TouchEvent) => { if (chatStore.selectionMode) return; swipeTouchstart(e); };
+const onTouchmove = (e: TouchEvent) => { if (chatStore.selectionMode) return; swipeTouchmove(e); };
+const onTouchend = () => { if (chatStore.selectionMode) return; swipeTouchend(); };
 
 const swipeArrowOpacity = computed(() => Math.min(swipeOffsetX.value / 60, 1));
 
@@ -745,6 +760,15 @@ const replyPreviewSender = computed(() => {
 
     <!-- Bubble container -->
     <div class="relative min-w-0 max-w-[85%] md:max-w-[80%] lg:max-w-[65%] overflow-hidden">
+      <!-- Selection tap-target: while selecting, a tap anywhere on the bubble
+           toggles selection instead of opening media / replies / downloads.
+           Overlaying the whole bubble (vs the tiny checkbox only) is what makes
+           multi-select usable on mobile (WEE-66 / #863, #924). -->
+      <div
+        v-if="chatStore.selectionMode"
+        class="absolute inset-0 z-20 cursor-pointer"
+        @click.stop="handleBubbleClick"
+      />
       <!-- Reply action (on hover) -->
       <button
         class="absolute top-1/2 hidden h-6 w-6 -translate-y-1/2 items-center justify-center rounded-full text-text-on-main-bg-color opacity-0 transition-opacity hover:bg-neutral-grad-0 group-hover:flex group-hover:opacity-100"

--- a/src/features/messaging/ui/MessageInput.vue
+++ b/src/features/messaging/ui/MessageInput.vue
@@ -19,7 +19,7 @@ import { useVoiceRecorder } from "../model/use-voice-recorder";
 import { useVideoCircleRecorder } from "../model/use-video-circle-recorder";
 import { useMentionAutocomplete } from "../model/use-mention-autocomplete";
 import MentionAutocomplete from "./MentionAutocomplete.vue";
-import { useMobile } from "@/shared/lib/composables/use-media-query";
+import { useMobile, useLandscapePhone } from "@/shared/lib/composables/use-media-query";
 import { useResolvedRoomName } from "@/entities/chat/lib/use-resolved-room-name";
 import { shouldSendOnEnter } from "../model/enter-key-behavior";
 import { isSendButtonVisible, isSendButtonDisabled } from "../model/send-button-state";
@@ -32,6 +32,11 @@ import { readShareUriAsBlob } from "@/shared/lib/share-target";
 const PEER_KEYS_GRACE_MS = 2000;
 
 const isMobile = useMobile();
+const isLandscapePhone = useLandscapePhone();
+// A landscape phone must behave like mobile (#829): width-based `useMobile`
+// reports it as desktop, which kept secondary buttons open and made Enter send
+// mid-edit instead of inserting a newline.
+const isMobileLike = computed(() => isMobile.value || isLandscapePhone.value);
 
 const props = defineProps<{
   showDonate?: boolean;
@@ -228,7 +233,7 @@ const cancelEdit = () => {
   nextTick(() => { if (textareaRef.value) textareaRef.value.style.height = "auto"; });
 };
 
-const maxTextareaHeight = computed(() => isMobile.value ? 120 : 200);
+const maxTextareaHeight = computed(() => isMobileLike.value ? 120 : 200);
 
 let resizeRaf = 0;
 const autoGrow = () => {
@@ -260,6 +265,7 @@ const autoResize = autoGrow;
 // through AttachmentPanel either way.
 const inputLayout = computed(() => deriveInputLayout({
   isMobile: isMobile.value,
+  isLandscapePhone: isLandscapePhone.value,
   text: text.value,
   showDonate: !!props.showDonate,
 }));
@@ -392,7 +398,7 @@ const handleSend = async () => {
 const handleKeydown = (e: KeyboardEvent) => {
   if (mention.handleKeydown(e)) return;
 
-  if (shouldSendOnEnter({ key: e.key, shiftKey: e.shiftKey, isComposing: e.isComposing, isMobile: isMobile.value, isNative })) {
+  if (shouldSendOnEnter({ key: e.key, shiftKey: e.shiftKey, isComposing: e.isComposing, isMobile: isMobileLike.value, isNative })) {
     e.preventDefault();
     handleSend();
   }

--- a/src/features/messaging/ui/MessageList.vue
+++ b/src/features/messaging/ui/MessageList.vue
@@ -6,6 +6,7 @@ import { useThemeStore } from "@/entities/theme";
 import { isConsecutiveMessage } from "@/entities/chat/lib/message-utils";
 import { cleanMatrixIds, resolveSystemText } from "@/entities/chat/lib/chat-helpers";
 import { formatDate } from "@/shared/lib/format";
+import { stripMentionAddresses } from "@/shared/lib/message-format";
 import { UserAvatar } from "@/entities/user";
 import { useMessages } from "../model/use-messages";
 import { useFileDownload } from "../model/use-file-download";
@@ -145,8 +146,19 @@ const handleContextAction = (action: string, message: import("@/entities/chat").
         && (sel.anchorNode as Element | null)
             ?.parentElement
             ?.closest(`[data-message-id="${message.id}"]`) != null;
-      const payload = isSelectionInBubble ? selectedText : message.content;
-      navigator.clipboard.writeText(payload).then(() => toast(t("chat.copiedToClipboard")));
+      // Copying the whole bubble must yield readable text — strip the
+      // `@hexaddr:Name` mention wire-syntax down to `@Name` (renamed contacts
+      // resolved via local alias), matching what the bubble renders (#897).
+      // A manual in-bubble selection is copied verbatim.
+      const payload = isSelectionInBubble
+        ? selectedText
+        : stripMentionAddresses(message.content, (userId) => chatStore.getLocalAlias(userId));
+      navigator.clipboard.writeText(payload)
+        .then(() => toast(t("chat.copiedToClipboard")))
+        .catch((e) => {
+          console.error("[MessageList] copy failed:", e);
+          toast(t("chat.copyFailed"), "error");
+        });
       break;
     }
     case "edit":

--- a/src/shared/lib/composables/use-media-query.ts
+++ b/src/shared/lib/composables/use-media-query.ts
@@ -29,3 +29,12 @@ export const useTablet = () =>
 
 /** Desktop: ≥ 1024px */
 export const useDesktop = () => useMediaQuery("(min-width: 1024px)");
+
+/** A touch phone held in landscape: short viewport (≤ 575px tall), landscape
+ *  orientation, coarse pointer. Width-based `useMobile()` misses these because
+ *  a landscape phone exceeds the 768px `md` breakpoint, which broke the message
+ *  edit layout (#829). `pointer: coarse` keeps short desktop windows out. */
+export const useLandscapePhone = () =>
+  useMediaQuery(
+    "(max-height: 575px) and (orientation: landscape) and (pointer: coarse)",
+  );

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -224,6 +224,7 @@ export const en = {
   "chat.typingMany": "{name} and {count} more are typing...",
   "chat.members": "{count} members",
   "chat.copiedToClipboard": "Copied to clipboard",
+  "chat.copyFailed": "Couldn't copy",
   "chat.updatingMessages": "Updating messages…",
   "chat.returnToLatest": "Return to latest",
 

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -226,6 +226,7 @@ export const ru: Record<TranslationKey, string> = {
   "chat.typingMany": "{name} и ещё {count} печатают...",
   "chat.members": "{count} участн.",
   "chat.copiedToClipboard": "Скопировано в буфер обмена",
+  "chat.copyFailed": "Не удалось скопировать",
   "chat.updatingMessages": "Обновление сообщений…",
   "chat.returnToLatest": "К последним",
 

--- a/src/shared/lib/local-db/__tests__/message-repository-soft-delete-filter.test.ts
+++ b/src/shared/lib/local-db/__tests__/message-repository-soft-delete-filter.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "fake-indexeddb/auto";
+import { ChatDatabase } from "../schema";
+import type { LocalMessage } from "../schema";
+import { MessageRepository } from "../message-repository";
+import { MessageType } from "@/entities/chat/model/types";
+
+/**
+ * WEE-66 / forta-bugs#864, #938 — a deleted message must not linger in the
+ * timeline as an undeletable placeholder. `getMessages` is the liveQuery
+ * source for the chat window; filtering softDeleted/deleted rows here makes the
+ * timeline drop deleted messages, matching the chat-list preview which already
+ * uses `getLastNonDeleted` (no more preview-vs-timeline desync, #938).
+ */
+
+let db: ChatDatabase;
+let repo: MessageRepository;
+
+const ROOM_ID = "!room:server";
+
+function makeMsg(overrides: Partial<LocalMessage> = {}): LocalMessage {
+  return {
+    eventId: overrides.eventId ?? `$evt_${Math.random().toString(36).slice(2)}`,
+    clientId: overrides.clientId ?? `cli_${Math.random().toString(36).slice(2)}`,
+    roomId: overrides.roomId ?? ROOM_ID,
+    senderId: overrides.senderId ?? "user1",
+    content: overrides.content ?? "hello",
+    timestamp: overrides.timestamp ?? Date.now(),
+    type: overrides.type ?? MessageType.text,
+    status: overrides.status ?? "synced",
+    version: 1,
+    softDeleted: false,
+    ...overrides,
+  } as LocalMessage;
+}
+
+beforeEach(async () => {
+  const name = `test-soft-delete-filter-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  db = new ChatDatabase(name);
+  await db.open();
+  repo = new MessageRepository(db);
+});
+
+afterEach(async () => {
+  await db.delete();
+});
+
+describe("MessageRepository.getMessages — excludes deleted rows", () => {
+  it("omits soft-deleted messages from the timeline", async () => {
+    await db.messages.add(makeMsg({ eventId: "$a", content: "first", timestamp: 1000 }));
+    await db.messages.add(makeMsg({ eventId: "$b", content: "gone", timestamp: 2000, softDeleted: true }));
+    await db.messages.add(makeMsg({ eventId: "$c", content: "third", timestamp: 3000 }));
+
+    const msgs = await repo.getMessages(ROOM_ID);
+
+    expect(msgs.map((m) => m.eventId)).toEqual(["$a", "$c"]);
+  });
+
+  it("omits server-redacted (deleted) messages from the timeline", async () => {
+    await db.messages.add(makeMsg({ eventId: "$a", content: "first", timestamp: 1000 }));
+    await db.messages.add(makeMsg({ eventId: "$b", content: "", timestamp: 2000, deleted: true }));
+
+    const msgs = await repo.getMessages(ROOM_ID);
+
+    expect(msgs.map((m) => m.eventId)).toEqual(["$a"]);
+  });
+
+  it("omits a pending message deleted locally by clientId", async () => {
+    await db.messages.add(makeMsg({ eventId: "$a", content: "first", timestamp: 1000 }));
+    await db.messages.add(
+      makeMsg({ eventId: null, clientId: "pending-1", content: "draft", timestamp: 2000, status: "pending", softDeleted: true }),
+    );
+
+    const msgs = await repo.getMessages(ROOM_ID);
+
+    expect(msgs.map((m) => m.clientId)).not.toContain("pending-1");
+  });
+
+  it("still returns non-deleted messages in chronological order", async () => {
+    await db.messages.add(makeMsg({ eventId: "$a", content: "first", timestamp: 1000 }));
+    await db.messages.add(makeMsg({ eventId: "$b", content: "second", timestamp: 2000 }));
+
+    const msgs = await repo.getMessages(ROOM_ID);
+
+    expect(msgs.map((m) => m.content)).toEqual(["first", "second"]);
+  });
+});
+
+describe("MessageRepository — deleted rows hidden across jump/pagination paths", () => {
+  it("getMessagesAfter (forward pagination) omits deleted rows", async () => {
+    await db.messages.add(makeMsg({ eventId: "$a", content: "a", timestamp: 1000 }));
+    await db.messages.add(makeMsg({ eventId: "$b", content: "gone", timestamp: 2000, softDeleted: true }));
+    await db.messages.add(makeMsg({ eventId: "$c", content: "c", timestamp: 3000 }));
+
+    const msgs = await repo.getMessagesAfter(ROOM_ID, 500);
+
+    expect(msgs.map((m) => m.eventId)).toEqual(["$a", "$c"]);
+  });
+
+  it("getMessagesAroundTimestamp (jump-to-unread) omits deleted rows", async () => {
+    await db.messages.add(makeMsg({ eventId: "$a", content: "a", timestamp: 1000 }));
+    await db.messages.add(makeMsg({ eventId: "$b", content: "gone", timestamp: 2000, deleted: true }));
+    await db.messages.add(makeMsg({ eventId: "$c", content: "c", timestamp: 3000 }));
+
+    const { messages } = await repo.getMessagesAroundTimestamp(ROOM_ID, 2000);
+
+    expect(messages.map((m) => m.eventId)).toEqual(["$a", "$c"]);
+  });
+
+  it("getMessageContext omits deleted rows around the target", async () => {
+    await db.messages.add(makeMsg({ eventId: "$a", content: "a", timestamp: 1000 }));
+    await db.messages.add(makeMsg({ eventId: "$b", content: "gone", timestamp: 2000, softDeleted: true }));
+    await db.messages.add(makeMsg({ eventId: "$target", content: "target", timestamp: 3000 }));
+
+    const ctx = await repo.getMessageContext(ROOM_ID, "$target");
+
+    expect(ctx).not.toBeNull();
+    expect(ctx!.messages.map((m) => m.eventId)).toEqual(["$a", "$target"]);
+  });
+
+  it("getMessageContext returns null when the target itself is deleted", async () => {
+    await db.messages.add(makeMsg({ eventId: "$target", content: "", timestamp: 3000, softDeleted: true }));
+
+    const ctx = await repo.getMessageContext(ROOM_ID, "$target");
+
+    expect(ctx).toBeNull();
+  });
+});

--- a/src/shared/lib/local-db/message-repository.ts
+++ b/src/shared/lib/local-db/message-repository.ts
@@ -55,7 +55,15 @@ export class MessageRepository {
   // ---------------------------------------------------------------------------
 
   /** Load messages for a room (paginated, chronological order).
-   *  Returns up to `limit` messages with timestamp < `beforeTimestamp`. */
+   *  Returns up to `limit` messages with timestamp < `beforeTimestamp`.
+   *
+   *  Deleted rows (softDeleted via local/peer redaction, or `deleted` parsed
+   *  from a server-redacted event) are filtered out so the timeline drops them
+   *  instead of rendering an undeletable "[message deleted]" placeholder
+   *  (WEE-66 / #864). This keeps the chat window consistent with the chat-list
+   *  preview, which already skips deleted rows via `getLastNonDeleted` (#938).
+   *  Deletions are rare, so the post-index `.filter()` reads only marginally
+   *  more rows than `limit`. */
   async getMessages(
     roomId: string,
     limit = 50,
@@ -68,6 +76,7 @@ export class MessageRepository {
       .where("[roomId+timestamp]")
       .between([roomId, lower], [roomId, upper], !clearedAtTs, !beforeTimestamp)
       .reverse()
+      .filter((m) => !m.softDeleted && !m.deleted)
       .limit(limit)
       .toArray();
 
@@ -345,15 +354,27 @@ export class MessageRepository {
       });
   }
 
-  /** Soft-delete a message locally */
-  async softDelete(eventId: string): Promise<void> {
-    await this.db.messages
+  /** Soft-delete a message locally.
+   *
+   *  Matches by `eventId` first, falling back to `clientId` when no row was
+   *  touched. A pending message (not yet confirmed by the server) has
+   *  `eventId: null` and is identified only by its clientId — `deleteMessage`
+   *  passes `eventId ?? clientId`, so without the clientId fallback the
+   *  redaction was a silent no-op for pending messages (WEE-66 / #773, #864).
+   *  Server redactions always carry a `$eventId`, and clientIds are UUIDs, so
+   *  the two id spaces never collide. */
+  async softDelete(id: string): Promise<void> {
+    const patch = { softDeleted: true, deletedAt: Date.now() };
+    const touched = await this.db.messages
       .where("eventId")
-      .equals(eventId)
-      .modify({
-        softDeleted: true,
-        deletedAt: Date.now(),
-      });
+      .equals(id)
+      .modify(patch);
+    if (touched === 0) {
+      await this.db.messages
+        .where("clientId")
+        .equals(id)
+        .modify(patch);
+    }
   }
 
   /** Mark replyTo.deleted on all messages referencing a given eventId */
@@ -590,16 +611,21 @@ export class MessageRepository {
     clearedAtTs?: number,
   ): Promise<{ messages: LocalMessage[]; anchorIndex: number }> {
     const lower = clearedAtTs ?? Dexie.minKey;
+    // Exclude deleted rows here too — otherwise jump-to-unread re-surfaces the
+    // undeletable "[message deleted]" placeholder that getMessages filters out
+    // (WEE-66 / #864).
     const [before, after] = await Promise.all([
       this.db.messages
         .where("[roomId+timestamp]")
         .between([roomId, lower], [roomId, timestamp], !clearedAtTs, true)
         .reverse()
+        .filter((m) => !m.softDeleted && !m.deleted)
         .limit(beforeCount)
         .toArray(),
       this.db.messages
         .where("[roomId+timestamp]")
         .between([roomId, timestamp], [roomId, Dexie.maxKey], false, true)
+        .filter((m) => !m.softDeleted && !m.deleted)
         .limit(afterCount)
         .toArray(),
     ]);
@@ -622,7 +648,7 @@ export class MessageRepository {
     return this.db.messages
       .where("[roomId+timestamp]")
       .between([roomId, effectiveAfter], [roomId, Dexie.maxKey], false, true)
-      .filter(m => m.senderId !== excludeSenderId && !m.softDeleted)
+      .filter(m => m.senderId !== excludeSenderId && !m.softDeleted && !m.deleted)
       .count();
   }
 
@@ -670,6 +696,9 @@ export class MessageRepository {
     const target = await this.getByEventId(targetEventId);
     if (!target || target.roomId !== roomId) return null;
     if (clearedAtTs && target.timestamp <= clearedAtTs) return null;
+    // A deleted message is no longer in the timeline — jumping to it would land
+    // on the placeholder getMessages now hides (WEE-66 / #864).
+    if (target.softDeleted || target.deleted) return null;
 
     const lower = clearedAtTs ?? Dexie.minKey;
     const [before, after] = await Promise.all([
@@ -677,11 +706,13 @@ export class MessageRepository {
         .where("[roomId+timestamp]")
         .between([roomId, lower], [roomId, target.timestamp], !clearedAtTs, false)
         .reverse()
+        .filter((m) => !m.softDeleted && !m.deleted)
         .limit(contextSize)
         .toArray(),
       this.db.messages
         .where("[roomId+timestamp]")
         .between([roomId, target.timestamp], [roomId, Dexie.maxKey], false, true)
+        .filter((m) => !m.softDeleted && !m.deleted)
         .limit(contextSize)
         .toArray(),
     ]);
@@ -703,6 +734,9 @@ export class MessageRepository {
     const msgs = await this.db.messages
       .where("[roomId+timestamp]")
       .between([roomId, effectiveAfter], [roomId, Dexie.maxKey], false, true)
+      // Forward pagination must hide deleted rows too, matching getMessages
+      // (WEE-66 / #864).
+      .filter((m) => !m.softDeleted && !m.deleted)
       .limit(limit)
       .toArray();
     return sortLocalMessagesTimelineAsc(msgs);

--- a/src/shared/ui/bottom-sheet/BottomSheet.vue
+++ b/src/shared/ui/bottom-sheet/BottomSheet.vue
@@ -119,6 +119,10 @@ onUnmounted(() => {
 }
 .bs-fade-leave-active {
   transition: opacity 0.2s ease-in;
+  /* Once the sheet starts closing, stop the fading backdrop from swallowing
+     the next tap. Without this, selecting "Select" and immediately tapping a
+     bubble loses the first tap to the closing overlay (WEE-66 / #863). */
+  pointer-events: none;
 }
 .bs-fade-enter-from,
 .bs-fade-leave-to {


### PR DESCRIPTION
## Summary
- **delete-for-all для pending (#773):** `softDelete` ищет по `eventId` ИЛИ `clientId`; server-redact ставится в очередь только для реальных `$eventId` — pending-сообщения (только clientId) удаляются локально без битого redact.
- **неудаляемый placeholder (#864, #938):** `getMessages` + пути jump/forward-пагинации фильтруют `softDeleted`/`deleted` → удалённые сообщения исчезают из ленты согласованно с превью чат-листа.
- **мультивыбор в DM на мобиле (#863, #924):** в selection-mode выключены long-press/контекст-меню/swipe; тап по любому месту баббла тоглит выбор; закрывающийся backdrop BottomSheet больше не «съедает» следующий тап.
- **edit в landscape (#829):** телефон в landscape теперь трактуется как mobile-like для раскладки инпута, высоты textarea и Enter-to-send.
- **копирование (#897):** копирование всего сообщения убирает `@hexaddr` mention-синтаксис → читаемый `@Name`.

## Linear
- Resolves WEE-66 (https://linear.app/wwwee/issue/WEE-66)

## Closes
Closes greenShirtMystery/forta-bugs#773
Closes greenShirtMystery/forta-bugs#864
Closes greenShirtMystery/forta-bugs#863
Closes greenShirtMystery/forta-bugs#924
Closes greenShirtMystery/forta-bugs#829
Closes greenShirtMystery/forta-bugs#897
Closes greenShirtMystery/forta-bugs#938

## Test plan
- [x] `vite build` (vue-tsc + bundle) проходит, 0 новых ошибок типов (49 — pre-existing baseline)
- [x] Unit/регрессионные тесты добавлены: `delete-message.test.ts`, `message-repository-soft-delete-filter.test.ts`, расширены `input-layout.test.ts` и `chat-store.test.ts`
- [x] Code review (superpowers:code-reviewer) — HIGH (фильтр на jump/forward-путях) исправлен, LOW адресованы
- [ ] Manual QA на реальном Android: мультивыбор (#863/#924) и edit в landscape (#829) требуют проверки на устройстве
- [ ] A6 регрессия: входящие redaction по-прежнему дают «🚫 Message deleted» в превью (WEE-43)