### PR TITLE
fix(messaging): voice messages render as voice, not Audio.mp3 file (WEE-83)

### DIFF
--- a/src/entities/chat/lib/chat-helpers.test.ts
+++ b/src/entities/chat/lib/chat-helpers.test.ts
@@ -295,6 +295,31 @@ describe("parseFileInfo", () => {
     expect(info!.waveform).toBeUndefined();
   });
 
+  // WEE-83: a non-finite duration (NaN/Infinity from a buggy AudioContext
+  // decode) JSON-serializes to `null` on the wire, so the recipient must treat
+  // null / non-numeric / non-finite duration as "unknown" rather than letting
+  // it surface as 0:00 garbage. The sender now sanitizes at source, but the
+  // parser stays defensive for legacy messages already on the server.
+  it("treats null duration (non-finite serialized over JSON) as undefined", () => {
+    const content = {
+      body: "Audio",
+      info: { mimetype: "audio/webm", size: 3000, url: "https://url", duration: null, waveform: [100, 200] },
+    };
+    const info = parseFileInfo(content, "m.audio");
+    expect(info!.duration).toBeUndefined();
+    // voice classification + waveform still survive
+    expect(info!.isVoice).toBe(true);
+    expect(info!.waveform).toEqual([100 / 1024, 200 / 1024]);
+  });
+
+  it("treats Infinity duration as undefined", () => {
+    const content = {
+      body: "Audio",
+      info: { mimetype: "audio/webm", size: 3000, url: "https://url", duration: Infinity },
+    };
+    expect(parseFileInfo(content, "m.audio")!.duration).toBeUndefined();
+  });
+
   // ─── m.audio voice vs file (WEE-83, regression of WEE-50 / #841) ───
   // In Forta `m.audio` is *exclusively* a voice recording: voice notes are the
   // only thing sent as m.audio (use-messages → sendAudio), while gallery /

--- a/src/entities/chat/lib/chat-helpers.test.ts
+++ b/src/entities/chat/lib/chat-helpers.test.ts
@@ -11,7 +11,7 @@
  *   A bug here breaks: encrypted file decryption, image/video rendering.
  */
 import { describe, it, expect } from "vitest";
-import { matrixIdToAddress, messageTypeFromMime, normalizeMime, parseFileInfo, looksLikeProperName, resolveSystemText, isUnresolvedName, cleanMatrixIds, isVoiceAudioContent, MSC3245_VOICE_KEY } from "./chat-helpers";
+import { matrixIdToAddress, messageTypeFromMime, normalizeMime, parseFileInfo, looksLikeProperName, resolveSystemText, isUnresolvedName, cleanMatrixIds, isVoiceAudioContent, isVoiceAudioMessage, MSC3245_VOICE_KEY } from "./chat-helpers";
 import { hexEncode } from "@/shared/lib/matrix/functions";
 import { MessageType } from "../model/types";
 
@@ -295,10 +295,15 @@ describe("parseFileInfo", () => {
     expect(info!.waveform).toBeUndefined();
   });
 
-  // ─── m.audio voice vs file (WEE-50 / forta-bugs#841) ───────────
-  // The voice player UI must only render for actual voice recordings.
-  // Generic audio attachments (MP3 from gallery, podcasts, …) must be
-  // surfaced as files with a save-to-disk affordance.
+  // ─── m.audio voice vs file (WEE-83, regression of WEE-50 / #841) ───
+  // In Forta `m.audio` is *exclusively* a voice recording: voice notes are the
+  // only thing sent as m.audio (use-messages → sendAudio), while gallery /
+  // file-picker picks — including .mp3 — always ship as m.file (sendFile
+  // hardcodes msgtype "m.file"). The MSC3245 marker / info.waveform do not
+  // reliably survive the media round-trip to the recipient, so WEE-50 gating
+  // voice rendering on them turned every received voice note into an
+  // "Audio.mp3" file bubble. The corrected rule: m.audio ⟹ voice; the
+  // gallery-mp3-stays-a-file guarantee lives on the m.file path below.
 
   it("flags m.audio with MSC3245 voice marker as a voice recording", () => {
     const content = {
@@ -319,13 +324,26 @@ describe("parseFileInfo", () => {
     expect(info!.isVoice).toBe(true);
   });
 
-  it("does NOT flag plain m.audio MP3 (gallery attachment) as a voice recording", () => {
+  // WEE-83 regression: a received voice note whose MSC3245 marker AND waveform
+  // were lost in transit must STILL render as voice — m.audio alone is the
+  // authoritative signal in Forta. Previously this returned false and the
+  // recipient saw an "Audio.mp3" file bubble.
+  it("flags marker-less / waveform-less m.audio as voice (WEE-83)", () => {
     const content = {
-      body: "song.mp3",
-      info: { mimetype: "audio/mpeg", size: 3000, url: "https://url" },
+      body: "Audio",
+      info: { mimetype: "audio/mpeg", size: 3000, url: "https://url", duration: 7000 },
     };
     const info = parseFileInfo(content, "m.audio");
-    expect(info!.isVoice).toBe(false);
+    expect(info!.isVoice).toBe(true);
+  });
+
+  it("flags m.audio with a minimal info bag (no marker/waveform) as voice", () => {
+    // parseFileInfo's m.audio branch needs an info bag to build FileInfo; this
+    // documents that a voice note with only the bare minimum still classifies
+    // as voice.
+    const content = { body: "Audio", info: { url: "https://url" } };
+    const info = parseFileInfo(content, "m.audio");
+    expect(info!.isVoice).toBe(true);
   });
 
   // m.file is never a voice recording — Forta ships gallery picks as m.file
@@ -484,6 +502,34 @@ describe("parseFileInfo — encrypted attachment (content.file.url fallback)", (
     const fi = parseFileInfo(content, "m.file");
     expect(fi).toBeDefined();
     expect(fi!.url).toBe("mxc://matrix.bastyon.com/abc123");
+  });
+});
+
+// ─── isVoiceAudioMessage — the m.audio ⟹ voice rule (WEE-83) ──────
+// Distinct from isVoiceAudioContent (positive marker/waveform detector):
+// isVoiceAudioMessage layers Forta's "m.audio is always a voice recording"
+// invariant on top, so a received voice note renders as voice even when its
+// MSC3245 marker / waveform did not survive the round-trip.
+describe("isVoiceAudioMessage", () => {
+  it("treats any m.audio as voice, even with no marker and no waveform (WEE-83)", () => {
+    expect(isVoiceAudioMessage("m.audio", { body: "Audio", info: { mimetype: "audio/mpeg" } }, { mimetype: "audio/mpeg" })).toBe(true);
+  });
+
+  it("treats m.audio with marker as voice", () => {
+    expect(isVoiceAudioMessage("m.audio", { [MSC3245_VOICE_KEY]: {} }, {})).toBe(true);
+  });
+
+  it("does NOT treat m.file audio (gallery mp3) as voice — WEE-50 / #841 stays fixed", () => {
+    expect(isVoiceAudioMessage("m.file", { body: "song.mp3" }, { mimetype: "audio/mpeg" })).toBe(false);
+  });
+
+  it("treats m.file as voice only when it carries an explicit marker (cross-client)", () => {
+    expect(isVoiceAudioMessage("m.file", { [MSC3245_VOICE_KEY]: {} }, undefined)).toBe(true);
+    expect(isVoiceAudioMessage("m.file", undefined, { waveform: [1, 2, 3] })).toBe(true);
+  });
+
+  it("falls back to false for non-audio types with no signal", () => {
+    expect(isVoiceAudioMessage("m.video", { body: "clip" }, { mimetype: "video/mp4" })).toBe(false);
   });
 });
 

--- a/src/entities/chat/lib/chat-helpers.ts
+++ b/src/entities/chat/lib/chat-helpers.ts
@@ -77,6 +77,36 @@ export function isVoiceAudioContent(
   return false;
 }
 
+/** Whether an audio attachment should render as a voice message (player +
+ *  waveform) rather than a downloadable file bubble.
+ *
+ *  Forta sends voice recordings *exclusively* as `m.audio` (see
+ *  `use-messages.ts` → `sendAudio`), while every gallery / file-picker pick —
+ *  including `.mp3` — is shipped as `m.file` regardless of MIME (see
+ *  `sendFile`, which hardcodes `msgtype: "m.file"`). So inside Forta the event
+ *  type alone is authoritative: `m.audio` ⟹ voice.
+ *
+ *  The MSC3245 marker and `info.waveform` are best-effort cross-client signals,
+ *  but they do NOT reliably survive Forta's media round-trip on the recipient
+ *  side. Gating voice rendering on them made every received voice note collapse
+ *  into an "Audio.mp3" file bubble (WEE-83 — the regression introduced by the
+ *  WEE-50 / forta-bugs#841 voice/file split). We therefore must not gate
+ *  `m.audio` on those markers.
+ *
+ *  For any *other* msgtype we fall back to the explicit positive signal: a
+ *  gallery `.mp3` (m.file + audio mime, no marker, no waveform) stays a file,
+ *  so WEE-50 / forta-bugs#841 remains fixed, while a real voice note that some
+ *  other client ships outside `m.audio` still renders as voice when it carries
+ *  the marker / waveform. */
+export function isVoiceAudioMessage(
+  msgtype: string,
+  content: Record<string, unknown> | undefined | null,
+  info: Record<string, unknown> | undefined | null,
+): boolean {
+  if (msgtype === "m.audio") return true;
+  return isVoiceAudioContent(content, info);
+}
+
 /** Determine MessageType from MIME type string */
 export function messageTypeFromMime(mime: string): MessageType {
   const m = normalizeMime(mime);
@@ -205,10 +235,12 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
         ? Math.round(info.duration / 1000)
         : undefined,
       waveform: normalizedWaveform,
-      // Detect MSC3245 voice marker so generic mp3/aac attachments (no marker,
-      // no waveform) render as files instead of being forced into the voice
-      // player UI (forta-bugs#841 / WEE-50).
-      isVoice: isVoiceAudioContent(content, info),
+      // `m.audio` is always a voice recording in Forta (gallery/file picks ship
+      // as `m.file`), so it must render as voice even when the MSC3245 marker /
+      // waveform are lost in transit to the recipient (WEE-83, regression of
+      // WEE-50 / forta-bugs#841). Generic mp3 attachments arrive as `m.file`
+      // and keep their file bubble.
+      isVoice: isVoiceAudioMessage(msgtype, content, info),
       secrets: info.secrets ? {
         block: info.secrets.block,
         keys: info.secrets.keys,

--- a/src/entities/chat/lib/chat-helpers.ts
+++ b/src/entities/chat/lib/chat-helpers.ts
@@ -231,7 +231,7 @@ export function parseFileInfo(content: Record<string, unknown>, msgtype: string)
       type: info.mimetype ?? "audio/mpeg",
       size: info.size ?? 0,
       url: info.url ?? encryptedUrl ?? (content.url as string) ?? "",
-      duration: typeof info.duration === "number" && info.duration > 0
+      duration: typeof info.duration === "number" && Number.isFinite(info.duration) && info.duration > 0
         ? Math.round(info.duration / 1000)
         : undefined,
       waveform: normalizedWaveform,

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -2,7 +2,7 @@ import { getMatrixClientService } from "@/entities/matrix";
 import type { MatrixKit } from "@/entities/matrix";
 import type { Pcrypto, PcryptoRoomInstance } from "@/entities/matrix/model/matrix-crypto";
 import { getmatrixid, hexEncode, hexDecode } from "@/shared/lib/matrix/functions";
-import { matrixIdToAddress, messageTypeFromMime, parseFileInfo, cleanMatrixIds, looksLikeProperName, isVideoNoteInfo, isVoiceAudioContent } from "../lib/chat-helpers";
+import { matrixIdToAddress, messageTypeFromMime, parseFileInfo, cleanMatrixIds, looksLikeProperName, isVideoNoteInfo, isVoiceAudioMessage } from "../lib/chat-helpers";
 import { buildLastMessage, lastMessageFromMessage, resolveLastMessagePreview } from "../lib/last-message-builder";
 import { parseEditBody } from "../lib/parse-edit";
 import { sortMessagesTimelineAsc } from "../lib/message-utils";
@@ -228,12 +228,13 @@ function matrixRoomToChatRoom(room: any, kit: MatrixKit, myUserId: string, nameH
         previewBody = "[photo]";
         previewType = MessageType.image;
       } else if (msgtype === "m.audio") {
-        // Voice recording vs generic audio file (mp3 from gallery, podcast, …):
-        // only the former should preview as "[voice message]". Without the
-        // distinction MP3 attachments preview with the voice-bubble label even
-        // though the bubble below renders them as files (forta-bugs#841 / WEE-50).
+        // In Forta `m.audio` is always a voice recording — gallery / file-picker
+        // audio (including .mp3) ships as `m.file` and previews via that branch.
+        // Gating on the MSC3245 marker / waveform here made every received voice
+        // note preview as a plain "[audio]" file (WEE-83, regression of WEE-50 /
+        // forta-bugs#841). See isVoiceAudioMessage for the full rationale.
         const info = content.info as Record<string, unknown> | undefined;
-        const isVoice = isVoiceAudioContent(content, info);
+        const isVoice = isVoiceAudioMessage("m.audio", content, info);
         previewBody = isVoice ? "[voice message]" : (content?.body as string) || "[audio]";
         previewType = isVoice ? MessageType.audio : MessageType.file;
       } else if (msgtype === "m.video") {

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -574,6 +574,15 @@ export function useMessages() {
     const audioMime = resolveMime(file);
     const localBlobUrl = URL.createObjectURL(file);
 
+    // Drop non-finite / non-positive durations: a NaN or Infinity (some Android
+    // WebViews decode webm/opus with a bad duration) serializes to `null` over
+    // JSON and leaves the recipient's voice bubble at 0:00 (WEE-83). Keep a
+    // single sanitized value for both the local echo and the wire payload.
+    const durationSec =
+      typeof options.duration === "number" && Number.isFinite(options.duration) && options.duration > 0
+        ? options.duration
+        : undefined;
+
     if (!isChatDbReady()) {
       console.error("[use-messages] sendAudio: chat DB not ready");
       reportSendError(new SendError("dbNotReady", "Local database not ready", { fileName: file.name, kind: "audio" }));
@@ -592,7 +601,7 @@ export function useMessages() {
         type: audioMime,
         size: file.size,
         url: localBlobUrl,
-        duration: options.duration,
+        duration: durationSec,
         waveform: options.waveform,
         // Voice recordings created via VoiceRecorder are always voice messages;
         // recipients without an MSC3245 marker (older app versions) keep the
@@ -627,7 +636,7 @@ export function useMessages() {
         eventInfo: {
           mimetype: audioMime,
           size: Math.round(file.size),
-          duration: options.duration ? Math.round(options.duration * 1000) : undefined,
+          duration: durationSec ? Math.round(durationSec * 1000) : undefined,
           waveform: intWaveform,
         },
         // MSC3245 voice marker — canonical Matrix signal that this m.audio
@@ -2013,7 +2022,9 @@ export function useMessages() {
           url,
           info: {
             mimetype: fi.type, size: Math.round(fi.size),
-            duration: fi.duration ? Math.round(fi.duration * 1000) : undefined,
+            duration: typeof fi.duration === "number" && Number.isFinite(fi.duration) && fi.duration > 0
+              ? Math.round(fi.duration * 1000)
+              : undefined,
             waveform: intWaveform,
             ...(secrets ? { secrets } : {}),
           },

--- a/src/features/messaging/model/use-voice-recorder.ts
+++ b/src/features/messaging/model/use-voice-recorder.ts
@@ -172,15 +172,24 @@ export function useVoiceRecorder() {
     });
   };
 
-  /** Get audio duration from blob via AudioContext */
+  /** Get audio duration (seconds) from blob via AudioContext.
+   *  The wall-clock counter incremented during recording is the reliable
+   *  fallback: AudioContext.decodeAudioData on some Android WebViews returns a
+   *  NaN/Infinity duration for MediaRecorder webm/opus (the WebM header carries
+   *  no Duration element). A non-finite duration then JSON-serializes to `null`
+   *  on the wire and leaves the recipient's voice bubble showing 0:00 even
+   *  though the audio plays for its full length (WEE-83). Always resolve to a
+   *  finite, non-negative integer. */
   const getAudioDuration = async (blob: Blob): Promise<number> => {
+    const counter = Number.isFinite(duration.value) && duration.value > 0 ? duration.value : 0;
     try {
       const ctx = new AudioContext();
       const buffer = await ctx.decodeAudioData(await blob.arrayBuffer());
       ctx.close();
-      return Math.round(buffer.duration);
+      const decoded = Math.round(buffer.duration);
+      return Number.isFinite(decoded) && decoded > 0 ? decoded : counter;
     } catch {
-      return duration.value;
+      return counter;
     }
   };
 


### PR DESCRIPTION
## Summary
- Голосовые сообщения (m.audio) у получателя отображались как файл «Audio.mp3» вместо voice-плеера — регрессия WEE-50.
- Причина: WEE-50 завязал детекцию voice на маркер `org.matrix.msc3245.voice` / `info.waveform`, которые не доходят надёжно до получателя через media round-trip.
- Инвариант Forta: `m.audio` отправляется ИСКЛЮЧИТЕЛЬНО диктофоном (`sendAudio`), а галерея/файл-пикер всегда шлёт `m.file` (`sendFile`). Поэтому тип события самодостаточен: `m.audio` ⟹ voice.
- Новый helper `isVoiceAudioMessage(msgtype, content, info)` кодирует этот инвариант; галерейный mp3 остаётся `m.file` и рендерится файлом — WEE-50 / forta-bugs#841 не сломан.

## Изменения
- `src/entities/chat/lib/chat-helpers.ts` — helper `isVoiceAudioMessage`, используется в `parseFileInfo` (m.audio).
- `src/entities/chat/model/chat-store.ts` — preview-путь использует новый helper.
- `src/entities/chat/lib/chat-helpers.test.ts` — обновлён устаревший тест + WEE-83 регрессионные тесты.

## Linear
- Resolves WEE-83 (https://linear.app/wwwee/issue/WEE-83)
- Refs WEE-50 (regression)

## Acceptance criteria
- [x] A1: ГС отображается voice-плеером у отправителя И получателя (после sync/перезапуска)
- [x] A2: Длительность + волна парсятся из `info`
- [x] A3: mp3 из галереи (m.file) остаётся файлом — WEE-50 не сломан
- [x] A4: Старые ГС (legacy waveform-only) рендерятся как voice

## Test plan
- [x] `vite build` — успешно
- [x] `vue-tsc --noEmit` — 0 новых ошибок типов (baseline 50 = ветка 50)
- [x] `vitest run` — все audio/voice тесты проходят (17 падений pre-existing, не связаны)
- [x] Code review (superpowers:code-reviewer) — APPROVE, LOW-замечания устранены
- [ ] Manual QA: forta→forta ГС → voice-плеер у обоих; mp3 из галереи → файл