### PR TITLE
fix(messages): serve cached chats/messages offline — read-path independent of connection (WEE-80)

### DIFF
--- a/src/entities/chat/model/__tests__/offline-read-sync-gate.test.ts
+++ b/src/entities/chat/model/__tests__/offline-read-sync-gate.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { setActivePinia } from "pinia";
+import { createTestingPinia } from "@pinia/testing";
+import type { LocalRoom } from "@/shared/lib/local-db";
+
+// Matrix client reports NOT ready — emulates a cold-start in airplane mode
+// where the SDK never connects.
+const mockMatrixService = {
+  getUserId: vi.fn(() => "@me:server"),
+  getRoom: vi.fn(() => undefined),
+  isReady: vi.fn(() => false),
+  getIgnoredMatrixUserIds: vi.fn(() => [] as string[]),
+  matrixId: vi.fn((id: string) => id),
+};
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: vi.fn(() => mockMatrixService),
+}));
+
+import { useChatStore } from "../chat-store";
+
+function makeLocalRoom(id: string, overrides: Partial<LocalRoom> = {}): LocalRoom {
+  return {
+    id,
+    name: "Room",
+    isGroup: false,
+    members: ["@me:server", "@peer:server"],
+    membership: "join",
+    unreadCount: 0,
+    lastReadInboundTs: 0,
+    lastReadOutboundTs: 0,
+    updatedAt: Date.now(),
+    syncedAt: Date.now(),
+    hasMoreHistory: true,
+    isDeleted: false,
+    deletedAt: null,
+    deleteReason: null,
+    ...overrides,
+  };
+}
+
+function makeKit(rooms: LocalRoom[]) {
+  return {
+    rooms: {
+      getAllRooms: vi.fn(async () => rooms),
+      observeRoomChanges: vi.fn(() => () => {}),
+      bulkSyncRooms: vi.fn(async () => {}),
+    },
+    eventWriter: { enableBatching: vi.fn(), setClearedAtTs: vi.fn() },
+  };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("WEE-80 — chat-store offline read path (no Matrix, no network)", () => {
+  let store: ReturnType<typeof useChatStore>;
+
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }));
+    store = useChatStore();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("A1: hydrates sortedRooms from Dexie even though Matrix is not ready", async () => {
+    const kit = makeKit([
+      makeLocalRoom("!a:s", { name: "Alice", lastMessageTimestamp: 2000 }),
+      makeLocalRoom("!b:s", { name: "Bob", lastMessageTimestamp: 1000 }),
+    ]);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store.setChatDbKit(kit as any);
+    await flush();
+    await flush();
+
+    expect(mockMatrixService.isReady()).toBe(false);
+    const ids = store.sortedRooms.map((r) => r.id);
+    expect(ids).toContain("!a:s");
+    expect(ids).toContain("!b:s");
+    // Newest conversation sorts first — list is usable offline.
+    expect(ids[0]).toBe("!a:s");
+  });
+
+  it("read-path skeleton (isSyncing) does NOT latch on a lost connection", () => {
+    vi.useFakeTimers();
+
+    // Wire helpers → starts the WEE-55 initial-sync watchdog.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store.setHelpers({} as any, {} as any);
+
+    // Genuine first-load phase: skeleton allowed.
+    expect(store.isSyncing).toBe(true);
+
+    // Watchdog gives up after 8s with no sync → degraded. Cached Dexie data is
+    // now authoritative, so the read path must stop reporting "syncing".
+    vi.advanceTimersByTime(8000);
+    expect(store.isSyncing).toBe(false);
+
+    // A failing/recovering Matrix poll (offline) must NOT re-raise the
+    // read-path skeleton — connection status is surfaced elsewhere (WEE-80).
+    store.setSyncState("ERROR");
+    expect(store.isSyncing).toBe(false);
+    store.setSyncState("RECONNECTING");
+    expect(store.isSyncing).toBe(false);
+  });
+});

--- a/src/entities/chat/model/chat-store-initial-sync.test.ts
+++ b/src/entities/chat/model/chat-store-initial-sync.test.ts
@@ -82,14 +82,24 @@ describe("chat-store WEE-55 initial-sync watchdog", () => {
     expect(store.initialSyncStatus).toBe("ready");
   });
 
-  it("keeps isSyncing true while the connection is lost, even after ready", () => {
+  // WEE-80 (forta-bugs#956): supersedes the original WEE-55 expectation that a
+  // lost connection re-raised isSyncing. The local-first read path must NOT
+  // depend on the network — once the first sync (or the watchdog degrade) has
+  // settled, the in-room message skeleton (isSyncing) stays down so cached
+  // Dexie content keeps rendering. Connection status is exposed separately via
+  // `syncState` (and the sync banner), not via isSyncing.
+  it("does NOT re-raise isSyncing when the connection drops after ready (WEE-80)", () => {
     store.setHelpers(mockMatrixService.kit as never, {} as never);
     store.refreshRooms("PREPARED");
     vi.advanceTimersByTime(150);
     expect(store.isSyncing).toBe(false);
 
     store.setSyncState("RECONNECTING");
-    expect(store.isSyncing).toBe(true);
+    expect(store.isSyncing).toBe(false);
+    expect(store.syncState).toBe("RECONNECTING"); // connection state still observable
+
+    store.setSyncState("ERROR");
+    expect(store.isSyncing).toBe(false);
   });
 
   it("upgrades degraded → ready when a real PREPARED sync arrives late", () => {

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -517,13 +517,20 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     }, INITIAL_SYNC_TIMEOUT_MS);
   };
 
-  /** True during initial sync or when connection is lost. Degraded mode is
-   *  intentionally NOT syncing — we have stopped blocking the UI. */
-  const isSyncing = computed(() =>
-    initialSyncStatus.value === "loading"
-    || syncState.value === "ERROR"
-    || syncState.value === "RECONNECTING",
-  );
+  /** True ONLY during the genuine first-load phase (before the first sync or
+   *  the watchdog degrade). It gates the in-room message skeleton.
+   *
+   *  WEE-80 (forta-bugs#956): local-first read path must NOT depend on the
+   *  network. Previously this also flipped true on `syncState` ERROR/
+   *  RECONNECTING, so a cold-start with no connection (or a lost connection)
+   *  left empty rooms stuck on an eternal "loading" skeleton instead of
+   *  rendering the cached Dexie truth ("No messages yet"), and caused the
+   *  message skeleton to flicker on every WebSocket reconnect (same flicker
+   *  ContactList.vue already side-steps). Connection status is surfaced
+   *  separately by the sync banner (use-sync-status), not by the read path.
+   *  `initialSyncStatus` leaves "loading" via the first real sync OR the 8s
+   *  degrade watchdog, so this still bounds the genuine first-load skeleton. */
+  const isSyncing = computed(() => initialSyncStatus.value === "loading");
 
   // Cache for decrypted room previews — persists across refreshRooms() rebuilds
   const decryptedPreviewCache = new Map<string, string>();

--- a/src/features/messaging/model/__tests__/offline-read.test.ts
+++ b/src/features/messaging/model/__tests__/offline-read.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "fake-indexeddb/auto";
+import { ChatDatabase } from "@/shared/lib/local-db/schema";
+import type { LocalMessage, LocalRoom } from "@/shared/lib/local-db/schema";
+import { MessageRepository } from "@/shared/lib/local-db/message-repository";
+import { RoomRepository } from "@/shared/lib/local-db/room-repository";
+import { MessageType } from "@/entities/chat/model/types";
+
+/**
+ * WEE-80 (forta-bugs#956) — local-first offline read.
+ *
+ * Invariant: chat history (rooms + messages) is read from Dexie via the
+ * repositories, with NO dependency on the Matrix client or network. A
+ * cold-start in airplane mode must surface whatever IndexedDB already holds.
+ * These tests touch the repositories directly — the same code paths the
+ * reactive `useLiveQuery` reads feed from — so they fail if a future change
+ * reintroduces a network/Matrix gate on the read path.
+ */
+
+let db: ChatDatabase;
+let msgRepo: MessageRepository;
+let roomRepo: RoomRepository;
+
+function makeMsg(roomId: string, overrides: Partial<LocalMessage> = {}): LocalMessage {
+  return {
+    eventId: overrides.eventId ?? `$evt_${Math.random().toString(36).slice(2)}`,
+    clientId: overrides.clientId ?? `cli_${Math.random().toString(36).slice(2)}`,
+    roomId,
+    senderId: "user1",
+    content: "hello",
+    timestamp: overrides.timestamp ?? Date.now(),
+    type: MessageType.text,
+    status: "synced",
+    version: 1,
+    softDeleted: false,
+    ...overrides,
+  } as LocalMessage;
+}
+
+function makeRoom(id: string, overrides: Partial<LocalRoom> = {}): LocalRoom {
+  return {
+    id,
+    name: "Room",
+    isGroup: false,
+    members: ["user1", "user2"],
+    membership: "join",
+    unreadCount: 0,
+    lastReadInboundTs: 0,
+    lastReadOutboundTs: 0,
+    updatedAt: Date.now(),
+    syncedAt: Date.now(),
+    hasMoreHistory: true,
+    isDeleted: false,
+    deletedAt: null,
+    deleteReason: null,
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  const name = `test-offline-read-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  db = new ChatDatabase(name);
+  await db.open();
+  msgRepo = new MessageRepository(db);
+  roomRepo = new RoomRepository(db);
+});
+
+afterEach(async () => {
+  await db.delete();
+});
+
+describe("WEE-80 — offline read from Dexie (no Matrix, no network)", () => {
+  it("A1: getAllRooms returns cached joined + invited rooms with no client started", async () => {
+    // Seed as if a prior online session persisted these, then went offline.
+    await roomRepo.bulkUpsertRooms([
+      makeRoom("!joined:s", { name: "Alice", membership: "join" }),
+      makeRoom("!invited:s", { name: "Bob", membership: "invite" }),
+    ]);
+
+    // No Matrix client, no connectivity — pure IndexedDB read.
+    const rooms = await roomRepo.getAllRooms();
+
+    const ids = rooms.map((r) => r.id).sort();
+    expect(ids).toEqual(["!invited:s", "!joined:s"]);
+  });
+
+  it("A1: getMessages returns the cached conversation offline, in timeline order", async () => {
+    const roomId = "!room:s";
+    await roomRepo.bulkUpsertRooms([makeRoom(roomId)]);
+    await db.messages.bulkAdd([
+      makeMsg(roomId, { eventId: "$m1", timestamp: 1000, content: "first" }),
+      makeMsg(roomId, { eventId: "$m2", timestamp: 2000, content: "second" }),
+      makeMsg(roomId, { eventId: "$m3", timestamp: 3000, content: "third" }),
+    ]);
+
+    const msgs = await msgRepo.getMessages(roomId);
+
+    expect(msgs.map((m) => m.content)).toEqual(["first", "second", "third"]);
+  });
+
+  it("A1: messages for the active room are readable while another room exists too", async () => {
+    await roomRepo.bulkUpsertRooms([makeRoom("!a:s"), makeRoom("!b:s")]);
+    await db.messages.bulkAdd([
+      makeMsg("!a:s", { timestamp: 10, content: "a-only" }),
+      makeMsg("!b:s", { timestamp: 20, content: "b-only" }),
+    ]);
+
+    const a = await msgRepo.getMessages("!a:s");
+    const b = await msgRepo.getMessages("!b:s");
+
+    expect(a.map((m) => m.content)).toEqual(["a-only"]);
+    expect(b.map((m) => m.content)).toEqual(["b-only"]);
+  });
+
+  it("A3: getAllRooms hides tombstoned rooms but keeps valid ones (cleanup never wipes the live read)", async () => {
+    await roomRepo.bulkUpsertRooms([
+      makeRoom("!valid:s", { name: "Keep me" }),
+      makeRoom("!removed:s", {
+        name: "Tombstoned",
+        isDeleted: true,
+        deletedAt: Date.now(),
+        deleteReason: "removed",
+      }),
+    ]);
+
+    const rooms = await roomRepo.getAllRooms();
+
+    expect(rooms.map((r) => r.id)).toEqual(["!valid:s"]);
+  });
+});


### PR DESCRIPTION
## Summary

- **WEE-80 (forta-bugs#956):** offline, chat history must read from Dexie (local-first), independent of network/Matrix.
- Investigation confirmed the room-list + message read path already hydrates from Dexie on a cold start offline (via the WEE-55 initial-sync watchdog and the WEE-61 cleanup guard). The **one remaining network coupling on the read path** was `chatStore.isSyncing`: it latched `true` on `syncState === "ERROR"/"RECONNECTING"`, gating the in-room message skeleton — so an empty room stayed on an eternal skeleton offline and the skeleton flickered on every reconnect.
- Fix: `isSyncing` now tracks **only** the genuine first-load phase (`initialSyncStatus === "loading"`), bounded by the 8s degrade watchdog and the first real sync. Connection status stays observable via the still-exported `syncState` ref and the separate sync banner (`use-sync-status`). The sole consumer is `MessageList.vue` (skeleton/empty-state, both additionally gated on `activeMessages.length === 0`); `ContactList.vue` already deliberately ignores `isSyncing`.
- Adds regression coverage locking the offline-read invariant at the repository and store layers.

## Changes

- `src/entities/chat/model/chat-store.ts` — `isSyncing` computed reduced to the first-load phase only.
- `src/entities/chat/model/chat-store-initial-sync.test.ts` — updated the WEE-55 test that asserted the old "latch on connection loss" behavior to the new WEE-80 contract (and asserts `syncState` stays observable).
- `src/features/messaging/model/__tests__/offline-read.test.ts` — **new**: repository-level regression (rooms + messages read from Dexie with no Matrix client; tombstones excluded).
- `src/entities/chat/model/__tests__/offline-read-sync-gate.test.ts` — **new**: store-level regression (`sortedRooms` hydrate from Dexie with Matrix not ready; `isSyncing` does not latch on ERROR/RECONNECTING after the first sync).

## Linear

- Resolves [WEE-80](https://linear.app/wwwee/issue/WEE-80) — messages: переписка не видна без интернета — local-first не отдаёт кэш offline

## Closes

Closes greenShirtMystery/forta-bugs#956

## Test plan

- [x] New + affected unit/regression tests pass (`offline-read`, `offline-read-sync-gate`, `chat-store-initial-sync`, plus the 264 messaging-ui + chat-store-model tests) on Node 22.
- [x] `vue-tsc --noEmit`: 0 new type errors in changed files (pre-existing ~49-error baseline unchanged).
- [x] Code review (`superpowers:code-reviewer`): APPROVE, no CRITICAL/HIGH.
- [ ] Manual QA on device: airplane-mode cold-start → chat list + opened conversation history visible from cache; reconnect → new messages catch up, nothing lost; empty room shows "No messages yet" offline (no eternal skeleton).

> Note: `npm run build` runs `vue-tsc` first and currently fails on the repo's pre-existing baseline type errors (unrelated to this change; none in the changed files). `npm run lint` — no lint script in this repo.