### PR TITLE
fix(calls): legacy speakerphone fallback so in-call speaker toggle works on OEMs (WEE-76)

### DIFF
--- a/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
@@ -190,6 +190,43 @@ class AudioRouter private constructor(private val context: Context) {
         @androidx.annotation.VisibleForTesting
         internal fun shouldClearWhenTargetMissing(device: Device): Boolean =
             device == Device.BLUETOOTH || device == Device.WIRED_HEADSET
+
+        /**
+         * WEE-76 (#944/#960) — desired legacy `isSpeakerphoneOn` value used to
+         * reinforce the modern [setCommunicationDevice] route for the built-in
+         * earpiece/speaker pair.
+         *
+         * Multi-user reports on 1.10.38/39 show the in-call speaker button never
+         * engaging the loudspeaker. On API 31+ the toggle routes ONLY through
+         * `setCommunicationDevice(TYPE_BUILTIN_SPEAKER)`, which on several OEMs
+         * is a silent no-op: it returns `false` under audio-stack contention, or
+         * `TYPE_BUILTIN_SPEAKER` is momentarily absent from
+         * `availableCommunicationDevices` (the WEE-54 guard then deliberately
+         * keeps the current earpiece route to avoid the A15 silence bug). Either
+         * way an explicit user tap does nothing — exactly the #944/#960 symptom,
+         * confirmed across multiple users (not a single OEM).
+         *
+         * The legacy `isSpeakerphoneOn` flag is the reliable cross-OEM switch for
+         * the built-in loudspeaker, so we mirror it to the requested built-in
+         * device after the modern call. It expresses the same routing as the
+         * modern path (no conflict on healthy devices) and is the same mechanism
+         * the API < 31 path ([setDeviceLegacy]) already uses.
+         *
+         * Returns:
+         *   - `true`  → engage the loudspeaker (SPEAKER)
+         *   - `false` → disengage the loudspeaker (EARPIECE)
+         *   - `null`  → leave untouched (BLUETOOTH / WIRED_HEADSET are owned by
+         *               [setCommunicationDevice]; the legacy flag must not fight
+         *               them — A5: zero change to the proven BT/wired path).
+         *
+         * Companion-scope so a JVM-only test covers it without an AudioManager.
+         */
+        @androidx.annotation.VisibleForTesting
+        internal fun legacySpeakerphoneTarget(device: Device): Boolean? = when (device) {
+            Device.SPEAKER -> true
+            Device.EARPIECE -> false
+            Device.BLUETOOTH, Device.WIRED_HEADSET -> null
+        }
     }
 
     enum class Device(val label: String) {
@@ -750,6 +787,23 @@ class AudioRouter private constructor(private val context: Context) {
                 LIFECYCLE_TAG,
                 "Built-in target $device not yet enumerated (Android 15 race) — keeping current routing",
             )
+        }
+
+        // WEE-76 (#944/#960): reinforce the built-in earpiece/speaker route with
+        // the legacy speakerphone flag. setCommunicationDevice(SPEAKER) is an
+        // unreliable no-op on several OEMs (returns false under contention, or
+        // the speaker is briefly un-enumerated and the guard above keeps the
+        // earpiece), so an explicit speaker tap never engaged the loudspeaker for
+        // many users. Mirroring isSpeakerphoneOn to the requested built-in device
+        // is the reliable cross-OEM switch and matches the modern route, so it is
+        // safe on healthy devices. BT/wired → null → left to the modern path.
+        legacySpeakerphoneTarget(device)?.let { speakerphoneOn ->
+            try {
+                @Suppress("DEPRECATION")
+                audioManager.isSpeakerphoneOn = speakerphoneOn
+            } catch (e: Exception) {
+                Log.w(LIFECYCLE_TAG, "legacy isSpeakerphoneOn=$speakerphoneOn threw", e)
+            }
         }
     }
 

--- a/android/app/src/test/java/com/forta/chat/plugins/calls/AudioRouterSpeakerphoneFallbackTest.kt
+++ b/android/app/src/test/java/com/forta/chat/plugins/calls/AudioRouterSpeakerphoneFallbackTest.kt
@@ -1,0 +1,77 @@
+package com.forta.chat.plugins.calls
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Regression tests for WEE-76 (#944 / #960) — speaker toggle never engages the
+ * loudspeaker on several OEMs.
+ *
+ * On API 31+ the in-call speaker button routes ONLY through
+ * `setCommunicationDevice(TYPE_BUILTIN_SPEAKER)`, which is a silent no-op on a
+ * number of devices: it returns `false` under audio-stack contention, or the
+ * built-in speaker is momentarily absent from `availableCommunicationDevices`
+ * (the WEE-54 guard then keeps the current earpiece route to avoid the Android
+ * 15 silence bug). Multiple users reported the toggle doing nothing.
+ *
+ * [AudioRouter.legacySpeakerphoneTarget] drives the cross-OEM legacy
+ * `isSpeakerphoneOn` reinforcement applied to the built-in earpiece/speaker pair
+ * after the modern routing call. Bluetooth / wired headsets stay owned by
+ * `setCommunicationDevice` (predicate returns null) so the proven removable-route
+ * path is untouched (A5).
+ *
+ * Pure predicate so it is covered by a JVM-only JUnit test without an
+ * AudioManager / Robolectric.
+ */
+class AudioRouterSpeakerphoneFallbackTest {
+
+    @Test
+    fun speakerRequest_engagesLegacyLoudspeaker() {
+        assertEquals(
+            "explicit SPEAKER request must engage the legacy loudspeaker flag — " +
+                "setCommunicationDevice(SPEAKER) is an unreliable no-op on several OEMs (#944/#960)",
+            true,
+            AudioRouter.legacySpeakerphoneTarget(AudioRouter.Device.SPEAKER),
+        )
+    }
+
+    @Test
+    fun earpieceRequest_disengagesLegacyLoudspeaker() {
+        assertEquals(
+            "EARPIECE request must disengage the loudspeaker so toggling back off works",
+            false,
+            AudioRouter.legacySpeakerphoneTarget(AudioRouter.Device.EARPIECE),
+        )
+    }
+
+    @Test
+    fun bluetoothRequest_leavesLegacyFlagUntouched() {
+        assertNull(
+            "Bluetooth is owned by setCommunicationDevice — the legacy speakerphone " +
+                "flag must not fight it (A5: zero change to the proven BT path)",
+            AudioRouter.legacySpeakerphoneTarget(AudioRouter.Device.BLUETOOTH),
+        )
+    }
+
+    @Test
+    fun wiredHeadsetRequest_leavesLegacyFlagUntouched() {
+        assertNull(
+            "wired/USB headset is owned by setCommunicationDevice — legacy flag untouched",
+            AudioRouter.legacySpeakerphoneTarget(AudioRouter.Device.WIRED_HEADSET),
+        )
+    }
+
+    @Test
+    fun builtInRoutesAreMutuallyExclusive() {
+        // The two built-in routes must map to opposite loudspeaker states so a
+        // speaker→earpiece→speaker sequence always lands on the right device.
+        val speaker = AudioRouter.legacySpeakerphoneTarget(AudioRouter.Device.SPEAKER)
+        val earpiece = AudioRouter.legacySpeakerphoneTarget(AudioRouter.Device.EARPIECE)
+        assertEquals(
+            "built-in routes must request opposite loudspeaker states",
+            speaker,
+            earpiece?.not(),
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- **#944 / #960 (speakerphone toggle no-op, multiple users):** on API 31+ the in-call speaker button routed **only** through `setCommunicationDevice(TYPE_BUILTIN_SPEAKER)`, which is a silent no-op on several OEMs — it returns `false` under audio-stack contention, or `TYPE_BUILTIN_SPEAKER` is momentarily absent from `availableCommunicationDevices` and the WEE-54 silence guard then deliberately keeps the earpiece route. Either way the tap did nothing.
- **Fix:** reinforce the built-in earpiece/speaker route with the legacy `isSpeakerphoneOn` flag (the reliable cross-OEM loudspeaker switch, same mechanism the API < 31 path already uses) via a pure `legacySpeakerphoneTarget()` predicate. Bluetooth / wired headsets return `null` → left entirely to `setCommunicationDevice` (A5-safe, zero change to the proven removable-route path and to healthy devices where the modern call already works).

## Scope
This change targets **A2 (speakerphone)** — the highest-confidence, multi-user-confirmed symptom. The mic one-way (#945, A1) and call-drop/error (#946, A3) symptoms are genuinely device/OEM-specific and require on-device logcat repro to localize safely; they are **not** addressed here and remain open for a device-repro pass (no lab device available in this session). Shipping the well-scoped speaker fix now rather than risking an 8th blind regression across the whole audio path.

## Linear
- Resolves WEE-76 (https://linear.app/wwwee/issue/WEE-76) — partial (A2); A1/A3 need device-repro

## Closes
Closes greenShirtMystery/forta-bugs#944
Closes greenShirtMystery/forta-bugs#960

## Test plan
- [x] `:app:testDebugUnitTest` green — new `AudioRouterSpeakerphoneFallbackTest` (5 cases) + existing `AudioRouterModeReapplyTest` / `VendorAudioPolicyTest`
- [x] JS calls-feature tests green (`call-controls-speaker`, `audio-watchdog` — 16/16)
- [ ] Manual QA on an **affected OEM** (Infinix/Tecno/Itel/Xiaomi): forta→forta call, tap speaker → audio moves to loudspeaker, tap again → back to earpiece
- [ ] Manual QA on a **healthy API 31+ device** (per review): confirm the redundant legacy `isSpeakerphoneOn` write does not perturb a working comm-device route
- [ ] Regression: WEE-49/60 (speakerphone OFF post-call, mic re-unmute) still intact; Bluetooth/wired switching unaffected