### PR TITLE
fix(media): long-press photo no longer freezes device (WEE-79)

### DIFF
--- a/src/features/messaging/ui/LinkPreviewCard.vue
+++ b/src/features/messaging/ui/LinkPreviewCard.vue
@@ -49,7 +49,8 @@ const imageError = ref(false);
       v-if="preview.imageUrl && !imageError"
       :src="preview.imageUrl"
       :alt="preview.title || ''"
-      class="block max-h-[200px] w-full object-cover"
+      class="block max-h-[200px] w-full object-cover select-none [-webkit-touch-callout:none] [-webkit-user-drag:none]"
+      draggable="false"
       loading="lazy"
       @error="imageError = true"
     />

--- a/src/features/messaging/ui/MessageBubble.vue
+++ b/src/features/messaging/ui/MessageBubble.vue
@@ -881,7 +881,7 @@ const replyPreviewSender = computed(() => {
             <span class="truncate max-w-full font-medium">{{ message.fileInfo?.name }}</span>
             <span v-if="isLikelyHeic" class="text-[10px] opacity-70">{{ t('message.heicNotSupported') }}</span>
           </div>
-          <img v-else-if="feedImageSrc" :src="feedImageSrc" :alt="message.fileInfo?.name" class="block max-h-[460px] max-w-full object-cover" :style="imageStyle" @load="emit('resize')" @error="onFeedImageError" />
+          <img v-else-if="feedImageSrc" :src="feedImageSrc" :alt="message.fileInfo?.name" class="block max-h-[460px] max-w-full object-cover select-none [-webkit-touch-callout:none] [-webkit-user-drag:none]" draggable="false" :style="imageStyle" @load="emit('resize')" @error="onFeedImageError" />
           <!-- Upload progress overlay -->
           <div v-if="isUploading" class="absolute inset-0 flex items-center justify-center bg-black/30">
             <button class="relative flex h-14 w-14 items-center justify-center" @click.stop="emit('cancelUpload', message)">
@@ -1027,7 +1027,8 @@ const replyPreviewSender = computed(() => {
             :controlslist="isVideoPlaying ? 'nodownload' : undefined"
             playsinline
             preload="metadata"
-            class="block h-full w-full object-contain"
+            draggable="false"
+            class="block h-full w-full object-contain select-none [-webkit-touch-callout:none] [-webkit-user-drag:none]"
             @loadedmetadata="onInlineVideoLoadedMetadata"
             @canplay="onInlineVideoCanPlay"
             @error="onInlineVideoError"

--- a/src/features/messaging/ui/VideoCirclePlayer.vue
+++ b/src/features/messaging/ui/VideoCirclePlayer.vue
@@ -121,8 +121,9 @@ onUnmounted(() => {
   <div ref="containerEl" class="video-circle-container relative inline-block cursor-pointer" @click="handleClick">
     <video
       ref="videoEl"
-      class="video-circle block h-[150px] w-[150px] object-cover sm:h-[200px] sm:w-[200px]"
+      class="video-circle block h-[150px] w-[150px] object-cover sm:h-[200px] sm:w-[200px] select-none [-webkit-touch-callout:none] [-webkit-user-drag:none]"
       :src="videoSrc ?? undefined"
+      draggable="false"
       muted
       playsinline
       preload="auto"

--- a/src/features/messaging/ui/__tests__/message-bubble-longpress-freeze-guard.test.ts
+++ b/src/features/messaging/ui/__tests__/message-bubble-longpress-freeze-guard.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const source = readFileSync(
+  resolve(__dirname, "../MessageBubble.vue"),
+  "utf-8",
+);
+const videoCircleSource = readFileSync(
+  resolve(__dirname, "../VideoCirclePlayer.vue"),
+  "utf-8",
+);
+const linkPreviewSource = readFileSync(
+  resolve(__dirname, "../LinkPreviewCard.vue"),
+  "utf-8",
+);
+
+/** All three webkit/native guards that suppress the WebView long-press drag. */
+const expectNativeDragGuard = (tag: string) => {
+  expect(tag).toMatch(/draggable="false"/);
+  expect(tag).toMatch(/\[-webkit-touch-callout:none\]/);
+  expect(tag).toMatch(/\[-webkit-user-drag:none\]/);
+  expect(tag).toMatch(/\bselect-none\b/);
+};
+
+/**
+ * WEE-79 / forta-bugs#948 — Long-press on a received photo froze the whole
+ * Android device (hard-reboot only). Root cause: Android WebView's *native*
+ * long-press on an `<img>`/`<video>` spins up a drag-and-drop with a
+ * full-resolution bitmap shadow. On a low-RAM device a multi-MB full-size
+ * photo (see WEE-71) makes that an instant native OOM that takes down the
+ * system UI — not just the app.
+ *
+ * The app's own long-press (pointer events, 500ms) opens the context menu and
+ * is unaffected by these CSS guards — they only suppress the *native* callout
+ * / drag bitmap. So the menu still opens; the device no longer freezes.
+ *
+ * These are source-level regression assertions (matching the established
+ * MessageBubble test style) because the guard is purely declarative CSS/markup
+ * that happy-dom does not execute as real WebView behaviour.
+ */
+describe("MessageBubble — native long-press media freeze guard (WEE-79)", () => {
+  /** Pull the single `<img>` tag that renders the feed photo (feedImageSrc). */
+  const feedImgTag = source.match(/<img v-else-if="feedImageSrc"[\s\S]*?\/>/)?.[0] ?? "";
+  /** Pull the inline `<video>` tag — anchored on its stable ref, not an
+   *  unrelated handler string, so reordering bindings don't silently drop it. */
+  const inlineVideoTag = source.match(/<video\b[\s\S]*?ref="inlineVideoRef"[\s\S]*?\/>/)?.[0] ?? "";
+
+  it("locates the feed image and inline video tags", () => {
+    expect(feedImgTag).not.toBe("");
+    expect(inlineVideoTag).not.toBe("");
+  });
+
+  it("disables native drag/callout on the feed photo", () => {
+    expectNativeDragGuard(feedImgTag);
+  });
+
+  it("disables native drag/callout on the inline video", () => {
+    expectNativeDragGuard(inlineVideoTag);
+  });
+
+  it("disables native drag/callout on the video-note (videoCircle) player", () => {
+    // Same freeze vector — a received video note is a full-res `<video>` the
+    // native long-press would also try to drag (review H1).
+    const videoNoteTag = videoCircleSource.match(/<video\b[\s\S]*?ref="videoEl"[\s\S]*?\/>/)?.[0] ?? "";
+    expect(videoNoteTag).not.toBe("");
+    expectNativeDragGuard(videoNoteTag);
+  });
+
+  it("disables native drag/callout on the link-preview image", () => {
+    const linkImgTag = linkPreviewSource.match(/<img\b[\s\S]*?@error="imageError = true"\s*\/>/)?.[0] ?? "";
+    expect(linkImgTag).not.toBe("");
+    expectNativeDragGuard(linkImgTag);
+  });
+
+  it("keeps the app long-press handler intact (menu still opens)", () => {
+    // The fix must NOT remove our own long-press → context-menu emission;
+    // only the native WebView callout is suppressed.
+    expect(source).toMatch(/useLongPress\(/);
+    expect(source).toMatch(/emit\("contextmenu", \{ message: props\.message/);
+  });
+
+  it("does not blanket-disable text selection (copy-fragment still works)", () => {
+    // A3 regression: the guard is scoped to media tags via class tokens, not a
+    // global `user-select: none` on the bubble — text bubbles must stay
+    // selectable for the in-bubble copy-fragment feature (WEE-42).
+    expect(source).not.toMatch(/class="[^"]*group relative flex gap-2[^"]*select-none/);
+  });
+});


### PR DESCRIPTION
## Summary
- Long-press on a received photo froze the **whole Android device** (hard-reboot only). Root cause: Android WebView's *native* long-press on an `<img>`/`<video>` spins up a native drag-and-drop with a full-resolution bitmap shadow — on a low-RAM device a multi-MB full-size photo (cf. WEE-71) makes that an instant native OOM that takes down the system UI, not just the app.
- Suppress the native callout/drag on all long-pressable chat media — feed image, inline video, video-note (`videoCircle`), and link-preview image — via `-webkit-touch-callout:none` + `-webkit-user-drag:none` + `select-none` + `draggable="false"` (matches the existing `MediaViewer.vue` / `ZoomableImage.vue` convention).
- The app's own pointer-based long-press (`useLongPress`, 500ms) still opens the context menu (A1). Text selection for the in-bubble copy-fragment feature (WEE-42) is untouched — `select-none` is scoped to media tags only (A3).
- Verified the JS action handlers (copy/forward/save) are already async/lightweight — copy copies **text** only, save is async download — so no heavy synchronous JS path exists.

## Linear
- Resolves WEE-79 (https://linear.app/wwwee/issue/WEE-79)

## Closes
Closes greenShirtMystery/forta-bugs#948

## Test plan
- [x] `vue-tsc --noEmit` — 0 errors in changed files (50 pre-existing baseline errors unrelated)
- [x] Unit/regression tests added (`message-bubble-longpress-freeze-guard.test.ts`, 7 assertions) — source-level, matching the established `MessageBubble-heic-fallback.test.ts` style (happy-dom can't execute real WebView drag)
- [x] `vitest run src/features/messaging/` — 466 passed
- [ ] Manual QA: long-press a received photo / video note on a low-RAM Android device → context menu opens, no device freeze