### PR TITLE
fix(messaging): queue sends when Matrix not ready + failed preview status (WEE-85)

### DIFF
--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -196,17 +196,12 @@ export function useMessages() {
         });
         localClientId = localMsg.clientId;
 
-        // 2. Validate readiness AFTER insert — if not ready, mark as failed
-        const matrixService = getMatrixClientService();
-        if (!matrixService.isReady()) {
-          console.error("[sendMessage] Matrix client not ready — message saved locally as failed", {
-            roomId, clientId: localClientId,
-          });
-          await dbKit.messages.markFailed(localClientId);
-          return true; // message IS visible (as failed)
-        }
-
-        // 3. Enqueue for background sync (no linkPreview in payload — always async)
+        // 2. Enqueue for background sync. If the Matrix client isn't ready yet
+        //    (boot / re-init window) the SyncEngine holds the op as "pending"
+        //    and flushes it once the client is ready, instead of an instant
+        //    failure (WEE-85). Real failures still surface after retry
+        //    exhaustion → "failed" (incl. chat-list preview, via markFailed).
+        //    (no linkPreview in payload — always async)
         await dbKit.syncEngine.enqueue(
           "send_message",
           roomId,
@@ -846,17 +841,9 @@ export function useMessages() {
         localClientId = localMsg.clientId;
         chatStore.replyingTo = null;
 
-        // 2. Validate readiness AFTER insert
-        const matrixService = getMatrixClientService();
-        if (!matrixService.isReady()) {
-          console.error("[sendReply] Matrix client not ready — message saved locally as failed", {
-            roomId, clientId: localClientId,
-          });
-          await dbKit.messages.markFailed(localClientId);
-          return true;
-        }
-
-        // 3. Enqueue for background sync (no linkPreview — always async)
+        // 2. Enqueue for background sync. Not-ready Matrix client (boot/re-init)
+        //    → SyncEngine queues the op until ready instead of instant-fail
+        //    (WEE-85). (no linkPreview — always async)
         await dbKit.syncEngine.enqueue(
           "send_message",
           roomId,
@@ -1011,17 +998,8 @@ export function useMessages() {
         });
         localClientId = localMsg.clientId;
 
-        // 2. Validate Matrix readiness
-        const matrixService = getMatrixClientService();
-        if (!matrixService.isReady()) {
-          console.error("[sendForward] Matrix client not ready — message saved locally as failed", {
-            roomId, clientId: localClientId,
-          });
-          await dbKit.messages.markFailed(localClientId);
-          return true;
-        }
-
-        // 3. Enqueue for sync
+        // 2. Enqueue for sync. Not-ready Matrix client (boot/re-init) →
+        //    SyncEngine queues the op until ready instead of instant-fail (WEE-85).
         await dbKit.syncEngine.enqueue(
           "send_message",
           roomId,
@@ -1502,15 +1480,9 @@ export function useMessages() {
         });
         localClientId = localMsg.clientId;
 
-        // 2. Validate readiness AFTER insert — if not ready, mark as failed
-        const matrixService = getMatrixClientService();
-        if (!matrixService.isReady()) {
-          console.error("[sendTransferMessage] Matrix client not ready — saved locally as failed");
-          await dbKit.messages.markFailed(localClientId);
-          return;
-        }
-
-        // 3. Enqueue for background sync — SyncEngine.syncSendTransfer() handles
+        // 2. Enqueue for background sync. Not-ready Matrix client (boot/re-init)
+        //    → SyncEngine queues the op until ready instead of instant-fail (WEE-85).
+        //    SyncEngine.syncSendTransfer() handles
         //    encryption and Matrix API call, then confirms via messageRepo.confirmSent()
         await dbKit.syncEngine.enqueue(
           "send_transfer",

--- a/src/shared/lib/local-db/__tests__/mark-failed-preview.test.ts
+++ b/src/shared/lib/local-db/__tests__/mark-failed-preview.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Dexie from "dexie";
+import "fake-indexeddb/auto";
+import { MessageRepository } from "../message-repository";
+import type { LocalMessage, LocalRoom, PendingOperation } from "../schema";
+
+/**
+ * Regression coverage for WEE-85 Part B (closing the WEE-64 gap):
+ * `MessageRepository.markFailed` must mirror the failed status onto the room's
+ * chat-list preview (`lastMessageLocalStatus`), not only the per-message
+ * status. Otherwise a failed send shows «не доставлено» in the open bubble but
+ * still «отправляется» in the sidebar preview — the rassinchron the user saw.
+ *
+ * Guarded by the same timestamp check as RoomRepository.syncLastMessageLocalStatus:
+ * only the room's CURRENT last message may rewrite the preview badge.
+ */
+
+class TestDb extends Dexie {
+  messages!: Dexie.Table<LocalMessage, number>;
+  rooms!: Dexie.Table<LocalRoom, string>;
+  pendingOps!: Dexie.Table<PendingOperation, number>;
+  attachments!: Dexie.Table<{ id?: number; localBlob?: Blob; size?: number; status?: string }, number>;
+  users!: Dexie.Table<{ address: string }, string>;
+  syncState!: Dexie.Table<{ key: string; value: string | number }, string>;
+  decryptionQueue!: Dexie.Table<{ id?: number; status: string }, number>;
+  listenedMessages!: Dexie.Table<{ messageId: string }, string>;
+
+  constructor(name: string) {
+    super(name, { indexedDB, IDBKeyRange });
+    this.version(1).stores({
+      messages:
+        "++localId, eventId, clientId, [roomId+timestamp], [roomId+status], senderId",
+      rooms: "id, updatedAt, membership, isDeleted",
+      pendingOps:
+        "++id, [roomId+createdAt], status, clientId, [status+nextAttemptAt]",
+      attachments: "++id, messageLocalId, status",
+      users: "address, updatedAt",
+      syncState: "key",
+      decryptionQueue: "++id, status, [status+nextAttemptAt]",
+      listenedMessages: "messageId",
+    });
+  }
+}
+
+const ROOM_ID = "!room:server";
+
+function seedRoom(db: TestDb): Promise<string> {
+  const room: LocalRoom = {
+    id: ROOM_ID,
+    name: "Test Room",
+    isGroup: false,
+    members: ["@me:server"],
+    membership: "join",
+    unreadCount: 0,
+    lastReadInboundTs: 0,
+    lastReadOutboundTs: 0,
+    updatedAt: 1,
+    isDeleted: false,
+    deletedAt: null,
+    deleteReason: null,
+    syncedAt: 0,
+    hasMoreHistory: true,
+  };
+  return db.rooms.put(room).then(() => room.id);
+}
+
+describe("MessageRepository.markFailed — WEE-85: chat-list preview reflects failure", () => {
+  let db: TestDb;
+  let messages: MessageRepository;
+
+  beforeEach(async () => {
+    db = new TestDb(`mark-failed-preview-${Date.now()}-${Math.random()}`);
+    messages = new MessageRepository(db as never);
+    await db.open();
+  });
+
+  afterEach(async () => {
+    await db.delete();
+  });
+
+  it("flips both message status and room preview to 'failed' for the last message", async () => {
+    await seedRoom(db);
+    const msg = await messages.createLocal({
+      roomId: ROOM_ID,
+      senderId: "@me:server",
+      content: "boom",
+    });
+    // Precondition: createLocal primed the preview to "pending".
+    expect((await db.rooms.get(ROOM_ID))?.lastMessageLocalStatus).toBe("pending");
+
+    await messages.markFailed(msg.clientId);
+
+    const message = await messages.getByClientId(msg.clientId);
+    const room = await db.rooms.get(ROOM_ID);
+    expect(message?.status).toBe("failed");
+    expect(room?.lastMessageLocalStatus).toBe("failed");
+  });
+
+  it("does NOT overwrite the preview when the failed message is no longer the last", async () => {
+    await seedRoom(db);
+    const stale = await messages.createLocal({
+      roomId: ROOM_ID,
+      senderId: "@me:server",
+      content: "stale",
+    });
+    // A newer message advanced the preview to a later timestamp + synced status.
+    await db.rooms.update(ROOM_ID, {
+      lastMessageTimestamp: stale.timestamp + 10_000,
+      lastMessageLocalStatus: "synced",
+    });
+
+    await messages.markFailed(stale.clientId);
+
+    const message = await messages.getByClientId(stale.clientId);
+    const room = await db.rooms.get(ROOM_ID);
+    expect(message?.status).toBe("failed"); // per-message status still flips
+    expect(room?.lastMessageLocalStatus).toBe("synced"); // preview untouched
+  });
+
+  it("is a no-op (no throw) for an unknown clientId", async () => {
+    await seedRoom(db);
+    await expect(messages.markFailed("does-not-exist")).resolves.toBeUndefined();
+  });
+});

--- a/src/shared/lib/local-db/__tests__/sync-engine-not-ready.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-not-ready.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Dexie from "dexie";
+import "fake-indexeddb/auto";
+import { SyncEngine } from "../sync-engine";
+import { MessageRepository } from "../message-repository";
+import { RoomRepository } from "../room-repository";
+import type { PendingOperation, LocalMessage, LocalRoom } from "../schema";
+
+/**
+ * Regression coverage for WEE-85 Part A: sending while the Matrix client is
+ * temporarily not ready (boot / re-init window) must NOT fail instantly nor
+ * burn retries. The SyncEngine's readiness gate releases a claimed op back to
+ * "pending" without incrementing `retries` and re-polls until `isReady()`
+ * turns true, at which point the queued message flushes normally.
+ *
+ * Before the fix, `use-messages.ts` flipped the message to "failed" the moment
+ * `isReady()` was false — so a send issued right after app start was lost.
+ *
+ * Test-isolation note: the SyncEngine reads readiness from the GLOBAL
+ * `getMatrixClientService()`. Sibling sync-engine suites share this mocked
+ * module under reduced isolation, so we model "not ready" by ADDING an
+ * `isReady` property to the shared mock only for the duration of a test and
+ * stripping it again afterwards (the engine gates ONLY on an explicit
+ * `isReady() === false`). The mock therefore looks exactly like every other
+ * suite's mock — no `isReady` — at all times outside this file's test bodies.
+ */
+
+const mockMatrix: {
+  isReady?: () => boolean;
+  sendEncryptedText: ReturnType<typeof vi.fn>;
+  sendText: ReturnType<typeof vi.fn>;
+} = {
+  sendEncryptedText: vi.fn(async () => "$server_event_id"),
+  sendText: vi.fn(async () => "$server_event_id"),
+};
+
+/** Present `isReady() === false` (not ready) or strip it (ready). */
+function setNotReady(notReady: boolean): void {
+  if (notReady) mockMatrix.isReady = () => false;
+  else delete mockMatrix.isReady;
+}
+
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: () => mockMatrix,
+}));
+
+class TestDb extends Dexie {
+  messages!: Dexie.Table<LocalMessage, number>;
+  rooms!: Dexie.Table<LocalRoom, string>;
+  pendingOps!: Dexie.Table<PendingOperation, number>;
+  attachments!: Dexie.Table<{ id?: number; localBlob?: Blob; size?: number; status?: string }, number>;
+  users!: Dexie.Table<{ address: string }, string>;
+  syncState!: Dexie.Table<{ key: string; value: string | number }, string>;
+  decryptionQueue!: Dexie.Table<{ id?: number; status: string }, number>;
+  listenedMessages!: Dexie.Table<{ messageId: string }, string>;
+
+  constructor(name: string) {
+    super(name, { indexedDB, IDBKeyRange });
+    this.version(1).stores({
+      messages:
+        "++localId, eventId, clientId, [roomId+timestamp], [roomId+status], senderId",
+      rooms: "id, updatedAt, membership, isDeleted",
+      pendingOps:
+        "++id, [roomId+createdAt], status, clientId, [status+nextAttemptAt]",
+      attachments: "++id, messageLocalId, status",
+      users: "address, updatedAt",
+      syncState: "key",
+      decryptionQueue: "++id, status, [status+nextAttemptAt]",
+      listenedMessages: "messageId",
+    });
+  }
+}
+
+interface Harness {
+  db: TestDb;
+  engine: SyncEngine;
+  messages: MessageRepository;
+  rooms: RoomRepository;
+}
+
+const ROOM_ID = "!room:server";
+
+function makeHarness(name: string): Harness {
+  const db = new TestDb(name);
+  const messages = new MessageRepository(db as never);
+  const rooms = new RoomRepository(db as never);
+  const getRoomCrypto = vi.fn(async () => undefined); // plaintext path
+  const engine = new SyncEngine(db as never, messages as never, rooms as never, getRoomCrypto);
+  return { db, engine, messages, rooms };
+}
+
+function seedRoom(db: TestDb): Promise<string> {
+  const room: LocalRoom = {
+    id: ROOM_ID,
+    name: "Test Room",
+    isGroup: false,
+    members: ["@me:server"],
+    membership: "join",
+    unreadCount: 0,
+    lastReadInboundTs: 0,
+    lastReadOutboundTs: 0,
+    updatedAt: 1,
+    isDeleted: false,
+    deletedAt: null,
+    deleteReason: null,
+    syncedAt: 0,
+    hasMoreHistory: true,
+  };
+  return db.rooms.put(room).then(() => room.id);
+}
+
+async function seedOp(db: TestDb, clientId: string): Promise<number> {
+  return (await db.pendingOps.add({
+    type: "send_message",
+    roomId: ROOM_ID,
+    payload: { content: "hello" },
+    status: "pending",
+    retries: 0,
+    maxRetries: 5,
+    createdAt: Date.now(),
+    clientId,
+    nextAttemptAt: 0,
+  } as PendingOperation)) as number;
+}
+
+function waitTicks(n = 1): Promise<void> {
+  return new Promise((resolve) => {
+    let remaining = n;
+    function next(): void {
+      if (remaining-- <= 0) resolve();
+      else setTimeout(next, 0);
+    }
+    next();
+  });
+}
+
+describe("SyncEngine — WEE-85: queue while Matrix not ready", () => {
+  let h: Harness;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    setNotReady(false); // default: ready (no isReady property on the shared mock)
+    mockMatrix.sendEncryptedText.mockImplementation(async () => "$server_event_id");
+    h = makeHarness(`sync-engine-not-ready-${Date.now()}-${Math.random()}`);
+    await h.db.open();
+  });
+
+  afterEach(async () => {
+    // Strip the "not ready" override FIRST so the shared mock can never gate a
+    // sibling suite's ops, even if teardown below throws.
+    setNotReady(false);
+    h.engine.dispose();
+    await new Promise((r) => setTimeout(r, 0));
+    await h.db.delete();
+  });
+
+  it("holds the op as pending without sending or burning a retry while not ready", async () => {
+    setNotReady(true);
+    try {
+      await seedRoom(h.db);
+      const msg = await h.messages.createLocal({
+        roomId: ROOM_ID,
+        senderId: "@me:server",
+        content: "sent during boot",
+      });
+      await seedOp(h.db, msg.clientId);
+
+      h.engine.processQueue();
+      await waitTicks(4);
+
+      const op = await h.db.pendingOps.where("clientId").equals(msg.clientId).first();
+      const message = await h.messages.getByClientId(msg.clientId);
+      // Invariants while not ready: the op is still queued (the gate cycles it
+      // between "syncing" and "pending" on each re-poll, so assert it is not a
+      // terminal "failed"), no send was attempted, no retry was consumed, and
+      // the message itself was never flipped to "failed".
+      expect(op).toBeDefined();
+      expect(op?.status).not.toBe("failed");
+      expect(op?.retries).toBe(0);
+      expect(mockMatrix.sendEncryptedText).not.toHaveBeenCalled();
+      expect(message?.status).toBe("pending");
+    } finally {
+      setNotReady(false);
+    }
+  });
+
+  it("flushes the queued op once the client becomes ready", async () => {
+    setNotReady(true);
+    let opId: number;
+    let clientId: string;
+    try {
+      await seedRoom(h.db);
+      const msg = await h.messages.createLocal({
+        roomId: ROOM_ID,
+        senderId: "@me:server",
+        content: "sent during boot",
+      });
+      clientId = msg.clientId;
+      opId = await seedOp(h.db, msg.clientId);
+
+      h.engine.processQueue();
+      await waitTicks(4);
+      expect(mockMatrix.sendEncryptedText).not.toHaveBeenCalled();
+    } finally {
+      // Client becomes ready (sync reached PREPARED).
+      setNotReady(false);
+    }
+
+    // Clear the gate's scheduled re-poll delay so the test doesn't wait it out.
+    await h.db.pendingOps.update(opId, { nextAttemptAt: 0 });
+    h.engine.processQueue();
+
+    await vi.waitFor(
+      async () => {
+        const op = await h.db.pendingOps.where("clientId").equals(clientId).first();
+        expect(op).toBeUndefined(); // delivered → op deleted
+      },
+      { timeout: 2000, interval: 10 },
+    );
+
+    const message = await h.messages.getByClientId(clientId);
+    expect(mockMatrix.sendEncryptedText).toHaveBeenCalledTimes(1);
+    expect(message?.status).toBe("synced");
+    expect(message?.eventId).toBe("$server_event_id");
+  });
+});

--- a/src/shared/lib/local-db/message-repository.ts
+++ b/src/shared/lib/local-db/message-repository.ts
@@ -496,12 +496,35 @@ export class MessageRepository {
     }
   }
 
-  /** Mark a pending message as failed (e.g. Matrix client not ready, enqueue error) */
+  /** Mark a pending message as failed (e.g. enqueue error).
+   *
+   *  Also mirrors the failed status onto the room's chat-list preview
+   *  (`lastMessageLocalStatus`), but only when this message is still the
+   *  room's last one — a timestamp guard symmetric to
+   *  RoomRepository.syncLastMessageLocalStatus, so a stale failure can't
+   *  overwrite the badge of a newer message. Without this the bubble shows
+   *  «не доставлено» while the sidebar preview stays «отправляется» (WEE-85,
+   *  closing the WEE-64 gap that only the SyncEngine fail-path covered).
+   *
+   *  Unlike SyncEngine.markMessageFailed this has NO already-confirmed (WEE-40)
+   *  guard — safe because its callers fire on a *synchronous* enqueue failure,
+   *  before any send is in flight, so there is no server-echo race to lose to.
+   *  Do not reuse from a post-send/async context without adding that guard. */
   async markFailed(clientId: string): Promise<void> {
-    await this.db.messages
-      .where("clientId")
-      .equals(clientId)
-      .modify({ status: "failed" as LocalMessageStatus });
+    await this.db.transaction("rw", [this.db.messages, this.db.rooms], async () => {
+      const msg = await this.db.messages.where("clientId").equals(clientId).first();
+      if (!msg) return;
+      await this.db.messages
+        .where("clientId")
+        .equals(clientId)
+        .modify({ status: "failed" as LocalMessageStatus });
+      const room = await this.db.rooms.get(msg.roomId);
+      if (room && room.lastMessageTimestamp === msg.timestamp) {
+        await this.db.rooms.update(msg.roomId, {
+          lastMessageLocalStatus: "failed" as LocalMessageStatus,
+        });
+      }
+    });
   }
 
   /** Update the eventId on a pending message (after server confirms) */

--- a/src/shared/lib/local-db/sync-engine.ts
+++ b/src/shared/lib/local-db/sync-engine.ts
@@ -11,6 +11,13 @@ type OnChangeCallback = (roomId: string) => void;
 const MAX_BACKOFF_MS = 30_000;
 const MIN_BACKOFF_MS = 1_000;
 
+/** Re-check interval while the Matrix client is not ready (boot / re-init).
+ *  A claimed send op is released back to "pending" WITHOUT counting a retry
+ *  and re-polled at this cadence, so messages sent during the not-ready
+ *  window queue up and flush once the client is ready instead of failing
+ *  instantly or exhausting maxRetries during a slow boot (WEE-85). */
+const MATRIX_NOT_READY_RETRY_MS = 1_000;
+
 /** Outbound message-creating ops whose transport status is mirrored onto the
  *  room's `lastMessageLocalStatus` (chat-list preview, WEE-64). Edit/reaction/
  *  delete/vote ops mutate an existing message and must never overwrite the
@@ -402,6 +409,25 @@ export class SyncEngine {
         // Nothing due right now — check whether an op is scheduled for later
         // so we can set a wake-up timer and then stop this tick cleanly.
         nextRetryDelay = await this.findNextRetryDelay();
+        return;
+      }
+
+      // Matrix-readiness gate (WEE-85): during the boot / re-init window the
+      // client object isn't ready (`isReady()` false). Sending now would throw
+      // and burn a retry, so instead release the op back to "pending" WITHOUT
+      // counting a retry and reschedule a short re-poll. The op flushes once
+      // the client is ready — mirroring how `online` gates the whole loop.
+      // Real failures still surface via maxRetries once the client is ready.
+      // NOTE: recovery is intentionally poll-based (this 1s re-poll, backed by
+      // the watchdog) — there is no `onReady` event that re-kicks the scheduler
+      // when Matrix becomes ready.
+      if (!this.isMatrixReady()) {
+        await this.db.pendingOps.update(op.id!, {
+          status: "pending",
+          nextAttemptAt: Date.now() + MATRIX_NOT_READY_RETRY_MS,
+        });
+        op = null; // don't execute; finally schedules the re-poll wake
+        nextRetryDelay = MATRIX_NOT_READY_RETRY_MS;
         return;
       }
 
@@ -1026,6 +1052,16 @@ export class SyncEngine {
     const msg = await this.messageRepo.getByClientId(clientId);
     if (!msg) return false;
     return Boolean(msg.eventId) || msg.status === "synced";
+  }
+
+  /** Whether the Matrix client is ready to transport ops. Gates ONLY on an
+   *  explicit `isReady() === false`; anything else (true, or a test double that
+   *  omits `isReady` / returns undefined) is treated as ready, so the gate is a
+   *  no-op under harnesses that don't model readiness. The real service always
+   *  returns a boolean, so prod behaviour is exactly `isReady() === true`. */
+  private isMatrixReady(): boolean {
+    const svc = getMatrixClientService() as { isReady?: () => boolean };
+    return svc.isReady?.() !== false;
   }
 
   /** Enqueue a new operation. Returns the operation ID. */


### PR DESCRIPTION
## Summary
- **Part A (P0):** Sending a message while the Matrix client is temporarily not ready (boot / re-init window) no longer instantly fails. The `SyncEngine` now has a readiness gate in `processTick`: a claimed op is released back to `pending` **without burning a retry** and re-polled until `isReady()`, then flushed. The 4 Dexie send paths (`sendMessage`/`sendReply`/`sendForward`/`sendTransfer`) drop the old `!isReady() → markFailed → return` gate and always enqueue. Real failures still surface via `maxRetries`.
- **Part B (closes WEE-64 gap):** `MessageRepository.markFailed` now mirrors `"failed"` onto the room's chat-list preview (`lastMessageLocalStatus`), timestamp-guarded to the room's last message — so a failed send reads «не доставлено» in both the bubble and the sidebar, instead of «отправляется» in the preview.

## Root cause
`use-messages.ts` gated on `matrixService.isReady()` right after the optimistic insert and called `markFailed` instantly during the not-ready window. `markFailed` only wrote `message.status`, never the WEE-64 room preview status → bubble/preview desync.

## Investigation note (Task 0 / A3)
`chatsReady` is monotonic — set on the first PREPARED/SYNCING and only reset on `destroy()` (logout/re-init), never on a network reconnect (matrix-js-sdk reconnects internally without re-init). So `chatsReady`/`isReady()` already recover after reconnect; no recovery fix was needed. The failing window is boot / re-init, which the queue gate now covers.

## Linear
- Resolves WEE-85 (https://linear.app/wwwee/issue/WEE-85)
- Refs WEE-64

## Test plan
- [x] `vite build` passes (exit 0)
- [x] `vue-tsc --noEmit` — no new type errors in changed files (pre-existing baseline unchanged)
- [x] Unit tests added: `sync-engine-not-ready.test.ts` (engine readiness gate: held while not ready / flushed when ready), `mark-failed-preview.test.ts` (preview = failed for last message, timestamp guard, unknown-id no-op)
- [x] Full suite: no new failures (16 pre-existing baseline failures unchanged), +5 new tests pass
- [x] Code review (`superpowers:code-reviewer`): Approve, no CRITICAL/HIGH; LOW doc-comment suggestions addressed
- [ ] Manual QA on device: send right after app start → message delivers (not instant-failed); airplane mode → send → restore network → delivered; genuine failure → preview shows «не доставлено»