### PR TITLE
fix(profile): avatar not wiped by profile re-sync (WEE-77)

### DIFF
--- a/src/entities/auth/lib/__tests__/sync-profile-to-matrix.test.ts
+++ b/src/entities/auth/lib/__tests__/sync-profile-to-matrix.test.ts
@@ -116,11 +116,35 @@ describe("syncProfileToMatrix", () => {
     expect(setAvatarMxc).not.toHaveBeenCalled();
   });
 
-  it("clears avatar via setAvatarMxc('') when image is explicitly empty", async () => {
-    // user removed their avatar; peers must see it cleared in Matrix too
+  it("does NOT clear the avatar when image is empty without an explicit clear flag (WEE-77)", async () => {
+    // Regression: a re-sync with an unloaded/empty avatar (Pocketnet still
+    // propagating, transient empty RPC row, or form opened before userInfo
+    // settled) must NOT wipe the valid Matrix avatar — forta-bugs#954/#943/#976.
     globalThis.fetch = vi.fn() as unknown as typeof fetch;
 
     await syncProfileToMatrix(matrix(), { image: "" });
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(uploadAvatar).not.toHaveBeenCalled();
+    expect(setAvatarMxc).not.toHaveBeenCalled();
+  });
+
+  it("does NOT clear the avatar on a name-only re-sync that leaves image empty (WEE-77)", async () => {
+    // The common flicker path: user edits only their name; the form still
+    // submits image:"" because the avatar wasn't loaded. Matrix avatar stays.
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+
+    await syncProfileToMatrix(matrix(), { name: "Alice", image: "" });
+
+    expect(setDisplayName).toHaveBeenCalledWith("Alice");
+    expect(setAvatarMxc).not.toHaveBeenCalled();
+  });
+
+  it("clears avatar via setAvatarMxc('') only on an explicit user clear (clearAvatar: true)", async () => {
+    // user genuinely removed their avatar; peers must see it cleared in Matrix
+    globalThis.fetch = vi.fn() as unknown as typeof fetch;
+
+    await syncProfileToMatrix(matrix(), { image: "", clearAvatar: true });
 
     expect(globalThis.fetch).not.toHaveBeenCalled();
     expect(uploadAvatar).not.toHaveBeenCalled();

--- a/src/entities/auth/lib/sync-profile-to-matrix.ts
+++ b/src/entities/auth/lib/sync-profile-to-matrix.ts
@@ -9,9 +9,17 @@
  * Failures must never block the calling Pocketnet save: we swallow them and
  * surface a console.warn so the user still sees a successful save.
  *
- * Semantics: an `undefined` field means "caller didn't touch this — leave
- * Matrix alone"; an empty string means "user explicitly cleared this field —
- * mirror the clear into Matrix" so peers don't see a stale name/avatar.
+ * Name semantics: an `undefined` name means "caller didn't touch this — leave
+ * Matrix alone"; an empty string means "user explicitly cleared the name —
+ * mirror the clear into Matrix" so peers don't see a stale name.
+ *
+ * Avatar semantics (WEE-77, forta-bugs#954/#943/#976): an empty `image` is
+ * NOT a clear by default. A profile re-sync routinely runs with no loaded
+ * avatar (Pocketnet still propagating, transient empty RPC row, form opened
+ * before userInfo settled) — treating that as a clear wiped valid avatars and
+ * caused the "avatar flickers / can't re-set it" reports. So an empty `image`
+ * means "no avatar to sync — leave Matrix's avatar untouched". A genuine
+ * user-initiated clear must pass `clearAvatar: true` explicitly.
  */
 
 /** Matrix homeserver upload limit. Synapse default is 50 MB; Pocketnet uploads
@@ -28,6 +36,11 @@ export interface MatrixProfileSync {
 export interface SyncProfileParams {
   name?: string;
   image?: string;
+  /** Explicit opt-in to mirror an avatar removal into Matrix. Only when this
+   *  is `true` does an empty `image` trigger `setAvatarMxc("")`. Without it an
+   *  empty `image` is a no-op so a stale/unloaded re-sync can't wipe a valid
+   *  avatar (WEE-77). */
+  clearAvatar?: boolean;
 }
 
 export async function syncProfileToMatrix(
@@ -45,6 +58,10 @@ export async function syncProfileToMatrix(
   if (params.image === undefined) return;
 
   if (params.image === "") {
+    // Guard: only an explicit user-clear wipes the Matrix avatar. An empty
+    // image from an ordinary re-sync means "nothing to upload", not "remove
+    // it" — see avatar semantics above (WEE-77).
+    if (!params.clearAvatar) return;
     try {
       await matrix.setAvatarMxc("");
     } catch (e) {

--- a/src/entities/auth/model/stores.ts
+++ b/src/entities/auth/model/stores.ts
@@ -317,6 +317,12 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
       // The helper swallows its own errors; .catch is here only so an
       // unexpected throw doesn't bubble up as an unhandled rejection.
       if (result?.success === true && matrixReady.value) {
+        // No `clearAvatar` flag: an empty `userData.image` here means the
+        // avatar simply wasn't loaded into the edit form (or Pocketnet hasn't
+        // propagated it yet), not that the user removed it. syncProfileToMatrix
+        // therefore leaves the existing Matrix avatar untouched rather than
+        // wiping it — root cause of WEE-77 / forta-bugs#954, #943, #976. A
+        // real "remove avatar" action would pass clearAvatar: true.
         void syncProfileToMatrix(getMatrixClientService(), {
           name: userData.name,
           image: userData.image,


### PR DESCRIPTION
## Summary
- Avatar periodically disappeared/flickered and re-uploads sometimes didn't stick because a profile save ran `syncProfileToMatrix` with an empty `image` (avatar not yet loaded into the form), which triggered a destructive `setAvatarMxc("")` and wiped the valid Matrix avatar.
- Empty `image` is now a no-op (Matrix avatar left untouched); a genuine user-initiated clear must pass a new explicit `clearAvatar: true` flag. There is no remove-avatar UI, so the destructive path is unreachable from production.
- WEE-26 name-clear semantics (empty name still clears via `setDisplayName("")`) are unchanged.

## Linear
- Resolves WEE-77 (https://linear.app/wwwee/issue/WEE-77)

## Closes
Closes greenShirtMystery/forta-bugs#954
Closes greenShirtMystery/forta-bugs#943
Closes greenShirtMystery/forta-bugs#976

## Test plan
- [x] `npx vue-tsc --noEmit` — 0 new errors (baseline unchanged; the 2 pre-existing `stores.ts` errors merely shifted line numbers)
- [x] `npm run test` — target suites green (`sync-profile-to-matrix.test.ts`, `profile-matrix-sync.test.ts`); 16 failures are pre-existing baseline, none in changed files
- [x] Unit regression tests added: empty image no longer clears; name-only re-sync keeps avatar; `clearAvatar: true` still clears
- [x] Code review (superpowers:code-reviewer) — APPROVE, no findings
- [ ] Manual QA on Android: set avatar → edit only name → save → avatar persists (no flicker); restart → avatar persists; re-upload after a save sticks

> Note: project has no `npm run lint` script.