### PR TITLE
fix(register): username validation matches Bastyon rules (WEE-78)

### DIFF
--- a/src/features/auth/ui/register-form/steps/ProfileStep.vue
+++ b/src/features/auth/ui/register-form/steps/ProfileStep.vue
@@ -5,6 +5,7 @@ import { useLocaleStore } from "@/entities/locale";
 import Avatar from "@/shared/ui/avatar/Avatar.vue";
 import { fileToBase64, uploadImage } from "@/shared/lib/upload-image";
 import { isNative } from "@/shared/lib/platform";
+import { validateUsername, USERNAME_MAX_LENGTH } from "./username-validation";
 
 const emit = defineEmits<{
   done: [data: { name: string; language: string; about: string; image?: string }]
@@ -38,30 +39,20 @@ const avatarUrl = ref("");
 const avatarUploading = ref(false);
 const avatarFileInput = ref<HTMLInputElement>();
 
-// Username format validation (matches pocketnet rules)
-// Allowed: latin letters, digits, space, dot, hyphen, underscore, @, #, &
-// Cyrillic is NOT allowed — blockchain rejects it at sendrawtransaction
-const USERNAME_REGEX = /^[a-zA-Z0-9 .\-_@#&]+$/;
-const USERNAME_MAX_LENGTH = 20;
-const RESERVED_NAMES = ["pocketnet", "bastyon"];
-
+// Username format validation lives in a pure, i18n-free module so it can be
+// unit-tested and kept in lockstep with Bastyon's name rules (see WEE-78).
+// Here we only map the structured error to localized copy.
 const validateNameFormat = (value: string): string | null => {
-  const trimmed = value.trim();
-  if (!trimmed) return null; // empty is handled by required
-  if (trimmed.length > USERNAME_MAX_LENGTH) {
-    return t("register.nameTooLong", { max: USERNAME_MAX_LENGTH });
+  const err = validateUsername(value);
+  if (!err) return null;
+  switch (err.code) {
+    case "tooLong":
+      return t("register.nameTooLong", { max: err.max });
+    case "invalidChars":
+      return t("register.nameInvalidChars");
+    case "reserved":
+      return t("register.nameReserved", { name: err.name });
   }
-  if (!USERNAME_REGEX.test(trimmed)) {
-    return t("register.nameInvalidChars");
-  }
-  // Check reserved names (case-insensitive, after stripping non-alpha)
-  const normalized = trimmed.toLowerCase().replace(/[^a-z]/g, "");
-  for (const reserved of RESERVED_NAMES) {
-    if (normalized.includes(reserved)) {
-      return t("register.nameReserved", { name: reserved });
-    }
-  }
-  return null;
 };
 
 const checkNameAvailability = () => {

--- a/src/features/auth/ui/register-form/steps/__tests__/username-validation.test.ts
+++ b/src/features/auth/ui/register-form/steps/__tests__/username-validation.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import {
+  isValidUsername,
+  validateUsername,
+  USERNAME_MAX_LENGTH,
+} from "../username-validation";
+
+/**
+ * WEE-78 regression: Forta username validation must match Bastyon name rules
+ * so an account created in Forta is always accepted by Bastyon.
+ *
+ * The old regex (`/^[a-zA-Z0-9 .\-_@#&]+$/`) allowed `@ # &`, hyphen and spaces
+ * — all forbidden by Bastyon (bug reports #418/#947/#417) — producing accounts
+ * that could not log into Bastyon. If this test fails, that incompatibility is
+ * back.
+ */
+describe("username-validation (Bastyon parity)", () => {
+  it("rejects @ # & and spaces (Bastyon parity)", () => {
+    expect(isValidUsername("john@doe")).toBe(false);
+    expect(isValidUsername("a b")).toBe(false);
+    expect(isValidUsername("john_doe.1")).toBe(true);
+  });
+
+  it("rejects every Bastyon-forbidden character", () => {
+    expect(isValidUsername("john#doe")).toBe(false);
+    expect(isValidUsername("john&doe")).toBe(false);
+    expect(isValidUsername("john-doe")).toBe(false); // hyphen is forbidden in Bastyon (#418)
+    expect(isValidUsername("john doe")).toBe(false);
+    expect(isValidUsername("имя")).toBe(false); // cyrillic — rejected by blockchain
+  });
+
+  it("accepts the Bastyon-compatible character set", () => {
+    expect(isValidUsername("john")).toBe(true);
+    expect(isValidUsername("John_Doe")).toBe(true);
+    expect(isValidUsername("user.name_42")).toBe(true);
+    expect(isValidUsername("ABC123")).toBe(true);
+  });
+
+  it("treats empty / whitespace-only as valid (handled by required field)", () => {
+    expect(isValidUsername("")).toBe(true);
+    expect(isValidUsername("   ")).toBe(true);
+  });
+
+  it("flags names longer than the max length", () => {
+    const tooLong = "a".repeat(USERNAME_MAX_LENGTH + 1);
+    expect(isValidUsername(tooLong)).toBe(false);
+    expect(validateUsername(tooLong)).toEqual({
+      code: "tooLong",
+      max: USERNAME_MAX_LENGTH,
+    });
+  });
+
+  it("returns a structured error code for invalid characters", () => {
+    expect(validateUsername("john@doe")).toEqual({ code: "invalidChars" });
+  });
+
+  it("blocks reserved names regardless of separators or case", () => {
+    expect(validateUsername("bastyon")).toEqual({ code: "reserved", name: "bastyon" });
+    expect(validateUsername("Pocketnet")).toEqual({ code: "reserved", name: "pocketnet" });
+    expect(validateUsername("b.a.s.t.y.o.n")).toEqual({ code: "reserved", name: "bastyon" });
+  });
+});

--- a/src/features/auth/ui/register-form/steps/username-validation.ts
+++ b/src/features/auth/ui/register-form/steps/username-validation.ts
@@ -1,0 +1,54 @@
+/**
+ * Username validation — Bastyon parity (WEE-78).
+ *
+ * Forta and Bastyon share one blockchain identity, so a name registered in
+ * Forta must be accepted by Bastyon too. Bastyon's name rule (mirrored by
+ * pocketnet's `clearname`, which strips everything outside `[a-zA-Z0-9_. *]`,
+ * and confirmed by bug reports #418/#947/#417) forbids `@ # & -` and spaces.
+ *
+ * We therefore validate against the conservative Bastyon-compatible subset:
+ * latin letters, digits, dot and underscore. Cyrillic is excluded because the
+ * blockchain rejects it at `sendrawtransaction`. Any name accepted here is
+ * guaranteed to be a valid Bastyon name, so the created account always works.
+ */
+
+// Allowed: latin letters, digits, dot, underscore.
+// Forbidden (unlike the old, too-permissive regex): @ # & hyphen and spaces.
+export const USERNAME_REGEX = /^[a-zA-Z0-9._]+$/;
+export const USERNAME_MAX_LENGTH = 20;
+export const RESERVED_NAMES = ["pocketnet", "bastyon"] as const;
+
+export type UsernameValidationError =
+  | { code: "tooLong"; max: number }
+  | { code: "invalidChars" }
+  | { code: "reserved"; name: string };
+
+/**
+ * Validate a username against Bastyon rules.
+ *
+ * Returns `null` when the value is valid (or empty — emptiness is handled by
+ * the `required` field), otherwise a structured error the UI maps to i18n copy.
+ * Pure and i18n-free so it can be unit-tested in isolation.
+ */
+export const validateUsername = (value: string): UsernameValidationError | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return null; // empty is handled by `required`
+  if (trimmed.length > USERNAME_MAX_LENGTH) {
+    return { code: "tooLong", max: USERNAME_MAX_LENGTH };
+  }
+  if (!USERNAME_REGEX.test(trimmed)) {
+    return { code: "invalidChars" };
+  }
+  // Reserved names: case-insensitive, after stripping non-alpha characters
+  // so "b.a.s.t.y.o.n" or "Bastyon_" can't slip through.
+  const normalized = trimmed.toLowerCase().replace(/[^a-z]/g, "");
+  for (const reserved of RESERVED_NAMES) {
+    if (normalized.includes(reserved)) {
+      return { code: "reserved", name: reserved };
+    }
+  }
+  return null;
+};
+
+/** Convenience boolean form of {@link validateUsername}. */
+export const isValidUsername = (value: string): boolean => validateUsername(value) === null;

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -848,7 +848,7 @@ export const en = {
   "register.registrationFailed": "Registration failed",
   "register.captchaLoadFailed": "Failed to load captcha",
   "register.nameTaken": "This name is already taken",
-  "register.nameInvalidChars": "Name contains invalid characters. Allowed: letters, digits, spaces, . - _ @ # &",
+  "register.nameInvalidChars": "Name can only contain latin letters, digits, dot and underscore",
   "register.nameTooLong": "Name must be {max} characters or less",
   "register.nameReserved": "Name cannot contain \"{name}\"",
   "register.usernameRejected": "Username unavailable",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -850,7 +850,7 @@ export const ru: Record<TranslationKey, string> = {
   "register.registrationFailed": "Ошибка регистрации",
   "register.captchaLoadFailed": "Не удалось загрузить капчу",
   "register.nameTaken": "Это имя уже занято",
-  "register.nameInvalidChars": "Имя содержит недопустимые символы. Допустимы: буквы, цифры, пробелы, . - _ @ # &",
+  "register.nameInvalidChars": "Имя может содержать только латинские буквы, цифры, точку и подчёркивание",
   "register.nameTooLong": "Имя должно быть не длиннее {max} символов",
   "register.nameReserved": "Имя не может содержать \"{name}\"",
   "register.usernameRejected": "Имя недоступно",


### PR DESCRIPTION
## Summary
- Narrow the registration username regex to the conservative Bastyon-compatible set `^[a-zA-Z0-9._]+$` (latin letters, digits, dot, underscore). The old `^[a-zA-Z0-9 .\-_@#&]+$` allowed `@ # &`, hyphen and spaces — all forbidden in Bastyon — so a name accepted by Forta could be rejected by Bastyon (shared blockchain identity → login failures, name collisions).
- Extract validation into a pure, i18n-free module (`username-validation.ts`) exposing `isValidUsername` / `validateUsername` (structured error union) for testability; `ProfileStep.vue` now maps the error code to localized copy.
- Fix the `register.nameInvalidChars` copy (en/ru) that advertised the wrong allowed set (`. - _ @ # &`).

Allowed set verified against pocketnet's `clearname` (`[^a-zA-Z0-9_. *]` strip) and bug report #418, which both confirm `@ # & -` are forbidden in Bastyon. The chosen subset is intentionally stricter than Bastyon so any Forta-accepted name is guaranteed Bastyon-valid.

## Linear
- Resolves WEE-78 (https://linear.app/wwwee/issue/WEE-78)

## Closes
Closes greenShirtMystery/forta-bugs#947
Closes greenShirtMystery/forta-bugs#418
Closes greenShirtMystery/forta-bugs#417

## Test plan
- [x] Build + tsc: no new errors (changed files clean; identical error set to master baseline). No `lint` script in repo.
- [x] Unit tests added: `username-validation.test.ts` (7/7 pass) — covers `@ # & -`/spaces/cyrillic rejection, accepted set, length, reserved-name bypass, structured error shape.
- [x] `superpowers:code-reviewer`: Approve, no critical/high findings.
- [ ] Manual QA: register with `john@doe` / `a b` / `john-doe` → rejected with clear error; `john_doe.1` → accepted; confirm resulting account logs into Bastyon.

## Out of scope
- Migration/renaming of already-incompatible accounts.
- Server-side Bastyon/pocketnet name rules.