### PR TITLE
fix(calls): dedupe incoming dialog, Android Back rejects, provider-aware call card (WEE-63)

### DIFF
--- a/src/features/messaging/ui/CallEventCard.vue
+++ b/src/features/messaging/ui/CallEventCard.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import type { Message } from "@/entities/chat";
 import { formatTime } from "@/shared/lib/format";
-import { useCallService } from "@/features/video-calls/model/call-service";
 import { useCallStore } from "@/entities/call";
+import { useChatStore } from "@/entities/chat";
+import { useCallLauncher, CallProviderPicker } from "@/features/video-calls";
 
 const props = defineProps<{
   message: Message;
@@ -11,8 +12,15 @@ const props = defineProps<{
 }>();
 
 const { t } = useI18n();
-const callService = useCallService();
 const callStore = useCallStore();
+const chatStore = useChatStore();
+
+// WEE-63 / forta-bugs#923 — route the call-back through the provider-aware
+// launcher so configured external meeting links (WEE-57) surface a picker
+// instead of silently placing a native call. Instantiated per-component so
+// each card in the virtual scroller owns its own picker state (sharing a
+// module-scope launcher would leak one card's open picker onto its siblings).
+const callLauncher = useCallLauncher();
 
 const missed = computed(() => props.message.callInfo?.missed ?? false);
 const isVideo = computed(() => props.message.callInfo?.callType === "video");
@@ -43,14 +51,20 @@ const timeStr = computed(() => formatTime(new Date(props.message.timestamp)));
 
 // WEE-49 / forta-bugs#754: tapping a call-event card initiates a callback
 // to the same peer using the same call type. Disabled while another call
-// is already active so the user does not accidentally fire startCall while
+// is already active so the user does not accidentally fire a call while
 // the existing call is still tearing down.
 const isClickable = computed(() => !callStore.isInCall);
 
-const handleCallback = () => {
+const handleCallback = (event?: MouseEvent) => {
   if (!isClickable.value) return;
   const callType = props.message.callInfo?.callType ?? "voice";
-  void callService.startCall(props.message.roomId, callType);
+  // DM vs group decides native-only vs picker. Unknown room (not yet synced)
+  // falls back to DM → native call, matching the pre-launcher behavior.
+  const isDm = !(
+    chatStore.rooms.find((r) => r.id === props.message.roomId)?.isGroup ?? false
+  );
+  const anchor = event ? { x: event.clientX, y: event.clientY } : undefined;
+  void callLauncher.launch(props.message.roomId, callType, isDm, anchor);
 };
 </script>
 
@@ -65,7 +79,7 @@ const handleCallback = () => {
       isClickable ? 'cursor-pointer hover:opacity-90 active:opacity-80' : 'cursor-default opacity-100',
     ]"
     :aria-label="`${callTypeLabel} — ${statusLabel} — ${t('call.callBack')}`"
-    @click="handleCallback"
+    @click="handleCallback($event)"
   >
     <!-- Phone / video icon in circle -->
     <div
@@ -117,6 +131,18 @@ const handleCallback = () => {
       </div>
     </div>
   </button>
+
+  <!-- WEE-57/WEE-63: provider picker (bottom sheet on touch, context menu on
+       desktop). Teleports to body, so this second root node renders no inline
+       DOM. -->
+  <CallProviderPicker
+    :show="callLauncher.pickerOpen.value"
+    :options="callLauncher.pickerOptions.value"
+    :x="callLauncher.pickerAnchor.value.x"
+    :y="callLauncher.pickerAnchor.value.y"
+    @pick="callLauncher.pick"
+    @close="callLauncher.closePicker"
+  />
 </template>
 
 <style scoped>

--- a/src/features/messaging/ui/__tests__/CallEventCard-callback.test.ts
+++ b/src/features/messaging/ui/__tests__/CallEventCard-callback.test.ts
@@ -6,6 +6,10 @@ import { resolve } from "path";
  * WEE-49 / forta-bugs#754: tapping a call-event card in the timeline
  * triggers a callback to the same peer using the same call type.
  *
+ * WEE-63 / forta-bugs#923: that callback now routes through the provider-aware
+ * launcher (`useCallLauncher`) instead of calling `startCall` directly, so a
+ * chat with configured external meeting links (WEE-57) surfaces a picker.
+ *
  * Source-level assertion in the same style as message-content-link-click —
  * mounting CallEventCard requires Pinia + the full call/messaging stack,
  * which is far more brittle than the click-handler contract this regression
@@ -15,10 +19,13 @@ const getSource = (): string =>
   readFileSync(resolve(__dirname, "../CallEventCard.vue"), "utf-8");
 
 describe("CallEventCard — callback handler", () => {
-  it("imports the call service so it can place a call from the card", () => {
+  it("routes the call-back through the provider-aware launcher (WEE-63)", () => {
     const source = getSource();
-    expect(source).toMatch(/from\s+['"]@\/features\/video-calls\/model\/call-service['"]/);
-    expect(source).toMatch(/\buseCallService\b/);
+    expect(source).toMatch(/from\s+['"]@\/features\/video-calls['"]/);
+    expect(source).toMatch(/\buseCallLauncher\b/);
+    // The launcher instance must be created in component setup (per-component),
+    // not at module scope, so virtual-scroller siblings don't share picker state.
+    expect(source).toMatch(/const\s+callLauncher\s*=\s*useCallLauncher\(\)/);
   });
 
   it("imports the call store so it can disable the card during an active call", () => {
@@ -27,14 +34,16 @@ describe("CallEventCard — callback handler", () => {
     expect(source).toMatch(/\buseCallStore\b/);
   });
 
-  it("declares a handleCallback handler that calls startCall(roomId, callType)", () => {
+  it("declares a handleCallback handler that launches with roomId + callType + isDm", () => {
     const source = getSource();
     expect(source).toMatch(/const\s+handleCallback\s*=/);
     // Must use the message's roomId + the original call type — defaulting
     // back to "voice" when callInfo is missing so an old-format call event
     // still produces a sensible voice call.
-    expect(source).toMatch(/startCall\(\s*props\.message\.roomId\s*,/);
     expect(source).toMatch(/callInfo\?\.callType\s*\?\?\s*['"]voice['"]/);
+    expect(source).toMatch(/callLauncher\.launch\(\s*props\.message\.roomId\s*,/);
+    // DM vs group is computed so groups with providers get a picker.
+    expect(source).toMatch(/isGroup/);
   });
 
   it("disables the click when another call is already active", () => {
@@ -46,13 +55,19 @@ describe("CallEventCard — callback handler", () => {
     expect(source).toMatch(/isClickable[\s\S]*?!callStore\.isInCall/);
   });
 
+  it("renders the provider picker bound to the launcher state", () => {
+    const source = getSource();
+    expect(source).toMatch(/<CallProviderPicker/);
+    expect(source).toMatch(/:show=['"]callLauncher\.pickerOpen\.value['"]/);
+    expect(source).toMatch(/@pick=['"]callLauncher\.pick['"]/);
+  });
+
   it("renders as a <button> so keyboard/AT users get the click affordance", () => {
     const source = getSource();
     // Wrapper element must be a <button>, not a <div> — pressing Enter on a
     // div would not fire @click, which would re-introduce #754 for keyboard-
     // only Android TalkBack users.
-    expect(source).toMatch(/<button[\s\S]*?@click=['"]handleCallback['"]/);
+    expect(source).toMatch(/<button[\s\S]*?@click=['"]handleCallback/);
     expect(source).toMatch(/type=['"]button['"]/);
   });
 });
-

--- a/src/features/video-calls/ui/IncomingCallModal.vue
+++ b/src/features/video-calls/ui/IncomingCallModal.vue
@@ -3,6 +3,7 @@ import { useCallStore, CallStatus } from "@/entities/call";
 import { UserAvatar } from "@/entities/user";
 import { useCallService } from "../model/call-service";
 import { isNative } from "@/shared/lib/platform";
+import { useAndroidBackHandler } from "@/shared/lib/composables/use-android-back-handler";
 
 const INCOMING_TIMEOUT_SECONDS = 30;
 
@@ -36,6 +37,16 @@ function onReject() {
   rejecting.value = true;
   callService.rejectCall();
 }
+
+// WEE-63 / forta-bugs#759 — Android Back on the incoming ringer rejects the
+// call instead of minimizing the app. Priority 100 (same tier as the active
+// call window) so it wins over chat/router handlers. Returns false when the
+// modal isn't showing so Back falls through to the normal handler chain.
+useAndroidBackHandler("incoming-call-modal", 100, () => {
+  if (!show.value) return false;
+  onReject();
+  return true;
+});
 
 const countdown = ref(INCOMING_TIMEOUT_SECONDS);
 let countdownInterval: ReturnType<typeof setInterval> | null = null;

--- a/src/features/video-calls/ui/__tests__/IncomingCallModal-back-handler.test.ts
+++ b/src/features/video-calls/ui/__tests__/IncomingCallModal-back-handler.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * WEE-63 / forta-bugs#759 — Android Back on the incoming-call ringer must
+ * reject the call, not minimize the app.
+ *
+ * The active CallWindow registers a priority-100 back handler that returns
+ * false while the call is still in the `incoming` state (CallWindow only
+ * shows once ringing/connecting/connected). Without a handler on the incoming
+ * modal itself, Back falls through to App.minimizeApp(). This regression
+ * asserts the modal registers its own handler that rejects when visible and
+ * passes through (returns false) otherwise.
+ *
+ * Source-level assertion: mounting IncomingCallModal needs Pinia + the call
+ * service stack; the back-handler contract is what this regression cares about.
+ */
+const getSource = (): string =>
+  readFileSync(resolve(__dirname, "../IncomingCallModal.vue"), "utf-8");
+
+describe("IncomingCallModal — Android Back handler", () => {
+  it("imports and registers the shared Android back handler", () => {
+    const source = getSource();
+    expect(source).toMatch(/useAndroidBackHandler/);
+    expect(source).toMatch(
+      /from\s+['"]@\/shared\/lib\/composables\/use-android-back-handler['"]/,
+    );
+  });
+
+  it("registers at priority 100 (same tier as the active call window)", () => {
+    const source = getSource();
+    expect(source).toMatch(
+      /useAndroidBackHandler\(\s*['"]incoming-call-modal['"]\s*,\s*100\s*,/,
+    );
+  });
+
+  it("rejects the call when visible and passes through otherwise", () => {
+    const source = getSource();
+    // Pass-through when hidden so the handler chain reaches lower-priority
+    // handlers / minimizeApp.
+    expect(source).toMatch(/if\s*\(\s*!show\.value\s*\)\s*return\s+false/);
+    // Reject + consume the event when the modal is up.
+    expect(source).toMatch(/onReject\(\)/);
+  });
+});

--- a/src/shared/lib/native-calls/native-call-bridge-ensure-visible.test.ts
+++ b/src/shared/lib/native-calls/native-call-bridge-ensure-visible.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * WEE-63 / forta-bugs#832, #893 — duplicate incoming-call "answer" dialog.
+ *
+ * `ensureIncomingCallVisible` prefers the idempotent native method, but on
+ * older builds that don't ship it, it falls back to `reportIncomingCall`,
+ * which is NOT idempotent: it can stack a second IncomingCallActivity on top
+ * of the one the FCM push handler already launched. The regression guard:
+ * skip that fallback when the SDK already tracks the callId.
+ *
+ * Source-level assertion rather than a behavioral test: `nativeCallBridge` is
+ * a module singleton whose `sdkHasCall` dynamically imports `@/entities/matrix`.
+ * A behavioral test must `vi.mock` platform + `@capacitor/core` + matrix, and
+ * those mocks leak across the shared suite (the singleton + dynamic import is
+ * not re-isolated per file in this repo's runner), making it order-dependent.
+ * The other native/integration regressions here use the same source-level
+ * approach for exactly this reason.
+ */
+const getSource = (): string =>
+  readFileSync(resolve(__dirname, "./native-call-bridge.ts"), "utf-8");
+
+describe("nativeCallBridge.ensureIncomingCallVisible — idempotent fallback guard", () => {
+  it("prefers the idempotent native ensureIncomingCallVisible when available", () => {
+    const source = getSource();
+    // The fast path must call the native method and return before any fallback.
+    expect(source).toMatch(
+      /typeof\s+plugin\.ensureIncomingCallVisible\s*===\s*['"]function['"]/,
+    );
+    expect(source).toMatch(/await\s+plugin\.ensureIncomingCallVisible\(options\)/);
+  });
+
+  it("guards the non-idempotent reportIncomingCall fallback with sdkHasCall", () => {
+    const source = getSource();
+    const method = source.slice(
+      source.indexOf("async ensureIncomingCallVisible"),
+      source.indexOf("async reportOutgoingCall"),
+    );
+    expect(method).not.toBe("");
+    // The sdkHasCall check must appear, and it must return early (skip the
+    // fallback) before reaching reportIncomingCall.
+    const guardIdx = method.indexOf("sdkHasCall(options.callId)");
+    const reportIdx = method.lastIndexOf("NativeCall.reportIncomingCall(options)");
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(reportIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(reportIdx);
+    // There must be a `return` between the guard and the fallback call so the
+    // duplicate raise is actually skipped, not merely logged.
+    const between = method.slice(guardIdx, reportIdx);
+    expect(between).toMatch(/return;/);
+  });
+});

--- a/src/shared/lib/native-calls/native-call-bridge.ts
+++ b/src/shared/lib/native-calls/native-call-bridge.ts
@@ -562,8 +562,19 @@ class NativeCallBridge {
     }
     // Older native build — best-effort fall back to reportIncomingCall.
     // It's not perfectly idempotent (it can stack a second Telecom call
-    // if one is already up), but anything is better than a silent
-    // ringer on the foreground sync path.
+    // if one is already up), so on the cold-start-from-push path it can
+    // raise a *second* answer dialog on top of the IncomingCallActivity the
+    // FCM handler already launched — exactly the duplicate-ringer bug in
+    // forta-bugs#832 / #893 (WEE-63). Guard it: if the SDK already tracks
+    // this callId, the push path has (or is about to) surface a ringer, so
+    // skip the non-idempotent fallback rather than stack a duplicate.
+    if (await this.sdkHasCall(options.callId)) {
+      console.warn(
+        '[NativeCallBridge] skipping non-idempotent reportIncomingCall fallback — SDK already has call:',
+        options.callId,
+      );
+      return;
+    }
     try {
       await NativeCall.reportIncomingCall(options);
     } catch (e) {


### PR DESCRIPTION
## Summary
- **Duplicate incoming dialog (#832/#893):** `ensureIncomingCallVisible`'s legacy `reportIncomingCall` fallback is non-idempotent and stacked a second native `IncomingCallActivity` on top of the FCM-launched one. Now guarded with `sdkHasCall(callId)` — fallback is skipped when a ringer is already up.
- **Android Back on incoming (#759):** `IncomingCallModal` registers `useAndroidBackHandler("incoming-call-modal", 100, …)` that rejects the call when visible and passes through (returns false) otherwise, instead of minimizing the app.
- **Provider-aware call card (#923):** `CallEventCard` routes the call-back through `useCallLauncher().launch(...)` (per-component instance) so configured external meeting providers (WEE-57) surface a picker; renders a teleported `<CallProviderPicker>`.
- H2 (early dedup — `markIncomingCallSeen` before first `await`) was already present in master; not re-touched.

## Linear
- Resolves WEE-63 (https://linear.app/wwwee/issue/WEE-63)

## Closes
Closes greenShirtMystery/forta-bugs#832
Closes greenShirtMystery/forta-bugs#893
Closes greenShirtMystery/forta-bugs#886
Closes greenShirtMystery/forta-bugs#759
Closes greenShirtMystery/forta-bugs#519
Closes greenShirtMystery/forta-bugs#431
Closes greenShirtMystery/forta-bugs#853
Closes greenShirtMystery/forta-bugs#923

## Test plan
- [x] `npx vite build` — bundle builds clean
- [x] `npx vue-tsc --noEmit` — 0 new type errors in changed files (50 total = pre-existing master baseline)
- [x] `npm run test` — 16 failures, all pre-existing baseline (video-embed, open-profile-url, chat-helpers, display-result, ChatWindow); none in changed files. New/updated tests: 11/11 green, order-independent under the shared runner.
- [x] Code review (superpowers:code-reviewer) — Approve, no CRITICAL/HIGH
- [ ] Manual QA: mobile→mobile incoming from killed state (FCM cold-start) shows exactly one dialog; Android Back rejects; tap a call card with a configured provider opens the picker

## Notes
- The Android Back handler is the in-WebView ringer guard (#759 path). On native, the incoming UI is the native `IncomingCallActivity`, which owns the hardware Back independently.