### PR TITLE
fix(calls): release camera/mic tracks on call end (web + native) (WEE-89)

### DIFF
--- a/src/features/video-calls/model/call-service.test.ts
+++ b/src/features/video-calls/model/call-service.test.ts
@@ -1311,3 +1311,195 @@ describe('call-service permission flow', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// WEE-89 — camera/mic released after a call (web recording-indicator leak,
+// regression of WEE-47). matrix-js-sdk doesn't reliably stop the local
+// getUserMedia tracks on web, so the tab's 🔴 indicator stays lit and the
+// mic stays captured after ended/hangup/reject. The fix stops every local
+// track on all teardown paths via releaseLocalMedia().
+// ---------------------------------------------------------------------------
+describe('local media release on call teardown (WEE-89)', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockCallStore.isInCall = false;
+    mockCallStore.activeCall = null;
+    mockCallStore.matrixCall = null;
+    mockCallStore.videoMuted = false;
+    mockEnsureCallPermissions.mockResolvedValue(undefined);
+    mockGetUser.mockReset();
+    mockGetUser.mockReturnValue({ name: 'Peer' });
+    mockLoadUsersBatch.mockReset();
+    mockLoadUsersBatch.mockResolvedValue(undefined);
+    const { __resetFinalizeCallStateForTests } = await import('./finalize-call');
+    __resetFinalizeCallStateForTests();
+  });
+
+  /** Track stub whose stop() is observable. */
+  function track(stop: Mock) {
+    return { stop } as unknown as MediaStreamTrack;
+  }
+
+  /**
+   * MatrixCall stub carrying observable local tracks. `on`/`off` reuse the
+   * shared mocks so wireCallEvents registrations land in mockOn.mock.calls
+   * and can be captured below.
+   */
+  function makeCallWithTracks(
+    userStops: Mock[],
+    screenStops: Mock[] = [],
+  ): Record<string, unknown> {
+    return {
+      callId: 'test-call-id',
+      roomId: 'test-room-id',
+      type: 'voice',
+      on: mockOn,
+      off: mockOff,
+      placeVoiceCall: mockPlaceVoiceCall,
+      placeVideoCall: mockPlaceVideoCall,
+      answer: mockAnswer,
+      reject: mockReject,
+      hangup: mockHangup,
+      isMicrophoneMuted: vi.fn(() => false),
+      localUsermediaStream: { getTracks: () => userStops.map(track) },
+      localScreensharingStream: screenStops.length
+        ? { getTracks: () => screenStops.map(track) }
+        : null,
+      remoteUsermediaStream: null,
+      remoteScreensharingStream: null,
+      remoteUsermediaFeed: null,
+      getOpponentMember: vi.fn(() => ({ userId: '@peer:matrix.org' })),
+    };
+  }
+
+  function captureHandler(event: string) {
+    const entry = mockOn.mock.calls.find((c: unknown[]) => c[0] === event);
+    return entry?.[1] as ((...args: unknown[]) => void) | undefined;
+  }
+
+  it('stops all local media tracks when the call ends (A1: web indicator clears)', async () => {
+    const stopAudio = vi.fn();
+    const stopVideo = vi.fn();
+    const fakeCall = makeCallWithTracks([stopAudio, stopVideo]);
+    const { createNewMatrixCall } = await import('matrix-js-sdk-bastyon/lib/webrtc/call');
+    vi.mocked(createNewMatrixCall).mockReturnValueOnce(fakeCall as never);
+
+    const { useCallService } = await import('./call-service');
+    await useCallService().startCall('!room:matrix.org', 'voice');
+
+    const onState = captureHandler('State');
+    expect(onState).toBeTruthy();
+    onState?.('ended', 'connected');
+
+    expect(stopAudio).toHaveBeenCalledTimes(1);
+    expect(stopVideo).toHaveBeenCalledTimes(1);
+  });
+
+  it('also stops screenshare tracks on call end', async () => {
+    const stopMic = vi.fn();
+    const stopScreen = vi.fn();
+    const fakeCall = makeCallWithTracks([stopMic], [stopScreen]);
+    const { createNewMatrixCall } = await import('matrix-js-sdk-bastyon/lib/webrtc/call');
+    vi.mocked(createNewMatrixCall).mockReturnValueOnce(fakeCall as never);
+
+    const { useCallService } = await import('./call-service');
+    await useCallService().startCall('!room:matrix.org', 'voice');
+
+    captureHandler('State')?.('ended', 'connected');
+
+    expect(stopMic).toHaveBeenCalledTimes(1);
+    expect(stopScreen).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops local media tracks when the SDK fires Hangup before Ended', async () => {
+    const stop = vi.fn();
+    const fakeCall = makeCallWithTracks([stop]);
+    const { createNewMatrixCall } = await import('matrix-js-sdk-bastyon/lib/webrtc/call');
+    vi.mocked(createNewMatrixCall).mockReturnValueOnce(fakeCall as never);
+
+    const { useCallService } = await import('./call-service');
+    await useCallService().startCall('!room:matrix.org', 'voice');
+
+    captureHandler('Hangup')?.();
+
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops local media tracks on user-initiated hangup (A2: mic freed)', async () => {
+    const stop = vi.fn();
+    mockCallStore.matrixCall = makeCallWithTracks([stop]);
+
+    const { useCallService } = await import('./call-service');
+    useCallService().hangup();
+
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops local media tracks on reject', async () => {
+    const stop = vi.fn();
+    mockCallStore.matrixCall = makeCallWithTracks([stop]);
+
+    const { useCallService } = await import('./call-service');
+    useCallService().rejectCall();
+
+    expect(stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw on reject when no local stream was acquired (ringing reject)', async () => {
+    const fakeCall = makeCallWithTracks([]);
+    fakeCall.localUsermediaStream = null;
+    mockCallStore.matrixCall = fakeCall;
+
+    const { useCallService } = await import('./call-service');
+    expect(() => useCallService().rejectCall()).not.toThrow();
+    expect(mockReject).toHaveBeenCalled();
+  });
+
+  it('does NOT stop local media while the call is still connected (A3: active call works)', async () => {
+    const stop = vi.fn();
+    const fakeCall = makeCallWithTracks([stop]);
+    const { createNewMatrixCall } = await import('matrix-js-sdk-bastyon/lib/webrtc/call');
+    vi.mocked(createNewMatrixCall).mockReturnValueOnce(fakeCall as never);
+
+    const { useCallService } = await import('./call-service');
+    await useCallService().startCall('!room:matrix.org', 'voice');
+
+    captureHandler('State')?.('connected', 'connecting');
+
+    expect(stop).not.toHaveBeenCalled();
+  });
+
+  // The answerCall connecting-watchdog unwires SDK listeners before
+  // call.hangup(), so onHangup/onState→ended never run — the media acquired
+  // by call.answer() must be released by the watchdog itself.
+  it('stops local media when the answerCall connecting-watchdog times out', async () => {
+    vi.useFakeTimers();
+    try {
+      const stop = vi.fn();
+      const fakeCall = makeCallWithTracks([stop]);
+      mockCallStore.matrixCall = fakeCall;
+      mockCallStore.activeCall = {
+        callId: 'test-call-id',
+        roomId: 'test-room-id',
+        type: 'voice',
+        direction: 'incoming',
+        peerName: 'Peer',
+        status: 'incoming',
+      };
+      // call.answer resolves (media acquired) but the call never connects.
+      mockAnswer.mockResolvedValue(undefined);
+
+      const { useCallService } = await import('./call-service');
+      void useCallService().answerCall();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Keep status stuck at connecting so the watchdog fires.
+      (mockCallStore.activeCall as { status: string }).status = 'connecting';
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(stop).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/features/video-calls/model/call-service.ts
+++ b/src/features/video-calls/model/call-service.ts
@@ -324,6 +324,32 @@ function unwireCallEvents(call: MatrixCall) {
   boundHandlers = null;
 }
 
+/**
+ * Stop every local camera/mic (and screenshare) track held by a call.
+ *
+ * WEE-89 (regression of WEE-47): matrix-js-sdk does not reliably stop the
+ * local getUserMedia tracks when a call ends on web, so the browser keeps
+ * the camera/microphone captured and the tab's recording indicator (🔴)
+ * stays lit after the call is over — a privacy problem. On mobile the held
+ * mic also blocks the next call / the system from re-acquiring it. Stop the
+ * tracks explicitly on every platform.
+ *
+ * Native audio-routing teardown stays in finalizeCall(); this only releases
+ * the getUserMedia tracks the SDK leaves behind. MediaStreamTrack.stop() is
+ * idempotent (a no-op on an already-ended track), so calling this from the
+ * overlapping teardown paths (onState→ended, onHangup, onError, rejectCall,
+ * hangup) is safe.
+ */
+function releaseLocalMedia(call: MatrixCall): void {
+  for (const stream of [call.localUsermediaStream, call.localScreensharingStream]) {
+    try {
+      stream?.getTracks().forEach((track) => track.stop());
+    } catch (e) {
+      console.warn("[call-service] releaseLocalMedia: track.stop failed:", e);
+    }
+  }
+}
+
 function wireCallEvents(call: MatrixCall, direction: "outgoing" | "incoming") {
   // Defensive: remove any prior handlers first
   unwireCallEvents(call);
@@ -397,6 +423,11 @@ function wireCallEvents(call: MatrixCall, direction: "outgoing" | "incoming") {
       playEndTone();
       callStore.stopTimer();
       unwireCallEvents(call);
+      // WEE-89: stop local camera/mic tracks on every platform. The SDK
+      // doesn't reliably release getUserMedia on web, leaving the tab's
+      // recording indicator lit after the call. Native finalizeCall below
+      // still handles audio routing.
+      releaseLocalMedia(call);
       // Single point of native cleanup. Idempotent per callId — if
       // hangup() / rejectCall() already finalized this call, this is a
       // no-op. Steps (stopAudioRouting → reportCallEnded → dismissCallUI
@@ -432,6 +463,10 @@ function wireCallEvents(call: MatrixCall, direction: "outgoing" | "incoming") {
     stopAllSounds();
     clearIncomingTimeout();
     clearConnectingWatchdog();
+    // WEE-89: release local media here too — the SDK sometimes fires Hangup
+    // before State transitions to Ended (rejected-while-ringing), so don't
+    // wait for onState→ended to stop the camera/mic tracks.
+    releaseLocalMedia(call);
     // Also tear down the native surface. Without this, when the remote
     // cancels a call we never answered, or when another of our devices
     // picks up (m.call.select_answer), the SDK fires Hangup but the
@@ -458,6 +493,9 @@ function wireCallEvents(call: MatrixCall, direction: "outgoing" | "incoming") {
     clearIncomingTimeout();
     clearConnectingWatchdog();
     unwireCallEvents(call);
+    // WEE-89: a failed call may have already acquired local media; release
+    // it so the camera/mic don't stay captured after the error.
+    releaseLocalMedia(call);
     if (isNative) {
       void finalizeCall("error", call.callId);
     }
@@ -987,6 +1025,9 @@ export function useCallService() {
       useBugReport().open({ context: tRaw("bugReport.ctx.placeCall"), error: e });
       stopAllSounds();
       unwireCallEvents(call);
+      // WEE-89: placeCall may have run getUserMedia before throwing — release
+      // any acquired camera/mic tracks so they aren't left captured.
+      releaseLocalMedia(call);
       callStore.updateStatus(CallStatus.failed);
       callStore.scheduleClearCall(2000);
       // H1/H7 + Session 23: native side of startAudioRouting may have
@@ -1384,6 +1425,10 @@ export function useCallService() {
       try {
         call.hangup(CallErrorCode.UserHangup, false);
       } catch { /* ignore */ }
+      // WEE-89: listeners are unwired above, so onHangup/onState→ended won't
+      // fire — release the media acquired in call.answer() ourselves so the
+      // camera/mic don't stay captured after a watchdog timeout.
+      releaseLocalMedia(call);
       callStore.updateStatus(CallStatus.failed);
       callStore.scheduleClearCall(2000);
       if (isNative) {
@@ -1424,6 +1469,9 @@ export function useCallService() {
       useBugReport().open({ context: tRaw("bugReport.ctx.answerCall"), error: e });
       clearConnectingWatchdog();
       unwireCallEvents(call);
+      // WEE-89: call.answer may have run getUserMedia before throwing —
+      // release any acquired camera/mic tracks so they aren't left captured.
+      releaseLocalMedia(call);
       callStore.updateStatus(CallStatus.failed);
       callStore.scheduleClearCall(2000);
       // H1 + H7 + Session 23: always tear down audio routing on answer
@@ -1495,6 +1543,11 @@ export function useCallService() {
       void finalizeCall("reject", call.callId);
     }
 
+    // WEE-89: a call rejected after it acquired media (e.g. answered then
+    // declined elsewhere) must release the camera/mic. No-op when rejected
+    // while still ringing (no local stream acquired yet).
+    releaseLocalMedia(call);
+
     unwireCallEvents(call);
 
     if (callStore.activeCall) {
@@ -1536,6 +1589,11 @@ export function useCallService() {
     if (isNative) {
       void finalizeCall("hangup", call.callId);
     }
+
+    // WEE-89: stop local tracks immediately on user hangup so the browser's
+    // recording indicator clears without waiting for the SDK's Ended
+    // transition (which onState→ended also releases — idempotent).
+    releaseLocalMedia(call);
 
     // Fallback cleanup if SDK doesn't fire Ended event (#11)
     callStore.scheduleClearCall(3000);


### PR DESCRIPTION
## Summary
- After a call ended/hung up/was rejected, the app kept the camera/mic captured: on **web** the SDK doesn't reliably stop local `getUserMedia` tracks, so the tab's recording indicator (🔴) stayed lit (privacy, regression of WEE-47); on **mobile** the held mic blocked the next call.
- Added a `releaseLocalMedia(call)` helper in `call-service.ts` that stops every local usermedia + screenshare track (idempotent, per-stream try/catch, null-safe).
- Called it on **all** teardown paths on every platform: `onState→ended`, `onHangup`, `onError`, `startCall`/`answerCall` catch blocks, the `answerCall` connecting-watchdog timeout, `rejectCall`, and `hangup()`. Native `finalizeCall()` (audio routing) is left untouched — the helper only releases the getUserMedia tracks the SDK leaves behind.

## Linear
- Resolves WEE-89 (https://linear.app/wwwee/issue/WEE-89)
- Refs WEE-47, WEE-87

## Acceptance criteria
- **A1** Web: recording indicator clears after the call → covered by "stops all local media tracks when the call ends".
- **A2** Mobile: mic freed after the call → covered by "stops local media tracks on user-initiated hangup".
- **A3** Regression: active call keeps media; media is NOT stopped while connected → covered by "does NOT stop local media while the call is still connected".

## Test plan
- [x] `npm run build` — 0 new tsc errors (50 pre-existing baseline, none in changed files)
- [x] `npx vue-tsc --noEmit` — no errors in changed files
- [x] `npm run test` — full `call-service.test.ts` green (52 tests, 8 new for WEE-89); suite delta = baseline only (16 pre-existing unrelated failures)
- [x] No `lint` script in repo (N/A)
- [x] Code review (`superpowers:code-reviewer`) — 1 HIGH (missed watchdog teardown path) found & fixed + test added
- [ ] Manual QA: web — call → end → 🔴 tab indicator goes out; mobile — after call mic is free for next call/system