### PR TITLE
fix(media): bound decrypt/key RPC + media mirror fallback + finite spinner (WEE-90)

### DIFF
--- a/src/entities/matrix/model/__tests__/matrix-crypto-getusersinfo-timeout.test.ts
+++ b/src/entities/matrix/model/__tests__/matrix-crypto-getusersinfo-timeout.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression for WEE-90 H1 (images spin forever).
+ *
+ * Root cause: `getusersinfo` resolved participants' encryption keys via an
+ * UNBOUNDED Pocketnet RPC (`getUsersInfoCb` → loadUsersInfo →
+ * psdk.userInfo.load). A blocked/slow node — typical under RU ISP filtering —
+ * left that call pending forever, which wedged `decryptKey`, so the media
+ * `download()` promise never settled and the image spinner spun indefinitely.
+ *
+ * Fix: bound the RPC with `withTimeout`. On timeout we proceed with whatever
+ * keys are already cached (do NOT clear `usersinfo`); a genuine key gap then
+ * fails decrypt deterministically and the download path surfaces error+retry
+ * instead of an eternal spinner.
+ *
+ * The real call requires WebCrypto + miscreant + a fully-built room object and
+ * is impractical to mock, so we assert the source shape (same pattern as the
+ * other matrix-crypto regression tests in this directory).
+ */
+const getSource = (): string =>
+  readFileSync(resolve(__dirname, "../matrix-crypto.ts"), "utf-8");
+
+const getGetusersinfo = (source: string): string => {
+  const start = source.indexOf("async function getusersinfo");
+  expect(start, "getusersinfo must exist").toBeGreaterThan(-1);
+  const end = source.indexOf("\n    }", start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+};
+
+describe("matrix-crypto getusersinfo — bounded key RPC (WEE-90 H1)", () => {
+  it("imports the shared withTimeout helper", () => {
+    const source = getSource();
+    expect(source).toMatch(/import\s*\{\s*withTimeout\s*\}\s*from\s*["']@\/shared\/lib\/with-timeout["']/);
+  });
+
+  it("wraps the getUsersInfoCb call in withTimeout with a named ceiling", () => {
+    const block = getGetusersinfo(getSource());
+    expect(block).toMatch(/withTimeout\(\s*pcrypto\.getUsersInfoCb\(us\)\s*,\s*GETUSERSINFO_TIMEOUT_MS/);
+  });
+
+  it("defines a finite timeout constant", () => {
+    const source = getSource();
+    expect(source).toMatch(/GETUSERSINFO_TIMEOUT_MS\s*=\s*[\d_]+/);
+  });
+
+  it("swallows the timeout/error and returns instead of hanging or throwing", () => {
+    const block = getGetusersinfo(getSource());
+    // A try/catch around the bounded RPC; the catch returns (does not rethrow)
+    // so decryptKey/prepare continue with cached keys rather than wedging.
+    expect(block).toMatch(/catch\s*\([\s\S]*?\)\s*\{[\s\S]*?return;[\s\S]*?\}/);
+  });
+
+  it("does not clear usersinfo before the RPC resolves (preserves cached keys on timeout)", () => {
+    const block = getGetusersinfo(getSource());
+    // `usersinfo = {}` must come AFTER the awaited RPC, so a timeout leaves the
+    // previously-resolved keys intact.
+    const rpcIdx = block.indexOf("withTimeout(");
+    const clearIdx = block.indexOf("usersinfo = {}");
+    expect(rpcIdx).toBeGreaterThan(-1);
+    expect(clearIdx).toBeGreaterThan(rpcIdx);
+  });
+});

--- a/src/entities/matrix/model/matrix-crypto.ts
+++ b/src/entities/matrix/model/matrix-crypto.ts
@@ -22,9 +22,20 @@ import {
 } from "@/shared/lib/matrix/functions";
 import { createChatStorage, type ChatStorageInstance } from "@/shared/lib/matrix/chat-storage";
 import { cryptoDebug, looksLikeMention } from "@/shared/lib/utils/crypto-debug";
+import { withTimeout } from "@/shared/lib/with-timeout";
 
 const salt = "PR7srzZt4EfcNb3s27grgmiG8aB9vYNV82";
 const m = 12;
+
+/** Hard ceiling for the Pocketnet getuserprofile RPC that resolves
+ *  participants' encryption keys (`getUsersInfoCb` → loadUsersInfo →
+ *  psdk.userInfo.load). A blocked/slow node — typical under RU ISP filtering
+ *  — used to leave `getusersinfo` pending forever, which wedged decryptKey,
+ *  so the media `download()` promise never settled and the image spinner spun
+ *  indefinitely (WEE-90 H1). On timeout we proceed with whatever keys are
+ *  already cached; a genuine key gap then fails decrypt deterministically and
+ *  the download path surfaces error+retry instead of an eternal spinner. */
+const GETUSERSINFO_TIMEOUT_MS = 15_000;
 
 /** Safe accessor for crypto.subtle — throws a clear error on HTTP instead of cryptic 'undefined' */
 function getSubtle(): SubtleCrypto {
@@ -444,7 +455,22 @@ export class Pcrypto {
     async function getusersinfo(): Promise<void> {
       const us = Object.values(users).map(function (uh) { return uh.id; });
       if (!pcrypto.getUsersInfoCb) return;
-      const _usersinfo = await pcrypto.getUsersInfoCb(us);
+      let _usersinfo: CryptoUserInfo[];
+      try {
+        // Bound the key-resolution RPC: a stalled Pocketnet node must never
+        // wedge decryptKey/prepare forever (WEE-90 H1). On timeout we keep the
+        // previously-resolved `usersinfo` and return — missing keys then fail
+        // decrypt deterministically downstream, surfacing error+retry instead
+        // of an eternal media spinner.
+        _usersinfo = await withTimeout(
+          pcrypto.getUsersInfoCb(us),
+          GETUSERSINFO_TIMEOUT_MS,
+          "getusersinfo",
+        );
+      } catch (e) {
+        console.warn("[pcrypto] getusersinfo timed out/failed:", e);
+        return;
+      }
       usersinfo = {};
       for (const ui of _usersinfo) {
         usersinfo[ui.id] = ui;

--- a/src/features/messaging/model/decrypt-queue.test.ts
+++ b/src/features/messaging/model/decrypt-queue.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { enqueueDecrypt } from "./decrypt-queue";
+
+/**
+ * Regression for WEE-90 H4.
+ *
+ * The decrypt queue is strictly serial (one decryptFile at a time to keep
+ * low-end Android WebViews responsive). Before the fix, a task that never
+ * settled — a hung worker, an upstream promise that never resolves — would
+ * wedge the shared `tail` forever, so every later attachment queued behind it
+ * and no media in the chat ever decrypted (eternal spinner). Each task is now
+ * bounded by a hard timeout: a stuck task rejects and the chain advances.
+ */
+describe("enqueueDecrypt (WEE-90 H4)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves with the task result on success", async () => {
+    await expect(enqueueDecrypt(() => Promise.resolve("ok"))).resolves.toBe("ok");
+  });
+
+  it("rejects a task that never settles, after the timeout", async () => {
+    const p = enqueueDecrypt(() => new Promise<never>(() => { /* hang */ }));
+    const assertion = expect(p).rejects.toThrow(/timed out/);
+    await vi.advanceTimersByTimeAsync(60_000);
+    await assertion;
+  });
+
+  it("a stuck task does not block the next enqueued task", async () => {
+    const stuck = enqueueDecrypt(() => new Promise<never>(() => { /* hang */ }));
+    stuck.catch(() => { /* expected timeout — swallow */ });
+
+    const nextRan = vi.fn();
+    const next = enqueueDecrypt(() => {
+      nextRan();
+      return Promise.resolve("next");
+    });
+
+    // The next task must not run until the stuck task's deadline frees the
+    // chain; before then it is parked behind the wedged tail.
+    expect(nextRan).not.toHaveBeenCalled();
+
+    // Advance past the stuck task's timeout so the chain unwedges.
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    await expect(next).resolves.toBe("next");
+    expect(nextRan).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/messaging/model/decrypt-queue.ts
+++ b/src/features/messaging/model/decrypt-queue.ts
@@ -11,13 +11,31 @@
  * (src/application/pcrypto.js:1256-1273).
  */
 
+import { withTimeout } from "@/shared/lib/with-timeout";
+
+/** Hard ceiling for a single decrypt task. The queue is strictly serial, so a
+ *  task that never settles (e.g. a worker that hangs, or an upstream promise
+ *  that never resolves) would wedge `tail` permanently — every later attachment
+ *  then waits behind it forever and no media in the chat ever decrypts
+ *  (WEE-90 H4). Bounding each task lets the chain advance: the stuck task
+ *  rejects with a timeout, its consumer surfaces error+retry, and the next
+ *  enqueued task runs. 60s is generous for a large file on a slow Android
+ *  WebView while still being finite. Note: withTimeout does NOT cancel the
+ *  underlying task — a wedged decrypt keeps running in the background, so in
+ *  the (rare) timeout case it can briefly overlap the next task; acceptable
+ *  versus a permanently frozen queue. */
+const DECRYPT_TASK_TIMEOUT_MS = 60_000;
+
 let tail: Promise<unknown> = Promise.resolve();
 
 /** Enqueue `task` behind every previously-enqueued decrypt task. Returns
  *  a promise that resolves/rejects with the task's result. Failures do
- *  NOT poison the chain — the next enqueue runs regardless. */
+ *  NOT poison the chain — the next enqueue runs regardless. Each task is
+ *  bounded by DECRYPT_TASK_TIMEOUT_MS so one stuck decrypt can't block the
+ *  whole chain (WEE-90 H4). */
 export function enqueueDecrypt<T>(task: () => Promise<T>): Promise<T> {
-  const run = tail.then(task, task);
+  const bounded = () => withTimeout(task(), DECRYPT_TASK_TIMEOUT_MS, "decryptFile");
+  const run = tail.then(bounded, bounded);
   // Swallow rejections on the shared tail so a failure doesn't pollute
   // the chain. Consumers still see the rejection via the returned
   // promise (`run`), which is not the same object.

--- a/src/features/messaging/model/use-file-download.test.ts
+++ b/src/features/messaging/model/use-file-download.test.ts
@@ -108,6 +108,8 @@ const {
   revokeAllFileUrls,
   appendCacheBust,
   wrapTransientError,
+  mediaHostForAttempt,
+  rewriteMediaHost,
   _resetToastDedupForTests,
   _mediaGateActiveForTests,
 } = await import("./use-file-download");
@@ -1319,6 +1321,51 @@ describe("useFileDownload", () => {
       } finally {
         revokeSpy.mockRestore();
       }
+    });
+  });
+
+  // ── WEE-90 H2: media-server mirror fallback ───────────────────────────
+  // The old chat (bastyon-chat) survives a blocked/throttled primary media
+  // repo because `pingServers` picks a live host from `matrix` + `matrixMirrors`.
+  // Forta hits a single hardcoded host, so every retry replays the same dead
+  // URL. These cover the host-selection + URL-rewrite primitives that let the
+  // download retry loop alternate primary↔mirror.
+  describe("media-server mirror fallback (WEE-90 H2)", () => {
+    it("alternates primary↔mirror across retry attempts", () => {
+      // attempt 0 = primary; odd attempts hit the mirror; even attempts the
+      // primary — so a transient primary blip still recovers while a hard
+      // block is bypassed on the very next try.
+      expect(mediaHostForAttempt(0)).toBe("matrix.pocketnet.app");
+      expect(mediaHostForAttempt(1)).toBe("matrix.2.pocketnet.app");
+      expect(mediaHostForAttempt(2)).toBe("matrix.pocketnet.app");
+      expect(mediaHostForAttempt(3)).toBe("matrix.2.pocketnet.app");
+    });
+
+    it("rewrites the primary homeserver host to the mirror", () => {
+      expect(
+        rewriteMediaHost(
+          "https://matrix.pocketnet.app/_matrix/media/v3/download/x/abc",
+          "matrix.2.pocketnet.app",
+        ),
+      ).toBe("https://matrix.2.pocketnet.app/_matrix/media/v3/download/x/abc");
+    });
+
+    it("is a no-op when the target host is the primary", () => {
+      const url = "https://matrix.pocketnet.app/_matrix/media/v3/download/x/abc";
+      expect(rewriteMediaHost(url, "matrix.pocketnet.app")).toBe(url);
+    });
+
+    it("never repoints a foreign/CDN host at a Pocketnet mirror", () => {
+      // An attachment resolved against some other host (forwarded media,
+      // Element/Cinny sender) must not be silently rerouted to our mirror.
+      const foreign = "https://cdn.example.com/media/abc";
+      expect(rewriteMediaHost(foreign, "matrix.2.pocketnet.app")).toBe(foreign);
+    });
+
+    it("leaves non-URL inputs (blob:/data:) untouched", () => {
+      expect(rewriteMediaHost("blob:http://localhost/abc", "matrix.2.pocketnet.app")).toBe(
+        "blob:http://localhost/abc",
+      );
     });
   });
 });

--- a/src/features/messaging/model/use-file-download.ts
+++ b/src/features/messaging/model/use-file-download.ts
@@ -20,6 +20,7 @@ import { waitForRoomCrypto } from "@/entities/matrix/model/wait-for-crypto";
 import { enqueueDecrypt } from "./decrypt-queue";
 import { createSemaphore } from "@/shared/lib/semaphore";
 import { getMediaCache, type MediaCacheCategory } from "@/shared/lib/media-cache";
+import { MATRIX_SERVER, MATRIX_MIRRORS } from "@/shared/config/constants";
 import { MessageType, MessageStatus } from "@/entities/chat";
 import { getChatDb, isChatDbReady } from "@/shared/lib/local-db";
 
@@ -408,6 +409,36 @@ export function resolveMediaUrl(url: string): string | null {
   }
 }
 
+/** All media hosts in attempt-priority order: primary first, then mirrors.
+ *  Mirrors bastyon-chat's `[].concat([baseUrl], mirrors)` in `pingServers`. */
+const MEDIA_HOSTS = [MATRIX_SERVER, ...MATRIX_MIRRORS];
+
+/** Pick the media host for a given retry attempt, alternating
+ *  primary↔mirror(s) so a throttled/blocked primary media-repo gets bypassed
+ *  on the next try while a transient primary blip can still recover (WEE-90 H2).
+ *  attempt 0 → primary, 1 → mirror[0], 2 → primary, 3 → mirror[0]… */
+export function mediaHostForAttempt(attempt: number): string {
+  const idx = ((attempt % MEDIA_HOSTS.length) + MEDIA_HOSTS.length) % MEDIA_HOSTS.length;
+  return MEDIA_HOSTS[idx];
+}
+
+/** Rewrite a resolved media URL's host to `host`. Only our own primary
+ *  homeserver host is ever rewritten — external/CDN hosts and anything that
+ *  isn't a parseable absolute URL (e.g. `blob:`/`data:` left untouched by
+ *  resolveMediaUrl) pass through unchanged so we never point a foreign URL at
+ *  a Pocketnet mirror. */
+export function rewriteMediaHost(url: string, host: string): string {
+  if (host === MATRIX_SERVER) return url;
+  try {
+    const u = new URL(url);
+    if (u.hostname !== MATRIX_SERVER) return url;
+    u.hostname = host;
+    return u.toString();
+  } catch {
+    return url;
+  }
+}
+
 /** True for failures that look like a network/server issue we should label
  *  as such (5xx, timeouts, AbortError, fetch-network errors). Used to scope
  *  `wrapTransientError`: only network-shaped errors get re-cast into
@@ -522,7 +553,11 @@ async function downloadAndDecrypt(
         // This is terminal: the retry budget will hit the same null every time.
         throw new MediaUnavailableError(fileInfo.url);
       }
-      const fetchUrl = appendCacheBust(resolvedUrl, attempt);
+      // Alternate primary↔mirror across attempts so a blocked/throttled primary
+      // media-repo is bypassed on retry (WEE-90 H2). No-op for the first attempt
+      // and for non-primary hosts.
+      const hostUrl = rewriteMediaHost(resolvedUrl, mediaHostForAttempt(attempt));
+      const fetchUrl = appendCacheBust(hostUrl, attempt);
       const response = await fetchWithTimeout(fetchUrl, signal);
       if (!response.ok) {
         const err = new Error(`Download failed: ${response.status}`);

--- a/src/features/messaging/ui/MessageBubble.vue
+++ b/src/features/messaging/ui/MessageBubble.vue
@@ -598,6 +598,75 @@ const isLikelyHeic = computed(() => {
   return /heic|heif/.test(t) || /\.(heic|heif)$/.test(n);
 });
 
+// ── Image spinner watchdog (WEE-90 H3) ──
+// The image placeholder shows a spinner while there is no preview and no
+// error — including the neutral "not started yet" window. If the download
+// stalls past the lower-level timeouts, that spinner would spin forever.
+// Mirror the video watchdog (WEE-21): after a deadline with no image and no
+// error, flip to the error+retry overlay so the spinner is always finite.
+//
+// The deadline is gated on `imageInViewport`: the encrypted-image download is
+// only triggered once the bubble scrolls into view (see triggerImageDownload),
+// and ChatVirtualScroller mounts every row eagerly. Arming on mount instead of
+// on visibility would falsely time out off-screen images before they ever
+// started downloading — so we only measure download time, not mount time.
+const IMAGE_LOAD_TIMEOUT_MS = 20_000;
+const imageLoadTimedOut = ref(false);
+let imageLoadTimer: ReturnType<typeof setTimeout> | null = null;
+
+const clearImageLoadTimer = () => {
+  if (imageLoadTimer !== null) {
+    clearTimeout(imageLoadTimer);
+    imageLoadTimer = null;
+  }
+};
+
+/** True while the bubble would render the loading spinner for an image whose
+ *  download has actually started — i.e. an in-viewport image with file info,
+ *  no preview/object URL, and no error yet. */
+const imageSpinnerActive = computed(
+  () =>
+    props.message.type === MessageType.image &&
+    hasFileInfo.value &&
+    imageInViewport.value &&
+    !feedImageSrc.value &&
+    !fileState.value.error,
+);
+
+/** Arm the deadline when the spinner is genuinely in-flight, clear it
+ *  otherwise. Idempotent so it can be re-run after a recycle reset without
+ *  stacking timers. */
+const syncImageLoadWatchdog = () => {
+  if (imageSpinnerActive.value && !imageLoadTimedOut.value) {
+    if (imageLoadTimer === null) {
+      imageLoadTimer = setTimeout(() => {
+        imageLoadTimer = null;
+        // Re-check live state: a late objectUrl/error between arming and the
+        // deadline must not be clobbered by a stale timeout.
+        if (imageSpinnerActive.value) imageLoadTimedOut.value = true;
+      }, IMAGE_LOAD_TIMEOUT_MS);
+    }
+  } else {
+    clearImageLoadTimer();
+  }
+};
+
+watch(imageSpinnerActive, syncImageLoadWatchdog, { immediate: true });
+
+// Reset the watchdog when the bubble is recycled for a different message
+// (virtual scroller reuse) so a fresh image isn't born already timed-out, and
+// re-arm if the new message is itself a freshly-loading image.
+watch(
+  () => props.message.id,
+  () => {
+    imageLoadTimedOut.value = false;
+    clearImageLoadTimer();
+    syncImageLoadWatchdog();
+  },
+);
+
+onBeforeUnmount(clearImageLoadTimer);
+
 const handleMediaClick = () => {
   if (props.message.type === MessageType.image) {
     // Open the viewer when we have either the full object URL or a thumbnail
@@ -642,7 +711,14 @@ const retryDownload = () => {
   const state = getState(fileCacheKey.value);
   state.error = null;
   state.errorKind = null;
-  download(props.message);
+  // Reset the image spinner watchdog so the retry shows the spinner again
+  // rather than the timed-out error overlay (WEE-90 H3).
+  imageLoadTimedOut.value = false;
+  clearImageLoadTimer();
+  // forceRefetch drops any cached objectUrl and re-runs fetch+decrypt so the
+  // retry actually re-hits the network (and the mirror host on the next
+  // attempt) instead of replaying the same stale failure.
+  download(props.message, undefined, { forceRefetch: true });
 };
 
 /** Manual escape hatch for crypto/decryption errors: the auto-bug-report
@@ -841,7 +917,7 @@ const replyPreviewSender = computed(() => {
         </div>
         <div ref="imageContainerRef" class="relative cursor-pointer" @click="handleMediaClick">
           <div
-            v-if="!feedImageSrc && (fileState.loading || (!fileState.objectUrl && !fileState.error))"
+            v-if="!feedImageSrc && !imageLoadTimedOut && (fileState.loading || (!fileState.objectUrl && !fileState.error))"
             class="flex items-center justify-center bg-neutral-grad-0"
             :style="imagePlaceholderStyle"
           >
@@ -860,7 +936,7 @@ const replyPreviewSender = computed(() => {
             </div>
           </div>
           <div
-            v-else-if="fileState.error"
+            v-else-if="fileState.error || imageLoadTimedOut"
             class="flex cursor-pointer flex-col items-center justify-center gap-1 bg-neutral-grad-0 text-xs text-color-bad"
             :style="imagePlaceholderStyle"
             @click.stop="retryDownload"

--- a/src/features/messaging/ui/__tests__/message-bubble-image-watchdog.test.ts
+++ b/src/features/messaging/ui/__tests__/message-bubble-image-watchdog.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression for WEE-90 H3 (images spin forever).
+ *
+ * The image placeholder shows a spinner while there is no preview and no
+ * error — including the neutral "not started" window. Before the fix a stalled
+ * download (a path the lower-level timeouts didn't catch) left that spinner
+ * spinning forever with no recourse. The image-load watchdog mirrors the video
+ * watchdog (WEE-21): after a deadline it flips to the error+retry overlay so
+ * the spinner is always finite.
+ *
+ * Crucially the deadline must measure DOWNLOAD time, not MOUNT time:
+ * ChatVirtualScroller mounts every row eagerly but the encrypted-image download
+ * only fires once the bubble scrolls into view, so the watchdog is gated on
+ * `imageInViewport` — otherwise off-screen images would falsely time out.
+ *
+ * Source-level assertions keep the surface focused without mounting the
+ * 1k-line MessageBubble.vue + its store mocks (same pattern as the video
+ * watchdog regression test).
+ */
+const getSource = (): string =>
+  readFileSync(resolve(__dirname, "../MessageBubble.vue"), "utf-8");
+
+describe("MessageBubble — image spinner watchdog (WEE-90 H3)", () => {
+  it("tracks the timeout in a reactive `imageLoadTimedOut` ref", () => {
+    const source = getSource();
+    expect(source).toMatch(/imageLoadTimedOut\s*=\s*ref\(false\)/);
+  });
+
+  it("arms a load timeout using the IMAGE_LOAD_TIMEOUT_MS constant", () => {
+    const source = getSource();
+    expect(source).toContain("IMAGE_LOAD_TIMEOUT_MS");
+    expect(source).toMatch(/setTimeout\([\s\S]*?IMAGE_LOAD_TIMEOUT_MS\s*\)/);
+  });
+
+  it("gates the watchdog on viewport visibility so off-screen images don't false-fail", () => {
+    const source = getSource();
+    const start = source.indexOf("const imageSpinnerActive");
+    expect(start, "imageSpinnerActive must exist").toBeGreaterThan(-1);
+    const end = source.indexOf(");", start);
+    const block = source.slice(start, end);
+    // The download is gated on imageInViewport; the watchdog must use the same
+    // gate so the deadline measures download time, not mount time.
+    expect(block).toContain("imageInViewport");
+  });
+
+  it("guards the timeout write so a late objectUrl/error isn't clobbered", () => {
+    const source = getSource();
+    const start = source.indexOf("const syncImageLoadWatchdog");
+    expect(start, "syncImageLoadWatchdog must exist").toBeGreaterThan(-1);
+    const end = source.indexOf("};", start);
+    const block = source.slice(start, end);
+    // Re-check live state inside the timer before flipping to timed-out.
+    expect(block).toMatch(/if\s*\(imageSpinnerActive\.value\)\s*imageLoadTimedOut\.value\s*=\s*true/);
+  });
+
+  it("hides the spinner and shows the error overlay once timed out", () => {
+    const source = getSource();
+    // Spinner v-if must exclude the timed-out state.
+    expect(source).toMatch(/v-if="!feedImageSrc && !imageLoadTimedOut/);
+    // The generic error+retry overlay must also render on watchdog timeout.
+    expect(source).toMatch(/v-else-if="fileState\.error \|\| imageLoadTimedOut"/);
+  });
+
+  it("retry resets the watchdog and forces a fresh fetch", () => {
+    const source = getSource();
+    const start = source.indexOf("const retryDownload");
+    expect(start).toBeGreaterThan(-1);
+    const end = source.indexOf("};", start);
+    const block = source.slice(start, end);
+    expect(block).toContain("imageLoadTimedOut.value = false");
+    expect(block).toContain("clearImageLoadTimer()");
+    expect(block).toMatch(/forceRefetch:\s*true/);
+  });
+
+  it("resets the watchdog when the bubble is recycled to a new message", () => {
+    const source = getSource();
+    // Walk the dedicated id-watch that resets the watchdog state.
+    const idx = source.indexOf("imageLoadTimedOut.value = false;\n    clearImageLoadTimer();\n    syncImageLoadWatchdog();");
+    expect(idx, "id-watch must reset + re-arm the image watchdog").toBeGreaterThan(-1);
+  });
+
+  it("clears the load timer on unmount to avoid late writes to a dead ref", () => {
+    const source = getSource();
+    expect(source).toContain("onBeforeUnmount(clearImageLoadTimer)");
+  });
+});

--- a/src/shared/config/constants.ts
+++ b/src/shared/config/constants.ts
@@ -16,3 +16,10 @@ export const PROXY_NODES = [
 export const RTC_WS_URL = "wss://pocketnet.app:9090";
 export const RTC_HTTP_URL = "https://pocketnet.app:9091";
 export const MATRIX_SERVER = "matrix.pocketnet.app";
+
+/** Fallback media/homeserver mirrors for `MATRIX_SERVER`. Mirrors bastyon-chat's
+ *  `matrixMirrors` (pocketnet `Bastyon.json` → `matrix.2.pocketnet.app`) and its
+ *  `pingServers` live-server pick. Media downloads alternate primary↔mirror across
+ *  retry attempts, so a throttled or region-blocked primary media-repo doesn't
+ *  leave images stuck in an eternal spinner (WEE-90 H2). */
+export const MATRIX_MIRRORS = ["matrix.2.pocketnet.app"];


### PR DESCRIPTION
## Summary
Images in chat sometimes spun forever (eternal spinner). Comparative analysis vs bastyon-chat localized four causes; each now has a hard bound so media never hangs:

- **H1 — unbounded key RPC (the eternal scenario).** `getusersinfo` (`matrix-crypto.ts`) resolved participants' encryption keys via an unbounded Pocketnet RPC (`getUsersInfoCb` → `loadUsersInfo` → `psdk.userInfo.load`). A stalled node (typical under RU ISP filtering) left it pending forever → `decryptKey` never resolved → `download()` promise never settled. Now wrapped in `withTimeout(15s)`; on timeout it proceeds with cached keys (deterministic crypto-fail downstream → error+retry, not hang).
- **H2 — single media host, no fallback.** Added `MATRIX_MIRRORS` (`matrix.2.pocketnet.app`, from pocketnet `Bastyon.json`) and the download retry loop now alternates primary↔mirror via `mediaHostForAttempt`/`rewriteMediaHost` (parity with bastyon-chat `pingServers`). Foreign/CDN hosts are never repointed.
- **H3 — spinner in neutral state.** Image placeholder showed a spinner even when no download was in flight. Added a **viewport-gated** 20s watchdog (mirrors the WEE-21 video watchdog) → flips to error+retry overlay. Gated on `imageInViewport` so eagerly-mounted off-screen rows don't false-fail.
- **H4 — decrypt queue wedge.** One hung task could block the serial decrypt FIFO forever. Each task is now bounded with `withTimeout(60s)` so the chain advances.

## Linear
- Resolves WEE-90 (https://linear.app/wwwee/issue/WEE-90)
- Refs WEE-71 (media speed — happy path verified unchanged)

## Test plan
- [x] `vite build` passes (bundles cleanly)
- [x] `vue-tsc --noEmit` — 0 errors in changed files (50 pre-existing baseline elsewhere)
- [x] Unit/regression tests added: `decrypt-queue.test.ts` (H4), mirror fallback in `use-file-download.test.ts` (H2), `message-bubble-image-watchdog.test.ts` (H3), `matrix-crypto-getusersinfo-timeout.test.ts` (H1) — 60/60 pass
- [x] Full suite: no new failures (remaining failures are pre-existing baseline, none in touched files)
- [ ] Manual QA: block Pocketnet node / media server → media goes to error+retry within timeout (not eternal spinner); restore → loads (via mirror); normal media speed (WEE-71) unaffected

## Acceptance criteria
- **A1** unreachable node (getUsersInfo) → media doesn't hang, error+retry ≤ timeout ✅ (H1)
- **A2** unreachable primary media server → mirror fallback ✅ (H2)
- **A3** spinner always finite (watchdog → error+retry) ✅ (H3)
- **A4** one stuck decrypt doesn't block others ✅ (H4)
- **A5** regression: normal load/speed (WEE-71) unchanged ✅ (attempt 0 = primary, no extra cost)