### PR TITLE
fix(calls): bidirectional audio on realme/ColorOS — extend start-time mic-unmute (WEE-87)

### DIFF
--- a/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
@@ -140,7 +140,8 @@ class AudioRouter private constructor(private val context: Context) {
          * the OEM re-apply window.
          *
          * [applyVendorStartTweaks] clears the global mic-mute flag once at t=0
-         * for vendors that need it (HONOR MagicOS), but MIUI/MagicOS can
+         * for vendors that need it (HONOR MagicOS, realme RealmeUI / OPPO
+         * ColorOS / Xiaomi MIUI — WEE-87), but those same aggressive ROMs can
          * re-assert that flag in the same async window they reset the audio
          * mode (the [modeReapplyScheduleMs] ticks). When that happens the
          * one-time unmute is clobbered and the peer hears one-way silence.
@@ -455,11 +456,12 @@ class AudioRouter private constructor(private val context: Context) {
      * unrecognised devices, so this is a no-op on the working majority.
      */
     private fun applyVendorStartTweaks() {
-        // HONOR MagicOS (#872/#873): the comm-device routing above can leave the
-        // global mic-mute flag asserted, producing caller-only / self-echo
-        // one-way audio. An explicit unmute releases the capture path. Wrapped
-        // because the setter is documented to throw on a few privacy-shield
-        // ROMs and must never crash call setup.
+        // Aggressive Chinese ROMs (HONOR MagicOS #872/#873; realme RealmeUI /
+        // OPPO ColorOS / Xiaomi MIUI — WEE-87 #993/#994/#995): the comm-device
+        // routing above can leave the global mic-mute flag asserted, producing
+        // caller-only / self-echo one-way audio. An explicit unmute releases the
+        // capture path. Wrapped because the setter is documented to throw on a
+        // few privacy-shield ROMs and must never crash call setup.
         if (VendorAudioPolicy.requiresExplicitMicUnmuteOnStart(vendor)) {
             try {
                 audioManager.setMicrophoneMute(false)

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/VendorAudioPolicy.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/VendorAudioPolicy.kt
@@ -97,20 +97,54 @@ object VendorAudioPolicy {
     }
 
     /**
-     * HONOR MagicOS (#872/#873 — caller-only / self-echo one-way audio).
+     * Aggressive Chinese ROMs (MagicOS / RealmeUI / ColorOS / MIUI) that are
+     * known to re-assert the process-global microphone-mute flag during call
+     * setup, stranding the local capture path in silence so the peer hears
+     * nothing. These all already ship broken HW AEC (see
+     * [BROKEN_HW_AEC_VENDORS]) — the same audio HAL that mutes capture also
+     * flips the mute flag — so they are the family that needs the explicit
+     * start-time + reapply-window unmute, not just MagicOS.
      *
-     * On MagicOS the explicit `setCommunicationDevice` routing applied by
-     * [AudioRouter.start] can leave the global microphone-mute flag asserted,
-     * so the local capture path is silent and the peer hears nothing while the
+     * Deliberately excludes SAMSUNG / GENERIC (working HW AEC, proven WEE-54
+     * generic path — acceptance criterion A5) and HUAWEI (its #874 symptom was
+     * HW-AEC capture mute, fixed via [prefersSoftwareAudioProcessing]; no
+     * mic-mute-flag report, so its routing path stays untouched).
+     */
+    private val AGGRESSIVE_MIC_MUTE_VENDORS = setOf(
+        CallVendor.HONOR,
+        CallVendor.REALME,
+        CallVendor.OPPO,
+        CallVendor.XIAOMI,
+    )
+
+    /**
+     * Aggressive Chinese ROMs (HONOR MagicOS #872/#873, realme RealmeUI / OPPO
+     * ColorOS / Xiaomi MIUI WEE-87 #993/#994/#995) — caller-only / one-way audio
+     * because the global microphone-mute flag is left asserted.
+     *
+     * On these HALs the explicit `setCommunicationDevice` routing applied by
+     * [AudioRouter.start] can leave the global microphone-mute flag asserted, so
+     * the local capture path is silent and the peer hears nothing while the
      * caller hears themselves. An explicit `setMicrophoneMute(false)` after the
-     * mode flip releases it.
+     * mode flip releases it, and the OEM mode-reapply window re-releases it on
+     * each tick because these same ROMs re-assert the flag asynchronously after
+     * setup (see [AudioRouter.shouldReapplyMicUnmute]).
      *
-     * Gated to HONOR rather than applied everywhere on *start* because forcing
-     * an unmute mid-setup is only known-needed on MagicOS; the post-call reset
-     * ([shouldUnmuteMicOnStop]) is what covers every other vendor.
+     * WEE-87: WEE-76 gated this to HONOR only, so the mirror-image one-way
+     * reports on realme 12 (#994 — peer hears me, I don't) / realme C25s (#995 —
+     * I hear, peer doesn't) and the both-way silence on 1.10.40 (#993) slipped
+     * through. Extending to the ColorOS/RealmeUI/MIUI family closes that gap.
+     *
+     * Still gated (not applied everywhere on *start*) because the proven generic
+     * WEE-54 path must stay byte-for-byte unchanged on the working majority
+     * (Samsung / Pixel / OnePlus / unknown OEMs — A5); the post-call reset
+     * ([shouldUnmuteMicOnStop]) is what defensively covers every other vendor.
+     * Re-asserting the unmute is itself safe (it can only release a stuck
+     * capture path, never break a healthy one), so this gate is about avoiding
+     * needless mid-call AudioManager churn on devices that never exhibit the bug.
      */
     fun requiresExplicitMicUnmuteOnStart(vendor: CallVendor): Boolean =
-        vendor == CallVendor.HONOR
+        vendor in AGGRESSIVE_MIC_MUTE_VENDORS
 
     /**
      * Post-call defensive microphone unmute for **every** vendor

--- a/android/app/src/test/java/com/forta/chat/plugins/calls/VendorAudioPolicyTest.kt
+++ b/android/app/src/test/java/com/forta/chat/plugins/calls/VendorAudioPolicyTest.kt
@@ -87,7 +87,7 @@ class VendorAudioPolicyTest {
     }
 
     // -------------------------------------------------------------------------
-    // requiresExplicitMicUnmuteOnStart() — HONOR-only (A1)
+    // requiresExplicitMicUnmuteOnStart() — aggressive Chinese ROM family (A1)
     // -------------------------------------------------------------------------
 
     @Test
@@ -96,11 +96,32 @@ class VendorAudioPolicyTest {
     }
 
     @Test
-    fun nonHonorVendorsDoNotForceMicUnmuteOnStart() {
-        // Gated to HONOR so the proven generic start path is untouched on every
-        // other device (A5). Post-call reset covers the rest.
+    fun colorOsFamilyRequiresExplicitMicUnmuteOnStart() {
+        // WEE-87 regression: WEE-76 gated the start-time mic unmute to HONOR
+        // only, leaving realme RealmeUI (#994/#995), OPPO ColorOS and Xiaomi
+        // MIUI — the same aggressive HALs that re-assert the global mic-mute
+        // flag mid-setup — without the protection. Mirror-image one-way audio
+        // and 1.10.40 both-way silence followed. These must now opt in.
+        for (v in listOf(CallVendor.REALME, CallVendor.OPPO, CallVendor.XIAOMI)) {
+            assertTrue(
+                "$v (ColorOS/RealmeUI/MIUI) must force a mic unmute mid-setup",
+                VendorAudioPolicy.requiresExplicitMicUnmuteOnStart(v),
+            )
+        }
+    }
+
+    @Test
+    fun workingVendorsDoNotForceMicUnmuteOnStart() {
+        // SAMSUNG / GENERIC ship working HW AEC and must stay byte-for-byte on
+        // the proven generic WEE-54 start path (A5). HUAWEI's #874 symptom was
+        // HW-AEC capture mute (fixed via software AEC), not a mic-mute flag, so
+        // its routing path stays untouched too. Derived as the complement of the
+        // aggressive family over the WHOLE enum so a future CallVendor (e.g.
+        // VIVO / ONEPLUS) is automatically asserted negative until someone opts
+        // it in deliberately — the regression net stays exhaustive.
+        val aggressive = setOf(CallVendor.HONOR, CallVendor.REALME, CallVendor.OPPO, CallVendor.XIAOMI)
         for (v in CallVendor.entries) {
-            if (v == CallVendor.HONOR) continue
+            if (v in aggressive) continue
             assertFalse(
                 "$v must not force a mic unmute mid-setup",
                 VendorAudioPolicy.requiresExplicitMicUnmuteOnStart(v),


### PR DESCRIPTION
## Summary
- **Root cause:** `VendorAudioPolicy.requiresExplicitMicUnmuteOnStart()` was gated to `HONOR` only. That predicate drives both mic-unmute protections in `AudioRouter` — the t=0 `setMicrophoneMute(false)` in `applyVendorStartTweaks()` **and** the OEM mode-reapply window ticks (`shouldReapplyMicUnmute`). realme RealmeUI / OPPO ColorOS / Xiaomi MIUI are the same aggressive ROMs that re-assert the global mic-mute flag mid call-setup, but were excluded → local capture path stays muted → peer hears one-way / no audio on 1.10.40.
- **Fix:** extend the predicate to the ColorOS/RealmeUI/MIUI family `{HONOR, REALME, OPPO, XIAOMI}` via a documented `AGGRESSIVE_MIC_MUTE_VENDORS` set. Samsung/Pixel/OnePlus/unknown stay byte-for-byte on the proven generic WEE-54 path (A5). HUAWEI excluded (its #874 symptom was HW-AEC capture mute, already fixed via software AEC). No `AudioRouter` logic change — both call sites already key off this predicate; only doc comments updated.
- **Why safe:** re-asserting `setMicrophoneMute(false)` can only release a stuck capture path, never break a healthy one (same reasoning as the always-true `shouldUnmuteMicOnStop`); the reapply tick is additionally guarded by `isMicMuted` → no-op on healthy devices.

## H0 check (per ticket)
WEE-76 fix (`10b4585`) **is** an ancestor of `v1.10.40` (and not of `v1.10.39`) → this is a genuine post-WEE-76 regression / new OEM case, **not** a duplicate of WEE-76 verification.

## Linear
- Resolves WEE-87 (https://linear.app/wwwee/issue/WEE-87)

## Closes
Closes greenShirtMystery/forta-bugs#989
Closes greenShirtMystery/forta-bugs#993
Closes greenShirtMystery/forta-bugs#994
Closes greenShirtMystery/forta-bugs#995

Refs WEE-76.

## Test plan
- [x] Kotlin unit tests — `VendorAudioPolicyTest` extended (family + exhaustive complement asserts SAMSUNG/GENERIC/HUAWEI + any future enum value stay off the unmute path). Full `calls` package: **94 tests, 0 failures** (`:app:testDebugUnitTest`).
- [x] Native-only change — no TS surface touched (build/lint/tsc/vitest unaffected).
- [ ] **Manual on-device QA (required — no lab device):** forta→forta realme↔realme — both sides hear each other + ringback present. realme is the only device class with a confirmed before/after report; OPPO/XIAOMI ride on documented-safe ROM-family analogy.
- [ ] Regression: confirm WEE-60/76 fixes (other OEMs) still work (A3).