### PR TITLE
fix(messaging): sender can play own voice message (WEE-88)

### DIFF
--- a/src/features/messaging/model/use-file-download.test.ts
+++ b/src/features/messaging/model/use-file-download.test.ts
@@ -106,6 +106,7 @@ global.fetch = vi.fn(() => Promise.resolve(mockFetchResponse)) as Mock;
 const {
   useFileDownload,
   revokeAllFileUrls,
+  invalidateDownloadCache,
   appendCacheBust,
   wrapTransientError,
   _resetToastDedupForTests,
@@ -1319,6 +1320,115 @@ describe("useFileDownload", () => {
       } finally {
         revokeSpy.mockRestore();
       }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // WEE-88 — sender cannot play their OWN voice (#990 spinner / #986 silent)
+  // -------------------------------------------------------------------------
+  // Root cause: seedLocalUrl used to write the optimistic blob: URL into the
+  // long-lived module `cache`. After confirmMediaSent the blob is revoked
+  // (~5s), but the cache entry survived — so the post-confirm re-download
+  // short-circuited on `cache.has()` and handed the player a DEAD blob. The
+  // receiver never seeds a blob, so it always decrypted the server copy and
+  // heard the message fine. The fix keeps the seed instance-local so the
+  // blob→mxc transition re-downloads the durable server file.
+  describe("own voice playback — sender's own message (WEE-88)", () => {
+    it("seedLocalUrl does NOT poison the long-lived cache: a confirmed own voice re-downloads from the server", async () => {
+      const fetchSpy = global.fetch as Mock;
+      fetchSpy.mockClear();
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        status: 200,
+        blob: () => Promise.resolve(new Blob([new Uint8Array([1, 2, 3])], { type: "audio/ogg" })),
+      });
+
+      const blobUrl = "blob:http://localhost:5173/own-voice-88";
+      const cacheKey = "client_voice_88";
+
+      // 1) Pending send: the sender's bubble seeds the local blob for instant
+      //    playback while the upload is still in flight.
+      const scope1 = effectScope();
+      await scope1.run(async () => {
+        const { seedLocalUrl, getState } = useFileDownload();
+        seedLocalUrl(cacheKey, blobUrl);
+        expect(getState(cacheKey).objectUrl).toBe(blobUrl);
+      });
+      scope1.stop();
+
+      // 2) confirmMediaSent flips the row to a real mxc URL and revokes the
+      //    blob. A fresh download() (the watch-triggered re-fetch) must hit the
+      //    server — NOT replay the dead blob from a poisoned module cache.
+      const scope2 = effectScope();
+      await scope2.run(async () => {
+        const { download } = useFileDownload();
+        const confirmed = {
+          id: "$evt_voice_88",
+          _key: cacheKey,
+          roomId: "!room:server",
+          senderId: "@me:server",
+          content: "Audio",
+          timestamp: Date.now(),
+          status: "sent",
+          type: "audio",
+          fileInfo: {
+            name: "voice.ogg",
+            type: "audio/ogg",
+            size: 4096,
+            url: "mxc://server/voice88",
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        const result = await download(confirmed);
+
+        // The server file was fetched (no short-circuit on a stale blob).
+        expect(fetchSpy).toHaveBeenCalled();
+        // The returned URL is a fresh decrypted objectUrl, never the dead blob.
+        expect(result).not.toBe(blobUrl);
+      });
+      scope2.stop();
+    });
+
+    it("invalidateDownloadCache drops the entry so the next download re-fetches the server copy", async () => {
+      const fetchSpy = global.fetch as Mock;
+      fetchSpy.mockClear();
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        status: 200,
+        blob: () => Promise.resolve(new Blob([new Uint8Array([9])], { type: "audio/ogg" })),
+      });
+
+      const scope = effectScope();
+      await scope.run(async () => {
+        const { download } = useFileDownload();
+        const msg = {
+          id: "$evt_inv_88",
+          _key: "client_inv_88",
+          roomId: "!room:server",
+          senderId: "@me:server",
+          content: "Audio",
+          timestamp: Date.now(),
+          status: "sent",
+          type: "audio",
+          fileInfo: { name: "v.ogg", type: "audio/ogg", size: 1, url: "mxc://server/inv88" },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+
+        await download(msg);
+        const callsAfterFirst = fetchSpy.mock.calls.length;
+
+        // Second download hits the cache — no new network call.
+        await download(msg);
+        expect(fetchSpy.mock.calls.length).toBe(callsAfterFirst);
+
+        // After invalidation (the blob→mxc watch path), the next download must
+        // re-fetch instead of replaying the cached entry.
+        invalidateDownloadCache("client_inv_88");
+        await download(msg);
+        expect(fetchSpy.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+      });
+      scope.stop();
     });
   });
 });

--- a/src/features/messaging/model/use-file-download.ts
+++ b/src/features/messaging/model/use-file-download.ts
@@ -1001,12 +1001,22 @@ export function useFileDownload() {
     }
   };
 
-  /** Seed the cache with a local blob URL (e.g. for pending voice messages).
-   *  This avoids the full download+decrypt pipeline for files we already have locally. */
+  /** Seed a local blob URL (e.g. for pending voice messages) so the player can
+   *  start immediately, skipping the download+decrypt pipeline for bytes we
+   *  already hold locally.
+   *
+   *  Seeds ONLY the per-instance reactive `state` — never the long-lived module
+   *  `cache`. The optimistic blob is revoked ~5s after `confirmMediaSent`
+   *  (sync-engine.ts). If it leaked into `cache`, the post-confirm
+   *  `watch → download()` in VoiceMessage.vue would short-circuit on
+   *  `cache.has(cacheKey)` and hand the player a *dead* blob URL for the
+   *  SENDER's own voice — an eternal loading spinner (#990) or a silent, empty
+   *  `<audio>` (#986). The receiver never seeds a blob, so it decrypts the
+   *  server copy and plays fine. Keeping the seed instance-local lets the
+   *  blob→mxc transition re-download the durable server file (WEE-88). */
   const seedLocalUrl = (cacheKey: string, blobUrl: string) => {
-    if (cache.has(cacheKey)) return;
-    cache.set(cacheKey, blobUrl);
     const state = getState(cacheKey);
+    if (state.objectUrl) return;
     state.objectUrl = blobUrl;
     state.loading = false;
     state.error = null;

--- a/src/features/messaging/ui/VoiceMessage.vue
+++ b/src/features/messaging/ui/VoiceMessage.vue
@@ -2,7 +2,7 @@
 import { ref, computed, onMounted, watch } from "vue";
 import type { Message } from "@/entities/chat";
 import { MessageStatus } from "@/entities/chat/model/types";
-import { useFileDownload } from "../model/use-file-download";
+import { useFileDownload, invalidateDownloadCache } from "../model/use-file-download";
 import { useAudioPlayback } from "../model/use-audio-playback";
 import { getChatDb } from "@/shared/lib/local-db";
 
@@ -53,6 +53,12 @@ watch(
   () => props.message.fileInfo?.url,
   (newUrl, oldUrl) => {
     if (newUrl && newUrl !== oldUrl && !newUrl.startsWith("blob:")) {
+      // Send just confirmed: the optimistic blob is about to be revoked
+      // (sync-engine, ~5s after confirmMediaSent). Drop any stale cache entry
+      // for this key so download() re-fetches the durable server copy instead
+      // of replaying a dead blob — otherwise the sender's own voice spins
+      // forever (#990) or plays silent (#986). (WEE-88)
+      invalidateDownloadCache(fileCacheKey.value);
       download(props.message);
     }
   },

--- a/src/features/messaging/ui/__tests__/voice-own-playback.test.ts
+++ b/src/features/messaging/ui/__tests__/voice-own-playback.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Regression for WEE-88 (forta-bugs#990, #986).
+ *
+ * The SENDER could not play their own voice/audio message: either an eternal
+ * loading spinner (#990) or audible-to-peer-but-silent-to-self (#986). The
+ * receiver always heard it fine.
+ *
+ * Root cause: `seedLocalUrl` wrote the optimistic `blob:` URL into the
+ * long-lived module `cache`. After `confirmMediaSent`, the blob is revoked
+ * (~5s, sync-engine), but the cache entry survived. The post-confirm
+ * `watch → download()` in VoiceMessage.vue then short-circuited on
+ * `cache.has()` and handed the player a DEAD blob URL — spinner / silent.
+ *
+ * The fix has two parts, asserted here at the source level (mounting
+ * VoiceMessage.vue would drag in the audio singleton + file-download + Dexie
+ * stack; the behavioural contract is covered in use-file-download.test.ts):
+ *
+ *   1. `seedLocalUrl` seeds ONLY the per-instance state, never `cache`.
+ *   2. VoiceMessage.vue invalidates the cache on the blob→mxc transition so
+ *      download() re-fetches the durable server copy.
+ */
+
+const voiceMessageSource = (): string =>
+  readFileSync(resolve(__dirname, "../VoiceMessage.vue"), "utf-8");
+
+const fileDownloadSource = (): string =>
+  readFileSync(resolve(__dirname, "../../model/use-file-download.ts"), "utf-8");
+
+/** Extract the body of the `seedLocalUrl` arrow function. */
+const seedLocalUrlBody = (): string => {
+  const src = fileDownloadSource();
+  const start = src.indexOf("const seedLocalUrl =");
+  expect(start, "seedLocalUrl must exist in use-file-download.ts").toBeGreaterThan(-1);
+  // The function ends at the first `};` after its declaration.
+  const end = src.indexOf("};", start);
+  expect(end).toBeGreaterThan(start);
+  return src.slice(start, end);
+};
+
+describe("VoiceMessage — own voice playback (WEE-88)", () => {
+  it("seedLocalUrl seeds only the instance state, never the long-lived cache", () => {
+    const body = seedLocalUrlBody();
+    // The blob must NOT be written to the module `cache` — that is precisely
+    // the poisoning that left the sender replaying a revoked blob.
+    expect(body).not.toMatch(/cache\.set\(/);
+    // It still seeds the reactive per-instance state so pending playback works.
+    expect(body).toContain("state.objectUrl");
+  });
+
+  it("still seeds the local blob for a pending voice message (instant playback)", () => {
+    const src = voiceMessageSource();
+    // onMounted seeds the live blob when the message is still sending.
+    expect(src).toContain("seedLocalUrl(fileCacheKey.value, url)");
+    expect(src).toMatch(/isPending\.value && url\.startsWith\("blob:"\)/);
+  });
+
+  it("invalidates the download cache on the blob→server URL transition", () => {
+    const src = voiceMessageSource();
+    expect(src).toContain("invalidateDownloadCache");
+    // The invalidation must sit inside the fileInfo.url watch, guarded on the
+    // non-blob (confirmed) URL, immediately before the re-download.
+    const watchStart = src.indexOf("() => props.message.fileInfo?.url");
+    expect(watchStart, "url watch must exist").toBeGreaterThan(-1);
+    const watchSlice = src.slice(watchStart, watchStart + 600);
+    expect(watchSlice).toContain('!newUrl.startsWith("blob:")');
+    expect(watchSlice).toContain("invalidateDownloadCache(fileCacheKey.value)");
+    expect(watchSlice).toContain("download(props.message)");
+  });
+
+  it("imports invalidateDownloadCache from the download composable", () => {
+    const src = voiceMessageSource();
+    expect(src).toMatch(
+      /import\s*\{[^}]*invalidateDownloadCache[^}]*\}\s*from\s*["']\.\.\/model\/use-file-download["']/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Сендер не мог прослушать **своё** голосовое/аудио: вечный спиннер (#990) или проигрывание без звука (#986). Получатель слышал нормально.
- **Root cause:** `seedLocalUrl` писал оптимистичный `blob:`-URL в долгоживущий модульный `cache` (ключ — `_key`/clientId). После `confirmMediaSent` blob ревокался (~5s, sync-engine), но запись в `cache` оставалась → пост-confirm `watch → download()` коротко замыкался на `cache.has()` и отдавал плееру **мёртвый** blob.
- **Fix:** `seedLocalUrl` теперь сидит только per-instance `state.objectUrl` (не модульный `cache`); `VoiceMessage.vue` инвалидирует кэш на переходе `blob→mxc` перед `download()`, чтобы скачать серверную копию.

H2 (audio-route после звонка, `MODE_IN_COMMUNICATION`) — out of scope, относится к WEE-87/WEE-76. Дед-блоб объясняет оба симптома (#990 спиннер при загрузке мёртвого blob, #986 «играет» пустой/нулевой blob без звука).

## Linear
- Resolves WEE-88 (https://linear.app/wwwee/issue/WEE-88)

## Closes
Closes greenShirtMystery/forta-bugs#990
Closes greenShirtMystery/forta-bugs#986

## Test plan
- [x] `vue-tsc --noEmit` — 0 ошибок в затронутых файлах (50 baseline в несвязанных файлах master)
- [x] Unit tests added: `use-file-download.test.ts` (WEE-88 describe), `ui/__tests__/voice-own-playback.test.ts` — все зелёные
- [x] Полный `vitest run` — 17 падающих тестов pre-existing baseline (Bastyon-адреса / video-embed / ChatWindow / sync-engine WEE-64), ни один не связан с voice/audio
- [x] Code review (`superpowers:code-reviewer`) — APPROVE, без CRITICAL/HIGH
- [ ] Manual QA (Android): отправить ГС → сразу прослушать у себя (звук есть, без спиннера); A3-регрессия: получатель слышит ГС как раньше