### PR TITLE
fix(contacts): keep contacts on new device + search/add/delete fixes (WEE-65)

### DIFF
--- a/src/app/providers/initializers/app-initializer.ts
+++ b/src/app/providers/initializers/app-initializer.ts
@@ -398,25 +398,57 @@ export class AppInitializer {
     }
   }
 
-  /** Search Pocketnet users by text query — calls "searchusers" RPC.
-   *  Throws on transport / availability errors so callers can trigger fallback
-   *  (Matrix user_directory). The old silent-empty behaviour masked CORS failures
-   *  on web and left users looking at an empty list with no signal. */
-  async searchUsers(query: string): Promise<Array<{ address: string; name: string; image: string }>> {
-    await this.initApi();
-    if (!this._available || !this.api) {
-      throw new Error("search_service_unavailable");
-    }
-    try {
-      const data = await this.api.rpc("searchusers", [query, "users"]);
-      const results = (data as Array<Record<string, unknown>>) || [];
-      return results.map((info) => ({
+  /** Normalize a raw `searchusers` RPC record into a local user shape. */
+  private mapSearchUserRecords(
+    records: Array<Record<string, unknown>>,
+  ): Array<{ address: string; name: string; image: string }> {
+    return records
+      .map((info) => ({
         address: (info.address as string) ?? "",
         name: info.name ? decodeURI(info.name as string) : "",
         image: (info.i as string) ?? (info.image as string) ?? "",
-      })).filter(u => u.address);
+      }))
+      .filter((u) => u.address);
+  }
+
+  /** Search Pocketnet users by text query — calls the "searchusers" RPC.
+   *
+   *  WEE-65 (H3): the Bastyon SDK (`this.api`) only exists inside the Bastyon
+   *  WebView. On standalone Android / Electron `_available` is false, so the old
+   *  code threw `search_service_unavailable` and the user got an empty list with
+   *  no way to find anyone by nick. We now fall back to the centralized
+   *  cross-node RPC client ({@link callPocketnetRpc}) — the same failover path
+   *  `getBlockHeight` uses — which works without the SDK globals. The SDK path
+   *  is still tried first when available (richer, already-authenticated), then
+   *  the direct node failover covers standalone and SDK-transport failures.
+   *
+   *  Still throws only when BOTH paths fail, so callers (useContacts) can fall
+   *  through to the Matrix user_directory / local-cache tiers. */
+  async searchUsers(query: string): Promise<Array<{ address: string; name: string; image: string }>> {
+    await this.initApi();
+
+    // Primary: Bastyon SDK Api (only present inside the Bastyon WebView).
+    if (this._available && this.api) {
+      try {
+        const data = await this.api.rpc("searchusers", [query, "users"]);
+        return this.mapSearchUserRecords((data as Array<Record<string, unknown>>) || []);
+      } catch (e) {
+        console.warn("[appInit] searchUsers via SDK failed — falling back to direct node failover:", e);
+      }
+    }
+
+    // Fallback: direct searchusers with cross-node failover. Works on standalone
+    // Android / Electron (no SDK globals) and recovers from SDK-transport errors.
+    try {
+      const envelope = await callPocketnetRpc<Array<Record<string, unknown>>>({
+        method: "searchusers",
+        parameters: [query, "users"],
+      });
+      const payload = unwrapRpcPayload(envelope);
+      const records = Array.isArray(payload) ? payload : [];
+      return this.mapSearchUserRecords(records);
     } catch (e) {
-      console.error("[appInit] searchUsers error:", e);
+      console.error("[appInit] searchUsers error (all paths failed):", e);
       throw e instanceof Error ? e : new Error(String(e));
     }
   }

--- a/src/app/providers/initializers/search-users-fallback.test.ts
+++ b/src/app/providers/initializers/search-users-fallback.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * WEE-65 (H3) — user search must work OUTSIDE the Bastyon WebView.
+ *
+ * The Bastyon SDK (`this.api`) only exists inside the Bastyon WebView; on
+ * standalone Android / Electron the platform globals are undefined, so
+ * `AppInitializer` runs with `_available = false`. The old `searchUsers` threw
+ * `search_service_unavailable` in that mode and the user got an empty list with
+ * no way to find anyone by nick. These tests pin the fix: standalone search
+ * falls back to the centralized cross-node RPC client (`callPocketnetRpc`).
+ */
+
+// Spy for the centralized RPC failover client.
+const mockCallPocketnetRpc = vi.fn();
+
+vi.mock("@/shared/lib/pocketnet", () => ({
+  configurePocketnetNodes: vi.fn(),
+  buildNodeBaseUrls: vi.fn(() => []),
+  callPocketnetRpc: (req: unknown) => mockCallPocketnetRpc(req),
+  // Mirror the real envelope unwrap: data → result → body.
+  unwrapRpcPayload: (envelope: { data?: unknown; result?: unknown }) =>
+    envelope?.data ?? envelope?.result ?? envelope,
+}));
+
+// Avoid loading the heavy Bastyon chat-scripts / SDK config in the test env.
+vi.mock("../chat-scripts", () => ({
+  PocketnetInstanceConfigurator: { setTimeDifference: vi.fn() },
+}));
+vi.mock("../chat-scripts/config/pocketnetinstance", () => ({
+  PocketnetInstance: { options: { listofproxies: null } },
+}));
+
+import { createAppInitializer } from "./app-initializer";
+
+describe("AppInitializer.searchUsers — standalone RPC fallback (WEE-65 H3)", () => {
+  beforeEach(() => {
+    mockCallPocketnetRpc.mockReset();
+  });
+
+  it("falls back to callPocketnetRpc when the SDK is unavailable (standalone)", async () => {
+    // Cyrillic name is URI-encoded by the backend; the mapper must decode it.
+    mockCallPocketnetRpc.mockResolvedValue({
+      data: [
+        { address: "PTargetAddr12345678901234567890AB", name: "%D0%92%D0%B0%D1%81%D1%8F", i: "img-url" },
+      ],
+    });
+
+    const init = createAppInitializer();
+    const results = await init.searchUsers("вася");
+
+    expect(mockCallPocketnetRpc).toHaveBeenCalledWith({
+      method: "searchusers",
+      parameters: ["вася", "users"],
+    });
+    expect(results).toEqual([
+      { address: "PTargetAddr12345678901234567890AB", name: "Вася", image: "img-url" },
+    ]);
+  });
+
+  it("drops records without an address and tolerates a non-array payload", async () => {
+    mockCallPocketnetRpc.mockResolvedValue({
+      data: [
+        { address: "", name: "Ghost" },
+        { address: "PValidAddr1234567890123456789012AB", name: "Real" },
+      ],
+    });
+
+    const init = createAppInitializer();
+    const results = await init.searchUsers("x");
+
+    expect(results).toEqual([
+      { address: "PValidAddr1234567890123456789012AB", name: "Real", image: "" },
+    ]);
+  });
+
+  it("returns [] when the RPC payload is not an array", async () => {
+    mockCallPocketnetRpc.mockResolvedValue({ data: { error: "nope" } });
+
+    const init = createAppInitializer();
+    const results = await init.searchUsers("x");
+
+    expect(results).toEqual([]);
+  });
+
+  it("throws only when the fallback RPC fails (so callers can try Matrix/local tiers)", async () => {
+    mockCallPocketnetRpc.mockRejectedValue(new Error("all nodes down"));
+
+    const init = createAppInitializer();
+    await expect(init.searchUsers("x")).rejects.toThrow("all nodes down");
+  });
+});
+
+describe("AppInitializer.searchUsers — SDK-first then fallback (WEE-65 H3)", () => {
+  beforeEach(() => {
+    mockCallPocketnetRpc.mockReset();
+    // Simulate the Bastyon WebView: platform globals exist, so the constructor
+    // sets `_available = true` and the SDK path is tried first.
+    vi.stubGlobal("Api", class {
+      initIf() { return Promise.resolve(); }
+      rpc() { throw new Error("sdk transport error"); }
+    });
+    vi.stubGlobal("Actions", class {
+      init() { /* no-op */ }
+    });
+    vi.stubGlobal("pSDK", class {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("falls back to callPocketnetRpc when the SDK path throws", async () => {
+    mockCallPocketnetRpc.mockResolvedValue({
+      data: [{ address: "PFallbackAddr123456789012345678AB", name: "Fallback", i: "" }],
+    });
+
+    const init = createAppInitializer();
+    const results = await init.searchUsers("q");
+
+    expect(mockCallPocketnetRpc).toHaveBeenCalledWith({
+      method: "searchusers",
+      parameters: ["q", "users"],
+    });
+    expect(results).toEqual([
+      { address: "PFallbackAddr123456789012345678AB", name: "Fallback", image: "" },
+    ]);
+  });
+});

--- a/src/entities/chat/model/__tests__/room-cleanup-newdevice.test.ts
+++ b/src/entities/chat/model/__tests__/room-cleanup-newdevice.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { cleanupStaleRooms, type CleanupContext, ORPHAN_SYNC_SAFETY_MS } from "../room-cleanup";
+import type { LocalRoom } from "@/shared/lib/local-db";
+
+/**
+ * WEE-65 (H1) — ⚠️ DATA LOSS on a NEW / reinstalled device.
+ *
+ * On a fresh install every room lands in Dexie with `syncedAt = undefined`
+ * *before* the first sync materializes it into the Matrix SDK. The previous
+ * guard collapsed that to epoch 0 (`syncedAt ?? 0`), so `now - 0` always
+ * exceeded the safety window and valid never-synced rooms (= contacts) were
+ * tombstoned before the first sync could claim them. These tests pin the fix:
+ * a never-synced room is kept unconditionally, while the WEE-61 behaviour
+ * (already-synced orphans still GC'd) is preserved.
+ */
+
+function makeLocalRoom(overrides: Partial<LocalRoom> = {}): LocalRoom {
+  const base: LocalRoom = {
+    id: "!r:s",
+    name: "Room",
+    isGroup: false,
+    members: [],
+    membership: "join",
+    unreadCount: 0,
+    lastReadInboundTs: 0,
+    lastReadOutboundTs: 0,
+    updatedAt: Date.now(),
+    lastMessageTimestamp: undefined,
+    syncedAt: Date.now(),
+    hasMoreHistory: true,
+    isDeleted: false,
+    deletedAt: null,
+    deleteReason: null,
+  };
+  // Spread last so an explicit `syncedAt: undefined` override survives (it must,
+  // to model a never-synced room).
+  return { ...base, ...overrides };
+}
+
+function makeContext(rooms: LocalRoom[], sdkRoomIds: Set<string>): CleanupContext & { _deletedIds: string[] } {
+  const deletedIds: string[] = [];
+  return {
+    getAllRooms: () => Promise.resolve(rooms),
+    deleteRooms: async (ids) => {
+      deletedIds.push(...ids);
+    },
+    isRoomInSdk: (id) => sdkRoomIds.has(id),
+    getRoomHistoryVisibility: () => null,
+    _deletedIds: deletedIds,
+  } as CleanupContext & { _deletedIds: string[] };
+}
+
+describe("cleanupStaleRooms — new-device data-loss guard (WEE-65 H1)", () => {
+  it("does NOT tombstone a never-synced room (syncedAt undefined) absent from the SDK", async () => {
+    // New device: room exists in Dexie, sync hasn't materialized it into the SDK
+    // yet, and it has never been synced. It must survive.
+    const rooms = [makeLocalRoom({ id: "!new:s", syncedAt: undefined })];
+    const ctx = makeContext(rooms, new Set()); // empty SDK
+
+    const count = await cleanupStaleRooms(ctx);
+
+    expect(count).toBe(0);
+    expect(ctx._deletedIds).toEqual([]);
+  });
+
+  it("treats syncedAt=0 (legacy/unset) the same as never-synced — keeps it", async () => {
+    const rooms = [makeLocalRoom({ id: "!zero:s", syncedAt: 0 })];
+    const ctx = makeContext(rooms, new Set());
+
+    const count = await cleanupStaleRooms(ctx);
+
+    expect(count).toBe(0);
+    expect(ctx._deletedIds).toEqual([]);
+  });
+
+  it("protects 50+ never-synced rooms on a fresh login over a slow network (#907/#455)", async () => {
+    const rooms = Array.from({ length: 60 }, (_, i) =>
+      makeLocalRoom({ id: `!room${i}:s`, syncedAt: undefined }),
+    );
+    const ctx = makeContext(rooms, new Set()); // SDK loaded none yet
+
+    const count = await cleanupStaleRooms(ctx);
+
+    expect(count).toBe(0);
+    expect(ctx._deletedIds).toEqual([]);
+  });
+
+  it("keeps never-synced rooms of ALL types — groups too (#972)", async () => {
+    const rooms = [
+      makeLocalRoom({ id: "!dm:s", isGroup: false, syncedAt: undefined }),
+      makeLocalRoom({ id: "!group:s", isGroup: true, syncedAt: undefined }),
+    ];
+    const ctx = makeContext(rooms, new Set());
+
+    const count = await cleanupStaleRooms(ctx);
+
+    expect(count).toBe(0);
+    expect(ctx._deletedIds).toEqual([]);
+  });
+
+  it("WEE-61 regression preserved: an already-synced orphan past the window is STILL removed", async () => {
+    const rooms = [
+      makeLocalRoom({ id: "!stale:s", syncedAt: Date.now() - ORPHAN_SYNC_SAFETY_MS - 60_000 }),
+    ];
+    const ctx = makeContext(rooms, new Set());
+
+    const count = await cleanupStaleRooms(ctx);
+
+    expect(count).toBe(1);
+    expect(ctx._deletedIds).toEqual(["!stale:s"]);
+  });
+
+  it("WEE-61 regression preserved: a freshly-synced room (within window) is kept", async () => {
+    const rooms = [makeLocalRoom({ id: "!fresh:s", syncedAt: Date.now() - 5_000 })];
+    const ctx = makeContext(rooms, new Set());
+
+    const count = await cleanupStaleRooms(ctx);
+
+    expect(count).toBe(0);
+    expect(ctx._deletedIds).toEqual([]);
+  });
+
+  it("a never-synced room present in the SDK falls through to other checks (no false delete)", async () => {
+    // In SDK + not leave + not world_readable → kept.
+    const rooms = [makeLocalRoom({ id: "!insdk:s", syncedAt: undefined })];
+    const ctx = makeContext(rooms, new Set(["!insdk:s"]));
+
+    const count = await cleanupStaleRooms(ctx);
+
+    expect(count).toBe(0);
+    expect(ctx._deletedIds).toEqual([]);
+  });
+});

--- a/src/entities/chat/model/room-cleanup.ts
+++ b/src/entities/chat/model/room-cleanup.ts
@@ -90,12 +90,21 @@ export async function cleanupStaleRooms(ctx: CleanupContext): Promise<number> {
       continue;
     }
     if (!ctx.isRoomInSdk(room.id)) {
-      // DATA-LOSS GUARD (WEE-61): a recently-synced room may simply not be
-      // materialized into SDK memory yet on a slow cold-start. Only treat it as
-      // a genuine orphan if it hasn't synced for longer than the safety window.
-      const syncedAt = room.syncedAt ?? 0;
-      if (now - syncedAt < ORPHAN_SYNC_SAFETY_MS) {
-        continue; // fresh — keep, SDK just hasn't loaded it yet
+      // DATA-LOSS GUARD (WEE-61 + WEE-65): a recently-synced room may simply not
+      // be materialized into SDK memory yet on a slow cold-start. Only treat it
+      // as a genuine orphan if it hasn't synced for longer than the safety
+      // window.
+      //
+      // WEE-65 — NEW-DEVICE DATA LOSS: on a fresh install / reinstall every room
+      // lands in Dexie with `syncedAt = undefined` *before* the first sync
+      // materializes it into the SDK. The previous `syncedAt ?? 0` collapsed
+      // that to epoch 0, so `now - 0` always exceeded the window and valid
+      // never-synced rooms (= contacts) were tombstoned before the first sync
+      // could claim them. A never-synced room is therefore kept unconditionally;
+      // it is only ever removed once it HAS a syncedAt older than the window
+      // (i.e. it was synced before and has since gone genuinely orphaned).
+      if (!room.syncedAt || now - room.syncedAt < ORPHAN_SYNC_SAFETY_MS) {
+        continue; // never-synced (new device) or fresh — keep
       }
       toRemove.push(room.id);
       continue;

--- a/src/features/contacts/ui/ContactList.vue
+++ b/src/features/contacts/ui/ContactList.vue
@@ -781,11 +781,35 @@ const handleCtxAction = (action: string) => {
   ctxMenu.value.show = false;
 };
 
+/** WEE-65 (H2 / #334): a "contact" IS its DM room, so deleting the chat used to
+ *  destroy the contact with no way back. For 1:1 rooms the delete dialog now
+ *  offers "Clear history" (keeps the contact — wipes messages via the existing
+ *  sync-safe `clearHistory` watermark) alongside the full "Delete and leave".
+ *  Group rooms keep the single destructive delete. */
+const deleteTargetIsDm = computed<boolean>(() => {
+  const id = deleteConfirm.value.roomId;
+  if (!id) return false;
+  const room = chatStore.rooms.find(r => r.id === id);
+  return !!room && !room.isGroup;
+});
+
+const closeDeleteConfirm = () => {
+  deleteConfirm.value = { show: false, roomId: null };
+};
+
 const confirmDeleteRoom = () => {
   if (deleteConfirm.value.roomId) {
     chatStore.removeRoom(deleteConfirm.value.roomId);
   }
-  deleteConfirm.value = { show: false, roomId: null };
+  closeDeleteConfirm();
+};
+
+/** Clear only the message history; the DM room (= contact) survives. */
+const confirmClearHistory = () => {
+  if (deleteConfirm.value.roomId) {
+    chatStore.clearHistory(deleteConfirm.value.roomId);
+  }
+  closeDeleteConfirm();
 };
 
 // Per-room long press: cache a single useLongPress instance per room
@@ -1084,11 +1108,35 @@ const onRoomContextMenu = (e: MouseEvent, room: ChatRoom) => {
         >
           <div class="w-full max-w-xs rounded-xl bg-background-total-theme p-5 shadow-xl">
             <h3 class="mb-3 text-base font-semibold text-text-color">{{ t("contactList.deleteChat") }}</h3>
-            <p class="mb-4 text-sm text-text-on-main-bg-color">{{ t("contactList.deleteChatConfirm") }}</p>
-            <div class="flex gap-2">
+            <p class="mb-4 text-sm text-text-on-main-bg-color">
+              {{ deleteTargetIsDm ? t("contactList.deleteDmConfirm") : t("contactList.deleteChatConfirm") }}
+            </p>
+            <!-- DM: offer "clear history" (keeps contact) vs "delete and leave" -->
+            <div v-if="deleteTargetIsDm" class="flex flex-col gap-2">
+              <button
+                class="w-full rounded-lg bg-color-bg-ac px-4 py-2.5 text-sm font-medium text-text-on-bg-ac-color transition-colors hover:bg-color-bg-ac-1"
+                @click="confirmClearHistory"
+              >
+                {{ t("contactList.clearHistory") }}
+              </button>
+              <button
+                class="w-full rounded-lg bg-color-bad px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-color-bad/90"
+                @click="confirmDeleteRoom"
+              >
+                {{ t("contactList.deleteAndLeave") }}
+              </button>
+              <button
+                class="w-full rounded-lg bg-neutral-grad-0 px-4 py-2.5 text-sm font-medium text-text-color transition-colors hover:bg-neutral-grad-2"
+                @click="closeDeleteConfirm"
+              >
+                {{ t("contactList.cancel") }}
+              </button>
+            </div>
+            <!-- Group: single destructive delete -->
+            <div v-else class="flex gap-2">
               <button
                 class="flex-1 rounded-lg bg-neutral-grad-0 px-4 py-2.5 text-sm font-medium text-text-color transition-colors hover:bg-neutral-grad-2"
-                @click="deleteConfirm = { show: false, roomId: null }"
+                @click="closeDeleteConfirm"
               >
                 {{ t("contactList.cancel") }}
               </button>

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -12,6 +12,8 @@ export const en = {
   "contacts.searchPlaceholder": "Search contacts...",
   "contacts.noFound": "No contacts found",
   "contacts.noYet": "No contacts yet",
+  "contacts.addContact": "Add contact",
+  "contacts.addPlaceholder": "Search by name or address...",
 
   // ── Contact list ──
   "contactList.loadingChats": "Loading your chats and contacts",
@@ -34,6 +36,9 @@ export const en = {
   "contactList.delete": "Delete",
   "contactList.deleteChat": "Delete chat?",
   "contactList.deleteChatConfirm": "Do you really want to leave and delete this chat?",
+  "contactList.deleteDmConfirm": "Clear just the message history, or delete the chat entirely? The contact stays if you only clear history.",
+  "contactList.clearHistory": "Clear history",
+  "contactList.deleteAndLeave": "Delete and leave",
   "contactList.cancel": "Cancel",
   "contactList.draft": "Draft",
 

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -14,6 +14,8 @@ export const ru: Record<TranslationKey, string> = {
   "contacts.searchPlaceholder": "Поиск контактов...",
   "contacts.noFound": "Контакты не найдены",
   "contacts.noYet": "Контактов пока нет",
+  "contacts.addContact": "Добавить контакт",
+  "contacts.addPlaceholder": "Поиск по имени или адресу...",
 
   // ── Contact list ──
   "contactList.loadingChats": "Загружаем ваши чаты и контакты",
@@ -36,6 +38,9 @@ export const ru: Record<TranslationKey, string> = {
   "contactList.delete": "Удалить",
   "contactList.deleteChat": "Удалить чат?",
   "contactList.deleteChatConfirm": "Вы действительно хотите выйти и удалить этот чат?",
+  "contactList.deleteDmConfirm": "Очистить только историю переписки или удалить чат полностью? Контакт сохранится, если очистить историю.",
+  "contactList.clearHistory": "Очистить историю",
+  "contactList.deleteAndLeave": "Удалить и выйти",
   "contactList.cancel": "Отмена",
   "contactList.draft": "Черновик",
 

--- a/src/widgets/sidebar/ui/ContactsPanel.vue
+++ b/src/widgets/sidebar/ui/ContactsPanel.vue
@@ -4,6 +4,7 @@ import { useUserStore } from "@/entities/user/model";
 import Avatar from "@/shared/ui/avatar/Avatar.vue";
 import { useResolvedRoomName } from "@/entities/chat/lib/use-resolved-room-name";
 import { isUnresolvedName } from "@/entities/chat/lib/chat-helpers";
+import { ContactSearch } from "@/features/contacts";
 import { RecycleScroller } from "vue-virtual-scroller";
 import "vue-virtual-scroller/dist/vue-virtual-scroller.css";
 
@@ -15,6 +16,42 @@ const { resolve: resolveRoomName } = useResolvedRoomName();
 const { t } = useI18n();
 const searchQuery = ref("");
 const searchOpen = ref(false);
+
+// WEE-65 (H4 / #168, #545, #819): explicit "Add contact" entry. The Contacts
+// tab previously only filtered EXISTING DM rooms locally, so there was no
+// discoverable way to find a new user and start a chat from here. Add-mode
+// reuses the proven global directory search (`ContactSearch`) which already
+// wires `useContacts.searchUsers` (RPC → Matrix → local) + `getOrCreateRoom`,
+// so picking a user creates/opens the DM. Self-contained: opening add-mode
+// closes the local filter, and a created room hands off via `selectRoom`.
+const addMode = ref(false);
+const addQuery = ref("");
+
+const openAddContact = () => {
+  searchOpen.value = false;
+  searchQuery.value = "";
+  addQuery.value = "";
+  addMode.value = true;
+};
+
+const closeAddContact = () => {
+  addMode.value = false;
+  addQuery.value = "";
+};
+
+const handleAddRoomCreated = (roomId: string) => {
+  chatStore.setActiveRoom(roomId);
+  closeAddContact();
+  emit("selectRoom");
+};
+
+// ContactSearch also surfaces chat/message hits; tapping one in add-mode should
+// open that room rather than no-op.
+const handleAddSelectMessage = (payload: { roomId: string }) => {
+  chatStore.setActiveRoom(payload.roomId);
+  closeAddContact();
+  emit("selectRoom");
+};
 
 interface ContactItem {
   id: string;
@@ -139,13 +176,28 @@ const toggleSearch = () => {
 
 <template>
   <div class="flex h-full flex-col">
-    <!-- Header -->
+    <!-- Header (browse mode) -->
     <div
-      class="flex h-14 shrink-0 items-center gap-3 border-b border-neutral-grad-0 px-4"
+      v-if="!addMode"
+      class="flex h-14 shrink-0 items-center gap-1 border-b border-neutral-grad-0 px-4"
     >
       <span class="flex-1 text-base font-semibold text-text-color">{{ t("nav.contacts") }}</span>
       <button
         class="btn-press flex h-11 w-11 items-center justify-center rounded-full text-text-on-main-bg-color transition-colors hover:bg-neutral-grad-0"
+        :title="t('contacts.addContact')"
+        :aria-label="t('contacts.addContact')"
+        @click="openAddContact"
+      >
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+          <circle cx="9" cy="7" r="4" />
+          <line x1="19" y1="8" x2="19" y2="14" />
+          <line x1="22" y1="11" x2="16" y2="11" />
+        </svg>
+      </button>
+      <button
+        class="btn-press flex h-11 w-11 items-center justify-center rounded-full text-text-on-main-bg-color transition-colors hover:bg-neutral-grad-0"
+        :aria-label="t('contacts.searchPlaceholder')"
         @click="toggleSearch"
       >
         <svg
@@ -175,8 +227,46 @@ const toggleSearch = () => {
       </button>
     </div>
 
+    <!-- Header (add-contact mode) -->
+    <div
+      v-else
+      class="flex h-14 shrink-0 items-center gap-3 border-b border-neutral-grad-0 px-4"
+    >
+      <button
+        class="btn-press flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-text-on-main-bg-color transition-colors hover:bg-neutral-grad-0"
+        :aria-label="t('contactList.cancel')"
+        @click="closeAddContact"
+      >
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="19" y1="12" x2="5" y2="12" />
+          <polyline points="12 19 5 12 12 5" />
+        </svg>
+      </button>
+      <span class="flex-1 text-base font-semibold text-text-color">{{ t("contacts.addContact") }}</span>
+    </div>
+
+    <!-- Add-contact mode: directory search + create DM (reuses ContactSearch) -->
+    <template v-if="addMode">
+      <div class="shrink-0 border-b border-neutral-grad-0 px-3 py-2">
+        <input
+          v-model="addQuery"
+          type="text"
+          :placeholder="t('contacts.addPlaceholder')"
+          class="h-9 w-full rounded-lg bg-neutral-grad-0 px-3 text-sm text-text-color outline-none placeholder:text-text-on-main-bg-color focus:ring-1 focus:ring-color-bg-ac"
+          autofocus
+        />
+      </div>
+      <ContactSearch
+        :query="addQuery"
+        class="flex-1 overflow-y-auto py-1"
+        @room-created="handleAddRoomCreated"
+        @select-message="handleAddSelectMessage"
+        @clear="addQuery = ''"
+      />
+    </template>
+
     <!-- Search bar -->
-    <div v-if="searchOpen" class="shrink-0 border-b border-neutral-grad-0 px-3 py-2">
+    <div v-if="!addMode && searchOpen" class="shrink-0 border-b border-neutral-grad-0 px-3 py-2">
       <input
         v-model="searchQuery"
         type="text"
@@ -187,7 +277,7 @@ const toggleSearch = () => {
     </div>
 
     <!-- List -->
-    <div class="flex-1 overflow-hidden">
+    <div v-if="!addMode" class="flex-1 overflow-hidden">
       <!-- Skeleton while rooms haven't loaded yet -->
       <div v-if="contacts.length === 0 && !chatStore.roomsInitialized" class="space-y-1 p-2">
         <div v-for="i in 5" :key="i" class="flex items-center gap-3 px-4 py-2.5">
@@ -197,9 +287,22 @@ const toggleSearch = () => {
       </div>
       <div
         v-else-if="contacts.length === 0"
-        class="p-6 text-center text-sm text-text-on-main-bg-color"
+        class="flex flex-col items-center gap-3 p-6 text-center text-sm text-text-on-main-bg-color"
       >
-        {{ searchQuery.trim() ? t("contacts.noFound") : t("contacts.noYet") }}
+        <span>{{ searchQuery.trim() ? t("contacts.noFound") : t("contacts.noYet") }}</span>
+        <button
+          v-if="!searchQuery.trim()"
+          class="btn-press inline-flex items-center gap-2 rounded-lg bg-color-bg-ac px-4 py-2 text-sm font-medium text-text-on-bg-ac-color transition-colors hover:bg-color-bg-ac-1"
+          @click="openAddContact"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+            <circle cx="9" cy="7" r="4" />
+            <line x1="19" y1="8" x2="19" y2="14" />
+            <line x1="22" y1="11" x2="16" y2="11" />
+          </svg>
+          {{ t("contacts.addContact") }}
+        </button>
       </div>
       <RecycleScroller
         v-else


### PR DESCRIPTION
## Summary
- **H1 (⚠️ data-loss)** — orphan-cleanup no longer tombstones **never-synced** rooms on a new/reinstalled device. `room-cleanup.ts` used `syncedAt ?? 0`, so on a fresh install (where rooms land in Dexie with `syncedAt = undefined` before the first sync) `now - 0` always exceeded the 24h window and valid rooms (= contacts) were deleted. Now never-synced rooms are kept unconditionally; the WEE-61 GC of already-synced orphans is preserved.
- **H3 (search)** — `AppInitializer.searchUsers` threw `search_service_unavailable` when the Bastyon SDK was absent (standalone Android / Electron). It now falls back to the centralized cross-node `callPocketnetRpc` failover client (same path `getBlockHeight` uses), throwing only when both paths fail.
- **H4 (discoverability)** — explicit **"Add contact"** button in `ContactsPanel` (header + empty-state CTA) opening an add-mode that reuses the proven `ContactSearch` directory search + `getOrCreateRoom`.
- **H2 (delete)** — DM delete dialog now offers **"Clear history"** (keeps the contact via the existing sync-safe `clearHistory`) vs **"Delete and leave"**. Groups keep the single destructive delete.
- **H5 (referral)** — referral/invite toast (`invite.accepted` / `acceptFailed`) was already present in `App.vue`; verified A5 is met.

## Linear
- Resolves WEE-65 (https://linear.app/wwwee/issue/WEE-65)

## Closes
Closes greenShirtMystery/forta-bugs#907
Closes greenShirtMystery/forta-bugs#455
Closes greenShirtMystery/forta-bugs#334
Closes greenShirtMystery/forta-bugs#701
Closes greenShirtMystery/forta-bugs#819
Closes greenShirtMystery/forta-bugs#168
Closes greenShirtMystery/forta-bugs#545
Closes greenShirtMystery/forta-bugs#927
Closes greenShirtMystery/forta-bugs#926

## Test plan
- [x] `vite build` green; `vue-tsc --noEmit` reports **0 new errors** in changed files (50 total = documented pre-existing master baseline)
- [x] Unit tests added: `room-cleanup-newdevice.test.ts` (never-synced survives cleanup; WEE-61 regression both directions; groups; 50+ rooms) + `search-users-fallback.test.ts` (standalone RPC fallback, SDK-throw→fallback, cyrillic decode, empty/non-array payloads, throw-when-all-fail)
- [x] Full suite: 2650 pass; 16 failing are the documented pre-existing baseline in unrelated files (chat-helpers, display-result, open-profile-url, video-embed, ChatWindow)
- [ ] Manual QA (Android): fresh login with 50+ chats on a slow network → no contact/chat disappears before first sync (A1/A6); search by cyrillic nick finds a user (A2); "Add contact" flow (A3); DM delete → "Clear history" keeps the contact (A4)

## Out of scope (per ticket)
- Full "contacts as a separate entity" decouple (Dexie migration)
- Homeserver displayName indexing; presence