### PR TITLE
fix(contacts): don't show 'no results' in add-mode before a query is typed (WEE-65)

### DIFF
--- a/src/widgets/sidebar/ui/ContactsPanel.vue
+++ b/src/widgets/sidebar/ui/ContactsPanel.vue
@@ -256,13 +256,23 @@ const toggleSearch = () => {
           autofocus
         />
       </div>
+      <!-- Render results only once there's a query — ContactSearch's empty
+           state ("No chats or users found") would otherwise show on an empty
+           input. Until then, show a neutral prompt. -->
       <ContactSearch
+        v-if="addQuery.trim()"
         :query="addQuery"
         class="flex-1 overflow-y-auto py-1"
         @room-created="handleAddRoomCreated"
         @select-message="handleAddSelectMessage"
         @clear="addQuery = ''"
       />
+      <div
+        v-else
+        class="flex flex-1 items-start justify-center p-6 text-center text-sm text-text-on-main-bg-color"
+      >
+        {{ t("contacts.addPlaceholder") }}
+      </div>
     </template>
 
     <!-- Search bar -->


### PR DESCRIPTION
## Summary
Follow-up to #193. In the Contacts tab "Add contact" mode, the reused `ContactSearch` was rendered unconditionally, so its empty-state ("Чаты и пользователи не найдены" / "No chats or users found") appeared immediately — before the user typed anything.

Fix: render `ContactSearch` only when the add-query is non-empty (matching `ChatSidebar`'s pattern). Until then, show a neutral prompt placeholder.

## Linear
- Part of WEE-65 (https://linear.app/wwwee/issue/WEE-65)

## Test plan
- [x] `vite build` green; no tsc errors in `ContactsPanel.vue`
- [ ] Manual QA: open Contacts tab → "Add contact" → empty input shows the prompt, not "No results"; typing a query shows directory results