### PR TITLE
fix(media): show placeholder until image paints, not alt filename (WEE-91)

### DIFF
--- a/src/features/messaging/ui/MessageBubble.vue
+++ b/src/features/messaging/ui/MessageBubble.vue
@@ -570,6 +570,7 @@ watch(imageInViewport, (visible) => {
 watch(() => props.message.id, () => {
   imageDecodeFailed.value = false;
   thumbnailFetchFailed.value = false;
+  imageLoaded.value = false;
   if (imageInViewport.value) triggerImageDownload();
 });
 
@@ -592,6 +593,30 @@ const onFeedImageError = () => {
 // intrinsic size, blowing past the bubble's max-h and producing the
 // "huge blurry preview" reported in forta-bugs#757 and #743.
 const imageDecodeFailed = ref(false);
+
+// WEE-91: thumbnail-first (WEE-71) made `feedImageSrc` available the instant a
+// server-thumbnail URL resolves, before the browser has fetched the image. The
+// old spinner gated on `!feedImageSrc`, so it was skipped and the bare `<img>`
+// rendered its `alt` (the filename, e.g. "img1.png") until `@load` fired —
+// looking like a broken image. Track per-image load state and keep a
+// placeholder over the `<img>` until it actually paints.
+const imageLoaded = ref(false);
+// Reset on src change (new message or thumbnail→full fallback) so a recycled
+// bubble or a swapped source shows the placeholder again until it repaints.
+watch(feedImageSrc, () => {
+  imageLoaded.value = false;
+});
+
+/** The `<img>` branch is active (a source exists, no error/decode-fallback UI)
+ *  but the image hasn't painted yet — show the placeholder, not the alt text. */
+const showImagePlaceholder = computed(
+  () =>
+    !!feedImageSrc.value &&
+    !imageLoaded.value &&
+    !fileState.value.error &&
+    !imageDecodeFailed.value,
+);
+
 const isLikelyHeic = computed(() => {
   const t = (props.message.fileInfo?.type ?? "").toLowerCase();
   const n = (props.message.fileInfo?.name ?? "").toLowerCase();
@@ -881,7 +906,15 @@ const replyPreviewSender = computed(() => {
             <span class="truncate max-w-full font-medium">{{ message.fileInfo?.name }}</span>
             <span v-if="isLikelyHeic" class="text-[10px] opacity-70">{{ t('message.heicNotSupported') }}</span>
           </div>
-          <img v-else-if="feedImageSrc" :src="feedImageSrc" :alt="message.fileInfo?.name" class="block max-h-[460px] max-w-full object-cover select-none [-webkit-touch-callout:none] [-webkit-user-drag:none]" draggable="false" :style="imageStyle" @load="emit('resize')" @error="onFeedImageError" />
+          <img v-else-if="feedImageSrc" :src="feedImageSrc" alt="" class="block max-h-[460px] max-w-full object-cover select-none [-webkit-touch-callout:none] [-webkit-user-drag:none]" draggable="false" :style="imageStyle" @load="imageLoaded = true; emit('resize')" @error="onFeedImageError" />
+          <!-- WEE-91: placeholder over the image until it paints — never the alt filename -->
+          <div
+            v-if="showImagePlaceholder"
+            class="absolute left-0 top-0 flex items-center justify-center bg-neutral-grad-0"
+            :style="imagePlaceholderStyle"
+          >
+            <div class="contain-strict h-8 w-8 animate-spin rounded-full border-2 border-color-bg-ac border-t-transparent" />
+          </div>
           <!-- Upload progress overlay -->
           <div v-if="isUploading" class="absolute inset-0 flex items-center justify-center bg-black/30">
             <button class="relative flex h-14 w-14 items-center justify-center" @click.stop="emit('cancelUpload', message)">

--- a/src/features/messaging/ui/__tests__/message-bubble-image-placeholder.test.ts
+++ b/src/features/messaging/ui/__tests__/message-bubble-image-placeholder.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const source = readFileSync(
+  resolve(__dirname, "../MessageBubble.vue"),
+  "utf-8",
+);
+
+/**
+ * WEE-91 — regression of WEE-71 (thumbnail-first). A server-thumbnail URL
+ * resolves synchronously, so `feedImageSrc` is truthy before the browser has
+ * fetched the image. The old spinner gated on `!feedImageSrc`, so it was
+ * skipped and the bare `<img>` showed its `alt` (the filename "img1.png")
+ * until `@load`, looking like a broken image.
+ *
+ * Fix: track per-image load state, keep a placeholder over the `<img>` until
+ * it paints, and stop rendering the filename as visible `alt` content.
+ */
+describe("MessageBubble — image placeholder until @load (WEE-91)", () => {
+  it("tracks per-image load state with an `imageLoaded` ref", () => {
+    expect(source).toMatch(/const imageLoaded = ref\(false\)/);
+  });
+
+  it("flips `imageLoaded` true on the <img> @load handler", () => {
+    expect(source).toMatch(/@load="imageLoaded = true; emit\('resize'\)"/);
+  });
+
+  it("resets `imageLoaded` when the source changes (thumbnail→full fallback)", () => {
+    // A watch on feedImageSrc resets the flag so a swapped source re-shows
+    // the placeholder until the new image paints.
+    expect(source).toMatch(/watch\(feedImageSrc,[\s\S]*?imageLoaded\.value = false/);
+  });
+
+  it("resets `imageLoaded` when the bubble is recycled for a different message", () => {
+    // Virtual scroller reuses the instance — without the reset a loaded image
+    // would suppress the placeholder for the next (still-loading) message.
+    expect(source).toMatch(/watch\(\(\) => props\.message\.id[\s\S]*?imageLoaded\.value = false/);
+  });
+
+  it("gates the placeholder on src-present-but-not-loaded, excluding error states", () => {
+    expect(source).toMatch(/const showImagePlaceholder = computed/);
+    expect(source).toMatch(/!!feedImageSrc\.value/);
+    expect(source).toMatch(/!imageLoaded\.value/);
+    expect(source).toMatch(/!fileState\.value\.error/);
+    expect(source).toMatch(/!imageDecodeFailed\.value/);
+  });
+
+  it("renders a sized placeholder overlay while the image loads", () => {
+    expect(source).toMatch(/v-if="showImagePlaceholder"[\s\S]*?:style="imagePlaceholderStyle"/);
+    // Spinner inside the overlay.
+    expect(source).toMatch(/v-if="showImagePlaceholder"[\s\S]*?animate-spin/);
+  });
+
+  it("does not render the filename as visible alt content on the feed <img>", () => {
+    // The feed image uses an empty alt so the filename ("img1.png") never
+    // shows while the image is still loading.
+    expect(source).toMatch(/<img v-else-if="feedImageSrc"[^>]*\salt=""/);
+    expect(source).not.toMatch(/<img v-else-if="feedImageSrc"[^>]*:alt="message\.fileInfo\?\.name"/);
+  });
+
+  it("keeps the thumbnail-first @error recovery intact (WEE-71)", () => {
+    // A3/A4: error fallback (full-size recovery + decode-fail placeholder)
+    // must still be wired.
+    expect(source).toMatch(/@error="onFeedImageError"/);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes a WEE-71 regression: thumbnail-first made `feedImageSrc` truthy the instant a server-thumbnail URL resolves, so the `!feedImageSrc` spinner was skipped and the bare `<img>` showed its `alt` (the filename "img1.png") until `@load` — looking like a broken image.
- Track per-image load state (`imageLoaded` ref + `showImagePlaceholder` computed); keep a sized spinner placeholder over the `<img>` until it actually paints; reset on src change and on virtual-scroller recycle.
- `<img alt="">` so the filename never renders as visible content. `@load` flips `imageLoaded` and still emits `resize`. Error / decode-fail / thumbnail-`@error` recovery paths untouched.

## Linear
- Resolves WEE-91 (https://linear.app/wwwee/issue/WEE-91)
- Refs WEE-71 (regression source)

## Acceptance criteria
- A1: loading → placeholder/spinner, never the filename ✅
- A2: image appears on its own after load (no tap) ✅
- A3: `@error` → error placeholder + retry, intact ✅
- A4: thumbnail-first speed (WEE-71) preserved ✅

## Test plan
- [x] `vue-tsc --noEmit` — 0 errors in changed files (50 pre-existing baseline errors unrelated)
- [x] `npm run test` — new regression test `message-bubble-image-placeholder.test.ts` (8 cases) passes; 2646 pass / 16 pre-existing baseline failures (unrelated)
- [x] Code review (superpowers:code-reviewer) — APPROVE, no CRITICAL/HIGH
- [ ] Manual QA on slow network: open chat with photo → spinner/placeholder shown (not "img1.png") → image appears without tap