### PR TITLE
perf(media): decrypt file attachments in the crypto Web Worker, in parallel (WEE-92)

### DIFF
--- a/src/entities/matrix/model/matrix-crypto.ts
+++ b/src/entities/matrix/model/matrix-crypto.ts
@@ -11,7 +11,19 @@ import pbkdf2 from "pbkdf2";
 // @ts-expect-error — no types for bn.js default export
 import BN from "bn.js";
 
-import { workerDecrypt, workerEncrypt } from "@/shared/lib/crypto-worker/bridge";
+import {
+  workerDecrypt,
+  workerEncrypt,
+  workerDecryptFile,
+  isCryptoWorkerSupported,
+  isWorkerInfraError,
+} from "@/shared/lib/crypto-worker/bridge";
+import {
+  deriveFileKey,
+  encryptFileBuffer,
+  decryptFileBuffer,
+  resolveDecryptedMime,
+} from "@/shared/lib/crypto-worker/file-cipher";
 
 import {
   sha224,
@@ -37,17 +49,8 @@ const m = 12;
  *  the download path surfaces error+retry instead of an eternal spinner. */
 const GETUSERSINFO_TIMEOUT_MS = 15_000;
 
-/** Safe accessor for crypto.subtle — throws a clear error on HTTP instead of cryptic 'undefined' */
-function getSubtle(): SubtleCrypto {
-  const subtle = globalThis.crypto?.subtle;
-  if (!subtle) {
-    throw new Error(
-      "crypto.subtle is unavailable (requires HTTPS or localhost). " +
-      "Serve the app over HTTPS to enable encryption."
-    );
-  }
-  return subtle;
-}
+// crypto.subtle access lives in shared/lib/crypto-worker/file-cipher.ts
+// (shared with the crypto Web Worker, WEE-92).
 
 // secp256k1 curve order
 const secp256k1CurveN = new BN(
@@ -77,43 +80,26 @@ function _base64ToArrayBuffer(base64: string): ArrayBuffer {
   return bytes.buffer;
 }
 
-// ---- PcryptoFile: AES-CBC file encryption (unchanged) ----
+// ---- PcryptoFile: AES-CBC file encryption ----
+// Cipher internals live in shared/lib/crypto-worker/file-cipher.ts so the
+// main thread and the crypto Web Worker share one format (WEE-92).
 
 export class PcryptoFile {
-  private iv = new Uint8Array([19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34]);
-
   async randomKey(): Promise<string> {
     const array = new Uint32Array(24);
     return window.crypto.getRandomValues(array).toString();
   }
 
   async deriveKey(str: string): Promise<CryptoKey> {
-    const subtle = getSubtle();
-    const enc = new TextEncoder();
-    const keyMaterial = await subtle.importKey(
-      "raw",
-      enc.encode(str),
-      "PBKDF2",
-      false,
-      ["deriveBits", "deriveKey"]
-    );
-    return subtle.deriveKey(
-      { name: "PBKDF2", salt: enc.encode("matrix.pocketnet"), iterations: 10000, hash: "SHA-256" },
-      keyMaterial,
-      { name: "AES-CBC", length: 256 },
-      true,
-      ["encrypt", "decrypt"]
-    );
+    return deriveFileKey(str);
   }
 
   async encrypt(data: ArrayBuffer, secret: string): Promise<ArrayBuffer> {
-    const key = await this.deriveKey(secret);
-    return getSubtle().encrypt({ name: "AES-CBC", iv: this.iv }, key, data);
+    return encryptFileBuffer(data, secret);
   }
 
   async decrypt(data: ArrayBuffer, secret: string): Promise<ArrayBuffer> {
-    const key = await this.deriveKey(secret);
-    return getSubtle().decrypt({ name: "AES-CBC", iv: this.iv }, key, data);
+    return decryptFileBuffer(data, secret);
   }
 
   async encryptFile(file: Blob, secret: string): Promise<File> {
@@ -138,12 +124,9 @@ export class PcryptoFile {
   async decryptFile(file: Blob, secret: string, originalMime?: string): Promise<File> {
     const buffer = await readFile(file);
     const decrypted = await this.decrypt(buffer, secret);
-    const type = originalMime
-      ? originalMime
-      : file.type.startsWith("encrypted/")
-        ? file.type.replace("encrypted/", "")
-        : "application/octet-stream";
-    return new File([decrypted], "decrypted", { type });
+    return new File([decrypted], "decrypted", {
+      type: resolveDecryptedMime(file.type, originalMime),
+    });
   }
 }
 
@@ -1140,6 +1123,26 @@ export class Pcrypto {
       },
 
       async decryptFile(file: Blob, secret: string, originalMime?: string): Promise<File> {
+        // Worker-first: PBKDF2 + AES-CBC runs off the main thread so several
+        // attachments can decrypt concurrently without freezing low-end
+        // WebViews (WEE-92). The buffer is transferred (zero-copy); readFile
+        // already produced a private copy, so detaching it is safe.
+        if (isCryptoWorkerSupported()) {
+          const buffer = await readFile(file);
+          try {
+            const decrypted = await workerDecryptFile(buffer, secret);
+            return new File([decrypted], "decrypted", {
+              type: resolveDecryptedMime(file.type, originalMime),
+            });
+          } catch (e) {
+            // Infra failures (worker died / terminated mid-flight) fall back
+            // to the main-thread path. Genuine decrypt failures (wrong key,
+            // corrupt ciphertext) are deterministic — rethrow, a retry on the
+            // main thread would fail identically.
+            if (!isWorkerInfraError(e)) throw e;
+            console.warn("[matrix-crypto] file-decrypt worker failed, falling back to main thread:", e);
+          }
+        }
         return pcrypto.pcryptoFile.decryptFile(file as File, secret, originalMime);
       },
 

--- a/src/features/messaging/model/__tests__/run-file-decrypt.test.ts
+++ b/src/features/messaging/model/__tests__/run-file-decrypt.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * WEE-92 — runFileDecrypt concurrency policy.
+ *
+ * Worker available → decrypt tasks run in PARALLEL (the work is off the main
+ * thread; mediaDownloadGate caps effective concurrency at the call site).
+ * Worker unavailable → legacy strictly-serial main-thread queue, the
+ * #306/#370 freeze guard.
+ */
+
+const isCryptoWorkerSupported = vi.fn<() => boolean>();
+
+vi.mock("@/shared/lib/crypto-worker/bridge", () => ({
+  isCryptoWorkerSupported: () => isCryptoWorkerSupported(),
+}));
+
+import { runFileDecrypt } from "../decrypt-queue";
+
+/** A task that records when it starts and settles only when told to. */
+function controlledTask(startLog: string[], name: string) {
+  let release!: () => void;
+  const gate = new Promise<void>((r) => { release = r; });
+  const task = async () => {
+    startLog.push(name);
+    await gate;
+    return name;
+  };
+  return { task, release };
+}
+
+const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  isCryptoWorkerSupported.mockReset();
+});
+
+describe("runFileDecrypt (WEE-92)", () => {
+  it("runs tasks in parallel when the crypto worker is available", async () => {
+    isCryptoWorkerSupported.mockReturnValue(true);
+    const started: string[] = [];
+    const a = controlledTask(started, "a");
+    const b = controlledTask(started, "b");
+
+    const pa = runFileDecrypt(a.task);
+    const pb = runFileDecrypt(b.task);
+    await tick();
+
+    // Both started before either finished — no serialisation.
+    expect(started).toEqual(["a", "b"]);
+
+    a.release(); b.release();
+    await expect(pa).resolves.toBe("a");
+    await expect(pb).resolves.toBe("b");
+  });
+
+  it("serialises tasks through the legacy queue when the worker is unavailable", async () => {
+    isCryptoWorkerSupported.mockReturnValue(false);
+    const started: string[] = [];
+    const a = controlledTask(started, "a");
+    const b = controlledTask(started, "b");
+
+    const pa = runFileDecrypt(a.task);
+    const pb = runFileDecrypt(b.task);
+    await tick();
+
+    // Only the first task started; the second waits in the queue.
+    expect(started).toEqual(["a"]);
+
+    a.release();
+    await pa;
+    await tick();
+    expect(started).toEqual(["a", "b"]);
+
+    b.release();
+    await expect(pb).resolves.toBe("b");
+  });
+
+  it("serialises LARGE files through the queue even with the worker (memory guard)", async () => {
+    isCryptoWorkerSupported.mockReturnValue(true);
+    const started: string[] = [];
+    const a = controlledTask(started, "big-a");
+    const b = controlledTask(started, "big-b");
+    const BIG = 64 * 1024 * 1024;
+
+    const pa = runFileDecrypt(a.task, { sizeBytes: BIG });
+    const pb = runFileDecrypt(b.task, { sizeBytes: BIG });
+    await tick();
+
+    // Three concurrent ~100MB video buffers would OOM low-end devices —
+    // large files keep the strictly-serial path.
+    expect(started).toEqual(["big-a"]);
+
+    a.release();
+    await pa;
+    await tick();
+    expect(started).toEqual(["big-a", "big-b"]);
+    b.release();
+    await pb;
+  });
+
+  it("propagates task rejections in the parallel path", async () => {
+    isCryptoWorkerSupported.mockReturnValue(true);
+    await expect(
+      runFileDecrypt(() => Promise.reject(new Error("OperationError"))),
+    ).rejects.toThrow("OperationError");
+  });
+
+  it("bounds a hung parallel task with the decrypt timeout", async () => {
+    isCryptoWorkerSupported.mockReturnValue(true);
+    vi.useFakeTimers();
+    try {
+      const p = runFileDecrypt(() => new Promise<never>(() => { /* hang */ }));
+      const assertion = expect(p).rejects.toThrow(/timed out/);
+      await vi.advanceTimersByTimeAsync(60_000);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/features/messaging/model/decrypt-queue.ts
+++ b/src/features/messaging/model/decrypt-queue.ts
@@ -12,6 +12,7 @@
  */
 
 import { withTimeout } from "@/shared/lib/with-timeout";
+import { isCryptoWorkerSupported } from "@/shared/lib/crypto-worker/bridge";
 
 /** Hard ceiling for a single decrypt task. The queue is strictly serial, so a
  *  task that never settles (e.g. a worker that hangs, or an upstream promise
@@ -41,4 +42,37 @@ export function enqueueDecrypt<T>(task: () => Promise<T>): Promise<T> {
   // promise (`run`), which is not the same object.
   tail = run.catch(() => undefined);
   return run;
+}
+
+/** Files at or above this size stay on the serial queue even when the
+ *  worker is available. A decrypt holds ciphertext + plaintext (~2× file
+ *  size) in memory; three concurrent 100 MB videos would spike ~600 MB of
+ *  transient buffers — OOM-kill territory on the same low-end devices this
+ *  feature targets. Photos and voice notes (the latency-sensitive bulk of
+ *  chat media) sit far below this line and still parallelise. */
+const LARGE_FILE_SERIAL_THRESHOLD_BYTES = 32 * 1024 * 1024;
+
+/** Run a file-decrypt task with the right concurrency policy (WEE-92).
+ *
+ *  With the crypto Web Worker available, decryption runs OFF the main
+ *  thread — the reason for serialising (#306/#370 main-thread freezes) is
+ *  gone, so tasks run in parallel. Effective parallelism is still capped by
+ *  `mediaDownloadGate` in use-file-download (its permit covers fetch +
+ *  decrypt), so a media-heavy chat can't stampede the worker. The same
+ *  per-task timeout applies: a wedged worker call surfaces error+retry
+ *  instead of an eternal spinner (WEE-90 H4).
+ *
+ *  Large files (≥ LARGE_FILE_SERIAL_THRESHOLD_BYTES) and environments
+ *  without worker support (exotic WebViews, worker construction failed)
+ *  keep the legacy strictly-serial queue — for memory pressure and the
+ *  #306/#370 main-thread freeze guard respectively. */
+export function runFileDecrypt<T>(
+  task: () => Promise<T>,
+  opts?: { sizeBytes?: number },
+): Promise<T> {
+  const isLarge = (opts?.sizeBytes ?? 0) >= LARGE_FILE_SERIAL_THRESHOLD_BYTES;
+  if (isCryptoWorkerSupported() && !isLarge) {
+    return withTimeout(task(), DECRYPT_TASK_TIMEOUT_MS, "decryptFile");
+  }
+  return enqueueDecrypt(task);
 }

--- a/src/features/messaging/model/use-file-download.ts
+++ b/src/features/messaging/model/use-file-download.ts
@@ -17,7 +17,7 @@ import {
   NetworkBlockedError,
 } from "@/shared/lib/network/typed-network-errors";
 import { waitForRoomCrypto } from "@/entities/matrix/model/wait-for-crypto";
-import { enqueueDecrypt } from "./decrypt-queue";
+import { runFileDecrypt } from "./decrypt-queue";
 import { createSemaphore } from "@/shared/lib/semaphore";
 import { getMediaCache, type MediaCacheCategory } from "@/shared/lib/media-cache";
 import { MATRIX_SERVER, MATRIX_MIRRORS } from "@/shared/config/constants";
@@ -597,13 +597,15 @@ async function downloadAndDecrypt(
         };
 
         const decryptKey = await roomCrypto.decryptKey(event);
-        // Serialise decryption: parallel decryptFile calls on low-end
-        // Android WebViews saturate the CPU and freeze the UI.
+        // Decrypt via the crypto Web Worker when available — parallel and
+        // off the main thread (WEE-92); falls back to the legacy serial
+        // main-thread queue otherwise (#306/#370 freeze guard).
         // Pass the declared plaintext MIME so new ciphertexts (stored as
         // application/octet-stream) restore with the right type instead
         // of falling through to a generic binary fallback.
-        const decryptedFile = await enqueueDecrypt(() =>
-          roomCrypto.decryptFile(blob, decryptKey, fileInfo.type),
+        const decryptedFile = await runFileDecrypt(
+          () => roomCrypto.decryptFile(blob, decryptKey, fileInfo.type),
+          { sizeBytes: blob.size },
         );
         blob = decryptedFile;
       }

--- a/src/shared/lib/crypto-worker/bridge-decrypt-file.test.ts
+++ b/src/shared/lib/crypto-worker/bridge-decrypt-file.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * WEE-92 — bridge protocol for the file-decrypt worker path.
+ *
+ * Real Workers don't exist in the test DOM, so we stub `globalThis.Worker`
+ * with a fake that records postMessage calls and lets each test script the
+ * response. This verifies the bridge contract: request shape, transferable
+ * list, resolve/reject mapping, and the isCryptoWorkerSupported probe.
+ */
+
+type Posted = { msg: Record<string, unknown>; transfer: Transferable[] };
+
+class FakeWorker {
+  static instances: FakeWorker[] = [];
+  static failConstruction = false;
+  posted: Posted[] = [];
+  onmessage: ((e: { data: unknown }) => void) | null = null;
+  onerror: ((e: { message: string; filename?: string; lineno?: number }) => void) | null = null;
+
+  constructor() {
+    if (FakeWorker.failConstruction) throw new Error("no workers here");
+    FakeWorker.instances.push(this);
+  }
+
+  postMessage(msg: Record<string, unknown>, transfer: Transferable[] = []) {
+    this.posted.push({ msg, transfer });
+  }
+
+  reply(id: number, payload: { result?: unknown; error?: string }) {
+    this.onmessage?.({ data: { id, ...payload } });
+  }
+
+  terminate() { /* noop */ }
+}
+
+async function loadBridge() {
+  vi.resetModules();
+  return import("./bridge");
+}
+
+beforeEach(() => {
+  FakeWorker.instances = [];
+  FakeWorker.failConstruction = false;
+  vi.stubGlobal("Worker", FakeWorker as unknown as typeof Worker);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("bridge — workerDecryptFile (WEE-92)", () => {
+  it("posts a decryptFile request and transfers the input buffer", async () => {
+    const { workerDecryptFile } = await loadBridge();
+    const data = new Uint8Array([1, 2, 3]).buffer;
+
+    void workerDecryptFile(data, "secret");
+    const w = FakeWorker.instances[0];
+    expect(w.posted).toHaveLength(1);
+
+    const { msg, transfer } = w.posted[0];
+    expect(msg.type).toBe("decryptFile");
+    expect(msg.secret).toBe("secret");
+    expect(msg.data).toBe(data);
+    // Zero-copy contract: the input buffer must be in the transfer list.
+    expect(transfer).toContain(data);
+  });
+
+  it("resolves with the worker's result buffer", async () => {
+    const { workerDecryptFile } = await loadBridge();
+    const p = workerDecryptFile(new ArrayBuffer(4), "s");
+
+    const w = FakeWorker.instances[0];
+    const id = w.posted[0].msg.id as number;
+    const decrypted = new Uint8Array([9, 9]).buffer;
+    w.reply(id, { result: decrypted });
+
+    await expect(p).resolves.toBe(decrypted);
+  });
+
+  it("rejects when the worker reports an error", async () => {
+    const { workerDecryptFile } = await loadBridge();
+    const p = workerDecryptFile(new ArrayBuffer(4), "s");
+
+    const w = FakeWorker.instances[0];
+    const id = w.posted[0].msg.id as number;
+    w.reply(id, { error: "OperationError" });
+
+    await expect(p).rejects.toThrow("OperationError");
+  });
+
+  it("rejects pending requests when the worker errors out", async () => {
+    const { workerDecryptFile } = await loadBridge();
+    const p = workerDecryptFile(new ArrayBuffer(4), "s");
+
+    const w = FakeWorker.instances[0];
+    w.onerror?.({ message: "boom" });
+
+    // Bridge prefixes infra failures with "Worker error" — the
+    // isWorkerInfraError classifier keys off this exact prefix.
+    await expect(p).rejects.toThrow(/^Worker error/);
+  });
+
+  it("REJECTS on an empty error string instead of resolving undefined (C1)", async () => {
+    // WebCrypto's OperationError often has an empty message. Treating "" as
+    // success would resolve `undefined`, wrap it into a File containing the
+    // text "undefined", and poison the media cache with corrupt bytes.
+    const { workerDecryptFile } = await loadBridge();
+    const p = workerDecryptFile(new ArrayBuffer(4), "s");
+
+    const w = FakeWorker.instances[0];
+    const id = w.posted[0].msg.id as number;
+    w.reply(id, { error: "" });
+
+    await expect(p).rejects.toThrow("worker operation failed");
+  });
+
+  it("drops the dead worker after onerror so the next send re-creates it (H1)", async () => {
+    // On WebViews where the module-worker script fails to LOAD (async, after
+    // a successful constructor), keeping the dead instance would swallow
+    // every later request: it never settles and burns the caller's full
+    // timeout with no infra-error fallback.
+    const { workerDecryptFile } = await loadBridge();
+    void workerDecryptFile(new ArrayBuffer(4), "s").catch(() => undefined);
+    expect(FakeWorker.instances).toHaveLength(1);
+
+    FakeWorker.instances[0].onerror?.({ message: "load failed" });
+
+    void workerDecryptFile(new ArrayBuffer(4), "s").catch(() => undefined);
+    // A fresh worker instance — the request lands on a live onerror/onmessage
+    // pair and fails fast instead of hanging.
+    expect(FakeWorker.instances).toHaveLength(2);
+  });
+});
+
+describe("bridge — isWorkerInfraError (WEE-92)", () => {
+  it("classifies bridge infra failures as infra", async () => {
+    const { isWorkerInfraError } = await loadBridge();
+    expect(isWorkerInfraError(new Error("Worker error: boom"))).toBe(true);
+    expect(isWorkerInfraError(new Error("Worker terminated"))).toBe(true);
+  });
+
+  it("classifies application errors as non-infra (no main-thread retry)", async () => {
+    const { isWorkerInfraError } = await loadBridge();
+    expect(isWorkerInfraError(new Error("OperationError"))).toBe(false);
+    expect(isWorkerInfraError(new Error("worker operation failed"))).toBe(false);
+    expect(isWorkerInfraError(new Error("decryptFile timed out after 60000ms"))).toBe(false);
+  });
+});
+
+describe("bridge — isCryptoWorkerSupported (WEE-92)", () => {
+  it("returns true when a Worker can be constructed (and caches)", async () => {
+    const { isCryptoWorkerSupported } = await loadBridge();
+    expect(isCryptoWorkerSupported()).toBe(true);
+    expect(isCryptoWorkerSupported()).toBe(true);
+    // Probe reuses the singleton — exactly one Worker constructed.
+    expect(FakeWorker.instances).toHaveLength(1);
+  });
+
+  it("returns false when Worker construction throws", async () => {
+    FakeWorker.failConstruction = true;
+    const { isCryptoWorkerSupported } = await loadBridge();
+    expect(isCryptoWorkerSupported()).toBe(false);
+  });
+
+  it("downgrades to false after onerror with NO prior successful response (N1)", async () => {
+    // Module-worker script that can never load (old WebViews ignoring
+    // type:"module"): constructor succeeds, load fails async. Keeping
+    // `supported=true` would bypass the serial freeze guard forever while
+    // every request burns a worker construction + infra fallback.
+    const { isCryptoWorkerSupported, workerDecryptFile } = await loadBridge();
+    expect(isCryptoWorkerSupported()).toBe(true);
+
+    void workerDecryptFile(new ArrayBuffer(4), "s").catch(() => undefined);
+    FakeWorker.instances[0].onerror?.({ message: "script load failed" });
+
+    expect(isCryptoWorkerSupported()).toBe(false);
+  });
+
+  it("keeps support after onerror when the worker HAS responded before (transient crash)", async () => {
+    const { isCryptoWorkerSupported, workerDecryptFile } = await loadBridge();
+
+    // First request succeeds — proves the script loads on this engine.
+    const p = workerDecryptFile(new ArrayBuffer(4), "s");
+    const w = FakeWorker.instances[0];
+    w.reply(w.posted[0].msg.id as number, { result: new ArrayBuffer(1) });
+    await p;
+
+    w.onerror?.({ message: "transient crash" });
+    expect(isCryptoWorkerSupported()).toBe(true);
+  });
+});

--- a/src/shared/lib/crypto-worker/bridge.ts
+++ b/src/shared/lib/crypto-worker/bridge.ts
@@ -10,6 +10,7 @@ import type {
   WorkerResponse,
   DecryptRequest,
   EncryptRequest,
+  DecryptFileRequest,
 } from "./crypto.worker";
 
 // ---------------------------------------------------------------------------
@@ -19,6 +20,12 @@ import type {
 let worker: Worker | null = null;
 let nextId = 1;
 const pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+
+/** Set once the worker delivers ANY response — proof the script actually
+ *  loaded and ran. Distinguishes a transient crash (keep using workers)
+ *  from a script that can never load on this WebView (downgrade support,
+ *  see onerror / WEE-92 N1). */
+let workerEverResponded = false;
 
 function getWorker(): Worker {
   if (!worker) {
@@ -35,12 +42,17 @@ function getWorker(): Worker {
       throw e;
     }
     worker.onmessage = (e: MessageEvent<WorkerResponse>) => {
+      workerEverResponded = true;
       const { id, result, error } = e.data;
       const p = pending.get(id);
       if (!p) return;
       pending.delete(id);
-      if (error) {
-        p.reject(new Error(error));
+      // Check presence, not truthiness: an empty error string (e.g. a
+      // DOMException with no message) must still reject — treating it as
+      // success would resolve with `undefined` and let corrupt data through
+      // (WEE-92 C1).
+      if (error !== undefined) {
+        p.reject(new Error(error || "worker operation failed"));
       } else {
         p.resolve(result);
       }
@@ -52,20 +64,82 @@ function getWorker(): Worker {
         p.reject(new Error("Worker error: " + e.message));
         pending.delete(id);
       }
+      // Drop the broken instance. On WebViews where the module-worker script
+      // fails to LOAD (async — the constructor itself succeeds), a kept-alive
+      // dead worker would swallow every later postMessage without ever
+      // settling it: each request then burns its full caller-side timeout
+      // with no fallback (WEE-92 H1). Re-creating per send keeps the failure
+      // fast and lets callers' infra-error fallback fire instead.
+      try { worker?.terminate(); } catch { /* already dead */ }
+      worker = null;
+      // If the worker NEVER produced a response, the script most likely can't
+      // load on this WebView at all (e.g. classic-worker engines ignoring
+      // type:"module") — every future attempt would also fail. Downgrade the
+      // support verdict so policy call sites (runFileDecrypt) return to the
+      // serial main-thread queue instead of burning a worker construction +
+      // infra-fallback per attachment forever (WEE-92 N1). A worker that has
+      // responded before just crashed transiently — keep support on.
+      if (!workerEverResponded) workerSupported = false;
     };
   }
   return worker;
 }
 
-function send<T>(msg: Omit<WorkerRequest, "id">): Promise<T> {
+function send<T>(msg: Omit<WorkerRequest, "id">, transfer?: Transferable[]): Promise<T> {
   return new Promise((resolve, reject) => {
+    // Construct the worker BEFORE registering the pending entry: a throwing
+    // constructor (e.g. re-creation after H1 teardown) must not leak a
+    // never-settled entry in `pending`, and the rejection carries the infra
+    // prefix so callers' fallback classification fires.
+    let w: Worker;
+    try {
+      w = getWorker();
+    } catch (e) {
+      reject(new Error("Worker error: " + (e instanceof Error ? e.message : String(e))));
+      return;
+    }
     const id = nextId++;
     pending.set(id, {
       resolve: resolve as (v: unknown) => void,
       reject,
     });
-    getWorker().postMessage({ ...msg, id });
+    // Transferables (large media buffers) move ownership instead of being
+    // structured-cloned — the caller's buffer is detached after this call.
+    w.postMessage({ ...msg, id }, transfer ?? []);
   });
+}
+
+/** Matches the bridge's own infrastructure failures ("Worker error: ...",
+ *  "Worker terminated") as opposed to application errors forwarded from the
+ *  worker (e.g. a deterministic decrypt failure). The prefix and this
+ *  classifier live together in this module so they can't drift apart. */
+const WORKER_INFRA_ERROR_RE = /^Worker (error|terminated)/;
+
+/** True for failures of the worker INFRASTRUCTURE (died, terminated,
+ *  failed to load) — the operation may succeed elsewhere (e.g. a
+ *  main-thread fallback). False for application errors the worker
+ *  computed deterministically (wrong key, corrupt ciphertext): retrying
+ *  those on another thread would fail identically. */
+export function isWorkerInfraError(e: unknown): boolean {
+  const msg = e instanceof Error ? e.message : String(e);
+  return WORKER_INFRA_ERROR_RE.test(msg);
+}
+
+/** True when a module Web Worker can be constructed in this environment.
+ *  Lazily probes once (by creating the singleton worker) and caches the
+ *  verdict — call sites use it to choose between the parallel worker path
+ *  and the legacy sequential main-thread fallback (WEE-92). */
+let workerSupported: boolean | null = null;
+export function isCryptoWorkerSupported(): boolean {
+  if (workerSupported === null) {
+    try {
+      getWorker();
+      workerSupported = true;
+    } catch {
+      workerSupported = false;
+    }
+  }
+  return workerSupported;
 }
 
 // ---------------------------------------------------------------------------
@@ -113,6 +187,21 @@ export function workerEncrypt(params: {
     type: "encrypt",
     ...params,
   } as Omit<EncryptRequest, "id">);
+}
+
+/**
+ * Decrypt a file attachment (PBKDF2 + AES-CBC) in the Worker thread.
+ * The input buffer is TRANSFERRED (detached) — pass a copy if the caller
+ * still needs it. Returns the decrypted bytes (also transferred, zero-copy).
+ */
+export function workerDecryptFile(
+  data: ArrayBuffer,
+  secret: string,
+): Promise<ArrayBuffer> {
+  return send<ArrayBuffer>(
+    { type: "decryptFile", data, secret } as Omit<DecryptFileRequest, "id">,
+    [data],
+  );
 }
 
 /**

--- a/src/shared/lib/crypto-worker/crypto.worker.ts
+++ b/src/shared/lib/crypto-worker/crypto.worker.ts
@@ -18,6 +18,8 @@ import pbkdf2 from "pbkdf2";
 // @ts-expect-error — no types for bn.js default export
 import BN from "bn.js";
 
+import { decryptFileBuffer } from "./file-cipher";
+
 // ---------------------------------------------------------------------------
 // Constants (must match matrix-crypto.ts)
 // ---------------------------------------------------------------------------
@@ -293,7 +295,21 @@ export interface ComputeKeysRequest {
   block: number;
 }
 
-export type WorkerRequest = DecryptRequest | EncryptRequest | ComputeKeysRequest;
+/** File-attachment decrypt (PBKDF2 + AES-CBC, see file-cipher.ts). `data` is
+ *  posted as a Transferable, and the decrypted buffer is transferred back —
+ *  no structured-clone copies of multi-megabyte media (WEE-92). */
+export interface DecryptFileRequest {
+  id: number;
+  type: "decryptFile";
+  data: ArrayBuffer;
+  secret: string;
+}
+
+export type WorkerRequest =
+  | DecryptRequest
+  | EncryptRequest
+  | ComputeKeysRequest
+  | DecryptFileRequest;
 
 export interface WorkerResponse {
   id: number;
@@ -352,11 +368,28 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
         } satisfies WorkerResponse);
         break;
       }
+      case "decryptFile": {
+        const decrypted = await decryptFileBuffer(msg.data, msg.secret);
+        // Transfer the result buffer back — zero-copy for large media.
+        (self as unknown as Worker).postMessage(
+          { id: msg.id, result: decrypted } satisfies WorkerResponse,
+          [decrypted],
+        );
+        break;
+      }
     }
   } catch (err) {
+    // WebCrypto rejects AES-CBC failures with a DOMException whose message is
+    // often EMPTY — an empty string is falsy and would be treated as success
+    // by the bridge, resolving the request with `undefined` (WEE-92 C1).
+    // Always send a non-empty error string.
+    const message =
+      err instanceof Error
+        ? err.message || err.name || "worker operation failed"
+        : String(err) || "worker operation failed";
     (self as unknown as Worker).postMessage({
       id: msg.id,
-      error: err instanceof Error ? err.message : String(err),
+      error: message,
     } satisfies WorkerResponse);
   }
 };

--- a/src/shared/lib/crypto-worker/file-cipher.test.ts
+++ b/src/shared/lib/crypto-worker/file-cipher.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  FILE_CIPHER_IV,
+  encryptFileBuffer,
+  decryptFileBuffer,
+  resolveDecryptedMime,
+} from "./file-cipher";
+
+/**
+ * WEE-92 — file-cipher is the single source of truth for the attachment
+ * format, shared by the main thread (PcryptoFile) and the crypto Web Worker.
+ * These tests pin the format: IV bytes, PBKDF2 round-trip, and wrong-key
+ * failure mode. If any of this drifts, existing chats stop decrypting.
+ */
+describe("file-cipher (WEE-92)", () => {
+  it("keeps the historical fixed IV byte-identical", () => {
+    // Every attachment ever sent was encrypted with this IV — changing it
+    // bricks all existing media.
+    expect(Array.from(FILE_CIPHER_IV)).toEqual([
+      19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34,
+    ]);
+  });
+
+  it("round-trips bytes through encrypt → decrypt", async () => {
+    const plain = new TextEncoder().encode("attachment bytes \u{1F4CE} тест");
+    const secret = "1111,2222,3333";
+
+    const encrypted = await encryptFileBuffer(plain.buffer.slice(0), secret);
+    expect(new Uint8Array(encrypted)).not.toEqual(plain);
+
+    const decrypted = await decryptFileBuffer(encrypted, secret);
+    expect(new Uint8Array(decrypted)).toEqual(plain);
+  });
+
+  it("matches the golden ciphertext — pins salt, iterations, and IV together", async () => {
+    // Generated with the production format (PBKDF2 "matrix.pocketnet" /
+    // 10000 / SHA-256 → AES-CBC-256, fixed IV). A round-trip test alone
+    // passes even if both sides drift together; this vector does not.
+    const expected = new Uint8Array([
+      21, 73, 180, 34, 65, 65, 214, 21, 50, 171, 111, 49, 40, 142, 173, 62,
+      48, 67, 188, 27, 193, 154, 33, 7, 230, 17, 114, 47, 16, 239, 175, 145,
+    ]);
+    const ct = await encryptFileBuffer(
+      new TextEncoder().encode("golden plaintext").buffer as ArrayBuffer,
+      "golden-secret",
+    );
+    expect(new Uint8Array(ct)).toEqual(expected);
+
+    const pt = await decryptFileBuffer(expected.buffer.slice(0), "golden-secret");
+    expect(new TextDecoder().decode(pt)).toBe("golden plaintext");
+  });
+
+  it("rejects on a wrong secret (deterministic crypto failure)", async () => {
+    const plain = new TextEncoder().encode("payload");
+    const encrypted = await encryptFileBuffer(plain.buffer.slice(0), "right-key");
+    await expect(decryptFileBuffer(encrypted, "wrong-key")).rejects.toBeDefined();
+  });
+
+  describe("resolveDecryptedMime", () => {
+    it("prefers the declared original MIME", () => {
+      expect(resolveDecryptedMime("application/octet-stream", "image/jpeg")).toBe("image/jpeg");
+    });
+
+    it("strips the legacy encrypted/ prefix when no original MIME", () => {
+      expect(resolveDecryptedMime("encrypted/video/mp4")).toBe("video/mp4");
+    });
+
+    it("falls back to octet-stream", () => {
+      expect(resolveDecryptedMime("application/octet-stream")).toBe("application/octet-stream");
+      expect(resolveDecryptedMime("")).toBe("application/octet-stream");
+    });
+  });
+});

--- a/src/shared/lib/crypto-worker/file-cipher.ts
+++ b/src/shared/lib/crypto-worker/file-cipher.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure PBKDF2 + AES-CBC file cipher — the single source of truth for the
+ * file-attachment encryption format (a direct port of bastyon-chat's
+ * PcryptoFile, see matrix-crypto.ts).
+ *
+ * Shared by the main thread (PcryptoFile) and the crypto Web Worker
+ * (decryptFile operation) so the two paths can never drift apart on IV,
+ * salt, iteration count, or key length. No DOM, no Vue — safe to import
+ * from a Worker context.
+ */
+
+/** Fixed IV — must stay byte-identical to historical PcryptoFile ciphertexts;
+ *  every existing attachment in every chat was encrypted with it. */
+export const FILE_CIPHER_IV = new Uint8Array([
+  19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34,
+]);
+
+const PBKDF2_SALT = "matrix.pocketnet";
+const PBKDF2_ITERATIONS = 10000;
+
+/** Safe accessor for crypto.subtle — throws a clear error instead of a
+ *  cryptic 'undefined' when the context is insecure (plain HTTP). Works in
+ *  both window and Worker scopes via globalThis. */
+function getSubtle(): SubtleCrypto {
+  const subtle = globalThis.crypto?.subtle;
+  if (!subtle) {
+    throw new Error(
+      "crypto.subtle is unavailable (requires HTTPS or localhost). " +
+      "Serve the app over HTTPS to enable encryption.",
+    );
+  }
+  return subtle;
+}
+
+/** Derive the AES-CBC key from the per-file secret string. */
+export async function deriveFileKey(secret: string): Promise<CryptoKey> {
+  const subtle = getSubtle();
+  const enc = new TextEncoder();
+  const keyMaterial = await subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    "PBKDF2",
+    false,
+    ["deriveBits", "deriveKey"],
+  );
+  return subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt: enc.encode(PBKDF2_SALT),
+      iterations: PBKDF2_ITERATIONS,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    { name: "AES-CBC", length: 256 },
+    true,
+    ["encrypt", "decrypt"],
+  );
+}
+
+/** Encrypt plaintext bytes with the per-file secret. */
+export async function encryptFileBuffer(
+  data: ArrayBuffer,
+  secret: string,
+): Promise<ArrayBuffer> {
+  const key = await deriveFileKey(secret);
+  return getSubtle().encrypt({ name: "AES-CBC", iv: FILE_CIPHER_IV }, key, data);
+}
+
+/** Decrypt ciphertext bytes with the per-file secret. Rejects (typically
+ *  with a DOMException OperationError) when the secret is wrong or the
+ *  ciphertext is corrupted. */
+export async function decryptFileBuffer(
+  data: ArrayBuffer,
+  secret: string,
+): Promise<ArrayBuffer> {
+  const key = await deriveFileKey(secret);
+  return getSubtle().decrypt({ name: "AES-CBC", iv: FILE_CIPHER_IV }, key, data);
+}
+
+/** Resolve the plaintext MIME for a decrypted attachment. New writers store
+ *  ciphertext as application/octet-stream and carry the real MIME in
+ *  fileInfo.type (`originalMime`); old clients used a legacy
+ *  "encrypted/<mime>" pseudo-type on the ciphertext blob itself. */
+export function resolveDecryptedMime(
+  ciphertextType: string,
+  originalMime?: string,
+): string {
+  if (originalMime) return originalMime;
+  if (ciphertextType.startsWith("encrypted/")) {
+    return ciphertextType.replace("encrypted/", "");
+  }
+  return "application/octet-stream";
+}


### PR DESCRIPTION
## Summary
- File-attachment decryption (PBKDF2 10k + AES-CBC) used to run on the **main thread**, strictly serialised through the decrypt queue — one slow file delayed every other attachment ("the message has arrived but the spinner keeps spinning").
- New `decryptFile` operation in the existing crypto Web Worker: zero-copy transferable `ArrayBuffer` in/out; `runFileDecrypt` runs decrypts **in parallel** (60s-bounded, capped at 3 by `mediaDownloadGate`) when the worker is available.
- Shared `file-cipher.ts` is the single source of truth for the cipher format (fixed IV, salt, iterations) for both threads; a **golden-vector test** pins the exact ciphertext bytes so existing attachments can never brick.
- Robust degradation: worker infra failures (`isWorkerInfraError`) fall back to the main-thread path; a module-worker script that never loads downgrades support so old WebViews return to the legacy serial queue (the #306/#370 freeze guard); files ≥ 32 MB stay serial for memory headroom.
- Hardened error contract: an empty WebCrypto error message previously would have resolved as success and persisted corrupt bytes into the media cache — now always rejects.

## Linear
- Resolves WEE-92 (https://linear.app/wwwee/issue/WEE-92)
- Refs WEE-90 (timeout/mirror — complementary), WEE-71/WEE-91 (media UX)

## Review
2 iterations of code review: C1 (empty-error → cache poisoning), H1 (dead worker swallows requests), N1 (support cache defeats serial guard), M1–M3 — all fixed with regression tests.

## Test plan
- [x] `vue-tsc --noEmit` — 0 errors in changed files (50 pre-existing baseline)
- [x] `npm run test` — 642/642 in messaging + matrix + crypto-worker; 30 new tests (cipher golden vector, bridge protocol/transferables, C1/H1/N1 regressions, concurrency policy)
- [ ] Manual QA: chat with many photos on a mid-range Android — images decrypt concurrently, UI stays responsive; airplane-mode/worker-kill still falls back gracefully