### PR TITLE
perf(crypto): parallel batched room-preview decrypt + main-thread fallback for crypto worker (WEE-96)

### DIFF
--- a/src/entities/chat/model/__tests__/preview-decrypt-retry.test.ts
+++ b/src/entities/chat/model/__tests__/preview-decrypt-retry.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia } from "pinia";
+import { createTestingPinia } from "@pinia/testing";
+import { makeRoom, makeMsg } from "@/test-utils";
+
+/**
+ * WEE-96 follow-up regression: at cold start the first preview-decrypt pass
+ * can exhaust DECRYPT_MAX_RETRIES while the RPC backend is still warming up,
+ * and incremental refreshes never re-attempt quiet rooms — previews stayed
+ * "[encrypted]" until the chat was opened. retryEncryptedPreviews() must
+ * re-run the pass with a fresh retry budget.
+ */
+
+const ROOM_ID = "!enc-room:server";
+
+const ENCRYPTED_EVENT = {
+  event: {
+    type: "m.room.message",
+    sender: "@peer:server",
+    content: { msgtype: "m.encrypted", body: "b64..." },
+    event_id: "$e1",
+    origin_server_ts: 1000,
+  },
+};
+
+const mxRoom = {
+  roomId: ROOM_ID,
+  getLiveTimeline: () => ({ getEvents: () => [ENCRYPTED_EVENT] }),
+};
+
+const mockMatrixService = {
+  getUserId: vi.fn(() => "@me:server"),
+  getRoom: vi.fn(() => mxRoom),
+  getRooms: vi.fn(() => [mxRoom]),
+  isReady: vi.fn(() => true),
+  sendReadReceipt: vi.fn(async () => true),
+  kit: {
+    client: { getUserId: () => "@me:server" },
+    isTetatetChat: vi.fn(() => true),
+    getRoomMembers: vi.fn(() => []),
+  },
+};
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: vi.fn(() => mockMatrixService),
+}));
+
+import { useChatStore } from "../chat-store";
+
+describe("chat-store — retryEncryptedPreviews (WEE-96 cold-start latch)", () => {
+  let store: ReturnType<typeof useChatStore>;
+  let decryptEvent: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    setActivePinia(createTestingPinia({ stubActions: false }));
+    store = useChatStore();
+    vi.clearAllMocks();
+    // clearAllMocks doesn't reset implementations — re-establish defaults so
+    // per-test mockReturnValue overrides don't leak between tests.
+    mockMatrixService.isReady.mockReturnValue(true);
+    mockMatrixService.getRooms.mockImplementation(() => [mxRoom]);
+    mockMatrixService.getRoom.mockImplementation(() => mxRoom);
+
+    decryptEvent = vi.fn();
+    const pcryptoStub = {
+      // Pre-seeded room instance — ensureRoomCrypto returns it directly
+      rooms: { [ROOM_ID]: { decryptEvent } },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store.setHelpers(mockMatrixService.kit as any, pcryptoStub as any);
+
+    store.addRoom(makeRoom({
+      id: ROOM_ID,
+      lastMessage: makeMsg({ roomId: ROOM_ID, content: "[encrypted]" }),
+    }));
+  });
+
+  it("decrypts the preview even after earlier passes exhausted the retry budget", async () => {
+    // Cold start: three passes fail (RPC down) — burns DECRYPT_MAX_RETRIES=3
+    decryptEvent.mockRejectedValue(new Error("getusersinfo timed out"));
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      store.retryEncryptedPreviews();
+      await vi.waitFor(() => expect(decryptEvent).toHaveBeenCalledTimes(attempt));
+    }
+
+    // Backend warmed up — the next scheduled pass must attempt again
+    // (without the fresh-budget clear it would be skipped forever).
+    decryptEvent.mockResolvedValue({ body: "real preview", msgtype: "m.text" });
+    store.retryEncryptedPreviews();
+
+    await vi.waitFor(() => {
+      const room = store.rooms.find((r) => r.id === ROOM_ID);
+      expect(room?.lastMessage?.content).toBe("real preview");
+    });
+  });
+
+  it("is a no-op when Matrix is not ready", () => {
+    mockMatrixService.isReady.mockReturnValueOnce(false);
+    store.retryEncryptedPreviews();
+    expect(mockMatrixService.getRooms).not.toHaveBeenCalled();
+  });
+
+  it("rotates the per-cycle cap so later passes reach rooms 21+", async () => {
+    // 25 encrypted rooms — one pass caps at 20; without rotation the retry
+    // passes would re-attempt the same first 20 forever and starve the rest.
+    const attempted = new Set<string>();
+    const roomsCrypto: Record<string, unknown> = {};
+    const mxRooms: unknown[] = [];
+    for (let i = 0; i < 25; i++) {
+      const id = `!r${i}:server`;
+      roomsCrypto[id] = {
+        decryptEvent: vi.fn(async () => {
+          attempted.add(id);
+          throw new Error("cold backend");
+        }),
+      };
+      mxRooms.push({ roomId: id, getLiveTimeline: () => ({ getEvents: () => [ENCRYPTED_EVENT] }) });
+      store.addRoom(makeRoom({
+        id,
+        lastMessage: makeMsg({ roomId: id, content: "[encrypted]" }),
+      }));
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockMatrixService.getRooms.mockReturnValue(mxRooms as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store.setHelpers(mockMatrixService.kit as any, { rooms: roomsCrypto } as any);
+
+    store.retryEncryptedPreviews();
+    await vi.waitFor(() => expect(attempted.size).toBe(20));
+
+    store.retryEncryptedPreviews();
+    await vi.waitFor(() => expect(attempted.size).toBe(25));
+  });
+
+  it("skips rooms whose preview is already decrypted", async () => {
+    // First pass succeeds and caches the result
+    decryptEvent.mockResolvedValue({ body: "real preview", msgtype: "m.text" });
+    store.retryEncryptedPreviews();
+    await vi.waitFor(() => expect(decryptEvent).toHaveBeenCalledTimes(1));
+
+    // A later warm-up pass must not redo the work
+    store.retryEncryptedPreviews();
+    await new Promise((r) => setTimeout(r, 50));
+    expect(decryptEvent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -597,6 +597,16 @@ export const useChatStore = defineStore(NAMESPACE, () => {
   const DECRYPT_MAX_RETRIES = 3;
   // Preview decrypt parallelism (WEE-96): rooms per batch, yield between batches
   const PREVIEW_DECRYPT_BATCH_SIZE = 5;
+  // Rooms attempted per decryptRoomPreviews pass (cap to avoid long pipelines)
+  const PREVIEW_DECRYPT_MAX_PER_CYCLE = 20;
+  // Rotation cursor so consecutive passes don't always pick the same first 20
+  // rooms — without it, retry passes that reset the failure budget would
+  // starve rooms 21+ of any attempt until the 15-min full refresh.
+  let previewCapCursor = 0;
+  // Delayed retry passes for encrypted previews after initial sync (WEE-96):
+  // covers RPC/Tor warm-up failures during the very first preview pass
+  const PREVIEW_RETRY_PASS_DELAYS_MS = [10_000, 30_000, 90_000] as const;
+  const previewRetryTimers: ReturnType<typeof setTimeout>[] = [];
 
   // Edit/delete state (Batch 3)
   const editingMessage = ref<{ id: string; content: string } | null>(null);
@@ -2937,6 +2947,14 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       // Start preview polling for rooms without preview after initial load
       setTimeout(() => syncPreviewPolling(), 1500);
 
+      // Retry "[encrypted]" previews after the RPC backend warms up (WEE-96):
+      // the initial pass often runs while getusersinfo still times out.
+      // Timers are tracked so cleanup() cancels them — otherwise a re-login
+      // within 90s would stack stale passes on top of the new session's own.
+      for (const delay of PREVIEW_RETRY_PASS_DELAYS_MS) {
+        previewRetryTimers.push(setTimeout(() => retryEncryptedPreviews(), delay));
+      }
+
       // Schedule room cleanup 30s after init, then every 30 minutes
       scheduleRoomCleanup();
     }
@@ -2995,8 +3013,15 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     }
     if (toDecrypt.length === 0) return;
 
-    // Cap at 20 rooms per cycle to avoid blocking
-    const capped = toDecrypt.slice(0, 20);
+    // Cap rooms per cycle to avoid blocking; rotate the window so repeated
+    // passes (incl. fresh-budget retry passes) eventually reach every room.
+    let capped = toDecrypt;
+    if (toDecrypt.length > PREVIEW_DECRYPT_MAX_PER_CYCLE) {
+      const start = previewCapCursor % toDecrypt.length;
+      capped = [...toDecrypt.slice(start), ...toDecrypt.slice(0, start)]
+        .slice(0, PREVIEW_DECRYPT_MAX_PER_CYCLE);
+      previewCapCursor = (start + PREVIEW_DECRYPT_MAX_PER_CYCLE) % toDecrypt.length;
+    }
 
     /** Decrypt one room's preview. Never throws — failures are recorded in
      *  decryptFailedRooms so the retry/backoff bookkeeping stays per-room. */
@@ -3059,6 +3084,27 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       }
       triggerRef(rooms);
     }
+  };
+
+  /** Cold-start retry for encrypted previews (WEE-96 follow-up).
+   *  During the first ~30s the sync-driven passes can exhaust
+   *  DECRYPT_MAX_RETRIES while the Pocketnet RPC / Tor proxy is still warming
+   *  up (getusersinfo timeouts). Incremental refreshes only re-attempt rooms
+   *  that CHANGE, so quiet rooms then stay "[encrypted]" until the next
+   *  15-min full refresh (which clears the failure map) or until the chat is
+   *  opened. These early passes re-run with a fresh retry budget so previews
+   *  appear within seconds of the backend warming up instead. */
+  const retryEncryptedPreviews = () => {
+    const matrixService = getMatrixClientService();
+    if (!matrixService.isReady()) return;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const matrixRooms = matrixService.getRooms() as any[];
+    if (!matrixRooms.length) return;
+    // Fresh budget: cold-start failures (RPC timeouts) must not count against
+    // the per-room retry cap. decryptRoomPreviews itself skips rooms whose
+    // preview is already decrypted, so a warm re-pass is a cheap O(n) scan.
+    decryptFailedRooms.clear();
+    decryptRoomPreviews(matrixRooms).then(() => debouncedCacheRooms());
   };
 
   // Pending read receipts: queued when tab is hidden, sent when visible.
@@ -6990,6 +7036,8 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     decryptedPreviewCache.clear();
     changedRoomIds.clear();
     decryptFailedRooms.clear();
+    for (const timer of previewRetryTimers) clearTimeout(timer);
+    previewRetryTimers.length = 0;
     peerKeysStatus.clear();
     matrixRoomAddresses.clear();
     profilesRequestedForRooms.clear();
@@ -7115,6 +7163,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     inviteCount,
     setActiveRoom,
     setHelpers,
+    retryEncryptedPreviews,
     muteMember,
     setMemberPowerLevel,
     setMessages,

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -25,6 +25,8 @@ import { computed, reactive, ref, shallowRef, triggerRef, watch } from "vue";
 import { perfMark, perfMeasure, perfCount } from "@/shared/lib/perf-markers";
 import { signalChatsInteractive } from "@/shared/lib/boot-signals";
 import { yieldToMain, yieldEveryN } from "@/shared/lib/yield-to-main";
+import { runInBatches } from "@/shared/lib/run-in-batches";
+import { isCryptoWorkerSupported } from "@/shared/lib/crypto-worker/bridge";
 import { createPatchScheduler } from "@/shared/lib/patch-scheduler";
 import { isNative } from "@/shared/lib/platform";
 import { notifyNewMessage } from "@/shared/lib/notifications/web-notifier";
@@ -593,6 +595,8 @@ export const useChatStore = defineStore(NAMESPACE, () => {
   const peerKeysStatus = reactive(new Map<string, PeerKeysStatus>());
   const DECRYPT_RETRY_DELAY = 10_000; // 10s before retrying a failed room
   const DECRYPT_MAX_RETRIES = 3;
+  // Preview decrypt parallelism (WEE-96): rooms per batch, yield between batches
+  const PREVIEW_DECRYPT_BATCH_SIZE = 5;
 
   // Edit/delete state (Batch 3)
   const editingMessage = ref<{ id: string; content: string } | null>(null);
@@ -2994,17 +2998,15 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     // Cap at 20 rooms per cycle to avoid blocking
     const capped = toDecrypt.slice(0, 20);
 
-    // Decrypt sequentially with yield between each room to keep UI responsive.
-    // Previously used Promise.all(batch of 5) which ran 5 heavy ECDH+pbkdf2
-    // computations without yielding — causing 370ms+ long tasks.
-    const decryptedResults: Array<{ roomId: string; body: string }> = [];
-
-    for (const { roomId, matrixRoom } of capped) {
+    /** Decrypt one room's preview. Never throws — failures are recorded in
+     *  decryptFailedRooms so the retry/backoff bookkeeping stays per-room. */
+    const decryptOnePreview = async (
+      { roomId, matrixRoom }: { roomId: string; matrixRoom: unknown },
+    ): Promise<{ roomId: string; body: string } | null> => {
       try {
         const roomCrypto = await ensureRoomCrypto(roomId);
-        if (!roomCrypto) continue;
+        if (!roomCrypto) return null;
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let timelineEvents: unknown[] = [];
         try {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -3022,9 +3024,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
 
           try {
             const decrypted = await roomCrypto.decryptEvent(raw);
-            if (decrypted.body) {
-              decryptedResults.push({ roomId, body: decrypted.body });
-            }
+            if (decrypted.body) return { roomId, body: decrypted.body };
           } catch {
             decryptFailedRooms.set(roomId, { count: (decryptFailedRooms.get(roomId)?.count ?? 0) + 1, lastAttempt: Date.now() });
           }
@@ -3033,10 +3033,20 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       } catch {
         decryptFailedRooms.set(roomId, { count: (decryptFailedRooms.get(roomId)?.count ?? 0) + 1, lastAttempt: Date.now() });
       }
+      return null;
+    };
 
-      // Yield to main thread between each room decryption
-      await yieldToMain();
-    }
+    // Decrypt in parallel batches with a yield in between (WEE-96). Heavy
+    // crypto (ECDH + pbkdf2 + AES-SIV) runs in the crypto worker, so the main
+    // thread only awaits worker roundtrips and key-resolution RPCs — those
+    // parallelize safely. The batch size also bounds concurrent getusersinfo
+    // calls during room prepare().
+    // When the worker is unavailable (main-thread fallback on old WebViews),
+    // batch=1 keeps the old per-room yield — 5 synchronous pbkdf2 chains
+    // back-to-back would recreate the 370ms+ long tasks this code once had.
+    const batchSize = isCryptoWorkerSupported() ? PREVIEW_DECRYPT_BATCH_SIZE : 1;
+    const batched = await runInBatches(capped, batchSize, decryptOnePreview, yieldToMain);
+    const decryptedResults = batched.filter((r): r is { roomId: string; body: string } => r !== null);
 
     // Apply ALL decrypted results in one pass with a single triggerRef
     if (decryptedResults.length > 0) {

--- a/src/entities/matrix/model/matrix-crypto.ts
+++ b/src/entities/matrix/model/matrix-crypto.ts
@@ -1051,6 +1051,8 @@ export class Pcrypto {
 
       // Internal decrypt — offloaded to Web Worker for zero main-thread blocking.
       // All heavy crypto (ECDH, pbkdf2, AES-SIV) runs in a separate thread.
+      // Falls back to the main-thread eaa path when the worker is unavailable
+      // (old WebViews without module-worker support) — WEE-96 A3.
       async _decrypt(
         userid: string,
         encData: { encrypted: string; nonce: string },
@@ -1068,21 +1070,37 @@ export class Pcrypto {
           _block = tetatet ? pcrypto.currentblock.height : 10;
         }
 
-        // Prepare serializable data for Worker (fast — no crypto, just array ops)
-        const workerUsers = prepareWorkerUsers(usersIds, v || version);
-        const myId = pcrypto.user!.userinfo!.id;
-        const privateKeys = getPrivateKeysHex();
+        if (isCryptoWorkerSupported()) {
+          // Prepare serializable data for Worker (fast — no crypto, just array ops)
+          const workerUsers = prepareWorkerUsers(usersIds, v || version);
+          const myId = pcrypto.user!.userinfo!.id;
+          const privateKeys = getPrivateKeysHex();
 
-        // All heavy crypto (ECDH + pbkdf2 + AES-SIV) runs in Worker thread
-        return workerDecrypt({
-          users: workerUsers,
-          myId,
-          privateKeys,
-          targetUserId: userid,
-          encData,
-          time: _time,
-          block: _block,
-        });
+          try {
+            // All heavy crypto (ECDH + pbkdf2 + AES-SIV) runs in Worker thread
+            return await workerDecrypt({
+              users: workerUsers,
+              myId,
+              privateKeys,
+              targetUserId: userid,
+              encData,
+              time: _time,
+              block: _block,
+            });
+          } catch (e) {
+            // Crypto errors (emptykey, MAC failure) must propagate — only
+            // worker infrastructure failures fall back to the main thread.
+            if (!isWorkerInfraError(e)) throw e;
+            console.warn("[pcrypto] crypto worker unavailable, decrypting on main thread:", e);
+          }
+        }
+
+        // Main-thread fallback for environments without (module) Worker
+        // support — same ECDH + pbkdf2 derivation via eaa, AES-SIV via miscreant.
+        const aeskeysls = eaa.aeskeys(_time, _block, usersIds, v || version);
+        const key = aeskeysls[userid];
+        if (!key) throw new Error("emptykey");
+        return decrypt(key, encData);
       },
 
       // Internal encrypt — offloaded to Web Worker.
@@ -1100,19 +1118,32 @@ export class Pcrypto {
           _block = pcrypto.currentblock.height;
         }
 
-        const workerUsers = prepareWorkerUsers(null, v || version);
-        const myId = pcrypto.user!.userinfo!.id;
-        const privateKeys = getPrivateKeysHex();
+        if (isCryptoWorkerSupported()) {
+          const workerUsers = prepareWorkerUsers(null, v || version);
+          const myId = pcrypto.user!.userinfo!.id;
+          const privateKeys = getPrivateKeysHex();
 
-        return workerEncrypt({
-          users: workerUsers,
-          myId,
-          privateKeys,
-          targetUserId: userid,
-          text,
-          time: _time,
-          block: _block,
-        });
+          try {
+            return await workerEncrypt({
+              users: workerUsers,
+              myId,
+              privateKeys,
+              targetUserId: userid,
+              text,
+              time: _time,
+              block: _block,
+            });
+          } catch (e) {
+            if (!isWorkerInfraError(e)) throw e;
+            console.warn("[pcrypto] crypto worker unavailable, encrypting on main thread:", e);
+          }
+        }
+
+        // Main-thread fallback — see _decrypt above.
+        const aeskeysls = eaa.aeskeys(_time, _block, null, v || version);
+        const key = aeskeysls[userid];
+        if (!key) throw new Error("emptykey");
+        return encrypt(text, key);
       },
 
       async encryptFile(file: Blob): Promise<{ file: File; secrets: Record<string, unknown> }> {

--- a/src/features/contacts/model/use-preview-timeout.test.ts
+++ b/src/features/contacts/model/use-preview-timeout.test.ts
@@ -1,0 +1,88 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { usePreviewTimeout } from "./use-preview-timeout";
+
+describe("usePreviewTimeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("marks room timed-out after the timeout elapses", () => {
+    const { noteResolving, isTimedOut } = usePreviewTimeout(10_000);
+
+    noteResolving("!room1");
+    expect(isTimedOut("!room1")).toBe(false);
+
+    vi.advanceTimersByTime(10_000);
+    expect(isTimedOut("!room1")).toBe(true);
+  });
+
+  test("noteResolving is idempotent — repeated calls don't restart the timer", () => {
+    const { noteResolving, isTimedOut } = usePreviewTimeout(10_000);
+
+    noteResolving("!room1");
+    vi.advanceTimersByTime(9_000);
+    noteResolving("!room1"); // re-render mid-countdown must not reset it
+    vi.advanceTimersByTime(1_000);
+    expect(isTimedOut("!room1")).toBe(true);
+  });
+
+  test("WEE-96 A4: success before timeout cancels the timer — no late re-render", () => {
+    const { noteResolving, noteReady, isTimedOut } = usePreviewTimeout(10_000);
+
+    noteResolving("!room1");
+    vi.advanceTimersByTime(5_000);
+    noteReady("!room1"); // preview decrypted at T+5s
+
+    vi.advanceTimersByTime(60_000);
+    // Without the cancel, the timer fired at T+10s and mutated the reactive
+    // set → a second row re-render with no visible change.
+    expect(isTimedOut("!room1")).toBe(false);
+  });
+
+  test("a room that timed out stays timed-out after late success (no skeleton re-phase)", () => {
+    const { noteResolving, noteReady, isTimedOut } = usePreviewTimeout(10_000);
+
+    noteResolving("!room1");
+    vi.advanceTimersByTime(10_000);
+    expect(isTimedOut("!room1")).toBe(true);
+
+    noteReady("!room1"); // late decrypt at T+15s
+    expect(isTimedOut("!room1")).toBe(true);
+
+    // A subsequent encrypted preview shows the label immediately instead of
+    // re-entering the skeleton phase.
+    noteResolving("!room1");
+    expect(isTimedOut("!room1")).toBe(true);
+  });
+
+  test("tracks rooms independently", () => {
+    const { noteResolving, noteReady, isTimedOut } = usePreviewTimeout(10_000);
+
+    noteResolving("!a");
+    noteResolving("!b");
+    noteReady("!a");
+    vi.advanceTimersByTime(10_000);
+
+    expect(isTimedOut("!a")).toBe(false);
+    expect(isTimedOut("!b")).toBe(true);
+  });
+
+  test("dispose clears all pending timers", () => {
+    const { noteResolving, isTimedOut, dispose } = usePreviewTimeout(10_000);
+
+    noteResolving("!room1");
+    dispose();
+    vi.advanceTimersByTime(60_000);
+    expect(isTimedOut("!room1")).toBe(false);
+  });
+
+  test("noteReady on unknown room is a no-op", () => {
+    const { noteReady, isTimedOut } = usePreviewTimeout(10_000);
+    noteReady("!never-seen");
+    expect(isTimedOut("!never-seen")).toBe(false);
+  });
+});

--- a/src/features/contacts/model/use-preview-timeout.ts
+++ b/src/features/contacts/model/use-preview-timeout.ts
@@ -1,0 +1,54 @@
+import { reactive, getCurrentScope, onScopeDispose } from "vue";
+
+// Cap the preview decryption skeleton: after this long we stop showing an
+// indefinite shimmer and surface a "🔒 Encrypted message" label instead. The
+// background decryption keeps retrying and will replace it once decrypted.
+export const PREVIEW_DECRYPT_TIMEOUT_MS = 10_000;
+
+/**
+ * Per-room preview-decrypt timeout tracking (WEE-96 A4).
+ *
+ * - `noteResolving(roomId)` arms a one-shot timer; when it fires, the room is
+ *   marked timed-out (reactive → the row re-renders skeleton → label once).
+ * - `noteReady(roomId)` cancels a pending timer when the preview decrypts
+ *   BEFORE the timeout — without this, the timer still fired after success
+ *   and the reactive Set mutation re-rendered the row a second time for no
+ *   visible change.
+ * - A room that DID time out stays timed-out: a later encrypted preview shows
+ *   the label immediately instead of re-entering the skeleton phase, so a
+ *   late decrypt success is a single label → text transition.
+ */
+export function usePreviewTimeout(timeoutMs: number = PREVIEW_DECRYPT_TIMEOUT_MS) {
+  const timedOut = reactive(new Set<string>());
+  // Plain Map — timers are bookkeeping, not render state
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  function noteResolving(roomId: string): void {
+    if (timedOut.has(roomId) || timers.has(roomId)) return;
+    timers.set(roomId, setTimeout(() => {
+      timers.delete(roomId);
+      timedOut.add(roomId); // reactive → preview re-renders as the label
+    }, timeoutMs));
+  }
+
+  function noteReady(roomId: string): void {
+    const timer = timers.get(roomId);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timers.delete(roomId);
+    }
+  }
+
+  function isTimedOut(roomId: string): boolean {
+    return timedOut.has(roomId);
+  }
+
+  function dispose(): void {
+    for (const timer of timers.values()) clearTimeout(timer);
+    timers.clear();
+  }
+
+  if (getCurrentScope()) onScopeDispose(dispose);
+
+  return { noteResolving, noteReady, isTimedOut, dispose };
+}

--- a/src/features/contacts/ui/ContactList.vue
+++ b/src/features/contacts/ui/ContactList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, reactive, computed, nextTick, watch, onUnmounted, triggerRef } from "vue";
+import { ref, computed, nextTick, watch, onUnmounted, triggerRef } from "vue";
+import { usePreviewTimeout } from "../model/use-preview-timeout";
 import { useChatStore } from "@/entities/chat";
 import type { ChatRoom, Message } from "@/entities/chat";
 import { MessageType, MessageStatus } from "@/entities/chat";
@@ -215,34 +216,23 @@ function getRoomTitle(room: ChatRoom): DisplayResult {
   );
 }
 
-// Cap the preview decryption skeleton: after this long we stop showing an
-// indefinite shimmer and surface a "🔒 Encrypted message" label instead. The
-// background DecryptionWorker keeps retrying and will replace it once decrypted.
-const PREVIEW_DECRYPT_TIMEOUT_MS = 10_000;
-const previewTimedOut = reactive(new Set<string>());
-const previewTimers = new Map<string, ReturnType<typeof setTimeout>>();
-
-function notePreviewResolving(roomId: string): void {
-  if (previewTimedOut.has(roomId) || previewTimers.has(roomId)) return;
-  previewTimers.set(roomId, setTimeout(() => {
-    previewTimers.delete(roomId);
-    previewTimedOut.add(roomId); // reactive → preview re-renders as the label
-  }, PREVIEW_DECRYPT_TIMEOUT_MS));
-}
+// Preview-decrypt skeleton timeout — extracted to a composable (WEE-96 A4):
+// the timer is cancelled when the preview decrypts in time, so the row isn't
+// re-rendered a second time by a stale timeout firing after success.
+const {
+  noteResolving: notePreviewResolving,
+  noteReady: notePreviewReady,
+  isTimedOut: isPreviewTimedOut,
+} = usePreviewTimeout();
 
 /** Resolving preview that degrades to the encrypted label after the timeout. */
 function resolvingPreview(roomId: string): DisplayResult {
   notePreviewResolving(roomId);
-  if (previewTimedOut.has(roomId)) {
+  if (isPreviewTimedOut(roomId)) {
     return { state: "failed", text: t("message.encryptedPreview") };
   }
   return { state: "resolving", text: "" };
 }
-
-onUnmounted(() => {
-  for (const timer of previewTimers.values()) clearTimeout(timer);
-  previewTimers.clear();
-});
 
 /** Unified display state for message preview: resolving → skeleton, failed → fallback, ready → text */
 function getPreview(room: ChatRoom): DisplayResult {
@@ -265,9 +255,10 @@ function getPreview(room: ChatRoom): DisplayResult {
       cleaned,
       room.lastMessage.decryptionStatus,
       t("message.encryptedPreview"),
-      { timedOut: previewTimedOut.has(room.id) },
+      { timedOut: isPreviewTimedOut(room.id) },
     );
     if (res.state === "resolving") notePreviewResolving(room.id);
+    else notePreviewReady(room.id);
     return res;
   }
   // Fallback: if Dexie doesn't have lastMessage but messages[] does (loaded via viewport-fetch),
@@ -294,9 +285,10 @@ function getPreview(room: ChatRoom): DisplayResult {
       cleaned,
       last.decryptionStatus,
       t("message.encryptedPreview"),
-      { timedOut: previewTimedOut.has(room.id) },
+      { timedOut: isPreviewTimedOut(room.id) },
     );
     if (res.state === "resolving") notePreviewResolving(room.id);
+    else notePreviewReady(room.id);
     return res;
   }
   // No lastMessage and no in-memory messages.

--- a/src/shared/lib/run-in-batches.test.ts
+++ b/src/shared/lib/run-in-batches.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from "vitest";
+import { runInBatches } from "./run-in-batches";
+
+describe("runInBatches", () => {
+  test("preserves input order in results", async () => {
+    const items = [1, 2, 3, 4, 5, 6, 7];
+    const results = await runInBatches(items, 3, async (n) => n * 10);
+    expect(results).toEqual([10, 20, 30, 40, 50, 60, 70]);
+  });
+
+  test("runs items within a batch concurrently, batches sequentially", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const items = Array.from({ length: 10 }, (_, i) => i);
+
+    await runInBatches(items, 5, async (n) => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+      return n;
+    });
+
+    // Parallel inside a batch (regression for WEE-96: previews were strictly
+    // sequential), but never more than one batch at a time.
+    expect(maxInFlight).toBe(5);
+  });
+
+  test("calls betweenBatches between batches but not after the last one", async () => {
+    let yields = 0;
+    await runInBatches([1, 2, 3, 4, 5], 2, async (n) => n, async () => {
+      yields++;
+    });
+    // 3 batches → 2 yields
+    expect(yields).toBe(2);
+  });
+
+  test("handles empty input", async () => {
+    const results = await runInBatches([], 5, async (n) => n);
+    expect(results).toEqual([]);
+  });
+
+  test("rejects when size < 1", async () => {
+    await expect(runInBatches([1], 0, async (n) => n)).rejects.toThrow("size must be >= 1");
+  });
+
+  test("propagates mapper rejection (Promise.all semantics)", async () => {
+    await expect(
+      runInBatches([1, 2], 2, async (n) => {
+        if (n === 2) throw new Error("boom");
+        return n;
+      }),
+    ).rejects.toThrow("boom");
+  });
+});

--- a/src/shared/lib/run-in-batches.ts
+++ b/src/shared/lib/run-in-batches.ts
@@ -1,0 +1,29 @@
+/**
+ * Run an async mapper over items in parallel batches of `size`.
+ *
+ * Items inside a batch run concurrently (Promise.all); batches run
+ * sequentially with an optional `betweenBatches` hook (e.g. yieldToMain)
+ * so long pipelines don't starve rendering/input on the main thread.
+ *
+ * The mapper is expected to handle its own errors — a rejection inside a
+ * batch rejects the whole call (Promise.all semantics).
+ */
+export async function runInBatches<T, R>(
+  items: readonly T[],
+  size: number,
+  fn: (item: T) => Promise<R>,
+  betweenBatches?: () => Promise<void>,
+): Promise<R[]> {
+  if (size < 1) throw new Error("runInBatches: size must be >= 1");
+
+  const results: R[] = [];
+  for (let i = 0; i < items.length; i += size) {
+    const batch = items.slice(i, i + size);
+    const settled = await Promise.all(batch.map(fn));
+    results.push(...settled);
+    if (betweenBatches && i + size < items.length) {
+      await betweenBatches();
+    }
+  }
+  return results;
+}


### PR DESCRIPTION
## Summary
- `decryptRoomPreviews()` расшифровывает превью параллельными батчами по 5 комнат (yield между батчами) вместо строго последовательного цикла — тяжёлая криптография (ECDH + PBKDF2 + AES-SIV) идёт в crypto worker. При недоступном воркере batch=1, чтобы не возвращать long tasks.
- Main-thread фолбэк для `_decrypt`/`_encrypt`: `isCryptoWorkerSupported()` / `isWorkerInfraError()` в bridge (name-tagged ошибки, один retry создания воркера перед латчем). Инфра-ошибки → фолбэк на `eaa.aeskeys`-путь; крипто-ошибки (`emptykey`, MAC failure) пробрасываются.
- Скелетон-таймаут превью вынесен в composable `usePreviewTimeout`: таймер отменяется при успешной расшифровке до таймаута (нет лишнего ререндера строки).
- **Follow-up (`79b14e9`), по результатам тестирования:** при холодном старте sync-проходы выжигали retry-бюджет, пока RPC/Tor прогревались → превью застревали на «Encrypted message» до захода в чат. Добавлен `retryEncryptedPreviews()` — проходы со свежим бюджетом через 10s/30s/90s после initial sync (таймеры отменяются в `cleanup()`) + ротация cap-окна в 20 комнат, чтобы retry-проходы доходили до комнат 21+.

## Linear
- Resolves WEE-96 (https://linear.app/wwwee/issue/WEE-96)

## Test plan
- [x] `vite build` passed; `vue-tsc` — 0 ошибок в изменённых файлах (baseline чистого дерева: 68 pre-existing)
- [x] Unit tests: `run-in-batches.test.ts` (6), `use-preview-timeout.test.ts` (7), `bridge-support.test.ts` (8, через стаб Worker), `preview-decrypt-retry.test.ts` (4) — 25/25 pass
- [x] Полный suite: 2704 pass / 17 fail — все 17 воспроизводятся на чистом дереве (pre-existing baseline)
- [x] Manual QA: холодный старт — превью зашифрованных комнат появляются без захода в чат; список не фризит