### PR TITLE
perf(send): per-room outbound queues in SyncEngine — no cross-room head-of-line blocking (WEE-94)

### DIFF
--- a/src/shared/lib/local-db/__tests__/sync-engine-per-room.test.ts
+++ b/src/shared/lib/local-db/__tests__/sync-engine-per-room.test.ts
@@ -1,0 +1,492 @@
+/**
+ * Regression coverage for WEE-94: per-room outbound queues in SyncEngine.
+ *
+ * Before the fix processTick() claimed ONE op per tick from a global FIFO —
+ * a slow send (heavy encryption, slow link, retry backoff) in room A delayed
+ * sends in rooms B…Z (head-of-line blocking).
+ *
+ * Invariants under test:
+ *   A1 — a hung/retrying send in room A must not delay a send in room B;
+ *   A2 — message order within one room stays strictly FIFO, including while
+ *        the room's head op is waiting out a retry backoff;
+ *   A3 — multi-tab: the atomic claim is preserved (no op runs twice) AND a
+ *        room busy in another tab is not entered out of order;
+ *   bounded parallelism — at most MAX_CONCURRENT_ROOMS rooms in flight.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Dexie from "dexie";
+import "fake-indexeddb/auto";
+import { SyncEngine } from "../sync-engine";
+import type { PendingOperation, LocalMessage, LocalRoom } from "../schema";
+
+// --- Matrix mock -------------------------------------------------------------
+
+const mockMatrix = {
+  sendEncryptedText: vi.fn<
+    (roomId: string, content: unknown, clientId?: string) => Promise<string>
+  >(async () => "$server_event_id"),
+  sendText: vi.fn<(roomId: string, body: string) => Promise<string>>(
+    async () => "$server_event_id",
+  ),
+};
+
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: () => mockMatrix,
+}));
+
+// --- Test DB -----------------------------------------------------------------
+
+class TestDb extends Dexie {
+  messages!: Dexie.Table<LocalMessage, number>;
+  rooms!: Dexie.Table<LocalRoom, string>;
+  pendingOps!: Dexie.Table<PendingOperation, number>;
+  attachments!: Dexie.Table<{ id?: number; localBlob?: Blob; size?: number }, number>;
+  users!: Dexie.Table<{ address: string }, string>;
+  syncState!: Dexie.Table<{ key: string; value: string | number }, string>;
+  decryptionQueue!: Dexie.Table<{ id?: number; status: string }, number>;
+  listenedMessages!: Dexie.Table<{ messageId: string }, string>;
+
+  constructor(name: string) {
+    super(name, { indexedDB, IDBKeyRange });
+    this.version(1).stores({
+      messages:
+        "++localId, eventId, clientId, [roomId+timestamp], [roomId+status], senderId",
+      rooms: "id, updatedAt, membership, isDeleted",
+      pendingOps:
+        "++id, [roomId+createdAt], status, clientId, [status+nextAttemptAt]",
+      attachments: "++id, messageLocalId, status",
+      users: "address, updatedAt",
+      syncState: "key",
+      decryptionQueue: "++id, status, [status+nextAttemptAt]",
+      listenedMessages: "messageId",
+    });
+  }
+}
+
+// --- Helpers -----------------------------------------------------------------
+
+interface Harness {
+  db: TestDb;
+  engine: SyncEngine;
+}
+
+function makeHarness(name: string): Harness {
+  const db = new TestDb(name);
+  const messageRepo = {
+    confirmSent: vi.fn(async () => undefined),
+    updateStatus: vi.fn(async () => undefined),
+    getByEventId: vi.fn(async () => undefined),
+    updateReactions: vi.fn(async () => undefined),
+    getByClientId: vi.fn(async () => undefined),
+  };
+  const roomRepo = {
+    updateRoom: vi.fn(async () => undefined),
+    syncLastMessageLocalStatus: vi.fn(async () => undefined),
+  };
+  const engine = new SyncEngine(
+    db as never,
+    messageRepo as never,
+    roomRepo as never,
+    vi.fn(async () => undefined), // plain-text path
+  );
+  return { db, engine };
+}
+
+async function seedOp(
+  db: TestDb,
+  overrides: Partial<PendingOperation> = {},
+): Promise<number> {
+  return db.pendingOps.add({
+    type: "send_message",
+    roomId: "!room:server",
+    payload: { content: "hello" },
+    status: "pending",
+    retries: 0,
+    maxRetries: 5,
+    createdAt: Date.now(),
+    clientId: `cli_${Math.random().toString(36).slice(2)}`,
+    nextAttemptAt: 0,
+    ...overrides,
+  } as PendingOperation);
+}
+
+/** Deferred promise the test can resolve/reject on demand — models a send
+ *  hanging on slow encryption / slow network. */
+function deferred<T>(): { promise: Promise<T>; resolve: (v: T) => void; reject: (e: unknown) => void } {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function waitTicks(n = 1): Promise<void> {
+  return new Promise((resolve) => {
+    let remaining = n;
+    function next(): void {
+      if (remaining-- <= 0) resolve();
+      else setTimeout(next, 0);
+    }
+    next();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SyncEngine — per-room queues (WEE-94)", () => {
+  let h: Harness;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockMatrix.sendEncryptedText.mockImplementation(async () => "$server_event_id");
+    h = makeHarness(`sync-engine-per-room-${Date.now()}-${Math.random()}`);
+    await h.db.open();
+  });
+
+  afterEach(async () => {
+    h.engine.dispose();
+    await waitTicks(2); // let spawned workers observe `disposed` before db teardown
+    await h.db.delete();
+  });
+
+  it("A1: a hung send in room A does not delay a send in room B", async () => {
+    const hung = deferred<string>();
+    mockMatrix.sendEncryptedText.mockImplementation(async (roomId: string) => {
+      if (roomId === "!a:s") return hung.promise; // room A: hangs until released
+      return "$ok";
+    });
+
+    await seedOp(h.db, { clientId: "op_a", roomId: "!a:s", payload: { content: "slow" } });
+    await seedOp(h.db, { clientId: "op_b", roomId: "!b:s", payload: { content: "fast" } });
+
+    h.engine.processQueue();
+
+    // Room B completes while room A is still in flight.
+    await vi.waitFor(
+      async () => {
+        const b = await h.db.pendingOps.where("clientId").equals("op_b").first();
+        expect(b).toBeUndefined(); // delivered → op deleted
+      },
+      { timeout: 2000, interval: 10 },
+    );
+    const a = await h.db.pendingOps.where("clientId").equals("op_a").first();
+    expect(a?.status).toBe("syncing"); // still in flight, not failed
+
+    // Release room A — it must complete too.
+    hung.resolve("$a_done");
+    await vi.waitFor(
+      async () => {
+        expect(await h.db.pendingOps.count()).toBe(0);
+      },
+      { timeout: 2000, interval: 10 },
+    );
+  });
+
+  it("A1: a retrying (backoff) op in room A does not delay room B", async () => {
+    mockMatrix.sendEncryptedText.mockImplementation(async (roomId: string) => {
+      if (roomId === "!a:s") throw new Error("transient network");
+      return "$ok";
+    });
+
+    await seedOp(h.db, { clientId: "op_a", roomId: "!a:s" });
+    await seedOp(h.db, { clientId: "op_b", roomId: "!b:s" });
+
+    const start = Date.now();
+    h.engine.processQueue();
+
+    await vi.waitFor(
+      async () => {
+        const b = await h.db.pendingOps.where("clientId").equals("op_b").first();
+        expect(b).toBeUndefined();
+      },
+      { timeout: 2000, interval: 10 },
+    );
+    // Min backoff is 2s — finishing under it proves B never waited for A.
+    expect(Date.now() - start).toBeLessThan(2000);
+
+    const a = await h.db.pendingOps.where("clientId").equals("op_a").first();
+    expect(a?.status).toBe("pending");
+    expect(a?.retries).toBe(1);
+  });
+
+  it("A2: order within one room is strictly FIFO", async () => {
+    const sent: string[] = [];
+    mockMatrix.sendEncryptedText.mockImplementation(
+      async (_roomId: string, content: unknown) => {
+        // Random per-send latency would surface order inversions if ops of
+        // one room ever ran concurrently.
+        await new Promise((r) => setTimeout(r, Math.random() * 10));
+        sent.push((content as { body: string }).body);
+        return "$ok";
+      },
+    );
+
+    for (let i = 1; i <= 5; i++) {
+      await seedOp(h.db, {
+        clientId: `op_${i}`,
+        roomId: "!same:s",
+        payload: { content: `msg ${i}` },
+      });
+    }
+
+    h.engine.processQueue();
+    await vi.waitFor(
+      async () => {
+        expect(await h.db.pendingOps.count()).toBe(0);
+      },
+      { timeout: 3000, interval: 10 },
+    );
+
+    expect(sent).toEqual(["msg 1", "msg 2", "msg 3", "msg 4", "msg 5"]);
+  });
+
+  it("A2: a later message must NOT overtake a retrying head in the same room", async () => {
+    let firstAttempts = 0;
+    mockMatrix.sendEncryptedText.mockImplementation(
+      async (_roomId: string, content: unknown) => {
+        const body = (content as { body: string }).body;
+        if (body === "first" && ++firstAttempts === 1) {
+          throw new Error("transient");
+        }
+        return "$ok";
+      },
+    );
+
+    const firstId = await seedOp(h.db, {
+      clientId: "op_first",
+      roomId: "!same:s",
+      payload: { content: "first" },
+    });
+    await seedOp(h.db, {
+      clientId: "op_second",
+      roomId: "!same:s",
+      payload: { content: "second" },
+    });
+
+    h.engine.processQueue();
+
+    // Head fails and enters backoff…
+    await vi.waitFor(
+      async () => {
+        const first = await h.db.pendingOps.where("clientId").equals("op_first").first();
+        expect(first?.retries).toBe(1);
+      },
+      { timeout: 1000, interval: 10 },
+    );
+    await waitTicks(4);
+
+    // …and the second op of the SAME room must still be untouched: one send
+    // attempt total (the failed head), second op still pending.
+    expect(mockMatrix.sendEncryptedText).toHaveBeenCalledTimes(1);
+    const second = await h.db.pendingOps.where("clientId").equals("op_second").first();
+    expect(second?.status).toBe("pending");
+
+    // Fast-forward the backoff; both flush in order.
+    await h.db.pendingOps.update(firstId, { nextAttemptAt: 0 });
+    h.engine.processQueue();
+    await vi.waitFor(
+      async () => {
+        expect(await h.db.pendingOps.count()).toBe(0);
+      },
+      { timeout: 2000, interval: 10 },
+    );
+    const bodies = mockMatrix.sendEncryptedText.mock.calls.map(
+      (c) => (c[1] as { body: string }).body,
+    );
+    expect(bodies).toEqual(["first", "first", "second"]);
+  });
+
+  it("A3: multi-tab — same op never executes twice, same room never runs concurrently", async () => {
+    const inFlightByRoom = new Map<string, number>();
+    let maxSameRoomConcurrency = 0;
+    mockMatrix.sendEncryptedText.mockImplementation(
+      async (roomId: string, content: unknown) => {
+        const current = (inFlightByRoom.get(roomId) ?? 0) + 1;
+        inFlightByRoom.set(roomId, current);
+        maxSameRoomConcurrency = Math.max(maxSameRoomConcurrency, current);
+        await new Promise((r) => setTimeout(r, 20));
+        inFlightByRoom.set(roomId, current - 1);
+        return `$ok_${(content as { body: string }).body}`;
+      },
+    );
+
+    // Second engine instance on the SAME db (simulates multi-tab browser).
+    const db2 = h.db;
+    const engineB = new SyncEngine(
+      db2 as never,
+      {
+        confirmSent: vi.fn(async () => undefined),
+        updateStatus: vi.fn(async () => undefined),
+        getByEventId: vi.fn(async () => undefined),
+        updateReactions: vi.fn(async () => undefined),
+        getByClientId: vi.fn(async () => undefined),
+      } as never,
+      {
+        updateRoom: vi.fn(async () => undefined),
+        syncLastMessageLocalStatus: vi.fn(async () => undefined),
+      } as never,
+      vi.fn(async () => undefined) as never,
+    );
+
+    await seedOp(h.db, { clientId: "op_1", roomId: "!same:s", payload: { content: "one" } });
+    await seedOp(h.db, { clientId: "op_2", roomId: "!same:s", payload: { content: "two" } });
+
+    h.engine.processQueue();
+    engineB.processQueue();
+
+    await vi.waitFor(
+      async () => {
+        expect(await h.db.pendingOps.count()).toBe(0);
+      },
+      { timeout: 3000, interval: 10 },
+    );
+    await waitTicks(3);
+
+    // Exactly two sends — one per op (no duplicate execution)…
+    expect(mockMatrix.sendEncryptedText).toHaveBeenCalledTimes(2);
+    // …and never two ops of the same room in flight at once (FIFO held).
+    expect(maxSameRoomConcurrency).toBe(1);
+    const bodies = mockMatrix.sendEncryptedText.mock.calls.map(
+      (c) => (c[1] as { body: string }).body,
+    );
+    expect(bodies).toEqual(["one", "two"]);
+
+    engineB.dispose();
+  });
+
+  it("pull-forward: a fresh send enqueued during a backoff wake is not delayed by it", async () => {
+    mockMatrix.sendEncryptedText.mockImplementation(async (roomId: string) => {
+      if (roomId === "!a:s") throw new Error("transient");
+      return "$ok";
+    });
+
+    // Room A fails and schedules a ~2-3s backoff wake (the only timer).
+    await seedOp(h.db, { clientId: "op_a", roomId: "!a:s" });
+    h.engine.processQueue();
+    await vi.waitFor(
+      async () => {
+        const a = await h.db.pendingOps.where("clientId").equals("op_a").first();
+        expect(a?.retries).toBe(1);
+      },
+      { timeout: 1000, interval: 10 },
+    );
+    await waitTicks(2); // let the wake timer get armed
+
+    // A fresh send in room B arrives while only the far-future wake exists.
+    // Before the scheduledAt pull-forward it waited out the backoff timer
+    // (or the 30s watchdog); now it must go out immediately.
+    const start = Date.now();
+    await seedOp(h.db, { clientId: "op_b", roomId: "!b:s" });
+    h.engine.processQueue();
+
+    await vi.waitFor(
+      async () => {
+        const b = await h.db.pendingOps.where("clientId").equals("op_b").first();
+        expect(b).toBeUndefined();
+      },
+      { timeout: 1500, interval: 10 },
+    );
+    expect(Date.now() - start).toBeLessThan(1500); // min backoff is 2s
+  });
+
+  it("runs at most MAX_CONCURRENT_ROOMS (3) rooms in parallel", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const gates: Array<() => void> = [];
+    mockMatrix.sendEncryptedText.mockImplementation(async () => {
+      inFlight++;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise<void>((r) => gates.push(r));
+      inFlight--;
+      return "$ok";
+    });
+
+    for (let i = 1; i <= 5; i++) {
+      await seedOp(h.db, { clientId: `op_${i}`, roomId: `!r${i}:s` });
+    }
+
+    h.engine.processQueue();
+
+    // The pool fills to exactly 3 and holds there while sends are gated.
+    await vi.waitFor(() => expect(inFlight).toBe(3), { timeout: 2000, interval: 10 });
+    await waitTicks(4);
+    expect(maxInFlight).toBe(3);
+
+    // Releasing sends lets the remaining rooms cycle through the pool.
+    const releaseAll = setInterval(() => {
+      gates.splice(0).forEach((release) => release());
+    }, 10);
+    try {
+      await vi.waitFor(
+        async () => {
+          expect(await h.db.pendingOps.count()).toBe(0);
+        },
+        { timeout: 3000, interval: 10 },
+      );
+    } finally {
+      clearInterval(releaseAll);
+    }
+    expect(maxInFlight).toBe(3);
+  });
+});
+
+describe("SyncEngine — watchdog releases expired 'syncing' claims (WEE-94)", () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMatrix.sendEncryptedText.mockImplementation(async () => "$server_event_id");
+    // Fake ONLY setInterval/clearInterval — keep setTimeout real so
+    // fake-indexeddb's internal queue and vi.waitFor still work.
+    vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+  });
+
+  afterEach(async () => {
+    h?.engine.dispose();
+    vi.useRealTimers();
+    await waitTicks(2);
+    await h?.db.delete();
+  });
+
+  it("an expired claim (crashed tab) unblocks its room on the next watchdog tick", async () => {
+    h = makeHarness(`sync-engine-lease-${Date.now()}-${Math.random()}`);
+    await h.db.open();
+
+    // A "syncing" row stranded by a crashed sibling tab 7 minutes ago…
+    await seedOp(h.db, {
+      clientId: "op_stuck",
+      roomId: "!x:s",
+      status: "syncing",
+      lastAttemptAt: Date.now() - 7 * 60_000,
+    });
+    // …and a newer pending op of the SAME room, blocked behind it.
+    await seedOp(h.db, { clientId: "op_blocked", roomId: "!x:s" });
+
+    // The room is busy from the engine's point of view — nothing is claimable.
+    h.engine.processQueue();
+    await waitTicks(4);
+    expect(mockMatrix.sendEncryptedText).not.toHaveBeenCalled();
+    expect(
+      (await h.db.pendingOps.where("clientId").equals("op_blocked").first())?.status,
+    ).toBe("pending");
+
+    // Watchdog tick (30s): the expired lease is released and the room drains
+    // in FIFO order — the formerly-stuck head first, then the blocked op.
+    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.waitFor(
+      async () => {
+        expect(await h.db.pendingOps.count()).toBe(0);
+      },
+      { timeout: 3000, interval: 10 },
+    );
+    const order = mockMatrix.sendEncryptedText.mock.calls.map(
+      (c) => (c[1] as { body: string }).body,
+    );
+    expect(order).toEqual(["hello", "hello"]); // both default payloads, 2 sends
+    expect(mockMatrix.sendEncryptedText).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/shared/lib/local-db/sync-engine.ts
+++ b/src/shared/lib/local-db/sync-engine.ts
@@ -11,6 +11,14 @@ type OnChangeCallback = (roomId: string) => void;
 const MAX_BACKOFF_MS = 30_000;
 const MIN_BACKOFF_MS = 1_000;
 
+/** Max rooms processed concurrently (WEE-94). Outbound ops stay strictly FIFO
+ *  *within* a room (message order is a hard invariant), but a slow room —
+ *  heavy encryption, slow link, retry backoff — must not head-of-line block
+ *  sends in other rooms. 3 mirrors the `mediaDownloadGate` budget from
+ *  use-file-download: enough overlap to hide one stuck room, small enough not
+ *  to saturate CPU/network on low-end Android. */
+const MAX_CONCURRENT_ROOMS = 3;
+
 /** Re-check interval while the Matrix client is not ready (boot / re-init).
  *  A claimed send op is released back to "pending" WITHOUT counting a retry
  *  and re-polled at this cadence, so messages sent during the not-ready
@@ -36,6 +44,13 @@ const SEND_OPS: ReadonlySet<PendingOperation["type"]> = new Set([
  *  tick we look for stuck pending ops and resume the queue if the underlying
  *  network is actually available. */
 const WATCHDOG_INTERVAL_MS = 30_000;
+
+/** Lease on a claimed ("syncing") op. Under per-room claims (WEE-94) a
+ *  stranded "syncing" row — crashed sibling tab, unexpected rejection —
+ *  blocks its whole room, not just itself, so the watchdog releases claims
+ *  older than this back to "pending". Must comfortably exceed the slowest
+ *  legitimate op: media encrypt (30s) + upload (4min) + send event (20s). */
+const SYNCING_LEASE_MS = 6 * 60_000;
 
 /** Per-phase media pipeline timeouts. Splitting one 5-minute cap into
  *  per-phase caps lets retries surface phase-specific failures (e.g. crypto
@@ -158,7 +173,8 @@ async function uploadWithRetry(
  *
  * Lifecycle:
  *   1. User action → MessageRepository writes to local DB + creates PendingOp
- *   2. SyncEngine.processQueue() picks up ops in FIFO order
+ *   2. SyncEngine.processQueue() picks up ops — strictly FIFO within a room,
+ *      up to MAX_CONCURRENT_ROOMS rooms in parallel (WEE-94)
  *   3. Each op: encrypt if needed → call Matrix API → update local message status
  *   4. On failure: exponential backoff + retry, or mark as "failed"
  *
@@ -166,11 +182,23 @@ async function uploadWithRetry(
  * `setOnline(true)` resumes.
  */
 export class SyncEngine {
+  /** True while the claim loop in processTick is running. Serializes claiming
+   *  (op execution itself runs concurrently per room — see `activeRooms`). */
   private processing = false;
+  /** Rooms with an op currently executing in THIS engine instance. Bounded by
+   *  MAX_CONCURRENT_ROOMS; claimDueOp skips these rooms so per-room FIFO holds. */
+  private activeRooms = new Set<string>();
+  /** A kick arrived while the claim loop was running. processTick re-runs the
+   *  loop once after it finishes so a room freed mid-loop is not stranded
+   *  until the watchdog. */
+  private rekick = false;
   private online = true;
   private scheduled = false;
   private disposed = false;
   private scheduledTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Epoch ms when the pending scheduledTimer fires; lets kickScheduler pull
+   *  an existing far-future wake (retry backoff) forward for new work. */
+  private scheduledAt = 0;
   /** Watchdog interval handle. Drains stuck queues even when no
    *  connectivity transition signal arrives (Android WebView sleep+wake). */
   private watchdogTimer: ReturnType<typeof setInterval> | null = null;
@@ -307,10 +335,11 @@ export class SyncEngine {
   // ---------------------------------------------------------------------------
 
   /**
-   * Process one op from the queue per tick, then yield to the event loop.
-   * Re-schedules itself via setTimeout until the queue is empty or a retry
-   * is not yet due. This prevents head-of-line blocking: a single failing op
-   * cannot hold the queue for its 30s backoff.
+   * Kick the claim loop. Each tick claims due ops — at most one in-flight op
+   * per room, at most MAX_CONCURRENT_ROOMS rooms in parallel (WEE-94) — and
+   * executes them concurrently. Within a room, order is strictly FIFO: only
+   * the room's head op is ever claimed, so a retrying head blocks its own
+   * room (message order is a hard invariant) but never other rooms.
    *
    * External callers use the public `processQueue()` which is a thin wrapper
    * kicking off the first tick without double-scheduling.
@@ -361,6 +390,8 @@ export class SyncEngine {
    *     wake-up timer was cleared; kick a fresh tick.
    */
   private async watchdogCheck(): Promise<void> {
+    await this.releaseExpiredClaims();
+
     const pending = await this.db.pendingOps
       .where("status")
       .anyOf(["pending", "syncing"])
@@ -382,114 +413,117 @@ export class SyncEngine {
     }
   }
 
-  /** Schedule processTick after `delayMs` unless a tick is already pending. */
+  /** Release "syncing" claims whose lease expired (WEE-94 self-heal). A row
+   *  stranded by a crashed sibling tab or a failed bookkeeping write blocks
+   *  its whole room under per-room claims, and recoverStrandedOps only runs
+   *  at startup — so the watchdog sweeps expired leases each tick. Rooms
+   *  with a live worker in THIS engine are skipped: their op is legitimately
+   *  in flight even if (pathologically) past the lease. Retries are NOT
+   *  incremented — recovery is not a transport failure. */
+  private async releaseExpiredClaims(): Promise<void> {
+    const cutoff = Date.now() - SYNCING_LEASE_MS;
+    const expired = await this.db.pendingOps
+      .where("status")
+      .equals("syncing")
+      .filter(
+        (op) =>
+          !this.activeRooms.has(op.roomId) &&
+          (op.lastAttemptAt ?? op.createdAt ?? 0) <= cutoff,
+      )
+      .toArray();
+    if (expired.length === 0) return;
+
+    console.info(
+      `[SyncEngine] watchdog: releasing ${expired.length} expired "syncing" claim(s)`,
+    );
+    for (const op of expired) {
+      await this.db.pendingOps.update(op.id!, {
+        status: "pending",
+        nextAttemptAt: Date.now(),
+      });
+    }
+  }
+
+  /** Schedule processTick after `delayMs` unless a tick is already pending.
+   *  A kick that arrives while the claim loop itself is running is deferred
+   *  via `rekick` (not dropped) — the loop re-runs once after finishing, so
+   *  a room freed by a just-completed worker is picked up immediately. */
   private kickScheduler(delayMs: number): void {
-    if (this.disposed || this.scheduled || this.processing || !this.online) return;
+    if (this.disposed || !this.online) return;
+    if (this.processing) {
+      this.rekick = true;
+      return;
+    }
+    const fireAt = Date.now() + Math.max(0, delayMs);
+    if (this.scheduled) {
+      // A timer is already pending. Keep it if it fires soon enough;
+      // otherwise pull it forward — e.g. a fresh send enqueued while the
+      // only pending timer is a 30s backoff wake must process immediately,
+      // not wait out the backoff (or the 30s watchdog).
+      if (fireAt >= this.scheduledAt) return;
+      if (this.scheduledTimer !== null) {
+        clearTimeout(this.scheduledTimer);
+        this.scheduledTimer = null;
+      }
+    }
     this.scheduled = true;
+    this.scheduledAt = fireAt;
     this.scheduledTimer = setTimeout(() => {
       this.scheduledTimer = null;
       this.processTick();
     }, Math.max(0, delayMs));
   }
 
+  /**
+   * Claim loop (WEE-94): claim due ops from distinct rooms until either no
+   * claimable op remains or MAX_CONCURRENT_ROOMS workers are in flight.
+   * Each claimed op is executed concurrently via runClaimedOp; its completion
+   * frees the room and kicks the scheduler again.
+   */
   private async processTick(): Promise<void> {
     this.scheduled = false;
     if (this.disposed || this.processing || !this.online) return;
     this.processing = true;
 
-    let op: PendingOperation | null = null;
     let nextRetryDelay: number | null = null; // smallest remaining wait
 
     try {
-      // Claim one due pending op transactionally so concurrent engines
-      // (multi-tab) can't both pick the same record.
-      op = await this.claimDueOp();
+      while (
+        !this.disposed &&
+        this.online &&
+        this.activeRooms.size < MAX_CONCURRENT_ROOMS
+      ) {
+        // Claim the head op of a free room transactionally so concurrent
+        // engines (multi-tab) can't both pick the same record.
+        const op = await this.claimDueOp();
 
-      if (!op) {
-        // Nothing due right now — check whether an op is scheduled for later
-        // so we can set a wake-up timer and then stop this tick cleanly.
-        nextRetryDelay = await this.findNextRetryDelay();
-        return;
-      }
+        if (!op) {
+          // Nothing claimable right now — check whether an op is scheduled
+          // for later so we can set a wake-up timer in the finally block.
+          nextRetryDelay = await this.findNextRetryDelay();
+          break;
+        }
 
-      // Matrix-readiness gate (WEE-85): during the boot / re-init window the
-      // client object isn't ready (`isReady()` false). Sending now would throw
-      // and burn a retry, so instead release the op back to "pending" WITHOUT
-      // counting a retry and reschedule a short re-poll. The op flushes once
-      // the client is ready — mirroring how `online` gates the whole loop.
-      // Real failures still surface via maxRetries once the client is ready.
-      // NOTE: recovery is intentionally poll-based (this 1s re-poll, backed by
-      // the watchdog) — there is no `onReady` event that re-kicks the scheduler
-      // when Matrix becomes ready.
-      if (!this.isMatrixReady()) {
-        await this.db.pendingOps.update(op.id!, {
-          status: "pending",
-          nextAttemptAt: Date.now() + MATRIX_NOT_READY_RETRY_MS,
+        this.activeRooms.add(op.roomId);
+        // Deliberately NOT awaited — rooms run in parallel. Errors are fully
+        // handled inside runClaimedOp; the finally here only frees the slot.
+        void this.runClaimedOp(op).finally(() => {
+          this.activeRooms.delete(op.roomId);
+          // Re-check the queue: this room is free again, and the op may have
+          // scheduled a retry whose wake-up needs (re)computing.
+          this.kickScheduler(0);
         });
-        op = null; // don't execute; finally schedules the re-poll wake
-        nextRetryDelay = MATRIX_NOT_READY_RETRY_MS;
-        return;
-      }
-
-      try {
-        await this.executeOperation(op);
-        // If dispose() was called while the send was in flight, skip writing
-        // to a DB we no longer own. The send itself already landed server-side;
-        // the next engine instance will reconcile via Matrix sync.
-        if (this.disposed) return;
-        await this.db.pendingOps.delete(op.id!);
-        this.onChange?.(op.roomId);
-      } catch (e) {
-        if (this.disposed) return;
-
-        // Race guard: Matrix may have accepted the event server-side even
-        // though the SDK threw (read timeout, CORS race, etc.). When the
-        // server-side `/sync` echo arrives via EventWriter → upsertFromServer
-        // the local message picks up its eventId and flips to "synced"
-        // before this catch runs. In that case the queued op is already
-        // satisfied — drop it without flagging the message as failed,
-        // otherwise the user sees a red retry indicator on a message the
-        // peer actually received (WEE-40).
-        if (op.clientId && (await this.isMessageAlreadyConfirmed(op.clientId))) {
-          await this.db.pendingOps.delete(op.id!);
-          this.onChange?.(op.roomId);
-          return;
-        }
-
-        const retries = op.retries + 1;
-        if (retries >= op.maxRetries) {
-          await this.db.pendingOps.update(op.id!, {
-            status: "failed",
-            retries,
-            errorMessage: String(e),
-            lastAttemptAt: Date.now(),
-          });
-          await this.markMessageFailed(op);
-          this.onChange?.(op.roomId);
-        } else {
-          const delay = computeBackoff(retries);
-          await this.db.pendingOps.update(op.id!, {
-            status: "pending",
-            retries,
-            lastAttemptAt: Date.now(),
-            nextAttemptAt: Date.now() + delay,
-          });
-          // We don't `await sleep(delay)` here — other due ops must proceed
-          // immediately. The delay is tracked via nextAttemptAt in the DB,
-          // and a wake-up timer is scheduled in the finally block below.
-        }
       }
     } finally {
       this.processing = false;
-      if (this.online) {
-        if (op) {
-          // We just processed one op. Immediately yield and check for the
-          // next due op. claimDueOp will skip any op whose nextAttemptAt is
-          // still in the future.
+      if (this.online && !this.disposed) {
+        if (this.rekick) {
+          // A worker finished (or new work arrived) mid-loop; re-run now.
+          this.rekick = false;
           this.kickScheduler(0);
         } else if (nextRetryDelay !== null) {
-          // Queue is empty of due ops but a retry is scheduled for later.
-          // Set a single wake-up timer so that retry is actually attempted.
+          // No due ops but a retry is scheduled for later. Set a single
+          // wake-up timer so that retry is actually attempted.
           this.scheduleWake(nextRetryDelay);
         }
       }
@@ -497,26 +531,170 @@ export class SyncEngine {
   }
 
   /**
-   * Atomically claim the next due pending op (status = "pending"
-   * and nextAttemptAt <= now). Returns null if nothing is due.
+   * Execute one claimed op and persist the outcome. Never rejects — a
+   * rejection escaping the spawn site's `.finally()` would surface as an
+   * unhandled promise rejection AND leave the op stuck in "syncing",
+   * blocking its whole room under per-room claims. Bookkeeping failures
+   * (Dexie closed during a logout race, quota errors) are caught here and
+   * the claim is released best-effort; the watchdog's SYNCING_LEASE_MS
+   * recovery is the backstop when even the release write fails.
+   */
+  private async runClaimedOp(op: PendingOperation): Promise<void> {
+    try {
+      await this.processClaimedOp(op);
+    } catch (e) {
+      if (this.disposed) return;
+      console.warn("[SyncEngine] op bookkeeping failed, releasing claim:", e);
+      try {
+        await this.db.pendingOps.update(op.id!, {
+          status: "pending",
+          nextAttemptAt: Date.now() + MIN_BACKOFF_MS,
+        });
+      } catch {
+        // DB is gone (logout/teardown race) — nothing to release; a future
+        // engine instance recovers the row via recoverStrandedOps / lease.
+      }
+    }
+  }
+
+  /**
+   * One claimed op: readiness gate → execute → persist success/failure.
+   * Runs concurrently — one in-flight instance per room, bounded by
+   * MAX_CONCURRENT_ROOMS. Transport errors are handled internally
+   * (backoff / failed); only bookkeeping failures propagate to runClaimedOp.
+   */
+  private async processClaimedOp(op: PendingOperation): Promise<void> {
+    // Matrix-readiness gate (WEE-85): during the boot / re-init window the
+    // client object isn't ready (`isReady()` false). Sending now would throw
+    // and burn a retry, so instead release the op back to "pending" WITHOUT
+    // counting a retry and reschedule a short re-poll. The op flushes once
+    // the client is ready — mirroring how `online` gates the whole loop.
+    // Real failures still surface via maxRetries once the client is ready.
+    // NOTE: recovery is intentionally poll-based (the released op's
+    // nextAttemptAt drives a re-poll via findNextRetryDelay, backed by the
+    // watchdog) — there is no `onReady` event that re-kicks the scheduler
+    // when Matrix becomes ready.
+    if (!this.isMatrixReady()) {
+      if (this.disposed) return;
+      await this.db.pendingOps.update(op.id!, {
+        status: "pending",
+        nextAttemptAt: Date.now() + MATRIX_NOT_READY_RETRY_MS,
+      });
+      return;
+    }
+
+    try {
+      await this.executeOperation(op);
+      // If dispose() was called while the send was in flight, skip writing
+      // to a DB we no longer own. The send itself already landed server-side;
+      // the next engine instance will reconcile via Matrix sync.
+      if (this.disposed) return;
+      await this.db.pendingOps.delete(op.id!);
+      this.onChange?.(op.roomId);
+    } catch (e) {
+      if (this.disposed) return;
+
+      // Race guard: Matrix may have accepted the event server-side even
+      // though the SDK threw (read timeout, CORS race, etc.). When the
+      // server-side `/sync` echo arrives via EventWriter → upsertFromServer
+      // the local message picks up its eventId and flips to "synced"
+      // before this catch runs. In that case the queued op is already
+      // satisfied — drop it without flagging the message as failed,
+      // otherwise the user sees a red retry indicator on a message the
+      // peer actually received (WEE-40).
+      if (op.clientId && (await this.isMessageAlreadyConfirmed(op.clientId))) {
+        await this.db.pendingOps.delete(op.id!);
+        this.onChange?.(op.roomId);
+        return;
+      }
+
+      const retries = op.retries + 1;
+      if (retries >= op.maxRetries) {
+        await this.db.pendingOps.update(op.id!, {
+          status: "failed",
+          retries,
+          errorMessage: String(e),
+          lastAttemptAt: Date.now(),
+        });
+        await this.markMessageFailed(op);
+        this.onChange?.(op.roomId);
+      } else {
+        const delay = computeBackoff(retries);
+        await this.db.pendingOps.update(op.id!, {
+          status: "pending",
+          retries,
+          lastAttemptAt: Date.now(),
+          nextAttemptAt: Date.now() + delay,
+        });
+        // We don't `await sleep(delay)` here — ops in other rooms must
+        // proceed immediately. The delay is tracked via nextAttemptAt in the
+        // DB; the post-completion kick recomputes the wake-up timer. Note
+        // that within THIS room the retrying op stays the head, so later
+        // messages in the room wait for it — FIFO order is a hard invariant.
+      }
+    }
+  }
+
+  /**
+   * Atomically claim the next claimable op (WEE-94). An op is claimable when
+   * it is the HEAD of its room's queue (first pending op of the room in
+   * creation order — FIFO within a room is a hard invariant), it is due
+   * (nextAttemptAt <= now), and its room is busy in neither this engine
+   * (`activeRooms`) nor any other tab (a "syncing" op of the same room).
+   * Returns null if nothing is claimable.
    *
-   * Uses the [status+nextAttemptAt] compound index added in v11 so this is
-   * O(log n) even with thousands of queued ops. Freshly-enqueued ops get
-   * nextAttemptAt=0 and are naturally prioritised over retry-scheduled ops
-   * (which have larger nextAttemptAt values). Within the same nextAttemptAt
-   * bucket Dexie falls back to the primary key order, which is creation
-   * order for `++id` — preserving FIFO for fresh sends.
+   * The whole select-and-mark runs in one rw-transaction on pendingOps, same
+   * as before — concurrent engines (multi-tab) can't both claim the same
+   * record, and a room claimed by another tab is excluded via its "syncing"
+   * marker row, so two tabs can't run the same room out of order either.
+   *
+   * Iteration walks the "status" index, whose entries within one status value
+   * are ordered by primary key (`++id` = creation order), and stops at the
+   * first claimable head. The realistic outbound queue is tiny (tens of ops);
+   * the previous O(log n) single-op lookup via [status+nextAttemptAt] cannot
+   * express "head per room", so a short ordered walk replaces it.
    */
   private async claimDueOp(): Promise<PendingOperation | null> {
     return this.db.transaction("rw", this.db.pendingOps, async () => {
       const now = Date.now();
-      const due = await this.db.pendingOps
-        .where("[status+nextAttemptAt]")
-        .between(["pending", -Infinity], ["pending", now], true, true)
-        .first();
-      if (!due) return null;
-      await this.db.pendingOps.update(due.id!, { status: "syncing" });
-      return { ...due, status: "syncing" };
+
+      // Rooms with an op currently in flight somewhere (this tab marks ops
+      // "syncing" too, but activeRooms is checked as well to close the gap
+      // between transaction commit and the worker registering the room).
+      const busyRooms = new Set<string>(this.activeRooms);
+      await this.db.pendingOps
+        .where("status")
+        .equals("syncing")
+        .each((op) => {
+          busyRooms.add(op.roomId);
+        });
+
+      // Walk pending ops in creation order; the first op seen for a room is
+      // that room's head. Only a due head of a free room may be claimed.
+      const seenRooms = new Set<string>();
+      let claimed: PendingOperation | null = null;
+      await this.db.pendingOps
+        .where("status")
+        .equals("pending")
+        .until(() => claimed !== null)
+        .each((op) => {
+          if (claimed || seenRooms.has(op.roomId)) return;
+          seenRooms.add(op.roomId);
+          if (busyRooms.has(op.roomId)) return;
+          if ((op.nextAttemptAt ?? 0) > now) return; // head not due → room waits
+          claimed = op;
+        });
+
+      if (!claimed) return null;
+      const head = claimed as PendingOperation;
+      // lastAttemptAt doubles as the claim lease timestamp — the watchdog
+      // releases "syncing" rows whose lease expired (SYNCING_LEASE_MS).
+      const claimedAt = Date.now();
+      await this.db.pendingOps.update(head.id!, {
+        status: "syncing",
+        lastAttemptAt: claimedAt,
+      });
+      return { ...head, status: "syncing", lastAttemptAt: claimedAt };
     });
   }
 


### PR DESCRIPTION
## Summary
- `claimDueOp()` now atomically claims only the due **head** op of a room that is busy neither locally (`activeRooms`) nor in another tab (existing `"syncing"` row) — strict FIFO within a room, parallelism across rooms.
- The claim loop runs up to `MAX_CONCURRENT_ROOMS = 3` concurrent room workers (budget mirrors `mediaDownloadGate` from WEE-71); a slow/retrying send in room A no longer delays rooms B…Z.
- Scheduler hardening found along the way: `kickScheduler` pulls a far-future backoff wake forward for fresh work (previously a new send enqueued during a 30s backoff wake waited it out), kicks arriving during the claim loop are deferred via `rekick` instead of dropped, `runClaimedOp` never rejects (a leaked rejection would strand the op as `"syncing"` and block its whole room), and the watchdog releases expired claim leases (`SYNCING_LEASE_MS` = 6 min) so a crashed sibling tab can't freeze a room until restart.

## Linear
- Resolves WEE-94 (https://linear.app/wwwee/issue/WEE-94)

## Test plan
- [x] Build + tsc passed locally (no errors in changed files; 50 pre-existing baseline errors untouched)
- [x] Unit/regression tests added: `src/shared/lib/local-db/__tests__/sync-engine-per-room.test.ts` (8 tests — A1 head-of-line ×2, A2 FIFO-in-room ×2, A3 multi-tab claim, bounded parallelism, scheduler pull-forward, watchdog lease release)
- [x] All 264 local-db tests green (incl. existing sync-engine suites — A4); full-suite failures match the pre-existing master baseline (the WEE-64 preview test is flaky on unmodified master too, verified by baseline runs)
- [ ] Manual QA: send messages in two chats while one chat is on a flaky link — second chat must not stall; message order within each chat unchanged