### PR TITLE
perf(chat-open): non-blocking Dexie write, sync liveQuery reset on room switch, unread banner from cache (WEE-95)

### DIFF
--- a/src/entities/chat/model/chat-store-room-switch.test.ts
+++ b/src/entities/chat/model/chat-store-room-switch.test.ts
@@ -1,0 +1,256 @@
+/**
+ * WEE-95 regression tests — chat opens slowly:
+ *  A1: loadRoomMessages must NOT await the Dexie write in the render-critical path
+ *  A2: switching rooms must synchronously drop the previous room's liveQuery
+ *      snapshot — room A's messages never flash inside room B
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia } from "pinia";
+import { createTestingPinia } from "@pinia/testing";
+import { useChatStore } from "./chat-store";
+import { MessageType } from "./types";
+import { makeRoom } from "@/test-utils";
+import type { LocalMessage, LocalRoom } from "@/shared/lib/local-db";
+
+// ── Mock Dexie's liveQuery ────────────────────────────────────────
+// The real liveQuery doesn't emit in the happy-dom test env (no IndexedDB
+// observability hooks) — execute the querier once per subscription instead.
+// Same approach as use-live-query.test.ts.
+vi.mock("dexie", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("dexie")>();
+  return {
+    ...actual,
+    liveQuery: (querier: () => unknown) => ({
+      subscribe(sub: { next: (v: unknown) => void; error: (e: unknown) => void }) {
+        let active = true;
+        Promise.resolve()
+          .then(() => querier())
+          .then(
+            (v) => { if (active) sub.next(v); },
+            (e) => { if (active) sub.error(e); },
+          );
+        return { unsubscribe() { active = false; } };
+      },
+    }),
+  };
+});
+
+// ── Mock matrix client service ────────────────────────────────────
+const makeTimelineEvent = (i: number) => ({
+  event: {
+    type: "m.room.message",
+    content: { msgtype: "m.text", body: `msg ${i}` },
+    event_id: `$e${i}`,
+    sender: "@peer:s",
+    origin_server_ts: 1000 + i,
+  },
+});
+
+const mockMatrixRoom = {
+  roomId: "!a:s",
+  getLiveTimeline: () => ({
+    getEvents: () => Array.from({ length: 25 }, (_, i) => makeTimelineEvent(i)),
+  }),
+  currentState: { getStateEvents: () => [] },
+};
+
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: vi.fn(() => ({
+    getRoom: vi.fn(() => mockMatrixRoom),
+    isReady: vi.fn(() => true),
+    getUserId: vi.fn(() => "@mock:s"),
+    getRooms: vi.fn(() => []),
+    getRoomAccountData: vi.fn(() => null),
+    getIgnoredMatrixUserIds: vi.fn(() => [] as string[]),
+    matrixId: vi.fn((id: string) => id),
+    isMe: vi.fn(() => false),
+    scrollback: vi.fn(() => Promise.resolve()),
+  })),
+  MatrixClientService: vi.fn(),
+  resetMatrixClientService: vi.fn(),
+}));
+
+vi.mock("@/shared/lib/cache/chat-cache", () => ({
+  cacheRooms: vi.fn(() => Promise.resolve()),
+  getCachedRooms: vi.fn(() => Promise.resolve([])),
+  cacheMessages: vi.fn(() => Promise.resolve()),
+  getCachedMessages: vi.fn(() => Promise.resolve([])),
+  getCacheTimestamp: vi.fn(() => Promise.resolve(null)),
+}));
+
+function makeLocalMsg(roomId: string, eventId: string, overrides: Partial<LocalMessage> = {}): LocalMessage {
+  return {
+    eventId,
+    clientId: `c_${eventId}`,
+    roomId,
+    senderId: "peer",
+    content: `content ${eventId}`,
+    timestamp: 1000,
+    type: MessageType.text,
+    status: "synced",
+    version: 1,
+    softDeleted: false,
+    ...overrides,
+  };
+}
+
+function makeLocalRoom(id: string, overrides: Partial<LocalRoom> = {}): LocalRoom {
+  return {
+    id,
+    name: "Room",
+    isGroup: false,
+    members: ["me", "peer"],
+    membership: "join",
+    unreadCount: 0,
+    lastReadInboundTs: 0,
+    lastReadOutboundTs: 0,
+    updatedAt: Date.now(),
+    syncedAt: Date.now(),
+    hasMoreHistory: true,
+    isDeleted: false,
+    deletedAt: null,
+    deleteReason: null,
+    ...overrides,
+  } as LocalRoom;
+}
+
+/** Minimal ChatDbKit mock — enough for setChatDbKit + liveQuery + loadRoomMessages */
+function makeKit(opts: {
+  getMessages?: (roomId: string) => Promise<LocalMessage[]>;
+  writeMessages?: () => Promise<void>;
+} = {}) {
+  return {
+    rooms: {
+      getAllRooms: vi.fn(async () => [makeLocalRoom("!a:s"), makeLocalRoom("!b:s")]),
+      observeRoomChanges: vi.fn(() => () => {}),
+      bulkSyncRooms: vi.fn(async () => {}),
+      getRoom: vi.fn(async () => undefined),
+      updateOutboundWatermark: vi.fn(async () => {}),
+    },
+    messages: {
+      getMessages: vi.fn((roomId: string) =>
+        opts.getMessages ? opts.getMessages(roomId) : Promise.resolve([] as LocalMessage[])),
+      patchUnresolvedReplies: vi.fn(async () => {}),
+      updateReactions: vi.fn(async () => {}),
+      getByEventIds: vi.fn(async () => []),
+    },
+    eventWriter: {
+      enableBatching: vi.fn(),
+      getClearedAtTs: vi.fn(() => undefined),
+      setClearedAtTs: vi.fn(),
+      flushWriteBuffer: vi.fn(() => Promise.resolve()),
+      clearUnread: vi.fn(async () => {}),
+      writeMessages: vi.fn((_msgs: unknown[]) => (opts.writeMessages ? opts.writeMessages() : Promise.resolve())),
+      writeEdit: vi.fn(async () => {}),
+    },
+    retryRoomDecryption: vi.fn(),
+  };
+}
+
+/** Wait for a condition (polls every 10ms, max 2s) */
+async function waitFor(fn: () => boolean, timeout = 2000) {
+  const start = Date.now();
+  while (!fn()) {
+    if (Date.now() - start > timeout) throw new Error("waitFor timed out");
+    await new Promise(r => setTimeout(r, 10));
+  }
+}
+
+describe("WEE-95 A2 — room switch drops stale liveQuery snapshot synchronously", () => {
+  let store: ReturnType<typeof useChatStore>;
+
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    setActivePinia(createTestingPinia({ stubActions: false }));
+    store = useChatStore();
+    store.rooms = [makeRoom({ id: "!a:s" }), makeRoom({ id: "!b:s" })];
+  });
+
+  it("messages of room A never appear in activeMessages after switching to room B", async () => {
+    let resolveB: ((msgs: LocalMessage[]) => void) | undefined;
+    const kit = makeKit({
+      getMessages: (roomId) => {
+        if (roomId === "!a:s") return Promise.resolve([makeLocalMsg("!a:s", "$a1")]);
+        // Room B's Dexie query is slow — the race window from the ticket
+        return new Promise<LocalMessage[]>((res) => { resolveB = res; });
+      },
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store.setChatDbKit(kit as any);
+
+    await store.setActiveRoom("!a:s");
+    await waitFor(() => store.activeMessages.length > 0);
+    expect(store.activeMessages[0]?.roomId).toBe("!a:s");
+
+    await store.setActiveRoom("!b:s");
+
+    // Synchronous reset: stale A-messages must be gone IMMEDIATELY,
+    // before room B's query resolves (the old code showed A's messages here).
+    expect(store.activeMessages.length).toBe(0);
+
+    // Let the new subscription start, then resolve room B's query
+    await waitFor(() => resolveB !== undefined);
+    resolveB!([makeLocalMsg("!b:s", "$b1")]);
+    await waitFor(() => store.activeMessages.length > 0);
+    expect(store.activeMessages[0]?.roomId).toBe("!b:s");
+  });
+
+  it("re-setting the SAME room does not clear messages (no skeleton flash)", async () => {
+    const kit = makeKit({
+      getMessages: (roomId) =>
+        roomId === "!a:s" ? Promise.resolve([makeLocalMsg("!a:s", "$a1")]) : Promise.resolve([]),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store.setChatDbKit(kit as any);
+
+    await store.setActiveRoom("!a:s");
+    await waitFor(() => store.activeMessages.length > 0);
+
+    await store.setActiveRoom("!a:s");
+    // No reset — stale-data-better-than-skeleton holds for the same room
+    expect(store.activeMessages.length).toBe(1);
+  });
+});
+
+describe("WEE-95 A1 — loadRoomMessages does not await the Dexie write", () => {
+  let store: ReturnType<typeof useChatStore>;
+
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    setActivePinia(createTestingPinia({ stubActions: false }));
+    store = useChatStore();
+    store.rooms = [makeRoom({ id: "!a:s" })];
+  });
+
+  it("resolves for the ACTIVE room even when the Dexie write never settles", async () => {
+    // Dexie transaction hangs (slow device / competing background writes)
+    const kit = makeKit({ writeMessages: () => new Promise<void>(() => {}) });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store.setChatDbKit(kit as any);
+    store.activeRoomId = "!a:s";
+
+    const outcome = await Promise.race([
+      store.loadRoomMessages("!a:s").then(() => "resolved" as const),
+      new Promise<"timeout">(r => setTimeout(() => r("timeout"), 1500)),
+    ]);
+
+    // Render-critical path must not be blocked by the write (A1)
+    expect(outcome).toBe("resolved");
+    // ...but the write itself was still dispatched (data persists in background)
+    expect(kit.eventWriter.writeMessages).toHaveBeenCalled();
+    const written = kit.eventWriter.writeMessages.mock.calls[0][0] as unknown[];
+    expect(written.length).toBeGreaterThan(0);
+  });
+
+  it("in-memory messages are available after loadRoomMessages despite a hung write", async () => {
+    const kit = makeKit({ writeMessages: () => new Promise<void>(() => {}) });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store.setChatDbKit(kit as any);
+    store.activeRoomId = "!a:s";
+
+    await store.loadRoomMessages("!a:s");
+
+    // setMessages() seeded the in-memory store from the Matrix timeline
+    expect((store.messages["!a:s"] ?? []).length).toBeGreaterThan(0);
+  });
+});

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -1243,7 +1243,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
   };
 
   // Primary message source: Dexie liveQuery (auto-subscribes to DB changes)
-  const { data: dexieMessages, isReady: dexieMessagesReady } = useLiveQuery(
+  const { data: dexieMessages, isReady: dexieMessagesReady, reset: resetDexieMessages } = useLiveQuery(
     () => {
       if (!activeRoomId.value || !chatDbKitRef.value) return [] as import("@/shared/lib/local-db").LocalMessage[];
       const clearedAtTs = chatDbKitRef.value.eventWriter.getClearedAtTs(activeRoomId.value);
@@ -3386,6 +3386,15 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     // This closes the race where buffered messages land in Dexie during the
     // re-subscription gap and would otherwise be missed until the next mutation.
     const flushPromise = chatDbKitRef.value?.eventWriter.flushWriteBuffer();
+    // WEE-95: synchronously drop the previous room's liveQuery snapshot and force
+    // a re-subscribe. useLiveQuery re-subscribes asynchronously (deps watcher) and
+    // intentionally keeps stale data, so without this reset the OLD room's messages
+    // remain in activeMessages until the new query emits — MessageList had to poll
+    // `activeMessages[0]?.roomId === roomId` every 10ms to paper over the flash.
+    if (roomId !== activeRoomId.value) {
+      resetDexieMessages([]);
+      _liveQueryGen.value++;
+    }
     activeRoomId.value = roomId;
     messageWindowSize.value = 50; // Reset pagination window
     if (flushPromise && roomId) {
@@ -5420,10 +5429,11 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       setMessages(roomId, filteredMsgs);
 
       // Dual-write: persist all parsed messages to Dexie.
-      // For the active room: awaited so data reaches IndexedDB before a potential F5.
-      // For stale rooms (user switched away): fire-and-forget to avoid blocking
-      // Dexie transactions that the active room needs.
-      const isActiveRoom = activeRoomId.value === roomId;
+      // WEE-95: fire-and-forget for ALL rooms — never block the render-critical
+      // path on a 100+ message Dexie transaction (200-800ms on slow devices,
+      // competing with background writes of other rooms). The active room's UI
+      // is fed by the liveQuery as soon as the write commits; if a refresh races
+      // the write, messages are re-fetched from Matrix on next open.
       if (chatDbKitRef.value && msgs.length > 0) {
         const parsedMessages: ParsedMessage[] = msgs
           .filter(m => m.id && !m.id.startsWith("msg_")) // Skip optimistic temp messages
@@ -5470,19 +5480,9 @@ export const useChatStore = defineStore(NAMESPACE, () => {
           }
         };
 
-        if (isActiveRoom) {
-          // Active room: await so data is persisted before user can F5
-          try {
-            await dexieWriteWork();
-          } catch (e) {
-            console.warn("[chat-store] EventWriter.writeMessages failed:", e);
-          }
-        } else {
-          // Stale room: fire-and-forget to unblock Dexie for the active room
-          dexieWriteWork().catch(e => {
-            console.warn("[chat-store] EventWriter.writeMessages (background) failed:", e);
-          });
-        }
+        dexieWriteWork().catch(e => {
+          console.warn("[chat-store] EventWriter.writeMessages failed:", e);
+        });
       }
 
       // Load server-synced pinned messages after messages are available

--- a/src/features/messaging/model/__tests__/unread-banner-plan.test.ts
+++ b/src/features/messaging/model/__tests__/unread-banner-plan.test.ts
@@ -1,0 +1,105 @@
+/**
+ * WEE-95 A3 — unread banner must come from the cached room record
+ * (dexieRoomMap), not from a full message scan, and must not block
+ * the first render with avoidable I/O.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { resolveUnreadBannerPlan } from "../unread-banner-plan";
+
+const makeSources = (overrides: Partial<Parameters<typeof resolveUnreadBannerPlan>[0]> = {}) => ({
+  cachedRoom: undefined as { unreadCount: number; lastReadInboundTs: number } | undefined,
+  getRoom: vi.fn(async () => undefined),
+  getLastMessageAtOrBefore: vi.fn(async () => undefined),
+  ...overrides,
+});
+
+describe("resolveUnreadBannerPlan (WEE-95)", () => {
+  it("uses the sync dexieRoomMap cache — Dexie getRoom is never called", async () => {
+    const sources = makeSources({
+      cachedRoom: { unreadCount: 0, lastReadInboundTs: 5000 },
+    });
+
+    const plan = await resolveUnreadBannerPlan(sources);
+
+    expect(sources.getRoom).not.toHaveBeenCalled();
+    expect(plan.scrollToBanner).toBe(false);
+    expect(plan.needsBootstrap).toBe(false);
+  });
+
+  it("falls back to Dexie getRoom only when the cache is cold", async () => {
+    const sources = makeSources({
+      cachedRoom: undefined,
+      getRoom: vi.fn(async () => ({ unreadCount: 3, lastReadInboundTs: 5000 })),
+      getLastMessageAtOrBefore: vi.fn(async () => ({ eventId: "$last", clientId: "c1" })),
+    });
+
+    const plan = await resolveUnreadBannerPlan(sources);
+
+    expect(sources.getRoom).toHaveBeenCalledTimes(1);
+    expect(plan).toEqual({
+      lastReadId: "$last",
+      unreadCount: 3,
+      scrollToBanner: true,
+      needsBootstrap: false,
+    });
+  });
+
+  it("no watermark → bootstrap needed, no anchor query (off the render path)", async () => {
+    const sources = makeSources({
+      cachedRoom: { unreadCount: 7, lastReadInboundTs: 0 },
+    });
+
+    const plan = await resolveUnreadBannerPlan(sources);
+
+    expect(plan.needsBootstrap).toBe(true);
+    expect(plan.scrollToBanner).toBe(false);
+    expect(sources.getLastMessageAtOrBefore).not.toHaveBeenCalled();
+  });
+
+  it("zero unread → no banner and NO anchor query", async () => {
+    const sources = makeSources({
+      cachedRoom: { unreadCount: 0, lastReadInboundTs: 5000 },
+    });
+
+    const plan = await resolveUnreadBannerPlan(sources);
+
+    expect(plan.scrollToBanner).toBe(false);
+    expect(plan.unreadCount).toBe(0);
+    expect(sources.getLastMessageAtOrBefore).not.toHaveBeenCalled();
+  });
+
+  it("unread > 0 → banner with anchor resolved at the watermark", async () => {
+    const getLastMessageAtOrBefore = vi.fn(async () => ({ eventId: "$anchor", clientId: "c9" }));
+    const sources = makeSources({
+      cachedRoom: { unreadCount: 4, lastReadInboundTs: 7777 },
+      getLastMessageAtOrBefore,
+    });
+
+    const plan = await resolveUnreadBannerPlan(sources);
+
+    expect(getLastMessageAtOrBefore).toHaveBeenCalledWith(7777);
+    expect(plan).toEqual({
+      lastReadId: "$anchor",
+      unreadCount: 4,
+      scrollToBanner: true,
+      needsBootstrap: false,
+    });
+  });
+
+  it("anchor falls back to clientId, then to null when message is gone", async () => {
+    const pendingOnly = makeSources({
+      cachedRoom: { unreadCount: 1, lastReadInboundTs: 100 },
+      getLastMessageAtOrBefore: vi.fn(async () => ({ eventId: null, clientId: "c42" })),
+    });
+    expect((await resolveUnreadBannerPlan(pendingOnly)).lastReadId).toBe("c42");
+
+    const missing = makeSources({
+      cachedRoom: { unreadCount: 1, lastReadInboundTs: 100 },
+      getLastMessageAtOrBefore: vi.fn(async () => undefined),
+    });
+    const plan = await resolveUnreadBannerPlan(missing);
+    // Banner still shows (count is known), anchor just can't be matched
+    expect(plan.lastReadId).toBeNull();
+    expect(plan.scrollToBanner).toBe(true);
+  });
+});

--- a/src/features/messaging/model/unread-banner-plan.ts
+++ b/src/features/messaging/model/unread-banner-plan.ts
@@ -1,0 +1,64 @@
+import type { LocalRoom, LocalMessage } from "@/shared/lib/local-db";
+
+/** Decision for the unread banner on room open (WEE-95). */
+export interface UnreadBannerPlan {
+  /** Stable id of the last read message — banner anchor (may be null when
+   *  the anchor message fell out of the local window) */
+  lastReadId: string | null;
+  unreadCount: number;
+  /** True when the banner should be frozen and scrolled to */
+  scrollToBanner: boolean;
+  /** Room has no read watermark yet — needs a first-visit bootstrap
+   *  (caller runs it fire-and-forget, off the render path) */
+  needsBootstrap: boolean;
+}
+
+export interface UnreadBannerSources {
+  /** Sync in-memory LocalRoom from chat-store's dexieRoomMap — preferred,
+   *  zero I/O. `unreadCount` here is the same value the sidebar badge shows,
+   *  so the banner always agrees with what the user saw before opening. */
+  cachedRoom: Pick<LocalRoom, "unreadCount" | "lastReadInboundTs"> | undefined;
+  /** Async Dexie fallback when the in-memory cache has no entry yet (cold boot) */
+  getRoom: () => Promise<Pick<LocalRoom, "unreadCount" | "lastReadInboundTs"> | undefined>;
+  /** Anchor lookup — cheap [roomId+timestamp] limit(1) point query */
+  getLastMessageAtOrBefore: (
+    watermarkTs: number,
+  ) => Promise<Pick<LocalMessage, "eventId" | "clientId"> | undefined>;
+}
+
+const noBanner = (needsBootstrap: boolean): UnreadBannerPlan => ({
+  lastReadId: null,
+  unreadCount: 0,
+  scrollToBanner: false,
+  needsBootstrap,
+});
+
+/**
+ * Resolve the unread-banner plan for a room being opened.
+ *
+ * WEE-95: previously this path scanned the room's messages with
+ * `countInboundAfter()` (a JS-filter pass — 100-500ms on 10k+ message rooms)
+ * before the first render. The unread count is already maintained in
+ * `dexieRoomMap`, so the common path is now fully synchronous; the only
+ * remaining await is the cheap anchor point-query, and only when there
+ * actually are unread messages.
+ */
+export async function resolveUnreadBannerPlan(
+  sources: UnreadBannerSources,
+): Promise<UnreadBannerPlan> {
+  const room = sources.cachedRoom ?? (await sources.getRoom());
+  const watermarkTs = room?.lastReadInboundTs ?? 0;
+
+  if (watermarkTs <= 0) return noBanner(true);
+
+  const unreadCount = room?.unreadCount ?? 0;
+  if (unreadCount <= 0) return noBanner(false);
+
+  const lastReadMsg = await sources.getLastMessageAtOrBefore(watermarkTs);
+  return {
+    lastReadId: lastReadMsg?.eventId ?? lastReadMsg?.clientId ?? null,
+    unreadCount,
+    scrollToBanner: true,
+    needsBootstrap: false,
+  };
+}

--- a/src/features/messaging/ui/MessageList.vue
+++ b/src/features/messaging/ui/MessageList.vue
@@ -24,6 +24,7 @@ import TypingBubble from "./TypingBubble.vue";
 import ChatVirtualScroller from "@/shared/ui/ChatVirtualScroller.vue";
 import { useI18n } from "@/shared/lib/i18n";
 import { useUnreadBanner } from "../model/use-unread-banner";
+import { resolveUnreadBannerPlan } from "../model/unread-banner-plan";
 import { useReadTracker } from "../model/use-read-tracker";
 import { decideFabAction, shouldAutoDismissBanner } from "../model/fab-decision";
 import UnreadBanner from "./UnreadBanner.vue";
@@ -570,6 +571,52 @@ let scrollThrottleRaf: number | null = null;
 // Track the settled safety timeout so it can be cleared on room switch
 let pendingSettledTimeout: ReturnType<typeof setTimeout> | null = null;
 
+/** Resolve when activeMessages belong to `roomId`, when the user switches to
+ *  another room, or after `timeoutMs` — whichever comes first. Event-driven
+ *  replacement for the old 10ms polling loop (WEE-95): setActiveRoom now resets
+ *  the liveQuery synchronously, so this only waits for its first emission. */
+const waitForRoomMessages = (roomId: string, timeoutMs: number): Promise<void> =>
+  new Promise<void>((resolve) => {
+    const matches = (msgs: readonly { roomId: string }[]) =>
+      msgs.length > 0 && msgs[0]?.roomId === roomId;
+    if (matches(chatStore.activeMessages)) {
+      resolve();
+      return;
+    }
+    let stop: (() => void) | null = null;
+    const finish = () => {
+      clearTimeout(timer);
+      stop?.();
+      resolve();
+    };
+    const timer = setTimeout(finish, timeoutMs);
+    stop = watch(
+      () => [chatStore.activeMessages, chatStore.activeRoomId] as const,
+      ([msgs, activeId]) => {
+        if (activeId !== roomId || matches(msgs)) finish();
+      },
+    );
+  });
+
+/** Resolve when the Dexie liveQuery produced its first emission, or after `timeoutMs`. */
+const waitForDexieReady = (timeoutMs: number): Promise<void> =>
+  new Promise<void>((resolve) => {
+    if (chatStore.dexieMessagesReady) {
+      resolve();
+      return;
+    }
+    let stop: (() => void) | null = null;
+    const finish = () => {
+      clearTimeout(timer);
+      stop?.();
+      resolve();
+    };
+    const timer = setTimeout(finish, timeoutMs);
+    stop = watch(() => chatStore.dexieMessagesReady, (ready) => {
+      if (ready) finish();
+    });
+  });
+
 // Load messages when active room changes
 watch(
   () => chatStore.activeRoomId,
@@ -619,54 +666,46 @@ watch(
 
     if (isChatDbReady()) {
       const dbKit = getChatDb();
-      const room = await dbKit.rooms.getRoom(roomId);
-      if (isStale()) return;
-
-      const watermarkTs = room?.lastReadInboundTs ?? 0;
-      const myAddr = authStore.address ?? "";
       const clearedAtTs = dbKit.eventWriter.getClearedAtTs(roomId);
 
+      // WEE-95: read watermark + unread count from the in-memory dexieRoomMap
+      // cache (sync, no I/O) instead of scanning the room's messages with
+      // countInboundAfter() — a 100-500ms JS-filter pass on 10k+ message rooms
+      // that blocked the first render. Dexie fallback only on a cold cache.
+      const plan = await resolveUnreadBannerPlan({
+        cachedRoom: chatStore.dexieRoomMap.get(roomId),
+        getRoom: () => dbKit.rooms.getRoom(roomId),
+        getLastMessageAtOrBefore: (ts) => dbKit.messages.getLastMessageAtOrBefore(roomId, ts, clearedAtTs),
+      });
+      if (isStale()) return;
+
       if (import.meta.env.DEV) {
-        console.log("[unread-banner] roomId=%s watermarkTs=%d myAddr=%s", roomId, watermarkTs, myAddr);
+        console.log("[unread-banner] roomId=%s unread=%d lastReadId=%s", roomId, plan.unreadCount, plan.lastReadId);
       }
 
-      if (watermarkTs > 0) {
-        const unreadCount = await dbKit.messages.countInboundAfter(roomId, watermarkTs, myAddr, clearedAtTs);
-        if (isStale()) return;
+      if (plan.needsBootstrap) {
+        // Bootstrap watermark for legacy rooms (first visit after feature was
+        // added) — fire-and-forget, must not delay the first render (WEE-95).
+        dbKit.messages.getLastNonDeleted(roomId, clearedAtTs)
+          .then((latestMsg) => {
+            if (latestMsg && latestMsg.timestamp > 0) {
+              return dbKit.rooms.markAsRead(roomId, latestMsg.timestamp);
+            }
+          })
+          .catch((e) => {
+            console.warn("[unread-banner] watermark bootstrap failed:", e);
+          });
+      } else if (plan.scrollToBanner) {
+        freezeBanner(plan.lastReadId, plan.unreadCount);
 
-        if (import.meta.env.DEV) {
-          console.log("[unread-banner] unreadCount=%d", unreadCount);
+        // Ensure the Dexie liveQuery window is large enough to include the
+        // last-read message so the banner can match it in virtualItems.
+        const neededWindow = plan.unreadCount + 20;
+        if (neededWindow > chatStore.messageWindowSize) {
+          chatStore.expandMessageWindow(neededWindow - chatStore.messageWindowSize);
         }
 
-        if (unreadCount > 0) {
-          const lastReadMsg = await dbKit.messages.getLastMessageAtOrBefore(roomId, watermarkTs, clearedAtTs);
-          if (isStale()) return;
-
-          const lastReadId = lastReadMsg?.eventId ?? lastReadMsg?.clientId ?? null;
-
-          if (import.meta.env.DEV) {
-            console.log("[unread-banner] lastReadId=%s lastReadMsg.ts=%d", lastReadId, lastReadMsg?.timestamp);
-          }
-
-          freezeBanner(lastReadId, unreadCount);
-
-          // Ensure the Dexie liveQuery window is large enough to include the
-          // last-read message so the banner can match it in virtualItems.
-          const neededWindow = unreadCount + 20;
-          if (neededWindow > chatStore.messageWindowSize) {
-            chatStore.expandMessageWindow(neededWindow - chatStore.messageWindowSize);
-          }
-
-          scrollToBanner = true;
-        }
-      } else {
-        // Bootstrap watermark for legacy rooms (first visit after feature was added).
-        // Set the watermark to the latest message so future visits can detect unread.
-        const latestMsg = await dbKit.messages.getLastNonDeleted(roomId, clearedAtTs);
-        if (isStale()) return;
-        if (latestMsg && latestMsg.timestamp > 0) {
-          await dbKit.rooms.markAsRead(roomId, latestMsg.timestamp);
-        }
+        scrollToBanner = true;
       }
     }
 
@@ -685,23 +724,16 @@ watch(
         const dbKit = getChatDb();
         const clearedAtPeek = dbKit.eventWriter.getClearedAtTs(roomId);
         const peek = await dbKit.messages.getMessages(roomId, 1, undefined, clearedAtPeek);
+        if (isStale()) return;
         if (peek.length > 0) {
-          const dexieWaitDeadline = Date.now() + 2000;
-          while (Date.now() < dexieWaitDeadline) {
-            if (isStale()) return;
-            const am = chatStore.activeMessages;
-            if (am.length > 0 && am[0]?.roomId === roomId) break;
-            await new Promise<void>(r => setTimeout(r, 10));
-          }
+          await waitForRoomMessages(roomId, 2000);
+          if (isStale()) return;
         }
       }
 
       if (chatStore.chatDbKitRef && !chatStore.dexieMessagesReady) {
-        const readyDeadline = Date.now() + 500;
-        while (!chatStore.dexieMessagesReady && Date.now() < readyDeadline) {
-          await new Promise(r => setTimeout(r, 10));
-          if (isStale()) return;
-        }
+        await waitForDexieReady(500);
+        if (isStale()) return;
       }
 
       const hasCached = chatStore.activeMessages.length > 0

--- a/src/shared/lib/local-db/use-live-query.ts
+++ b/src/shared/lib/local-db/use-live-query.ts
@@ -8,6 +8,11 @@ export interface LiveQueryResult<T> {
   isReady: Ref<boolean>;
   /** Last error from the query, or null if the query is healthy */
   error: Ref<Error | null>;
+  /** Intentionally drop the current snapshot (next emission overwrites it).
+   *  Stale-data-better-than-skeleton is the default across re-subscriptions;
+   *  call this only when stale data is actively wrong — e.g. on room switch
+   *  the previous room's messages must not flash in the new room (WEE-95). */
+  reset: (value: T) => void;
 }
 
 /**
@@ -36,9 +41,10 @@ export function useLiveQuery<T>(
 
   const subscribe = () => {
     subscription?.unsubscribe();
-    // Do NOT reset isReady — stale data is better than a skeleton flash.
+    // Do NOT reset isReady or data — stale data is better than a skeleton flash.
     // isReady stays true after the first emission so UI keeps showing
-    // existing messages while the new query settles.
+    // existing messages while the new query settles. Consumers that need to
+    // drop the snapshot intentionally call reset() instead.
     const observable = liveQuery(querier);
     subscription = observable.subscribe({
       next: (value: T) => {
@@ -85,5 +91,9 @@ export function useLiveQuery<T>(
     }
   });
 
-  return { data, isReady, error };
+  const reset = (value: T) => {
+    data.value = value;
+  };
+
+  return { data, isReady, error, reset };
 }


### PR DESCRIPTION
## Summary
- `loadRoomMessages` no longer awaits the Dexie write transaction (100+ messages, 200-800ms on slow devices) in the render-critical path — writes are fire-and-forget for all rooms; the UI is fed by the liveQuery as soon as the write commits.
- `setActiveRoom` synchronously resets the liveQuery snapshot (new `useLiveQuery.reset()`) and bumps `_liveQueryGen`, so the previous room's messages never flash in the new room; MessageList's 10ms polling loops replaced with event-driven `watch`-based waits.
- Unread banner reads `unreadCount`/`lastReadInboundTs` from the in-memory `dexieRoomMap` cache (sync, new `resolveUnreadBannerPlan` helper) instead of a `countInboundAfter()` message scan (100-500ms on 10k+ message rooms) before first render; legacy watermark bootstrap moved off the render path.

## Trade-offs (deliberate)
- F5/process-kill during the now-background write may show slightly less offline history on next open — data is re-fetched from Matrix when online (was the cost of the 200-800ms skeleton hold).
- Banner count now trusts the cached `unreadCount` (same value as the sidebar badge), which can drift until `recalculateUnreadCount` self-heals; degradation is graceful (banner falls back to scroll-to-bottom when the anchor is outside the window).

## Linear
- Resolves WEE-95 (https://linear.app/wwwee/issue/WEE-95)

## Test plan
- [x] `vite build` passes; `vue-tsc` — 50 pre-existing baseline errors, none in changed files
- [x] Unit/regression tests added: `chat-store-room-switch.test.ts` (A1 non-blocking write, A2 room-switch race — verified RED without the fix), `unread-banner-plan.test.ts` (6 cases incl. cold-cache fallback)
- [x] Full suite: 2695 passed, 16 pre-existing baseline failures (untouched files)
- [ ] Manual QA on device: re-open a room with local messages (instant render), rapid A→B room switching (no flash of A's messages), unread banner appears and matches the sidebar badge