### PR TITLE
perf(boot): defer recovery scans/Tor/telemetry, parallel Pcrypto init, initialSyncLimit 20, key cache (WEE-97)

### DIFF
--- a/src/app/providers/index.ts
+++ b/src/app/providers/index.ts
@@ -13,6 +13,12 @@ import { useLocaleStore } from "@/entities/locale";
 import { isElectron, isNative } from "@/shared/lib/platform";
 import { bootStatus } from "@/app/model/boot-status";
 import { withTimeout } from "@/shared/lib/with-timeout";
+import { whenChatsInteractive } from "@/shared/lib/boot-signals";
+
+// WEE-97 item 6: fallbacks so deferred boot work still runs when the
+// chats-interactive signal never fires (user parked on the login page).
+const TOR_DEFER_FALLBACK_MS = 15_000;
+const TELEMETRY_DEFER_FALLBACK_MS = 20_000;
 
 export const setupProviders = async (app: App) => {
   setupAssets();
@@ -56,23 +62,29 @@ export const setupProviders = async (app: App) => {
     syncStatusBar();
     watch(() => themeStore.isDarkMode, syncStatusBar);
 
-    // Collect device telemetry (non-blocking) and persist to Dexie
-    import('@/shared/lib/telemetry').then(({ collectTelemetry }) => {
-      collectTelemetry().then(async (snapshot) => {
-        const { isChatDbReady, getChatDb } = await import('@/shared/lib/local-db');
-        // Wait for DB to be ready (up to 10s)
-        for (let i = 0; i < 20 && !isChatDbReady(); i++) {
-          await new Promise(r => setTimeout(r, 500));
-        }
-        if (isChatDbReady()) {
-          const kit = getChatDb();
-          await kit.db.syncState.put({
-            key: 'device_telemetry',
-            value: JSON.stringify(snapshot),
-          });
-        }
-      }).catch((e) => console.warn('[Telemetry] Collection failed:', e));
-    }).catch((e) => console.warn('[Telemetry] Module load failed:', e));
+    // WEE-97 item 6: telemetry collection is deferred until the chat list is
+    // interactive (fallback: 20s — covers the login-page / boot-error case).
+    // It used to poll Dexie every 500ms from the very start of boot; after
+    // the signal the DB is already initialized, so the poll loop below is
+    // only exercised on the fallback path.
+    whenChatsInteractive(TELEMETRY_DEFER_FALLBACK_MS).then(() => {
+      import('@/shared/lib/telemetry').then(({ collectTelemetry }) => {
+        collectTelemetry().then(async (snapshot) => {
+          const { isChatDbReady, getChatDb } = await import('@/shared/lib/local-db');
+          // Wait for DB to be ready (up to 10s)
+          for (let i = 0; i < 20 && !isChatDbReady(); i++) {
+            await new Promise(r => setTimeout(r, 500));
+          }
+          if (isChatDbReady()) {
+            const kit = getChatDb();
+            await kit.db.syncState.put({
+              key: 'device_telemetry',
+              value: JSON.stringify(snapshot),
+            });
+          }
+        }).catch((e) => console.warn('[Telemetry] Collection failed:', e));
+      }).catch((e) => console.warn('[Telemetry] Module load failed:', e));
+    });
 
     // Wire store to native torService reactive state (always — for settings UI)
     const torStore = useTorStore();
@@ -80,28 +92,59 @@ export const setupProviders = async (app: App) => {
 
     // Only start Tor daemon if user previously opted in.
     // Default is "neveruse" (opt-in) — app boots instantly via clearnet.
+    //
+    // WEE-97 item 6: the daemon start is deferred until the chat list is
+    // interactive (fallback: 15s for the login-page case). The Matrix proxy
+    // was already best-effort — initMatrix reads torService.matrixBaseUrl
+    // once at connect time, and the daemon's 5-10s bootstrap virtually never
+    // beat it; the deferral just stops Tor from competing for CPU/IO during
+    // the critical boot path. The Settings UI keeps working: torStore.init()
+    // above wires reactive state unconditionally.
     if (torStore.isEnabled) {
-      bootStatus.setStep("tor");
-      const { torService } = await import('@/shared/lib/tor');
-      torService.initBackground();
+      whenChatsInteractive(TOR_DEFER_FALLBACK_MS).then(async () => {
+        const { torService } = await import('@/shared/lib/tor');
+        torService.initBackground();
 
-      // Notify user if Tor fails to start
-      const torWatch = watch(
-        () => torService.initFailed.value,
-        (failed) => {
-          if (failed) {
-            import('@/shared/lib/use-toast').then(({ useToast }) => {
-              const { toast } = useToast();
-              toast(
-                'Secure connection unavailable. You can enable Tor in Settings.',
-                'error',
-                8000,
-              );
-            });
-            torWatch(); // stop watching
-          }
-        },
-      );
+        // Once the daemon is bootstrapped, route the live Matrix session
+        // through the local reverse proxy. The proxy flag is consulted
+        // per-request in MatrixClientService, so this takes effect on the
+        // next /sync long-poll — previously a session that connected before
+        // Tor was ready stayed clearnet forever.
+        const applyMatrixProxy = () => {
+          if (!torService.matrixBaseUrl) return false;
+          import('@/entities/matrix').then(({ getMatrixClientService }) => {
+            getMatrixClientService().setTorProxyUrl(torService.matrixBaseUrl);
+            console.info('[TOR] Matrix proxy applied to live session');
+          }).catch((e) => console.warn('[TOR] Matrix proxy re-apply failed:', e));
+          return true;
+        };
+        if (!applyMatrixProxy()) {
+          const proxyWatch = watch(
+            () => torService.isReady.value,
+            (ready) => {
+              if (ready && applyMatrixProxy()) proxyWatch();
+            },
+          );
+        }
+
+        // Notify user if Tor fails to start
+        const torWatch = watch(
+          () => torService.initFailed.value,
+          (failed) => {
+            if (failed) {
+              import('@/shared/lib/use-toast').then(({ useToast }) => {
+                const { toast } = useToast();
+                toast(
+                  'Secure connection unavailable. You can enable Tor in Settings.',
+                  'error',
+                  8000,
+                );
+              });
+              torWatch(); // stop watching
+            }
+          },
+        );
+      });
     }
   }
 

--- a/src/entities/auth/model/__tests__/encryption-keys.test.ts
+++ b/src/entities/auth/model/__tests__/encryption-keys.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { generateEncryptionKeys, clearEncryptionKeysCache } from "../encryption-keys";
+
+// Deterministic stub of the global `bitcoin` SDK object: derivation output is
+// a pure function of (seed, path) so cache hits can be compared to fresh runs.
+const fromSeedSpy = vi.fn((seed: Buffer) => ({
+  derivePath: (path: string) => {
+    const material = Buffer.from(`${seed.toString("hex")}:${path}`);
+    return { privateKey: material, publicKey: material };
+  },
+}));
+
+(globalThis as unknown as { bitcoin: unknown }).bitcoin = {
+  bip32: { fromSeed: fromSeedSpy },
+  ECPair: { fromPrivateKey: (k: Buffer) => ({ priv: k }) },
+};
+
+const KEY_A = "aa".repeat(32);
+const KEY_B = "bb".repeat(32);
+
+describe("generateEncryptionKeys cache (WEE-97 item 5)", () => {
+  beforeEach(() => {
+    clearEncryptionKeysCache();
+    fromSeedSpy.mockClear();
+  });
+
+  it("derives 12 keys at m/33'/0'/0'/{1-12}'", () => {
+    const keys = generateEncryptionKeys(KEY_A);
+    expect(keys).toHaveLength(12);
+    expect(keys[0].public).toBe(
+      Buffer.from(`${KEY_A}:m/33'/0'/0'/1'`).toString("hex"),
+    );
+    expect(keys[11].public).toBe(
+      Buffer.from(`${KEY_A}:m/33'/0'/0'/12'`).toString("hex"),
+    );
+  });
+
+  it("A3: cached keys are identical to freshly derived ones", () => {
+    const fresh = generateEncryptionKeys(KEY_A);
+    const cached = generateEncryptionKeys(KEY_A);
+
+    // Same object — and therefore byte-for-byte identical to the derivation
+    expect(cached).toBe(fresh);
+    expect(cached.map((k) => k.public)).toEqual(fresh.map((k) => k.public));
+    // The expensive BIP32 derivation ran exactly once
+    expect(fromSeedSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-derives when the private key changes (account switch)", () => {
+    const keysA = generateEncryptionKeys(KEY_A);
+    const keysB = generateEncryptionKeys(KEY_B);
+
+    expect(fromSeedSpy).toHaveBeenCalledTimes(2);
+    expect(keysB[0].public).not.toBe(keysA[0].public);
+
+    // Switching back also re-derives (single-entry cache holds only the active account)
+    generateEncryptionKeys(KEY_A);
+    expect(fromSeedSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it("clearEncryptionKeysCache drops the memoized material", () => {
+    generateEncryptionKeys(KEY_A);
+    clearEncryptionKeysCache();
+    generateEncryptionKeys(KEY_A);
+    expect(fromSeedSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/entities/auth/model/encryption-keys.ts
+++ b/src/entities/auth/model/encryption-keys.ts
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------------------
+// Pcrypto encryption-key derivation (WEE-97 item 5)
+//
+// Derives 12 BIP32 key pairs at m/33'/0'/0'/{1-12}' from the account private
+// key — CPU-bound work on the main thread (~50-100ms on mid-range Android).
+// Memoized per private key: the derivation is deterministic, so re-deriving
+// on every initMatrix / profile read is pure waste. The cache holds exactly
+// one entry (the active account) and lives only in module memory — the same
+// exposure level as the private key itself, which SessionManager already
+// keeps in memory/localStorage.
+// ---------------------------------------------------------------------------
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare const bitcoin: any;
+
+export interface EncryptionKeyPair {
+  pair: unknown;
+  public: string;
+  private: Buffer;
+}
+
+let _cache: { privateKeyHex: string; keys: EncryptionKeyPair[] } | null = null;
+
+/** Generate 12 BIP32 key pairs at m/33'/0'/0'/{1-12}' for Pcrypto encryption.
+ *  Matches original: bitcoin.bip32.fromSeed(Buffer.from(privateKey, "hex")) */
+export function generateEncryptionKeys(privateKeyHex: string): EncryptionKeyPair[] {
+  if (_cache && _cache.privateKeyHex === privateKeyHex) {
+    return _cache.keys;
+  }
+
+  const key = Buffer.from(privateKeyHex, "hex");
+  const root = bitcoin.bip32.fromSeed(key);
+
+  const keys: EncryptionKeyPair[] = [];
+  for (let i = 1; i <= 12; i++) {
+    const child = root.derivePath(`m/33'/0'/0'/${i}'`);
+    keys.push({
+      pair: bitcoin.ECPair.fromPrivateKey(child.privateKey),
+      public: child.publicKey.toString("hex"),
+      private: child.privateKey,
+    });
+  }
+
+  // Freeze the cached array (shallow) — a caller mutating it would otherwise
+  // poison the cache for the rest of the session. Callers only read/.map().
+  Object.freeze(keys);
+  _cache = { privateKeyHex, keys };
+  return keys;
+}
+
+/** Drop cached key material (logout / account removal). */
+export function clearEncryptionKeysCache(): void {
+  _cache = null;
+}

--- a/src/entities/auth/model/stores.ts
+++ b/src/entities/auth/model/stores.ts
@@ -58,6 +58,7 @@ import {
 } from "../lib";
 import { connectMatrixWithRetry } from "../lib/connect-matrix-with-retry";
 import { createKeyPair } from "./key-pair";
+import { generateEncryptionKeys, clearEncryptionKeysCache } from "./encryption-keys";
 
 const NAMESPACE = "auth";
 
@@ -99,24 +100,6 @@ function hexDecode(hex: string): string {
     result += String.fromCharCode(ch);
   }
   return result;
-}
-
-/** Generate 12 BIP32 key pairs at m/33'/0'/0'/{1-12}' for Pcrypto encryption.
- *  Matches original: bitcoin.bip32.fromSeed(Buffer.from(privateKey, "hex")) */
-function generateEncryptionKeys(privateKeyHex: string) {
-  const key = Buffer.from(privateKeyHex, "hex");
-  const root = bitcoin.bip32.fromSeed(key);
-
-  const keys: Array<{ pair: unknown; public: string; private: Buffer }> = [];
-  for (let i = 1; i <= 12; i++) {
-    const child = root.derivePath(`m/33'/0'/0'/${i}'`);
-    keys.push({
-      pair: bitcoin.ECPair.fromPrivateKey(child.privateKey),
-      public: child.publicKey.toString("hex"),
-      private: child.privateKey,
-    });
-  }
-  return keys;
 }
 
 let _onSyncStatusCallback: ((state: string) => void) | null = null;
@@ -449,7 +432,19 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
           matrixKit.value?.chatIsPublic(room as Record<string, unknown>) ?? false,
         matrixId: (id: string) => matrixService.matrixId(id),
       });
-      await withTimeout(cryptoInstance.prepare(address.value ?? undefined), 10_000, "Pcrypto storage init");
+      // WEE-97 item 3: prepare() opens two IndexedDB stores (~50-150ms) —
+      // run it concurrently with the Matrix connection below instead of
+      // serializing the boot path. Safe because all Pcrypto ls/lse access is
+      // optional-chained (storage miss = cache miss), and rooms are only
+      // created after the first /sync, by which point prepare has resolved.
+      const pcryptoPreparePromise = withTimeout(
+        cryptoInstance.prepare(address.value ?? undefined),
+        10_000,
+        "Pcrypto storage init",
+      );
+      // Suppress premature unhandled-rejection (real handling happens in the
+      // Promise.all together with the Matrix connection below).
+      pcryptoPreparePromise.catch(() => {});
       pcrypto.value = cryptoInstance;
 
       // Step 7: Wire Matrix events → chat store
@@ -647,24 +642,29 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
       // state on cold start. Retry-with-backoff turns a single brittle attempt
       // into 3 attempts (1s/2s backoff, 45s per attempt) so transient transport
       // failures don't surface as a fatal boot error.
-      const connectResult = await connectMatrixWithRetry(matrixService, {
-        attemptTimeoutMs: 45_000,
-        maxAttempts: 3,
-        baseDelayMs: 1_000,
-        maxDelayMs: 30_000,
-        onAttempt: (attempt, max) => {
-          matrixError.value =
-            attempt === 1
-              ? "Connecting to Matrix server..."
-              : `Reconnecting to Matrix server (attempt ${attempt}/${max})...`;
-        },
-        onAttemptFail: (attempt, err) => {
-          console.warn(
-            `[auth] Matrix connect attempt ${attempt} failed:`,
-            err instanceof Error ? err.message : err,
-          );
-        },
-      });
+      // WEE-97 item 3: await the deferred Pcrypto storage init together with
+      // the connection — both must be settled before matrixReady flips.
+      const [connectResult] = await Promise.all([
+        connectMatrixWithRetry(matrixService, {
+          attemptTimeoutMs: 45_000,
+          maxAttempts: 3,
+          baseDelayMs: 1_000,
+          maxDelayMs: 30_000,
+          onAttempt: (attempt, max) => {
+            matrixError.value =
+              attempt === 1
+                ? "Connecting to Matrix server..."
+                : `Reconnecting to Matrix server (attempt ${attempt}/${max})...`;
+          },
+          onAttemptFail: (attempt, err) => {
+            console.warn(
+              `[auth] Matrix connect attempt ${attempt} failed:`,
+              err instanceof Error ? err.message : err,
+            );
+          },
+        }),
+        pcryptoPreparePromise,
+      ]);
 
       if (connectResult.ready) {
         bootStatus.setStep("sync");
@@ -1222,6 +1222,8 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
       }
       pcrypto.value = null;
     }
+    // WEE-97: drop memoized BIP32 key material with the rest of the session
+    clearEncryptionKeysCache();
 
     // ── 3. Clean up listeners & intervals ──
     if (_connectivityUnsub) { _connectivityUnsub(); _connectivityUnsub = null; }

--- a/src/entities/chat/model/chat-store-initial-sync.test.ts
+++ b/src/entities/chat/model/chat-store-initial-sync.test.ts
@@ -23,11 +23,13 @@ vi.mock("@/entities/matrix", () => ({
 }));
 
 import { useChatStore } from "./chat-store";
+import { isChatsInteractive, __resetBootSignalsForTests } from "@/shared/lib/boot-signals";
 
 describe("chat-store WEE-55 initial-sync watchdog", () => {
   let store: ReturnType<typeof useChatStore>;
 
   beforeEach(() => {
+    __resetBootSignalsForTests();
     vi.useFakeTimers();
     setActivePinia(createTestingPinia({ stubActions: false }));
     store = useChatStore();
@@ -118,6 +120,24 @@ describe("chat-store WEE-55 initial-sync watchdog", () => {
     expect(store.initialSyncStatus).toBe("ready");
     expect(store.roomsInitialized).toBe(true);
     expect(store.isSyncing).toBe(false);
+  });
+
+  // WEE-97: deferred boot work (recovery scans, Tor, telemetry) is released
+  // by the chats-interactive signal — it must fire on BOTH paths that flip
+  // roomsInitialized, or the deferred work waits for the 15-30s fallbacks.
+  it("WEE-97: signals chats-interactive when the first PREPARED refresh lands", () => {
+    expect(isChatsInteractive()).toBe(false);
+    store.setHelpers(mockMatrixService.kit as never, {} as never);
+    store.refreshRooms("PREPARED");
+    vi.advanceTimersByTime(150);
+    expect(isChatsInteractive()).toBe(true);
+  });
+
+  it("WEE-97: signals chats-interactive on watchdog degrade too", () => {
+    expect(isChatsInteractive()).toBe(false);
+    store.startInitialSyncWatch();
+    vi.advanceTimersByTime(8000);
+    expect(isChatsInteractive()).toBe(true);
   });
 
   it("cleanup resets the lifecycle back to 'loading'", () => {

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -23,6 +23,7 @@ import { useUserStore } from "@/entities/user/model";
 import { defineStore } from "pinia";
 import { computed, reactive, ref, shallowRef, triggerRef, watch } from "vue";
 import { perfMark, perfMeasure, perfCount } from "@/shared/lib/perf-markers";
+import { signalChatsInteractive } from "@/shared/lib/boot-signals";
 import { yieldToMain, yieldEveryN } from "@/shared/lib/yield-to-main";
 import { createPatchScheduler } from "@/shared/lib/patch-scheduler";
 import { isNative } from "@/shared/lib/platform";
@@ -516,6 +517,8 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       // cached room list (or the empty-state hint) becomes visible. A later
       // PREPARED sync still runs a full refresh and upgrades back to "ready".
       roomsInitialized.value = true;
+      // WEE-97: release deferred boot work (recovery scans, Tor, telemetry)
+      signalChatsInteractive();
     }, INITIAL_SYNC_TIMEOUT_MS);
   };
 
@@ -2899,6 +2902,9 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     // already flipped roomsInitialized=true before the first real sync landed.
     const firstSyncComplete = initialSyncStatus.value !== "ready";
     if (!roomsInitialized.value) roomsInitialized.value = true;
+    // WEE-97: release deferred boot work (recovery scans, Tor, telemetry).
+    // Idempotent — safe to call on every refresh after the first.
+    signalChatsInteractive();
     if (firstSyncComplete) {
       initialSyncStatus.value = "ready";
       clearInitialSyncTimer();

--- a/src/entities/matrix/model/matrix-client.ts
+++ b/src/entities/matrix/model/matrix-client.ts
@@ -307,13 +307,17 @@ export class MatrixClientService {
     }
 
     // Sync config: lazy loading for speed, members loaded explicitly when needed
-    // initialSyncLimit: 1 keeps sync payload small for accounts with many rooms.
-    // Only the last timeline event per room is included; full history is loaded
-    // on-demand when a room is opened (loadAllMessages).
+    // initialSyncLimit applies ONLY to the very first /sync (no saved token) —
+    // the SDK clones the filter inline with this timeline limit, while all
+    // incremental syncs use the uploaded filter above (limit 20). Was 1, which
+    // made the first sync return a single event per room and forced sequential
+    // per-room scrollback to fill timelines — skeletons on every first room
+    // open after install/re-login (WEE-97 item 4). 20 matches the incremental
+    // filter limit; full history is still loaded on-demand (loadAllMessages).
     await userClient.startClient({
       pollTimeout: 60000,
       resolveInvitesToProfiles: false,
-      initialSyncLimit: 1,
+      initialSyncLimit: 20,
       disablePresence: true,
       lazyLoadMembers: true,
       ...(syncFilter ? { filter: syncFilter } : {}),

--- a/src/shared/lib/boot-signals.test.ts
+++ b/src/shared/lib/boot-signals.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  signalChatsInteractive,
+  isChatsInteractive,
+  whenChatsInteractive,
+  __resetBootSignalsForTests,
+} from "./boot-signals";
+
+describe("boot-signals (WEE-97)", () => {
+  beforeEach(() => {
+    __resetBootSignalsForTests();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts not-interactive", () => {
+    expect(isChatsInteractive()).toBe(false);
+  });
+
+  it("whenChatsInteractive resolves when the signal fires", async () => {
+    const resolved = vi.fn();
+    whenChatsInteractive(60_000).then(resolved);
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).not.toHaveBeenCalled();
+
+    signalChatsInteractive();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(resolved).toHaveBeenCalledTimes(1);
+    expect(isChatsInteractive()).toBe(true);
+  });
+
+  it("resolves immediately when already signaled", async () => {
+    signalChatsInteractive();
+    const resolved = vi.fn();
+    whenChatsInteractive(60_000).then(resolved);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the timeout when the signal never fires", async () => {
+    const resolved = vi.fn();
+    whenChatsInteractive(5_000).then(resolved);
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(resolved).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(resolved).toHaveBeenCalledTimes(1);
+    // Fallback path does not mark chats as interactive
+    expect(isChatsInteractive()).toBe(false);
+  });
+
+  it("signal is idempotent", async () => {
+    signalChatsInteractive();
+    signalChatsInteractive();
+    const resolved = vi.fn();
+    whenChatsInteractive(60_000).then(resolved);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(resolved).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/shared/lib/boot-signals.ts
+++ b/src/shared/lib/boot-signals.ts
@@ -1,0 +1,66 @@
+// ---------------------------------------------------------------------------
+// Boot signals — lightweight cross-layer boot lifecycle notifications (WEE-97)
+//
+// Lets low-priority boot work (recovery table scans, Tor daemon start,
+// telemetry collection) wait until the chat list is interactive instead of
+// competing with the critical boot path for CPU and IndexedDB throughput.
+//
+// Lives in `shared` so both `shared/lib/local-db` (consumer) and
+// `entities/chat` (producer) can use it without violating FSD layering.
+// ---------------------------------------------------------------------------
+
+let chatsInteractiveResolved = false;
+let resolveChatsInteractive: () => void = () => {};
+let chatsInteractivePromise = createSignal();
+
+function createSignal(): Promise<void> {
+  chatsInteractiveResolved = false;
+  return new Promise<void>((resolve) => {
+    resolveChatsInteractive = () => {
+      chatsInteractiveResolved = true;
+      resolve();
+    };
+  });
+}
+
+/**
+ * Mark the chat list as interactive — the first sync-driven room refresh has
+ * been kicked off and roomsInitialized released the skeletons (or the
+ * degraded watchdog did). The refresh itself may still be writing in chunks;
+ * consumers that must avoid that write burst add their own settle delay.
+ * Idempotent; never resets — re-logins within one app lifetime resolve
+ * immediately, so deferral only applies to the cold-boot path where it
+ * matters.
+ */
+export function signalChatsInteractive(): void {
+  if (chatsInteractiveResolved) return;
+  resolveChatsInteractive();
+}
+
+/** True once the chats-interactive signal has fired. */
+export function isChatsInteractive(): boolean {
+  return chatsInteractiveResolved;
+}
+
+/**
+ * Resolve when the chat list becomes interactive, or after `fallbackMs` —
+ * whichever comes first. The fallback guarantees deferred work still runs
+ * when the signal never fires (user parked on the login page, Matrix boot
+ * failure, etc.). Note: a fallback-path resolution does NOT flip
+ * isChatsInteractive() — "deferred work may run" ≠ "chats are interactive".
+ */
+export function whenChatsInteractive(fallbackMs: number): Promise<void> {
+  if (chatsInteractiveResolved) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, fallbackMs);
+    chatsInteractivePromise.then(() => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+/** Test-only: reset the singleton signal between test cases. */
+export function __resetBootSignalsForTests(): void {
+  chatsInteractivePromise = createSignal();
+}

--- a/src/shared/lib/local-db/deferred-recovery.test.ts
+++ b/src/shared/lib/local-db/deferred-recovery.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import "fake-indexeddb/auto";
+import { initChatDb, closeChatDb } from "./index";
+import { ChatDatabase, type PendingOperation } from "./schema";
+import { SyncEngine } from "./sync-engine";
+import { MessageRepository } from "./message-repository";
+import { RoomRepository } from "./room-repository";
+import { SearchCacheRepository } from "./search-cache-repository";
+import { DecryptionWorker } from "./decryption-worker";
+import {
+  signalChatsInteractive,
+  __resetBootSignalsForTests,
+} from "@/shared/lib/boot-signals";
+
+// SyncEngine/DecryptionWorker construction touches the Matrix service —
+// stub it the same way the other sync-engine tests do.
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: () => ({
+    isReady: () => true,
+    sendEncryptedText: vi.fn(() => "$evt_server"),
+    sendText: vi.fn(() => "$evt_server"),
+    uploadContentMxc: vi.fn(() => "mxc://s/u"),
+  }),
+}));
+
+const SETTLE_MS = 1_000;
+const getRoomCrypto = async () => undefined;
+
+let userCounter = 0;
+
+describe("initChatDb deferred recovery (WEE-97 item 1)", () => {
+  let spies: {
+    recoverStrandedOps: ReturnType<typeof vi.spyOn>;
+    processQueue: ReturnType<typeof vi.spyOn>;
+    recoverStuckMedia: ReturnType<typeof vi.spyOn>;
+    cleanupCancelledUploads: ReturnType<typeof vi.spyOn>;
+    recoverAllStuckMessages: ReturnType<typeof vi.spyOn>;
+    tick: ReturnType<typeof vi.spyOn>;
+    gcTombstones: ReturnType<typeof vi.spyOn>;
+    gcSearchCache: ReturnType<typeof vi.spyOn>;
+  };
+
+  beforeEach(() => {
+    __resetBootSignalsForTests();
+    vi.useFakeTimers();
+    // snapshotStrandedOpIds is awaited before processQueue/recoverStrandedOps —
+    // mock it so the chain resolves in microtasks under fake timers.
+    vi.spyOn(SyncEngine.prototype, "snapshotStrandedOpIds").mockResolvedValue([] as never);
+    spies = {
+      recoverStrandedOps: vi.spyOn(SyncEngine.prototype, "recoverStrandedOps").mockResolvedValue(undefined as never),
+      processQueue: vi.spyOn(SyncEngine.prototype, "processQueue").mockResolvedValue(undefined as never),
+      recoverStuckMedia: vi.spyOn(MessageRepository.prototype, "recoverStuckMedia").mockResolvedValue(0 as never),
+      cleanupCancelledUploads: vi.spyOn(MessageRepository.prototype, "cleanupCancelledUploads").mockResolvedValue(0 as never),
+      recoverAllStuckMessages: vi.spyOn(DecryptionWorker.prototype, "recoverAllStuckMessages").mockResolvedValue(0 as never),
+      tick: vi.spyOn(DecryptionWorker.prototype, "tick").mockResolvedValue(undefined as never),
+      gcTombstones: vi.spyOn(RoomRepository.prototype, "garbageCollectTombstones").mockResolvedValue(0 as never),
+      gcSearchCache: vi.spyOn(SearchCacheRepository.prototype, "garbageCollect").mockResolvedValue(0 as never),
+    };
+  });
+
+  afterEach(() => {
+    closeChatDb();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  const freshUserId = () => `test-user-${++userCounter}`;
+
+  it("starts the queue and decryption tick immediately, defers recovery scans", async () => {
+    initChatDb(freshUserId(), getRoomCrypto);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Live-messaging machinery runs right away
+    expect(spies.processQueue).toHaveBeenCalledTimes(1);
+    expect(spies.tick).toHaveBeenCalledTimes(1);
+
+    // Heavy table scans do NOT run before the chats-interactive signal
+    expect(spies.recoverStrandedOps).not.toHaveBeenCalled();
+    expect(spies.recoverStuckMedia).not.toHaveBeenCalled();
+    expect(spies.cleanupCancelledUploads).not.toHaveBeenCalled();
+    expect(spies.recoverAllStuckMessages).not.toHaveBeenCalled();
+    expect(spies.gcTombstones).not.toHaveBeenCalled();
+    expect(spies.gcSearchCache).not.toHaveBeenCalled();
+  });
+
+  it("A2: recovery scans still run — after the signal + settle delay", async () => {
+    initChatDb(freshUserId(), getRoomCrypto);
+
+    signalChatsInteractive();
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+
+    expect(spies.recoverStrandedOps).toHaveBeenCalledTimes(1);
+    expect(spies.recoverStuckMedia).toHaveBeenCalledTimes(1);
+    expect(spies.cleanupCancelledUploads).toHaveBeenCalledTimes(1);
+    expect(spies.recoverAllStuckMessages).toHaveBeenCalledTimes(1);
+    expect(spies.gcTombstones).toHaveBeenCalledTimes(1);
+    expect(spies.gcSearchCache).toHaveBeenCalledTimes(1);
+    // recoverStrandedOps re-kicks the queue → second processQueue call
+    expect(spies.processQueue).toHaveBeenCalledTimes(2);
+  });
+
+  it("A2: recovery scans run via the 30s fallback when the signal never fires", async () => {
+    initChatDb(freshUserId(), getRoomCrypto);
+
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(spies.recoverStrandedOps).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1 + SETTLE_MS);
+    expect(spies.recoverStrandedOps).toHaveBeenCalledTimes(1);
+    expect(spies.recoverStuckMedia).toHaveBeenCalledTimes(1);
+  });
+
+  it("runDeferredRecovery is idempotent", async () => {
+    const kit = initChatDb(freshUserId(), getRoomCrypto);
+
+    kit.runDeferredRecovery?.();
+    kit.runDeferredRecovery?.();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(spies.recoverStrandedOps).toHaveBeenCalledTimes(1);
+
+    // The signal arriving later does not re-run the scans
+    signalChatsInteractive();
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+    expect(spies.recoverStrandedOps).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not run recovery after the kit is disposed (logout before signal)", async () => {
+    initChatDb(freshUserId(), getRoomCrypto);
+    closeChatDb();
+
+    signalChatsInteractive();
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+
+    expect(spies.recoverStrandedOps).not.toHaveBeenCalled();
+    expect(spies.recoverStuckMedia).not.toHaveBeenCalled();
+  });
+
+  it("passes the startup stranded-op snapshot to recoverStrandedOps", async () => {
+    const snapshotSpy = vi
+      .spyOn(SyncEngine.prototype, "snapshotStrandedOpIds")
+      .mockResolvedValue([7, 42] as never);
+
+    initChatDb(freshUserId(), getRoomCrypto);
+    signalChatsInteractive();
+    await vi.advanceTimersByTimeAsync(SETTLE_MS);
+
+    expect(snapshotSpy).toHaveBeenCalledTimes(1);
+    expect(spies.recoverStrandedOps).toHaveBeenCalledWith([7, 42]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SyncEngine.recoverStrandedOps(onlyIds) — real-Dexie behavior (no spies)
+// ---------------------------------------------------------------------------
+
+const makeOp = (overrides: Partial<PendingOperation>): PendingOperation => ({
+  type: "send_message" as PendingOperation["type"],
+  roomId: "!room:server",
+  payload: {},
+  status: "syncing",
+  retries: 1,
+  maxRetries: 5,
+  createdAt: Date.now(),
+  clientId: `client-${Math.random().toString(36).slice(2)}`,
+  ...overrides,
+});
+
+describe("SyncEngine.recoverStrandedOps with snapshot whitelist (WEE-97 H1)", () => {
+  let db: ChatDatabase;
+  let engine: SyncEngine;
+
+  beforeEach(() => {
+    db = new ChatDatabase(`stranded-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    engine = new SyncEngine(db, new MessageRepository(db), new RoomRepository(db), getRoomCrypto);
+  });
+
+  afterEach(async () => {
+    engine.dispose();
+    await db.delete();
+  });
+
+  it("resets only snapshot ops; ops claimed after the snapshot stay untouched", async () => {
+    // Stranded from a previous session — present at startup
+    const strandedId = (await db.pendingOps.add(makeOp({}))) as number;
+
+    const snapshot = await engine.snapshotStrandedOpIds();
+    expect(snapshot).toEqual([strandedId]);
+
+    // Simulate an op the live queue claimed AFTER the snapshot (mid-flight)
+    const inFlightId = (await db.pendingOps.add(makeOp({ retries: 2 }))) as number;
+
+    await engine.recoverStrandedOps(snapshot);
+
+    const recovered = await db.pendingOps.get(strandedId);
+    expect(recovered?.status).toBe("pending");
+    expect(recovered?.retries).toBe(0);
+
+    // The mid-flight op was NOT reset — no duplicate-send race
+    const inFlight = await db.pendingOps.get(inFlightId);
+    expect(inFlight?.status).toBe("syncing");
+    expect(inFlight?.retries).toBe(2);
+  });
+
+  it("without a whitelist resets every syncing op (legacy startup ordering)", async () => {
+    const a = (await db.pendingOps.add(makeOp({}))) as number;
+    const b = (await db.pendingOps.add(makeOp({}))) as number;
+
+    await engine.recoverStrandedOps();
+
+    expect((await db.pendingOps.get(a))?.status).toBe("pending");
+    expect((await db.pendingOps.get(b))?.status).toBe("pending");
+  });
+});

--- a/src/shared/lib/local-db/index.ts
+++ b/src/shared/lib/local-db/index.ts
@@ -67,6 +67,7 @@ import { EventWriter } from "./event-writer";
 import { DecryptionWorker } from "./decryption-worker";
 import { ListenedRepository } from "./listened-repository";
 import { SearchCacheRepository } from "./search-cache-repository";
+import { whenChatsInteractive } from "@/shared/lib/boot-signals";
 import type { PcryptoRoomInstance } from "@/entities/matrix/model/matrix-crypto";
 
 export interface ChatDbKit {
@@ -83,12 +84,24 @@ export interface ChatDbKit {
   searchCache: SearchCacheRepository;
   /** Debounced retry for a room — wire to key-arrival callbacks */
   retryRoomDecryption?: (roomId: string) => void;
+  /**
+   * Run the deferred recovery table scans (stranded ops, stuck media,
+   * stuck encrypted messages, cross-device heal, GC). Idempotent — fires
+   * automatically once the chat list is interactive (WEE-97), exposed for
+   * tests and manual triggering.
+   */
+  runDeferredRecovery?: () => void;
   /** Cleanup event listeners. Called on user switch / logout. */
   dispose?: () => void;
 }
 
 let currentKit: ChatDbKit | null = null;
 let currentUserId: string | null = null;
+
+/** WEE-97: max wait before deferred recovery scans run unconditionally. */
+const DEFERRED_RECOVERY_FALLBACK_MS = 30_000;
+/** WEE-97: settle delay after chats-interactive before recovery scans start. */
+const DEFERRED_RECOVERY_SETTLE_MS = 1_000;
 
 /**
  * Initialize (or re-initialize) the local-first chat database for a user.
@@ -154,55 +167,88 @@ export function initChatDb(
   window.addEventListener("online", onOnline);
 
   // Cleanup function for user switch / logout
+  let disposed = false;
   const disposeRetryTriggers = () => {
+    disposed = true;
     window.removeEventListener("online", onOnline);
     for (const timer of debouncedRetryTimers.values()) clearTimeout(timer);
     debouncedRetryTimers.clear();
     decryptionWorker.dispose();
   };
 
-  // Recover operations stranded in "syncing" state after app crash, then start queue
-  syncEngine.recoverStrandedOps().then(() => syncEngine.processQueue()).catch(() => {});
+  // Snapshot genuinely stranded "syncing" ops BEFORE the queue starts —
+  // indexed lookup, a few rows. The deferred recoverStrandedOps below resets
+  // only these ids, so it can never clobber an op the live queue has since
+  // claimed (SyncEngine ordering contract).
+  const strandedOpIdsPromise = syncEngine.snapshotStrandedOpIds().catch(() => [] as number[]);
 
-  // Recover media uploads stuck in "pending" from a previous session (fire-and-forget IIFEs lost on reload/crash)
-  messages.recoverStuckMedia().then((count) => {
-    if (count > 0) console.info(`[local-db] Recovered ${count} stuck media upload(s) → marked as failed`);
-  }).catch(() => {});
-
-  messages.cleanupCancelledUploads()
-    .then((count) => {
-      if (count > 0) console.info(`[local-db] Cleaned up ${count} cancelled upload(s)`);
-    })
-    .catch(() => {});
-
-  // Start processing any pending decryption jobs from previous session
+  // Start the outbound queue and pending decryption jobs immediately — both
+  // are needed for live messaging. Heavy recovery table scans are deferred
+  // below (WEE-97) so they don't compete with the first fullRoomRefresh.
+  strandedOpIdsPromise.then(() => syncEngine.processQueue()).catch(() => {});
   decryptionWorker.tick().catch(() => {});
 
-  // Re-enqueue messages stranded as "[encrypted]" in a previous session whose
-  // ciphertext is still on the row (e.g. failed during the 502 key-outage) but
-  // whose queue job died/was pruned. Self-limiting: recovered rows flip to "ok".
-  decryptionWorker.recoverAllStuckMessages().then((count) => {
-    if (count > 0) console.info(`[local-db] Re-queued ${count} stuck encrypted message(s) for decryption`);
-  }).catch(() => {});
+  // WEE-97: recovery/GC sweeps are full-table scans that used to run on every
+  // login BEFORE the chat list was interactive, competing with fullRoomRefresh
+  // writes. Deferred until the chats-interactive signal (or its fallback
+  // timeout — recovery is guaranteed to run even if boot never completes).
+  let deferredRecoveryRan = false;
+  const runDeferredRecovery = () => {
+    if (deferredRecoveryRan || disposed) return;
+    deferredRecoveryRan = true;
 
-  // Post-migration: re-fetch and enqueue cross-device messages marked by v5 migration.
-  // These have content="[encrypted]", decryptionStatus="pending", but no encryptedBody.
-  // We need to fetch the raw event from the server to enable DecryptionWorker to process them.
-  healCrossDeviceMessages(db, messages, decryptionWorker, getRoomCrypto).catch((e) => {
-    console.warn("[local-db] Cross-device heal sweep failed:", e);
+    // Recover operations stranded in "syncing" state after app crash, then
+    // re-kick the queue. Scoped to the startup snapshot so ops claimed by
+    // this session's already-running processQueue are never reset mid-flight.
+    strandedOpIdsPromise
+      .then((ids) => syncEngine.recoverStrandedOps(ids))
+      .then(() => syncEngine.processQueue())
+      .catch(() => {});
+
+    // Recover media uploads stuck in "pending" from a previous session (fire-and-forget IIFEs lost on reload/crash)
+    messages.recoverStuckMedia().then((count) => {
+      if (count > 0) console.info(`[local-db] Recovered ${count} stuck media upload(s) → marked as failed`);
+    }).catch(() => {});
+
+    messages.cleanupCancelledUploads()
+      .then((count) => {
+        if (count > 0) console.info(`[local-db] Cleaned up ${count} cancelled upload(s)`);
+      })
+      .catch(() => {});
+
+    // Re-enqueue messages stranded as "[encrypted]" in a previous session whose
+    // ciphertext is still on the row (e.g. failed during the 502 key-outage) but
+    // whose queue job died/was pruned. Self-limiting: recovered rows flip to "ok".
+    decryptionWorker.recoverAllStuckMessages().then((count) => {
+      if (count > 0) console.info(`[local-db] Re-queued ${count} stuck encrypted message(s) for decryption`);
+    }).catch(() => {});
+
+    // Post-migration: re-fetch and enqueue cross-device messages marked by v5 migration.
+    // These have content="[encrypted]", decryptionStatus="pending", but no encryptedBody.
+    // We need to fetch the raw event from the server to enable DecryptionWorker to process them.
+    healCrossDeviceMessages(db, messages, decryptionWorker, getRoomCrypto).catch((e) => {
+      console.warn("[local-db] Cross-device heal sweep failed:", e);
+    });
+
+    // Garbage-collect tombstoned rooms older than 30 days (non-blocking)
+    rooms.garbageCollectTombstones().catch((e) => {
+      console.warn("[local-db] Tombstone GC failed:", e);
+    });
+
+    // GC expired search-cache entries (non-blocking)
+    searchCache.garbageCollect().catch((e) => {
+      console.warn("[local-db] SearchCache GC failed:", e);
+    });
+  };
+
+  // Auto-trigger: chats interactive, or 30s fallback (login stuck / boot error).
+  // The extra 1s lets the first fullRoomRefresh write burst settle so the
+  // recovery scans don't contend with it on the Dexie connection.
+  whenChatsInteractive(DEFERRED_RECOVERY_FALLBACK_MS).then(() => {
+    setTimeout(runDeferredRecovery, DEFERRED_RECOVERY_SETTLE_MS);
   });
 
-  // Garbage-collect tombstoned rooms older than 30 days (non-blocking)
-  rooms.garbageCollectTombstones().catch((e) => {
-    console.warn("[local-db] Tombstone GC failed:", e);
-  });
-
-  // GC expired search-cache entries (non-blocking)
-  searchCache.garbageCollect().catch((e) => {
-    console.warn("[local-db] SearchCache GC failed:", e);
-  });
-
-  currentKit = { db, messages, rooms, channels, users, callProviders, syncEngine, eventWriter, decryptionWorker, listened, searchCache, retryRoomDecryption: retryRoomDebounced, dispose: disposeRetryTriggers };
+  currentKit = { db, messages, rooms, channels, users, callProviders, syncEngine, eventWriter, decryptionWorker, listened, searchCache, retryRoomDecryption: retryRoomDebounced, runDeferredRecovery, dispose: disposeRetryTriggers };
   currentUserId = userId;
 
   return currentKit;
@@ -233,7 +279,9 @@ export function isChatDbReady(): boolean {
  */
 export function closeChatDb(): void {
   if (currentKit) {
-    currentKit.decryptionWorker.dispose();
+    // dispose() also stops the decryption worker and cancels any deferred
+    // recovery still waiting on the chats-interactive signal (WEE-97).
+    currentKit.dispose?.();
     currentKit.db.close();
     currentKit = null;
     currentUserId = null;
@@ -246,7 +294,7 @@ export function closeChatDb(): void {
  */
 export async function deleteChatDb(): Promise<void> {
   if (currentKit) {
-    currentKit.decryptionWorker.dispose();
+    currentKit.dispose?.();
     await currentKit.db.delete();
     currentKit = null;
     currentUserId = null;

--- a/src/shared/lib/local-db/sync-engine.ts
+++ b/src/shared/lib/local-db/sync-engine.ts
@@ -219,9 +219,9 @@ export class SyncEngine {
       // Fire-and-forget — retryAllFailed itself calls processQueue().
       // NOTE: we intentionally do NOT call recoverStrandedOps() here because
       // it has a race with an already-in-flight processQueue() (it could
-      // reset a "syncing" op that's mid-execution). recoverStrandedOps is
-      // documented as "call once at startup before processQueue()" — callers
-      // own that ordering.
+      // reset a "syncing" op that's mid-execution). Callers own that ordering:
+      // run it before processQueue(), or pass the snapshotStrandedOpIds()
+      // whitelist when deferring it past queue start (WEE-97).
       this.retryAllFailed().catch((e) => {
         console.warn("[SyncEngine] retryAllFailed on reconnect failed:", e);
         this.processQueue();
@@ -230,15 +230,43 @@ export class SyncEngine {
   }
 
   /**
+   * Snapshot the ids of ops currently stranded in "syncing" — carried over
+   * from a previous session (crash mid-send). Indexed lookup over a handful
+   * of rows, NOT a table scan.
+   *
+   * WEE-97: recovery is deferred until after the chat list is interactive,
+   * but processQueue() starts immediately and marks in-flight ops "syncing".
+   * Taking this snapshot at startup (before processQueue) lets the deferred
+   * recoverStrandedOps(onlyIds) reset only genuinely stranded ops, never an
+   * op this session has since claimed.
+   */
+  async snapshotStrandedOpIds(): Promise<number[]> {
+    const ids = await this.db.pendingOps
+      .where("status")
+      .equals("syncing")
+      .primaryKeys();
+    return ids as number[];
+  }
+
+  /**
    * Recover operations stranded in "syncing" state (e.g. after app crash mid-send).
    * Resets them back to "pending" so processQueue() will pick them up.
-   * Must be called once at startup before processQueue().
+   *
+   * Ordering contract: either call once at startup BEFORE processQueue(), or
+   * — when deferred past processQueue() start (WEE-97) — pass the `onlyIds`
+   * snapshot taken at startup via snapshotStrandedOpIds() so ops claimed by
+   * the live queue in the meantime are never reset mid-flight.
    */
-  async recoverStrandedOps(): Promise<void> {
-    const stranded = await this.db.pendingOps
+  async recoverStrandedOps(onlyIds?: number[]): Promise<void> {
+    let stranded = await this.db.pendingOps
       .where("status")
       .equals("syncing")
       .toArray();
+
+    if (onlyIds) {
+      const allow = new Set(onlyIds);
+      stranded = stranded.filter((op) => op.id != null && allow.has(op.id));
+    }
 
     if (stranded.length === 0) return;
 


### PR DESCRIPTION
## Summary
- **Deferred recovery scans** (item 1): `recoverStrandedOps`/`recoverStuckMedia`/`recoverAllStuckMessages`/`healCrossDeviceMessages` + GC sweeps no longer run on every login before the chat list is interactive — they wait for the new `boot-signals` chats-interactive signal (30s fallback + 1s settle). `processQueue()`/`decryptionWorker.tick()` stay immediate. Deferred stranded-op recovery is scoped to a startup id snapshot so it can never reset an op the live queue claimed mid-flight.
- **Parallel `Pcrypto.prepare` with Matrix connect** (item 3): prepare (2 IndexedDB stores) runs concurrently with `connectMatrixWithRetry` via `Promise.all`; all `ls`/`lse` access is optional-chained, rooms are created only after first /sync. (Item 2 — `Promise.all` inside `prepare()` — was already on master.)
- **`initialSyncLimit` 1 → 20** (item 4): verified in matrix-js-sdk-bastyon that it applies ONLY to the very first /sync (no saved token); incremental syncs keep the uploaded filter (limit 20). Kills the per-room sequential scrollback / skeletons on first entry.
- **Memoized BIP32 key derivation** (item 5): `generateEncryptionKeys` extracted to `entities/auth/model/encryption-keys.ts` with a single-entry cache keyed by private key; cleared on logout; cached result is frozen and identity-equal to fresh derivation (A3 test).
- **Native: deferred Tor + telemetry** (item 6): both wait for chats-interactive (15s/20s fallbacks). Bonus: the Tor proxy is now re-applied to the live Matrix session once the daemon bootstraps — previously a session that connected before Tor was ready stayed clearnet forever.
- Side fixes: `closeChatDb`/`deleteChatDb` now call `kit.dispose()` (leaked `window online` listener).

## Linear
- Resolves WEE-97 (https://linear.app/wwwee/issue/WEE-97)

## Test plan
- [x] `vite build` passes; `vue-tsc` — 50 errors, all pre-existing baseline (none in changed files)
- [x] Unit + regression tests added: `boot-signals.test.ts`, `deferred-recovery.test.ts` (A2: recovery still runs after signal/fallback; H1 snapshot semantics on real Dexie), `encryption-keys.test.ts` (A3), 2 new cases in `chat-store-initial-sync.test.ts`; affected areas 721/721 pass
- [ ] Manual QA (A1): `console.time` boot → interactive chat list before/after on a mid-range Android device
- [ ] Manual QA (A4): native + Tor opted-in — daemon starts after chat list, Matrix switches to proxy once bootstrapped