### PR TITLE
perf(sync): batch Dexie writes during sync catch-up (WEE-93)

### DIFF
--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -5877,31 +5877,22 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       encryptedRaw: isEncrypted ? raw : undefined,
     };
     const myAddr = useAuthStore().address ?? "";
-    const isActiveRoom = roomId === activeRoomId.value;
-    if (isActiveRoom) {
-      // Active room: write immediately for instant UI feedback
-      chatDbKitRef.value.eventWriter.writeMessage(parsed, myAddr, activeRoomId.value).then(result => {
-        // Enqueue decryption retry if message couldn't be decrypted
-        if (isEncrypted && result !== "duplicate" && chatDbKitRef.value?.decryptionWorker) {
-          chatDbKitRef.value.decryptionWorker.enqueue(
-            raw.event_id as string,
-            roomId,
-            JSON.stringify(raw),
-          ).catch(() => {});
-        }
-      }).catch(e => {
-        console.warn("[chat-store] EventWriter.writeMessage failed:", e);
+    // WEE-93: ALL rooms (active included) write through the batched buffer.
+    // The active room used to write per-event "for instant feedback", but
+    // during sync catch-up that meant one Dexie transaction per backlog event
+    // — the main reason chats were slow to catch up after reconnect. The
+    // buffer flushes by size/150ms timer, so visible latency stays bounded
+    // while a burst lands in 1-2 transactions.
+    chatDbKitRef.value.eventWriter.writeMessageBuffered(parsed, myAddr, activeRoomId.value)
+      .catch(e => {
+        console.warn("[chat-store] EventWriter.writeMessageBuffered failed:", e);
       });
-    } else {
-      // Background room: batch writes to reduce liveQuery notifications
-      chatDbKitRef.value.eventWriter.writeMessageBuffered(parsed, myAddr, activeRoomId.value);
-      if (isEncrypted && chatDbKitRef.value?.decryptionWorker) {
-        chatDbKitRef.value.decryptionWorker.enqueue(
-          raw.event_id as string,
-          roomId,
-          JSON.stringify(raw),
-        ).catch(() => {});
-      }
+    if (isEncrypted && chatDbKitRef.value?.decryptionWorker) {
+      chatDbKitRef.value.decryptionWorker.enqueue(
+        raw.event_id as string,
+        roomId,
+        JSON.stringify(raw),
+      ).catch(() => {});
     }
   };
 

--- a/src/shared/lib/local-db/__tests__/decryption-worker.test.ts
+++ b/src/shared/lib/local-db/__tests__/decryption-worker.test.ts
@@ -326,6 +326,138 @@ describe("DecryptionWorker", () => {
     });
   });
 
+  // ── WEE-93: tick commits all results in a single transaction ──
+  describe("batched tick commits", () => {
+    it("decrypts N jobs and commits all results in one explicit transaction", async () => {
+      const { worker } = makeWorker(db, async (raw: any) => ({ body: `dec-${raw.n}` }));
+      await db.messages.bulkAdd([
+        { eventId: "$e1", roomId: "!r1", timestamp: 1, content: "[encrypted]", decryptionStatus: "pending" },
+        { eventId: "$e2", roomId: "!r1", timestamp: 2, content: "[encrypted]", decryptionStatus: "pending" },
+        { eventId: "$e3", roomId: "!r2", timestamp: 3, content: "[encrypted]", decryptionStatus: "pending" },
+      ] as any);
+      await db.decryptionQueue.bulkAdd([
+        { eventId: "$e1", roomId: "!r1", encryptedBody: '{"n":1}', status: "queued", attempts: 0, nextAttemptAt: 0, createdAt: Date.now() },
+        { eventId: "$e2", roomId: "!r1", encryptedBody: '{"n":2}', status: "queued", attempts: 0, nextAttemptAt: 0, createdAt: Date.now() },
+        { eventId: "$e3", roomId: "!r2", encryptedBody: '{"n":3}', status: "queued", attempts: 0, nextAttemptAt: 0, createdAt: Date.now() },
+      ]);
+
+      const txSpy = vi.spyOn(db, "transaction");
+      await worker.tick();
+
+      // One pick + one commit transaction for the whole tick (not one per job)
+      expect(txSpy).toHaveBeenCalledTimes(2);
+      expect(await db.decryptionQueue.count()).toBe(0);
+      const m1 = await db.messages.where("eventId").equals("$e1").first();
+      const m2 = await db.messages.where("eventId").equals("$e2").first();
+      const m3 = await db.messages.where("eventId").equals("$e3").first();
+      expect(m1?.content).toBe("dec-1");
+      expect(m2?.content).toBe("dec-2");
+      expect(m3?.content).toBe("dec-3");
+      expect(m1?.decryptionStatus).toBe("ok");
+      worker.dispose();
+    });
+
+    it("mixed batch: failures back off while successes commit", async () => {
+      const decryptFn = vi.fn().mockImplementation(async (raw: any) => {
+        if (raw.fail) throw new Error("no key");
+        return { body: "plain" };
+      });
+      const { worker } = makeWorker(db, decryptFn);
+      await db.messages.bulkAdd([
+        { eventId: "$ok", roomId: "!r1", timestamp: 1, content: "[encrypted]", decryptionStatus: "pending" },
+        { eventId: "$bad", roomId: "!r1", timestamp: 2, content: "[encrypted]", decryptionStatus: "pending" },
+      ] as any);
+      await db.decryptionQueue.bulkAdd([
+        { eventId: "$ok", roomId: "!r1", encryptedBody: '{}', status: "queued", attempts: 0, nextAttemptAt: 0, createdAt: Date.now() },
+        { eventId: "$bad", roomId: "!r1", encryptedBody: '{"fail":true}', status: "queued", attempts: 0, nextAttemptAt: 0, createdAt: Date.now() },
+      ]);
+
+      await worker.tick();
+
+      const okMsg = await db.messages.where("eventId").equals("$ok").first();
+      expect(okMsg?.content).toBe("plain");
+      expect(await db.decryptionQueue.where("eventId").equals("$ok").count()).toBe(0);
+
+      const badJob = await db.decryptionQueue.where("eventId").equals("$bad").first();
+      expect(badJob?.status).toBe("waiting");
+      expect(badJob?.attempts).toBe(1);
+      const badMsg = await db.messages.where("eventId").equals("$bad").first();
+      expect(badMsg?.content).toBe("[encrypted]");
+      worker.dispose();
+    });
+
+    it("tick with no ready jobs performs no commit transaction", async () => {
+      const { worker } = makeWorker(db);
+      const txSpy = vi.spyOn(db, "transaction");
+      await worker.tick();
+      // Only the pick transaction runs; no commit transaction
+      expect(txSpy.mock.calls.length).toBeLessThanOrEqual(1);
+      expect(await db.decryptionQueue.count()).toBe(0);
+      worker.dispose();
+    });
+
+    it("does NOT delete the job when the message row is not persisted yet", async () => {
+      // Message still sitting in the EventWriter write buffer → decrypt
+      // succeeds but there is no row to write to. The job must back off,
+      // not be deleted (deleting would strand the message as [encrypted]).
+      const { worker } = makeWorker(db, async () => ({ body: "plain" }));
+      await db.decryptionQueue.add({
+        eventId: "$notYet", roomId: "!r1", encryptedBody: '{}',
+        status: "queued", attempts: 0, nextAttemptAt: 0, createdAt: Date.now(),
+      });
+
+      await worker.tick();
+
+      const job = await db.decryptionQueue.where("eventId").equals("$notYet").first();
+      expect(job).toBeTruthy();
+      expect(job?.status).toBe("waiting");
+      expect(job?.attempts).toBe(1);
+      worker.dispose();
+    });
+  });
+
+  // ── WEE-93: jobs stranded in "processing" by a crashed session ──
+  describe("recoverOrphanedProcessing", () => {
+    it("re-queues processing jobs left over from a dead session", async () => {
+      const { worker } = makeWorker(db);
+      await db.decryptionQueue.bulkAdd([
+        { eventId: "$p1", roomId: "!r1", encryptedBody: '{}', status: "processing", attempts: 2, nextAttemptAt: 0, createdAt: Date.now() },
+        { eventId: "$p2", roomId: "!r1", encryptedBody: '{}', status: "processing", attempts: 0, nextAttemptAt: 0, createdAt: Date.now() },
+        { eventId: "$q1", roomId: "!r1", encryptedBody: '{}', status: "waiting", attempts: 1, nextAttemptAt: 99, createdAt: Date.now() },
+      ]);
+
+      const count = await worker.recoverOrphanedProcessing();
+      expect(count).toBe(2);
+
+      const jobs = await db.decryptionQueue.orderBy("eventId").toArray();
+      const p1 = jobs.find(j => j.eventId === "$p1");
+      const p2 = jobs.find(j => j.eventId === "$p2");
+      const q1 = jobs.find(j => j.eventId === "$q1");
+      expect(p1?.status).toBe("queued");
+      expect(p2?.status).toBe("queued");
+      expect(q1?.status).toBe("waiting"); // untouched
+      worker.dispose();
+    });
+
+    it("recovered jobs get decrypted on the next tick", async () => {
+      const { worker } = makeWorker(db);
+      await db.messages.add({ eventId: "$p1", roomId: "!r1", timestamp: 1, content: "[encrypted]", decryptionStatus: "pending" } as any);
+      await db.decryptionQueue.add({
+        eventId: "$p1", roomId: "!r1", encryptedBody: '{"type":"m.room.message"}',
+        status: "processing", attempts: 0, nextAttemptAt: 0, createdAt: Date.now(),
+      });
+
+      await worker.recoverOrphanedProcessing();
+      await db.decryptionQueue.toCollection().modify({ nextAttemptAt: 0 });
+      await worker.tick();
+
+      const msg = await db.messages.where("eventId").equals("$p1").first();
+      expect(msg?.content).toBe("decrypted");
+      expect(await db.decryptionQueue.count()).toBe(0);
+      worker.dispose();
+    });
+  });
+
   it("full flow: enqueue → fail → retryForRoom → succeed", async () => {
     let shouldFail = true;
     const conditionalCrypto = vi.fn().mockImplementation(async () => {

--- a/src/shared/lib/local-db/__tests__/event-writer-batching.test.ts
+++ b/src/shared/lib/local-db/__tests__/event-writer-batching.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "fake-indexeddb/auto";
+import { ChatDatabase } from "../schema";
+import { MessageRepository } from "../message-repository";
+import { RoomRepository } from "../room-repository";
+import { UserRepository } from "../user-repository";
+import { EventWriter, type ParsedMessage } from "../event-writer";
+import { MessageType } from "@/entities/chat/model/types";
+
+// WEE-93 regression tests: sync catch-up writes must be batched.
+// A1: N events of one flush → 1 Dexie transaction.
+// A2/A3: one room-preview write per room per batch, preview = newest message.
+
+let db: ChatDatabase;
+let msgRepo: MessageRepository;
+let roomRepo: RoomRepository;
+let userRepo: UserRepository;
+
+const ROOM_A = "!roomA:server";
+const ROOM_B = "!roomB:server";
+
+function makeParsed(overrides: Partial<ParsedMessage> = {}): ParsedMessage {
+  return {
+    eventId: overrides.eventId ?? `$evt_${Math.random().toString(36).slice(2)}`,
+    roomId: overrides.roomId ?? ROOM_A,
+    senderId: overrides.senderId ?? "user1",
+    content: overrides.content ?? "hello",
+    timestamp: overrides.timestamp ?? Date.now(),
+    type: overrides.type ?? MessageType.text,
+    ...overrides,
+  };
+}
+
+function makeWriter(opts?: { onChange?: (roomId: string) => void; fetchPreviewFn?: (url: string) => Promise<null> }) {
+  const writer = new EventWriter(db, msgRepo, roomRepo, userRepo, opts?.onChange, opts?.fetchPreviewFn);
+  writer.enableBatching();
+  return writer;
+}
+
+beforeEach(async () => {
+  const name = `test-ew-batching-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  db = new ChatDatabase(name);
+  await db.open();
+  msgRepo = new MessageRepository(db);
+  roomRepo = new RoomRepository(db);
+  userRepo = new UserRepository(db);
+});
+
+afterEach(async () => {
+  await db.delete();
+});
+
+describe("EventWriter batched flush (WEE-93)", () => {
+  it("A1: writes a backlog of N messages in a single Dexie transaction", async () => {
+    const writer = makeWriter();
+    const txSpy = vi.spyOn(db, "transaction");
+
+    for (let i = 0; i < 10; i++) {
+      await writer.writeMessageBuffered(
+        makeParsed({ timestamp: 1000 + i, content: `msg ${i}` }),
+        "me",
+        null,
+      );
+    }
+    expect(txSpy).not.toHaveBeenCalled(); // nothing written before flush
+
+    await writer.flushWriteBuffer();
+
+    expect(txSpy).toHaveBeenCalledTimes(1);
+    expect(await db.messages.count()).toBe(10);
+    await writer.disposeBuffer();
+  });
+
+  it("coalesces ensureRoomExists + preview writes to once per unique room", async () => {
+    const writer = makeWriter();
+    // Pre-create rooms so ensureRoomExists takes the read-only path
+    await db.rooms.bulkPut([
+      { id: ROOM_A, name: "A", avatar: "", isGroup: false, members: [], membership: "join", unreadCount: 0, topic: "", updatedAt: 0, syncedAt: 0, hasMoreHistory: true, lastReadInboundTs: 0, lastReadOutboundTs: 0, lastMessageReaction: null, isDeleted: false, deletedAt: null, deleteReason: null },
+      { id: ROOM_B, name: "B", avatar: "", isGroup: false, members: [], membership: "join", unreadCount: 0, topic: "", updatedAt: 0, syncedAt: 0, hasMoreHistory: true, lastReadInboundTs: 0, lastReadOutboundTs: 0, lastMessageReaction: null, isDeleted: false, deletedAt: null, deleteReason: null },
+    ]);
+
+    const previewSpy = vi.spyOn(roomRepo, "updateLastMessage");
+    const roomGetSpy = vi.spyOn(db.rooms, "get");
+
+    for (let i = 0; i < 5; i++) {
+      await writer.writeMessageBuffered(makeParsed({ roomId: ROOM_A, timestamp: 1000 + i }), "me", null);
+      await writer.writeMessageBuffered(makeParsed({ roomId: ROOM_B, timestamp: 2000 + i }), "me", null);
+    }
+    await writer.flushWriteBuffer();
+
+    // One preview write per room — not one per message (was 10)
+    expect(previewSpy).toHaveBeenCalledTimes(2);
+    // ensureRoomExists (1 get) + updateLastMessage guard (1 get) per room — not per message (was 20)
+    expect(roomGetSpy.mock.calls.length).toBeLessThanOrEqual(4);
+    await writer.disposeBuffer();
+  });
+
+  it("A3: room preview reflects the NEWEST message even when the batch is out of order", async () => {
+    const writer = makeWriter();
+    await writer.writeMessageBuffered(makeParsed({ timestamp: 3000, content: "newest" }), "me", null);
+    await writer.writeMessageBuffered(makeParsed({ timestamp: 1000, content: "oldest" }), "me", null);
+    await writer.writeMessageBuffered(makeParsed({ timestamp: 2000, content: "middle" }), "me", null);
+    await writer.flushWriteBuffer();
+
+    const room = await db.rooms.get(ROOM_A);
+    expect(room?.lastMessagePreview).toBe("newest");
+    expect(room?.lastMessageTimestamp).toBe(3000);
+
+    // All messages persisted, retrievable in timestamp order
+    const msgs = await db.messages.where("[roomId+timestamp]")
+      .between([ROOM_A, 0], [ROOM_A, Infinity]).toArray();
+    expect(msgs.map(m => m.content)).toEqual(["oldest", "middle", "newest"]);
+    await writer.disposeBuffer();
+  });
+
+  it("A2: onChange fires once per room per flush, not once per message", async () => {
+    const onChange = vi.fn();
+    const writer = makeWriter({ onChange });
+
+    for (let i = 0; i < 5; i++) {
+      await writer.writeMessageBuffered(makeParsed({ roomId: ROOM_A, timestamp: 1000 + i }), "me", null);
+    }
+    await writer.writeMessageBuffered(makeParsed({ roomId: ROOM_B, timestamp: 5000 }), "me", null);
+    await writer.flushWriteBuffer();
+
+    const calls = onChange.mock.calls.map(c => c[0]).sort();
+    expect(calls).toEqual([ROOM_A, ROOM_B]);
+    await writer.disposeBuffer();
+  });
+
+  it("keeps meaningful preview text when the newest batch message is still encrypted", async () => {
+    const writer = makeWriter();
+    await writer.writeMessageBuffered(
+      makeParsed({ timestamp: 1000, content: "plain text" }),
+      "me",
+      null,
+    );
+    await writer.writeMessageBuffered(
+      makeParsed({ timestamp: 2000, content: "[encrypted]", encryptedRaw: { type: "m.room.encrypted" } }),
+      "me",
+      null,
+    );
+    await writer.flushWriteBuffer();
+
+    const room = await db.rooms.get(ROOM_A);
+    // Sequential-write parity: plaintext preview preserved, metadata advanced
+    expect(room?.lastMessagePreview).toBe("plain text");
+    expect(room?.lastMessageTimestamp).toBe(2000);
+    expect(room?.lastMessageDecryptionStatus).toBe("pending");
+    await writer.disposeBuffer();
+  });
+
+  it("fetches link previews for inserted text messages (parity with writeMessage)", async () => {
+    const fetchPreviewFn = vi.fn().mockResolvedValue(null);
+    const writer = makeWriter({ fetchPreviewFn });
+
+    await writer.writeMessageBuffered(
+      makeParsed({ content: "look at https://example.com/page" }),
+      "me",
+      null,
+    );
+    await writer.writeMessageBuffered(makeParsed({ content: "no links here" }), "me", null);
+    await writer.flushWriteBuffer();
+
+    expect(fetchPreviewFn).toHaveBeenCalledTimes(1);
+    expect(fetchPreviewFn).toHaveBeenCalledWith("https://example.com/page");
+    await writer.disposeBuffer();
+  });
+
+  it("a corrupted message does not abort the rest of the batch", async () => {
+    const writer = makeWriter();
+    const upsertSpy = vi.spyOn(msgRepo, "upsertFromServer");
+    upsertSpy.mockRejectedValueOnce(new Error("corrupt"));
+
+    await writer.writeMessageBuffered(makeParsed({ timestamp: 1000, content: "bad" }), "me", null);
+    await writer.writeMessageBuffered(makeParsed({ timestamp: 2000, content: "good" }), "me", null);
+    await writer.flushWriteBuffer();
+
+    expect(await db.messages.count()).toBe(1);
+    const room = await db.rooms.get(ROOM_A);
+    expect(room?.lastMessagePreview).toBe("good");
+    await writer.disposeBuffer();
+  });
+});

--- a/src/shared/lib/local-db/__tests__/event-writer-reaction-buffer.test.ts
+++ b/src/shared/lib/local-db/__tests__/event-writer-reaction-buffer.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "fake-indexeddb/auto";
+import { ChatDatabase } from "../schema";
+import type { LocalMessage } from "../schema";
+import { MessageRepository } from "../message-repository";
+import { RoomRepository } from "../room-repository";
+import { UserRepository } from "../user-repository";
+import { EventWriter, type ParsedReaction } from "../event-writer";
+import { MessageType } from "@/entities/chat/model/types";
+
+// WEE-93: inbound reactions are buffered and flushed in a single transaction
+// (a sync backlog used to cost one read+write round-trip per reaction).
+
+let db: ChatDatabase;
+let msgRepo: MessageRepository;
+let roomRepo: RoomRepository;
+let userRepo: UserRepository;
+
+const ROOM_ID = "!room:server";
+
+function makeMsg(overrides: Partial<LocalMessage> = {}): LocalMessage {
+  return {
+    eventId: overrides.eventId ?? `$evt_${Math.random().toString(36).slice(2)}`,
+    clientId: overrides.clientId ?? `cli_${Math.random().toString(36).slice(2)}`,
+    roomId: overrides.roomId ?? ROOM_ID,
+    senderId: overrides.senderId ?? "user1",
+    content: overrides.content ?? "hello",
+    timestamp: overrides.timestamp ?? Date.now(),
+    type: overrides.type ?? MessageType.text,
+    status: "synced",
+    version: 1,
+    softDeleted: false,
+    ...overrides,
+  } as LocalMessage;
+}
+
+function makeReaction(overrides: Partial<ParsedReaction> = {}): ParsedReaction {
+  return {
+    eventId: overrides.eventId ?? `$react_${Math.random().toString(36).slice(2)}`,
+    targetEventId: overrides.targetEventId ?? "$target",
+    emoji: overrides.emoji ?? "👍",
+    senderAddress: overrides.senderAddress ?? "user2",
+    isMine: overrides.isMine ?? false,
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  const name = `test-ew-reactions-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  db = new ChatDatabase(name);
+  await db.open();
+  msgRepo = new MessageRepository(db);
+  roomRepo = new RoomRepository(db);
+  userRepo = new UserRepository(db);
+});
+
+afterEach(async () => {
+  await db.delete();
+});
+
+describe("EventWriter buffered reactions (WEE-93)", () => {
+  it("flushes N buffered reactions in a single transaction", async () => {
+    const writer = new EventWriter(db, msgRepo, roomRepo, userRepo);
+    writer.enableBatching();
+    await db.messages.bulkAdd([
+      makeMsg({ eventId: "$m1", timestamp: 1000 }),
+      makeMsg({ eventId: "$m2", timestamp: 2000 }),
+    ]);
+
+    const txSpy = vi.spyOn(db, "transaction");
+    await writer.writeReaction(makeReaction({ targetEventId: "$m1", emoji: "👍", senderAddress: "a" }));
+    await writer.writeReaction(makeReaction({ targetEventId: "$m1", emoji: "👍", senderAddress: "b" }));
+    await writer.writeReaction(makeReaction({ targetEventId: "$m1", emoji: "🔥", senderAddress: "a" }));
+    await writer.writeReaction(makeReaction({ targetEventId: "$m2", emoji: "❤️", senderAddress: "c" }));
+    expect(txSpy).not.toHaveBeenCalled(); // buffered, not yet written
+
+    await writer.flushWriteBuffer();
+    expect(txSpy).toHaveBeenCalledTimes(1);
+
+    const m1 = await db.messages.where("eventId").equals("$m1").first();
+    expect(m1?.reactions?.["👍"].count).toBe(2);
+    expect(m1?.reactions?.["👍"].users.sort()).toEqual(["a", "b"]);
+    expect(m1?.reactions?.["🔥"].count).toBe(1);
+    const m2 = await db.messages.where("eventId").equals("$m2").first();
+    expect(m2?.reactions?.["❤️"].count).toBe(1);
+    await writer.disposeBuffer();
+  });
+
+  it("tracks myEventId for own reactions through the buffer", async () => {
+    const writer = new EventWriter(db, msgRepo, roomRepo, userRepo);
+    writer.enableBatching();
+    await db.messages.add(makeMsg({ eventId: "$m1" }));
+
+    await writer.writeReaction(makeReaction({
+      eventId: "$myreact", targetEventId: "$m1", emoji: "👍", senderAddress: "me", isMine: true,
+    }));
+    await writer.flushWriteBuffer();
+
+    const m1 = await db.messages.where("eventId").equals("$m1").first();
+    expect(m1?.reactions?.["👍"].myEventId).toBe("$myreact");
+    await writer.disposeBuffer();
+  });
+
+  it("cascades the reaction to the room preview when target is the last message", async () => {
+    const writer = new EventWriter(db, msgRepo, roomRepo, userRepo);
+    writer.enableBatching();
+    await db.messages.add(makeMsg({ eventId: "$last" }));
+    await db.rooms.put({
+      id: ROOM_ID, name: "Room", avatar: "", isGroup: false, members: [], membership: "join",
+      unreadCount: 0, topic: "", updatedAt: 0, syncedAt: 0, hasMoreHistory: true,
+      lastReadInboundTs: 0, lastReadOutboundTs: 0, lastMessageReaction: null,
+      isDeleted: false, deletedAt: null, deleteReason: null,
+      lastMessageEventId: "$last",
+    });
+
+    await writer.writeReaction(makeReaction({ targetEventId: "$last", emoji: "🎉", senderAddress: "u9" }));
+    await writer.flushWriteBuffer();
+
+    const room = await db.rooms.get(ROOM_ID);
+    expect(room?.lastMessageReaction?.emoji).toBe("🎉");
+    expect(room?.lastMessageReaction?.senderAddress).toBe("u9");
+    await writer.disposeBuffer();
+  });
+
+  it("fires onChange once per room per flush", async () => {
+    const onChange = vi.fn();
+    const writer = new EventWriter(db, msgRepo, roomRepo, userRepo, onChange);
+    writer.enableBatching();
+    await db.messages.bulkAdd([
+      makeMsg({ eventId: "$m1", timestamp: 1000 }),
+      makeMsg({ eventId: "$m2", timestamp: 2000 }),
+    ]);
+
+    await writer.writeReaction(makeReaction({ targetEventId: "$m1", senderAddress: "a" }));
+    await writer.writeReaction(makeReaction({ targetEventId: "$m1", senderAddress: "b" }));
+    await writer.writeReaction(makeReaction({ targetEventId: "$m2", senderAddress: "c" }));
+    await writer.flushWriteBuffer();
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(ROOM_ID);
+    await writer.disposeBuffer();
+  });
+
+  it("writes immediately when batching is not enabled (fallback path)", async () => {
+    const writer = new EventWriter(db, msgRepo, roomRepo, userRepo);
+    await db.messages.add(makeMsg({ eventId: "$m1" }));
+
+    await writer.writeReaction(makeReaction({ targetEventId: "$m1", emoji: "👍", senderAddress: "a" }));
+
+    const m1 = await db.messages.where("eventId").equals("$m1").first();
+    expect(m1?.reactions?.["👍"].count).toBe(1);
+  });
+
+  it("flushes the message buffer first so a reaction to a still-buffered message is not dropped", async () => {
+    const writer = new EventWriter(db, msgRepo, roomRepo, userRepo);
+    writer.enableBatching();
+
+    // Target message is enqueued but NOT yet flushed to Dexie
+    await writer.writeMessageBuffered({
+      eventId: "$buffered",
+      roomId: ROOM_ID,
+      senderId: "user1",
+      content: "hi",
+      timestamp: 1000,
+      type: MessageType.text,
+    }, "me", null);
+    expect(await db.messages.count()).toBe(0);
+
+    // Force the REACTION buffer to flush (maxSize 100) while the message
+    // buffer still holds the target — flushReactions must land messages first.
+    for (let i = 0; i < 100; i++) {
+      await writer.writeReaction(makeReaction({
+        targetEventId: "$buffered",
+        emoji: "👍",
+        senderAddress: `user_${i}`,
+      }));
+    }
+    // maxSize flush is fire-and-forget — settle pending flush promises
+    await writer.flushWriteBuffer();
+
+    const msg = await db.messages.where("eventId").equals("$buffered").first();
+    expect(msg).toBeTruthy();
+    expect(msg?.reactions?.["👍"].count).toBe(100);
+    await writer.disposeBuffer();
+  });
+
+  it("drops reactions whose target message is missing without aborting others", async () => {
+    const writer = new EventWriter(db, msgRepo, roomRepo, userRepo);
+    writer.enableBatching();
+    await db.messages.add(makeMsg({ eventId: "$exists" }));
+
+    await writer.writeReaction(makeReaction({ targetEventId: "$ghost", senderAddress: "a" }));
+    await writer.writeReaction(makeReaction({ targetEventId: "$exists", emoji: "👍", senderAddress: "a" }));
+    await writer.flushWriteBuffer();
+
+    const msg = await db.messages.where("eventId").equals("$exists").first();
+    expect(msg?.reactions?.["👍"].count).toBe(1);
+    await writer.disposeBuffer();
+  });
+});

--- a/src/shared/lib/local-db/decryption-worker.ts
+++ b/src/shared/lib/local-db/decryption-worker.ts
@@ -87,7 +87,13 @@ export class DecryptionWorker {
     }
   }
 
-  /** Process all ready jobs in the queue. */
+  /** Process all ready jobs in the queue.
+   *
+   *  WEE-93: DB writes are batched per tick. Previously every job committed
+   *  its results (message update, room preview, job delete) as separate
+   *  transactions — a backlog tick of 20 jobs cost ~100+ IndexedDB
+   *  transactions on slow Android. Now: one bulk "processing" mark, a pure
+   *  decrypt phase with no DB writes, and one commit transaction per tick. */
   async tick(): Promise<void> {
     if (this.processing) return;
     this.processing = true;
@@ -95,24 +101,69 @@ export class DecryptionWorker {
     try {
       const now = Date.now();
 
-      const queuedJobs = await this.db.decryptionQueue
-        .where("[status+nextAttemptAt]")
-        .between(["queued", 0], ["queued", now], true, true)
-        .limit(BATCH_SIZE)
-        .toArray();
+      // Pick + bulk "processing" mark in ONE transaction so a concurrent
+      // retryForRoom reset can't be clobbered between read and mark.
+      const jobs = await this.db.transaction("rw", this.db.decryptionQueue, async () => {
+        const queuedJobs = await this.db.decryptionQueue
+          .where("[status+nextAttemptAt]")
+          .between(["queued", 0], ["queued", now], true, true)
+          .limit(BATCH_SIZE)
+          .toArray();
 
-      const remaining = BATCH_SIZE - queuedJobs.length;
-      const waitingJobs = remaining > 0
-        ? await this.db.decryptionQueue
-            .where("[status+nextAttemptAt]")
-            .between(["waiting", 0], ["waiting", now], true, true)
-            .limit(remaining)
-            .toArray()
-        : [];
+        const remaining = BATCH_SIZE - queuedJobs.length;
+        const waitingJobs = remaining > 0
+          ? await this.db.decryptionQueue
+              .where("[status+nextAttemptAt]")
+              .between(["waiting", 0], ["waiting", now], true, true)
+              .limit(remaining)
+              .toArray()
+          : [];
 
-      for (const job of [...queuedJobs, ...waitingJobs]) {
-        await this.processJob(job);
+        const picked = [...queuedJobs, ...waitingJobs];
+        if (picked.length > 0) {
+          await this.db.decryptionQueue
+            .where("id")
+            .anyOf(picked.map((j) => j.id!))
+            .modify({ status: "processing" });
+        }
+        return picked;
+      });
+
+      if (jobs.length === 0) return;
+
+      // Decrypt phase — pure crypto, no DB writes.
+      const results: Array<{ job: DecryptionJob; ok: boolean; body?: string; error?: unknown }> = [];
+      for (const job of jobs) {
+        try {
+          const raw = JSON.parse(job.encryptedBody);
+          const roomCrypto = await this.getRoomCrypto(job.roomId);
+          if (!roomCrypto) throw new Error("Room crypto not available");
+          const result = await roomCrypto.decryptEvent(raw);
+          results.push({ job, ok: true, body: result.body });
+        } catch (e) {
+          results.push({ job, ok: false, error: e });
+        }
       }
+
+      // Commit phase — one transaction for the whole tick.
+      await this.db.transaction(
+        "rw",
+        [this.db.messages, this.db.rooms, this.db.decryptionQueue],
+        async () => {
+          for (const r of results) {
+            try {
+              if (r.ok) {
+                await this.commitSuccess(r.job, r.body!);
+              } else {
+                await this.commitFailure(r.job, r.error);
+              }
+            } catch (err) {
+              // Fault-tolerant: one bad job must not abort the whole commit.
+              console.error("[decryption] commit failed for", r.job.eventId, err);
+            }
+          }
+        },
+      );
     } finally {
       this.processing = false;
       this.scheduleNext();
@@ -236,6 +287,20 @@ export class DecryptionWorker {
     });
   }
 
+  /** Boot recovery: re-queue jobs left in "processing" by a previous session
+   *  that died mid-tick. They are otherwise stranded forever — retryForRoom
+   *  skips "processing" jobs and requeueStuckMessage refuses to touch them.
+   *  Safe at init: no tick is running yet in this session. */
+  async recoverOrphanedProcessing(): Promise<number> {
+    const count = await this.db.decryptionQueue
+      .where("status").equals("processing")
+      .modify({ status: "queued", nextAttemptAt: Date.now() });
+    if (count > 0) {
+      console.info(`[decryption] recovered ${count} orphaned processing job(s)`);
+    }
+    return count;
+  }
+
   /** Retry all queued/waiting jobs immediately (called on online transition). */
   async retryAllWaiting(): Promise<void> {
     await this.db.decryptionQueue
@@ -274,94 +339,95 @@ export class DecryptionWorker {
     }
   }
 
-  private async processJob(job: DecryptionJob): Promise<void> {
-    await this.db.decryptionQueue.update(job.id!, { status: "processing" });
+  /** Commit a successful decrypt — runs inside the tick's commit transaction. */
+  private async commitSuccess(job: DecryptionJob, body: string): Promise<void> {
+    // Update message content in DB
+    const msg = await this.db.messages
+      .where("eventId").equals(job.eventId).first();
+    if (!msg) {
+      // Message row not persisted yet (e.g. still sitting in the EventWriter
+      // write buffer). Deleting the job here would discard the only retry
+      // handle and leave the message "[encrypted]" until the next boot sweep
+      // — back off and retry instead (bounded by MAX_ATTEMPTS).
+      await this.commitFailure(job, new Error("message row not yet persisted"));
+      return;
+    }
 
+    await this.db.messages.update(msg.localId!, {
+      content: body,
+      decryptionStatus: "ok",
+      encryptedBody: undefined,
+    });
+
+    // Update room preview if this is the latest message
+    if (this.roomRepo) {
+      await this.updateRoomPreviewIfLatest(msg.roomId, msg.eventId!, body, msg.senderId, msg.type, msg.timestamp);
+    }
+
+    // Clear room-level decryption status
     try {
-      const raw = JSON.parse(job.encryptedBody);
-      const roomCrypto = await this.getRoomCrypto(job.roomId);
-      if (!roomCrypto) throw new Error("Room crypto not available");
+      const room = await this.db.rooms.where("id").equals(job.roomId).first();
+      if (room && room.lastMessageEventId === job.eventId) {
+        await this.db.rooms.update(job.roomId, {
+          lastMessageDecryptionStatus: undefined,
+        });
+      }
+    } catch { /* non-critical */ }
 
-      const result = await roomCrypto.decryptEvent(raw);
+    // Remove completed job
+    await this.db.decryptionQueue.delete(job.id!);
+  }
 
-      // Success: update message content in DB
+  /** Commit a failed decrypt (backoff/dead) — runs inside the tick's commit transaction. */
+  private async commitFailure(job: DecryptionJob, e: unknown): Promise<void> {
+    const attempts = job.attempts + 1;
+    const isDead = attempts >= MAX_ATTEMPTS;
+
+    cryptoDebug("retry:fail", {
+      eventId: job.eventId,
+      roomId: job.roomId,
+      attempts,
+      isDead,
+      error: e instanceof Error ? e.message : String(e),
+    });
+
+    let delay: number;
+    if (attempts <= FAST_BACKOFF_MS.length) {
+      delay = FAST_BACKOFF_MS[attempts - 1];
+    } else {
+      const slowIdx = Math.min(
+        attempts - FAST_BACKOFF_MS.length - 1,
+        SLOW_BACKOFF_MS.length - 1,
+      );
+      delay = SLOW_BACKOFF_MS[slowIdx];
+    }
+    const jitter = Math.random() * delay * 0.2;
+
+    await this.db.decryptionQueue.update(job.id!, {
+      status: isDead ? "dead" : "waiting",
+      attempts,
+      nextAttemptAt: isDead ? 0 : Date.now() + delay + jitter,
+      lastError: String(e instanceof Error ? e.message : e),
+    });
+
+    // Mark message as failed if dead
+    if (isDead) {
       const msg = await this.db.messages
         .where("eventId").equals(job.eventId).first();
       if (msg) {
         await this.db.messages.update(msg.localId!, {
-          content: result.body,
-          decryptionStatus: "ok",
-          encryptedBody: undefined,
+          decryptionStatus: "failed",
         });
-
-        // Update room preview if this is the latest message
-        if (this.roomRepo) {
-          await this.updateRoomPreviewIfLatest(msg.roomId, msg.eventId!, result.body, msg.senderId, msg.type, msg.timestamp);
-        }
       }
 
-      // Clear room-level decryption status
       try {
         const room = await this.db.rooms.where("id").equals(job.roomId).first();
         if (room && room.lastMessageEventId === job.eventId) {
           await this.db.rooms.update(job.roomId, {
-            lastMessageDecryptionStatus: undefined,
+            lastMessageDecryptionStatus: "failed",
           });
         }
       } catch { /* non-critical */ }
-
-      // Remove completed job
-      await this.db.decryptionQueue.delete(job.id!);
-    } catch (e) {
-      const attempts = job.attempts + 1;
-      const isDead = attempts >= MAX_ATTEMPTS;
-
-      cryptoDebug("retry:fail", {
-        eventId: job.eventId,
-        roomId: job.roomId,
-        attempts,
-        isDead,
-        error: e instanceof Error ? e.message : String(e),
-      });
-
-      let delay: number;
-      if (attempts <= FAST_BACKOFF_MS.length) {
-        delay = FAST_BACKOFF_MS[attempts - 1];
-      } else {
-        const slowIdx = Math.min(
-          attempts - FAST_BACKOFF_MS.length - 1,
-          SLOW_BACKOFF_MS.length - 1,
-        );
-        delay = SLOW_BACKOFF_MS[slowIdx];
-      }
-      const jitter = Math.random() * delay * 0.2;
-
-      await this.db.decryptionQueue.update(job.id!, {
-        status: isDead ? "dead" : "waiting",
-        attempts,
-        nextAttemptAt: isDead ? 0 : Date.now() + delay + jitter,
-        lastError: String(e instanceof Error ? e.message : e),
-      });
-
-      // Mark message as failed if dead
-      if (isDead) {
-        const msg = await this.db.messages
-          .where("eventId").equals(job.eventId).first();
-        if (msg) {
-          await this.db.messages.update(msg.localId!, {
-            decryptionStatus: "failed",
-          });
-        }
-
-        try {
-          const room = await this.db.rooms.where("id").equals(job.roomId).first();
-          if (room && room.lastMessageEventId === job.eventId) {
-            await this.db.rooms.update(job.roomId, {
-              lastMessageDecryptionStatus: "failed",
-            });
-          }
-        } catch { /* non-critical */ }
-      }
     }
   }
 

--- a/src/shared/lib/local-db/deferred-recovery.test.ts
+++ b/src/shared/lib/local-db/deferred-recovery.test.ts
@@ -35,6 +35,7 @@ describe("initChatDb deferred recovery (WEE-97 item 1)", () => {
     recoverStuckMedia: ReturnType<typeof vi.spyOn>;
     cleanupCancelledUploads: ReturnType<typeof vi.spyOn>;
     recoverAllStuckMessages: ReturnType<typeof vi.spyOn>;
+    recoverOrphanedProcessing: ReturnType<typeof vi.spyOn>;
     tick: ReturnType<typeof vi.spyOn>;
     gcTombstones: ReturnType<typeof vi.spyOn>;
     gcSearchCache: ReturnType<typeof vi.spyOn>;
@@ -52,6 +53,10 @@ describe("initChatDb deferred recovery (WEE-97 item 1)", () => {
       recoverStuckMedia: vi.spyOn(MessageRepository.prototype, "recoverStuckMedia").mockResolvedValue(0 as never),
       cleanupCancelledUploads: vi.spyOn(MessageRepository.prototype, "cleanupCancelledUploads").mockResolvedValue(0 as never),
       recoverAllStuckMessages: vi.spyOn(DecryptionWorker.prototype, "recoverAllStuckMessages").mockResolvedValue(0 as never),
+      // WEE-93: cheap indexed reset that runs BEFORE the first tick — mocked so
+      // the recoverOrphanedProcessing → tick chain resolves in microtasks
+      // under fake timers (real Dexie ops don't settle here).
+      recoverOrphanedProcessing: vi.spyOn(DecryptionWorker.prototype, "recoverOrphanedProcessing").mockResolvedValue(0 as never),
       tick: vi.spyOn(DecryptionWorker.prototype, "tick").mockResolvedValue(undefined as never),
       gcTombstones: vi.spyOn(RoomRepository.prototype, "garbageCollectTombstones").mockResolvedValue(0 as never),
       gcSearchCache: vi.spyOn(SearchCacheRepository.prototype, "garbageCollect").mockResolvedValue(0 as never),
@@ -72,6 +77,8 @@ describe("initChatDb deferred recovery (WEE-97 item 1)", () => {
 
     // Live-messaging machinery runs right away
     expect(spies.processQueue).toHaveBeenCalledTimes(1);
+    // WEE-93: orphaned-"processing" reset precedes the first tick
+    expect(spies.recoverOrphanedProcessing).toHaveBeenCalledTimes(1);
     expect(spies.tick).toHaveBeenCalledTimes(1);
 
     // Heavy table scans do NOT run before the chats-interactive signal

--- a/src/shared/lib/local-db/event-writer.ts
+++ b/src/shared/lib/local-db/event-writer.ts
@@ -154,6 +154,11 @@ export class EventWriter {
 
   private writeBuffer: WriteBuffer | null = null;
 
+  /** Buffered inbound reactions (WEE-93) — flushed in one transaction.
+   *  Slightly longer delay than the message buffer so a reaction whose target
+   *  message is still sitting in the message buffer lands AFTER it. */
+  private reactionBuffer: WriteBuffer<ParsedReaction> | null = null;
+
   /**
    * Enable write batching. Creates an internal WriteBuffer that accumulates
    * messages and flushes them in a single Dexie transaction.
@@ -163,6 +168,10 @@ export class EventWriter {
     this.writeBuffer = new WriteBuffer(
       (items) => this.flushBatch(items),
       { delayMs: 150, maxSize: 50 },
+    );
+    this.reactionBuffer = new WriteBuffer<ParsedReaction>(
+      (items) => this.flushReactions(items),
+      { delayMs: 500, maxSize: 100 },
     );
   }
 
@@ -193,6 +202,7 @@ export class EventWriter {
   /** Force-flush the write buffer immediately. No-op if batching not enabled. */
   async flushWriteBuffer(): Promise<void> {
     await this.writeBuffer?.flushNow();
+    await this.reactionBuffer?.flushNow();
   }
 
   /** Flush remaining items and dispose the write buffer. */
@@ -200,6 +210,10 @@ export class EventWriter {
     if (this.writeBuffer) {
       await this.writeBuffer.dispose();
       this.writeBuffer = null;
+    }
+    if (this.reactionBuffer) {
+      await this.reactionBuffer.dispose();
+      this.reactionBuffer = null;
     }
   }
 
@@ -214,6 +228,17 @@ export class EventWriter {
   private async flushBatch(items: BufferedWrite[]): Promise<void> {
     perfMark("flush-batch:start");
     const changedRooms = new Set<string>();
+    const insertedItems: BufferedWrite[] = [];
+    // WEE-93: per-room coalescing within the batch. The room preview only needs
+    // the newest message per room (updateLastMessage's monotonic guard would
+    // discard the rest anyway), and ensureRoomExists only needs to run once per
+    // room — not once per message (N db.rooms.get() reads on a backlog batch).
+    const latestPerRoom = new Map<string, ParsedMessage>();
+    // Newest NON-encrypted-pending message per room: when the batch's newest
+    // message is "[encrypted]", writing the newest plaintext first preserves
+    // the sequential behaviour of keeping meaningful preview text instead of
+    // the "[encrypted]" placeholder.
+    const latestPlainPerRoom = new Map<string, ParsedMessage>();
 
     await this.db.transaction("rw", [this.db.messages, this.db.rooms], async () => {
       for (const item of items) {
@@ -221,8 +246,19 @@ export class EventWriter {
           const result = await this.messageRepo.upsertFromServer(item.localMsg, this.clearedAtTsCache.get(item.roomId));
 
           if (result === "inserted" || result === "updated") {
-            await this.ensureRoomExists(item.roomId);
-            await this.updateRoomPreview(item.parsed);
+            const parsed = item.parsed;
+            const prev = latestPerRoom.get(item.roomId);
+            // >= keeps the later batch item among equal timestamps — matches
+            // sequential updateLastMessage semantics (its guard is strict <).
+            if (!prev || parsed.timestamp >= prev.timestamp) {
+              latestPerRoom.set(item.roomId, parsed);
+            }
+            if (!(parsed.content === "[encrypted]" && parsed.encryptedRaw)) {
+              const prevPlain = latestPlainPerRoom.get(item.roomId);
+              if (!prevPlain || parsed.timestamp >= prevPlain.timestamp) {
+                latestPlainPerRoom.set(item.roomId, parsed);
+              }
+            }
           }
 
           if (result === "inserted") {
@@ -230,10 +266,25 @@ export class EventWriter {
             // getUnreadNotificationCount("total") is the single source of truth,
             // synced to Dexie via bulkSyncRooms during room refresh cycles.
             changedRooms.add(item.roomId);
+            insertedItems.push(item);
           }
         } catch (err) {
           // Fault-tolerant: one corrupted message must not abort the entire batch.
           console.error("[EventWriter] flushBatch: failed to write message, skipping:", item.parsed.eventId, err);
+        }
+      }
+
+      // One ensureRoomExists + (at most two) preview writes per unique room.
+      for (const [roomId, latest] of latestPerRoom) {
+        try {
+          await this.ensureRoomExists(roomId);
+          const latestPlain = latestPlainPerRoom.get(roomId);
+          if (latestPlain && latestPlain.eventId !== latest.eventId) {
+            await this.updateRoomPreview(latestPlain);
+          }
+          await this.updateRoomPreview(latest);
+        } catch (err) {
+          console.error("[EventWriter] flushBatch: failed to update room preview, skipping:", roomId, err);
         }
       }
     });
@@ -253,6 +304,18 @@ export class EventWriter {
         && this.pendingPollVotes.has(item.parsed.eventId)
       ) {
         await this.applyPendingPollUpdates(item.parsed.eventId);
+      }
+    }
+
+    // Async link preview for inserted messages — parity with writeMessage().
+    // Needed since the active room also writes through the buffer (WEE-93).
+    for (const item of insertedItems) {
+      const p = item.parsed;
+      if (!p.linkPreview && !p.noPreview && p.type === MessageType.text && this.fetchPreviewFn) {
+        const url = p.content.match(URL_RE)?.[0];
+        if (url) {
+          this.fetchAndStoreLinkPreview(url, item.localMsg);
+        }
       }
     }
 
@@ -354,37 +417,84 @@ export class EventWriter {
   // Reactions
   // ---------------------------------------------------------------------------
 
-  /** Apply a reaction to a message in the local DB */
+  /** Apply a reaction to a message in the local DB.
+   *  When batching is enabled, the reaction is enqueued and flushed together
+   *  with other reactions in a single transaction (WEE-93) — a sync backlog
+   *  of N reactions used to cost N separate read+write round-trips. */
   async writeReaction(reaction: ParsedReaction): Promise<void> {
-    const msg = await this.messageRepo.getByEventId(reaction.targetEventId);
-    if (!msg) return;
+    if (this.reactionBuffer) {
+      this.reactionBuffer.enqueue(reaction);
+      return;
+    }
+    await this.flushReactions([reaction]);
+  }
 
-    const reactions = msg.reactions ?? {};
-    if (!reactions[reaction.emoji]) {
-      reactions[reaction.emoji] = { count: 0, users: [] };
+  /** Flush buffered reactions: one read + one write per target message,
+   *  all inside a single Dexie transaction. onChange fires once per room. */
+  private async flushReactions(ops: ParsedReaction[]): Promise<void> {
+    // Deterministic ordering: a reaction's target message may still be sitting
+    // in the message buffer (e.g. reactionBuffer force-flushed at maxSize).
+    // Land messages first so the getByEventId lookups below don't drop fresh
+    // reactions whose targets are merely un-flushed.
+    await this.writeBuffer?.flushNow();
+
+    const changedRooms = new Set<string>();
+
+    // Group by target message — one getByEventId + one updateReactions each.
+    const byTarget = new Map<string, ParsedReaction[]>();
+    for (const op of ops) {
+      const list = byTarget.get(op.targetEventId);
+      if (list) list.push(op);
+      else byTarget.set(op.targetEventId, [op]);
     }
 
-    const data = reactions[reaction.emoji];
-    if (!data.users.includes(reaction.senderAddress)) {
-      data.users.push(reaction.senderAddress);
-      data.count = data.users.length;
+    await this.db.transaction("rw", [this.db.messages, this.db.rooms], async () => {
+      for (const [targetEventId, list] of byTarget) {
+        try {
+          const msg = await this.messageRepo.getByEventId(targetEventId);
+          if (!msg) continue; // target not in Dexie (yet) — same drop semantics as before
+
+          const reactions = msg.reactions ?? {};
+          let last: ParsedReaction | null = null;
+          for (const reaction of list) {
+            if (!reactions[reaction.emoji]) {
+              reactions[reaction.emoji] = { count: 0, users: [] };
+            }
+            const data = reactions[reaction.emoji];
+            if (!data.users.includes(reaction.senderAddress)) {
+              data.users.push(reaction.senderAddress);
+              data.count = data.users.length;
+            }
+            // Track our own reaction eventId for future removal
+            if (reaction.isMine && reaction.eventId.startsWith("$")) {
+              data.myEventId = reaction.eventId;
+            }
+            last = reaction;
+          }
+
+          await this.messageRepo.updateReactions(targetEventId, reactions);
+
+          // Cascade: update room preview if this is the last message
+          // (same transaction — rooms table is in scope).
+          if (last) {
+            await this.cascadeReactionToRoom(msg.roomId, targetEventId, {
+              emoji: last.emoji,
+              senderAddress: last.senderAddress,
+              timestamp: Date.now(),
+            });
+          }
+
+          changedRooms.add(msg.roomId);
+        } catch (err) {
+          // Fault-tolerant: one corrupted reaction must not abort the batch.
+          console.error("[EventWriter] flushReactions: failed for target, skipping:", targetEventId, err);
+        }
+      }
+    });
+
+    for (const roomId of changedRooms) {
+      this.onChange?.(roomId);
     }
-
-    // Track our own reaction eventId for future removal
-    if (reaction.isMine && reaction.eventId.startsWith("$")) {
-      data.myEventId = reaction.eventId;
-    }
-
-    await this.messageRepo.updateReactions(reaction.targetEventId, reactions);
-
-    // Cascade: update room preview if this is the last message (non-blocking)
-    this.cascadeReactionToRoom(msg.roomId, reaction.targetEventId, {
-      emoji: reaction.emoji,
-      senderAddress: reaction.senderAddress,
-      timestamp: Date.now(),
-    }).catch(() => {});
-
-    this.onChange?.(msg.roomId);
   }
 
   /** Remove a reaction (redaction of a reaction event) */

--- a/src/shared/lib/local-db/index.ts
+++ b/src/shared/lib/local-db/index.ts
@@ -186,7 +186,13 @@ export function initChatDb(
   // are needed for live messaging. Heavy recovery table scans are deferred
   // below (WEE-97) so they don't compete with the first fullRoomRefresh.
   strandedOpIdsPromise.then(() => syncEngine.processQueue()).catch(() => {});
-  decryptionWorker.tick().catch(() => {});
+  // WEE-93: first re-queue jobs stranded in "processing" by a session that
+  // died mid-tick (cheap indexed modify — NOT a table scan, safe before the
+  // deferred recovery block), then start the decryption worker.
+  decryptionWorker.recoverOrphanedProcessing()
+    .catch(() => {})
+    .then(() => decryptionWorker.tick())
+    .catch(() => {});
 
   // WEE-97: recovery/GC sweeps are full-table scans that used to run on every
   // login BEFORE the chat list was interactive, competing with fullRoomRefresh

--- a/src/shared/lib/local-db/write-buffer.ts
+++ b/src/shared/lib/local-db/write-buffer.ts
@@ -20,21 +20,25 @@ export interface WriteBufferOptions {
   maxSize?: number;
 }
 
-type FlushCallback = (items: BufferedWrite[]) => Promise<void>;
+type FlushCallback<T> = (items: T[]) => Promise<void>;
 
 // ---------------------------------------------------------------------------
 // WriteBuffer — accumulates DB writes and flushes them in a single batch
 // ---------------------------------------------------------------------------
 
-export class WriteBuffer {
-  private buffer: BufferedWrite[] = [];
+export class WriteBuffer<T = BufferedWrite> {
+  private buffer: T[] = [];
   private timer: ReturnType<typeof setTimeout> | null = null;
   private readonly delayMs: number;
   private readonly maxSize: number;
   private disposed = false;
+  /** In-flight flush chain — flushes are serialized and awaitable, so
+   *  flushNow() callers get a real "everything enqueued before this call
+   *  is committed" guarantee even when a maxSize force-flush is running. */
+  private inFlight: Promise<void> | null = null;
 
   constructor(
-    private readonly onFlush: FlushCallback,
+    private readonly onFlush: FlushCallback<T>,
     options?: WriteBufferOptions,
   ) {
     this.delayMs = options?.delayMs ?? 150;
@@ -42,7 +46,7 @@ export class WriteBuffer {
   }
 
   /** Add an item to the buffer. Starts the flush timer or force-flushes if full. */
-  enqueue(item: BufferedWrite): void {
+  enqueue(item: T): void {
     if (this.disposed) return;
 
     this.buffer.push(item);
@@ -61,9 +65,12 @@ export class WriteBuffer {
     }
   }
 
-  /** Immediately drain the buffer (returns when flush completes). */
+  /** Immediately drain the buffer (returns when flush completes — including
+   *  any flush that was already in flight when this was called). */
   async flushNow(): Promise<void> {
     this.clearTimer();
+    const pending = this.inFlight;
+    if (pending) await pending;
     await this.flush();
   }
 
@@ -71,6 +78,8 @@ export class WriteBuffer {
   async dispose(): Promise<void> {
     this.disposed = true;
     this.clearTimer();
+    const pending = this.inFlight;
+    if (pending) await pending;
     if (this.buffer.length > 0) {
       await this.flush();
     }
@@ -86,10 +95,19 @@ export class WriteBuffer {
     const items = this.buffer;
     this.buffer = [];
 
-    try {
-      await this.onFlush(items);
-    } catch (err) {
-      console.error("[WriteBuffer] flush failed:", err);
+    // Chain on any in-flight flush so batches commit in enqueue order.
+    const prev = this.inFlight ?? Promise.resolve();
+    const run = prev.then(async () => {
+      try {
+        await this.onFlush(items);
+      } catch (err) {
+        console.error("[WriteBuffer] flush failed:", err);
+      }
+    });
+    this.inFlight = run;
+    await run;
+    if (this.inFlight === run) {
+      this.inFlight = null;
     }
   }
 


### PR DESCRIPTION
## Summary
- Sync catch-up now writes batched: active room routes through the existing WriteBuffer (was one Dexie transaction per event), `flushBatch` coalesces `ensureRoomExists` + room-preview writes to once per unique room, and reactions get their own buffer (grouped per target message, single transaction, one `onChange` per room).
- DecryptionWorker `tick()` commits all results of a tick in ONE transaction (atomic pick+mark, pure decrypt phase, batched commit); jobs stranded in `"processing"` by a dead session are re-queued at boot; a missing message row backs off instead of deleting the job.
- WriteBuffer hardened: flushes are serialized via an awaitable in-flight chain, so `flushNow()` (used by `setActiveRoom`) now genuinely waits for in-flight maxSize force-flushes.

## Linear
- Resolves WEE-93 (https://linear.app/wwwee/issue/WEE-93)

## Test plan
- [x] `npx vue-tsc --noEmit` — 50 errors, all pre-existing baseline (0 in changed files)
- [x] `npm run test` — 2704 passed / 17 failed, same 6 pre-existing failing files as clean tree
- [x] New regression tests: `event-writer-batching.test.ts` (A1 single-transaction backlog, per-room coalescing, out-of-order preview, encrypted-newest preview, link-preview parity, fault tolerance), `event-writer-reaction-buffer.test.ts` (single-transaction flush, myEventId, cascade, ordering vs message buffer), `decryption-worker.test.ts` (batched tick commit, mixed success/failure, orphaned-processing recovery, missing-row backoff)
- [x] Code review (superpowers:code-reviewer): 1 HIGH + 3 MEDIUM found and fixed, re-review APPROVED
- [ ] Manual QA on Android: reconnect with a message backlog → chats catch up fast, sidebar doesn't flicker per message, reactions/decrypted previews land correctly