### PR TITLE
fix(chat-open): unread banner reads pre-open snapshot — setActiveRoom zeroes the badge first (WEE-95 follow-up)

### DIFF
--- a/src/entities/chat/model/chat-store-room-switch.test.ts
+++ b/src/entities/chat/model/chat-store-room-switch.test.ts
@@ -143,6 +143,9 @@ function makeKit(opts: {
       writeMessages: vi.fn((_msgs: unknown[]) => (opts.writeMessages ? opts.writeMessages() : Promise.resolve())),
       writeEdit: vi.fn(async () => {}),
     },
+    db: {
+      rooms: { update: vi.fn(async () => 1) },
+    },
     retryRoomDecryption: vi.fn(),
   };
 }
@@ -193,6 +196,23 @@ describe("WEE-95 A2 — room switch drops stale liveQuery snapshot synchronously
     resolveB!([makeLocalMsg("!b:s", "$b1")]);
     await waitFor(() => store.activeMessages.length > 0);
     expect(store.activeMessages[0]?.roomId).toBe("!b:s");
+  });
+
+  it("snapshots the pre-open unread count BEFORE zeroing the badge (banner source)", async () => {
+    const kit = makeKit();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    store.setChatDbKit(kit as any);
+    // Simulate server-reconciled unread state in the in-memory room cache
+    store.dexieRoomMap.set("!a:s", makeLocalRoom("!a:s", { unreadCount: 5, lastReadInboundTs: 1000 }));
+
+    await store.setActiveRoom("!a:s");
+
+    // Badge zeroed synchronously for the sidebar...
+    expect(store.dexieRoomMap.get("!a:s")?.unreadCount).toBe(0);
+    // ...but the banner can still read the pre-open value
+    expect(store.getPreOpenUnreadCount("!a:s")).toBe(5);
+    // The snapshot is scoped to the opened room only
+    expect(store.getPreOpenUnreadCount("!b:s")).toBeUndefined();
   });
 
   it("re-setting the SAME room does not clear messages (no skeleton flash)", async () => {

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -1197,6 +1197,16 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     _setUnreadCount(roomId, serverCount, "matrix-sync");
   };
 
+  /** Unread count as it was the moment the user opened the room (WEE-95).
+   *  setActiveRoom zeroes the badge synchronously (sidebar UX / WEE-44 push-tap),
+   *  but the unread banner renders AFTER that and needs the pre-open value. */
+  let _preOpenUnread: { roomId: string; count: number } | null = null;
+
+  /** Pre-open unread count for the unread banner; undefined when the room
+   *  wasn't opened via setActiveRoom (e.g. cold-boot deep link). */
+  const getPreOpenUnreadCount = (roomId: string): number | undefined =>
+    _preOpenUnread?.roomId === roomId ? _preOpenUnread.count : undefined;
+
   const markRoomAsRead = (roomId: string) => {
     _setUnreadCount(roomId, 0, "markAsRead");
 
@@ -3484,6 +3494,18 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       // useUnreadBanner can still see unread messages and show the banner.
       // The actual watermark advancement happens via useReadTracker (IntersectionObserver)
       // when the user scrolls through and actually sees the messages.
+      //
+      // WEE-95: snapshot the pre-open count FIRST — the unread banner reads it
+      // after this synchronous zeroing (MessageList's watcher runs post-flush),
+      // so without the snapshot the banner would never appear.
+      {
+        const lrPre = dexieRoomMap.get(roomId);
+        const inMemPre = getRoomById(roomId);
+        _preOpenUnread = {
+          roomId,
+          count: lrPre?.unreadCount ?? inMemPre?.unreadCount ?? 0,
+        };
+      }
       if (chatDbKitRef.value) {
         chatDbKitRef.value.eventWriter.clearUnread(roomId);
       }
@@ -7118,6 +7140,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     getDbKit,
     dexieMessagesReady,
     dexieRoomMap,
+    getPreOpenUnreadCount,
     dexieRoomsReady,
     expandMessageWindow,
     messageWindowSize,

--- a/src/features/messaging/model/__tests__/unread-banner-plan.test.ts
+++ b/src/features/messaging/model/__tests__/unread-banner-plan.test.ts
@@ -1,41 +1,71 @@
 /**
- * WEE-95 A3 — unread banner must come from the cached room record
- * (dexieRoomMap), not from a full message scan, and must not block
- * the first render with avoidable I/O.
+ * WEE-95 A3 — unread banner must come from the cached watermark + the
+ * pre-open count snapshot (setActiveRoom zeroes the badge synchronously
+ * BEFORE the banner computes), without a full message scan or avoidable
+ * I/O on the render path.
  */
 import { describe, it, expect, vi } from "vitest";
 import { resolveUnreadBannerPlan } from "../unread-banner-plan";
 
 const makeSources = (overrides: Partial<Parameters<typeof resolveUnreadBannerPlan>[0]> = {}) => ({
-  cachedRoom: undefined as { unreadCount: number; lastReadInboundTs: number } | undefined,
+  cachedRoom: undefined as { lastReadInboundTs: number } | undefined,
+  preOpenUnreadCount: undefined as number | undefined,
   getRoom: vi.fn(async () => undefined),
+  countUnreadAfter: vi.fn(async () => 0),
   getLastMessageAtOrBefore: vi.fn(async () => undefined),
   ...overrides,
 });
 
 describe("resolveUnreadBannerPlan (WEE-95)", () => {
-  it("uses the sync dexieRoomMap cache — Dexie getRoom is never called", async () => {
+  it("hot path is I/O-free: cached watermark + pre-open snapshot, no Dexie reads", async () => {
     const sources = makeSources({
-      cachedRoom: { unreadCount: 0, lastReadInboundTs: 5000 },
+      cachedRoom: { lastReadInboundTs: 5000 },
+      preOpenUnreadCount: 0,
     });
 
     const plan = await resolveUnreadBannerPlan(sources);
 
     expect(sources.getRoom).not.toHaveBeenCalled();
+    expect(sources.countUnreadAfter).not.toHaveBeenCalled();
     expect(plan.scrollToBanner).toBe(false);
     expect(plan.needsBootstrap).toBe(false);
   });
 
-  it("falls back to Dexie getRoom only when the cache is cold", async () => {
+  it("uses the pre-open snapshot, NOT a recount — badge was already zeroed by setActiveRoom", async () => {
+    const sources = makeSources({
+      cachedRoom: { lastReadInboundTs: 7777 },
+      preOpenUnreadCount: 4,
+      getLastMessageAtOrBefore: vi.fn(async () => ({ eventId: "$anchor", clientId: "c9" })),
+    });
+
+    const plan = await resolveUnreadBannerPlan(sources);
+
+    expect(sources.countUnreadAfter).not.toHaveBeenCalled();
+    expect(sources.getLastMessageAtOrBefore).toHaveBeenCalledWith(7777);
+    expect(plan).toEqual({
+      lastReadId: "$anchor",
+      unreadCount: 4,
+      scrollToBanner: true,
+      needsBootstrap: false,
+    });
+  });
+
+  it("cold boot (no snapshot): falls back to an honest recount from messages", async () => {
+    // Deep-link open before setActiveRoom snapshotted anything — the Dexie
+    // unreadCount field may already be zeroed by clearUnread, so the count
+    // must come from the messages themselves.
     const sources = makeSources({
       cachedRoom: undefined,
-      getRoom: vi.fn(async () => ({ unreadCount: 3, lastReadInboundTs: 5000 })),
+      preOpenUnreadCount: undefined,
+      getRoom: vi.fn(async () => ({ lastReadInboundTs: 5000 })),
+      countUnreadAfter: vi.fn(async () => 3),
       getLastMessageAtOrBefore: vi.fn(async () => ({ eventId: "$last", clientId: "c1" })),
     });
 
     const plan = await resolveUnreadBannerPlan(sources);
 
     expect(sources.getRoom).toHaveBeenCalledTimes(1);
+    expect(sources.countUnreadAfter).toHaveBeenCalledWith(5000);
     expect(plan).toEqual({
       lastReadId: "$last",
       unreadCount: 3,
@@ -44,21 +74,24 @@ describe("resolveUnreadBannerPlan (WEE-95)", () => {
     });
   });
 
-  it("no watermark → bootstrap needed, no anchor query (off the render path)", async () => {
+  it("no watermark → bootstrap needed, no count/anchor queries (off the render path)", async () => {
     const sources = makeSources({
-      cachedRoom: { unreadCount: 7, lastReadInboundTs: 0 },
+      cachedRoom: { lastReadInboundTs: 0 },
+      preOpenUnreadCount: 7,
     });
 
     const plan = await resolveUnreadBannerPlan(sources);
 
     expect(plan.needsBootstrap).toBe(true);
     expect(plan.scrollToBanner).toBe(false);
+    expect(sources.countUnreadAfter).not.toHaveBeenCalled();
     expect(sources.getLastMessageAtOrBefore).not.toHaveBeenCalled();
   });
 
   it("zero unread → no banner and NO anchor query", async () => {
     const sources = makeSources({
-      cachedRoom: { unreadCount: 0, lastReadInboundTs: 5000 },
+      cachedRoom: { lastReadInboundTs: 5000 },
+      preOpenUnreadCount: 0,
     });
 
     const plan = await resolveUnreadBannerPlan(sources);
@@ -68,33 +101,32 @@ describe("resolveUnreadBannerPlan (WEE-95)", () => {
     expect(sources.getLastMessageAtOrBefore).not.toHaveBeenCalled();
   });
 
-  it("unread > 0 → banner with anchor resolved at the watermark", async () => {
-    const getLastMessageAtOrBefore = vi.fn(async () => ({ eventId: "$anchor", clientId: "c9" }));
+  it("snapshot of 0 wins over a non-zero recount (read on another device)", async () => {
+    // Multi-device: everything was read on device A; server reconciliation
+    // already set the badge to 0 before the user tapped the room here.
     const sources = makeSources({
-      cachedRoom: { unreadCount: 4, lastReadInboundTs: 7777 },
-      getLastMessageAtOrBefore,
+      cachedRoom: { lastReadInboundTs: 5000 },
+      preOpenUnreadCount: 0,
+      countUnreadAfter: vi.fn(async () => 12), // stale local watermark would say 12
     });
 
     const plan = await resolveUnreadBannerPlan(sources);
 
-    expect(getLastMessageAtOrBefore).toHaveBeenCalledWith(7777);
-    expect(plan).toEqual({
-      lastReadId: "$anchor",
-      unreadCount: 4,
-      scrollToBanner: true,
-      needsBootstrap: false,
-    });
+    expect(plan.scrollToBanner).toBe(false);
+    expect(sources.countUnreadAfter).not.toHaveBeenCalled();
   });
 
   it("anchor falls back to clientId, then to null when message is gone", async () => {
     const pendingOnly = makeSources({
-      cachedRoom: { unreadCount: 1, lastReadInboundTs: 100 },
+      cachedRoom: { lastReadInboundTs: 100 },
+      preOpenUnreadCount: 1,
       getLastMessageAtOrBefore: vi.fn(async () => ({ eventId: null, clientId: "c42" })),
     });
     expect((await resolveUnreadBannerPlan(pendingOnly)).lastReadId).toBe("c42");
 
     const missing = makeSources({
-      cachedRoom: { unreadCount: 1, lastReadInboundTs: 100 },
+      cachedRoom: { lastReadInboundTs: 100 },
+      preOpenUnreadCount: 1,
       getLastMessageAtOrBefore: vi.fn(async () => undefined),
     });
     const plan = await resolveUnreadBannerPlan(missing);

--- a/src/features/messaging/model/unread-banner-plan.ts
+++ b/src/features/messaging/model/unread-banner-plan.ts
@@ -15,11 +15,21 @@ export interface UnreadBannerPlan {
 
 export interface UnreadBannerSources {
   /** Sync in-memory LocalRoom from chat-store's dexieRoomMap — preferred,
-   *  zero I/O. `unreadCount` here is the same value the sidebar badge shows,
-   *  so the banner always agrees with what the user saw before opening. */
-  cachedRoom: Pick<LocalRoom, "unreadCount" | "lastReadInboundTs"> | undefined;
+   *  zero I/O. Only the watermark is read from here: setActiveRoom does NOT
+   *  touch lastReadInboundTs (it advances later via the read tracker). */
+  cachedRoom: Pick<LocalRoom, "lastReadInboundTs"> | undefined;
+  /** Unread count snapshotted by setActiveRoom BEFORE it zeroes the badge.
+   *  The cached/Dexie unreadCount cannot be trusted here — by the time the
+   *  banner computes, setActiveRoom has already cleared it synchronously
+   *  (sidebar UX). The snapshot is server-reconciled (same value as the badge
+   *  the user just tapped), so multi-device reads are reflected. */
+  preOpenUnreadCount: number | undefined;
   /** Async Dexie fallback when the in-memory cache has no entry yet (cold boot) */
-  getRoom: () => Promise<Pick<LocalRoom, "unreadCount" | "lastReadInboundTs"> | undefined>;
+  getRoom: () => Promise<Pick<LocalRoom, "lastReadInboundTs"> | undefined>;
+  /** Honest unread recount from messages (index scan) — only used when no
+   *  pre-open snapshot exists (cold-boot deep link), where the zeroed Dexie
+   *  field would otherwise hide the banner. Rare path, scan cost acceptable. */
+  countUnreadAfter: (watermarkTs: number) => Promise<number>;
   /** Anchor lookup — cheap [roomId+timestamp] limit(1) point query */
   getLastMessageAtOrBefore: (
     watermarkTs: number,
@@ -36,12 +46,12 @@ const noBanner = (needsBootstrap: boolean): UnreadBannerPlan => ({
 /**
  * Resolve the unread-banner plan for a room being opened.
  *
- * WEE-95: previously this path scanned the room's messages with
+ * WEE-95: previously this path always scanned the room's messages with
  * `countInboundAfter()` (a JS-filter pass — 100-500ms on 10k+ message rooms)
- * before the first render. The unread count is already maintained in
- * `dexieRoomMap`, so the common path is now fully synchronous; the only
- * remaining await is the cheap anchor point-query, and only when there
- * actually are unread messages.
+ * before the first render. The common path is now fully synchronous (cached
+ * watermark + pre-open count snapshot); the scan survives only as the
+ * cold-boot fallback, and the only other await is the cheap anchor
+ * point-query when there actually are unread messages.
  */
 export async function resolveUnreadBannerPlan(
   sources: UnreadBannerSources,
@@ -51,7 +61,8 @@ export async function resolveUnreadBannerPlan(
 
   if (watermarkTs <= 0) return noBanner(true);
 
-  const unreadCount = room?.unreadCount ?? 0;
+  const unreadCount =
+    sources.preOpenUnreadCount ?? (await sources.countUnreadAfter(watermarkTs));
   if (unreadCount <= 0) return noBanner(false);
 
   const lastReadMsg = await sources.getLastMessageAtOrBefore(watermarkTs);

--- a/src/features/messaging/ui/MessageList.vue
+++ b/src/features/messaging/ui/MessageList.vue
@@ -668,13 +668,17 @@ watch(
       const dbKit = getChatDb();
       const clearedAtTs = dbKit.eventWriter.getClearedAtTs(roomId);
 
-      // WEE-95: read watermark + unread count from the in-memory dexieRoomMap
-      // cache (sync, no I/O) instead of scanning the room's messages with
-      // countInboundAfter() — a 100-500ms JS-filter pass on 10k+ message rooms
-      // that blocked the first render. Dexie fallback only on a cold cache.
+      // WEE-95: watermark from the in-memory dexieRoomMap cache + unread count
+      // from the pre-open snapshot (sync, no I/O) instead of scanning the
+      // room's messages with countInboundAfter() — a 100-500ms JS-filter pass
+      // on 10k+ message rooms that blocked the first render. The async
+      // fallbacks only run on a cold cache (boot deep-link).
       const plan = await resolveUnreadBannerPlan({
         cachedRoom: chatStore.dexieRoomMap.get(roomId),
+        preOpenUnreadCount: chatStore.getPreOpenUnreadCount(roomId),
         getRoom: () => dbKit.rooms.getRoom(roomId),
+        countUnreadAfter: (ts) =>
+          dbKit.messages.countInboundAfter(roomId, ts, authStore.address ?? "", clearedAtTs),
         getLastMessageAtOrBefore: (ts) => dbKit.messages.getLastMessageAtOrBefore(roomId, ts, clearedAtTs),
       });
       if (isStale()) return;


### PR DESCRIPTION
## Summary
Follow-up to #199 (the commit was pushed minutes after the squash-merge, so it missed the PR).

The banner cannot trust `dexieRoomMap.unreadCount`: `setActiveRoom` zeroes it **synchronously** (sidebar badge UX / push-tap, `_setUnreadCount(roomId, 0, "setActiveRoom")`) before MessageList's room-switch watcher computes the banner — so with #199 as merged, the unread banner never appears. The pre-#199 code recounted from the watermark for exactly this reason (see the comment at the `clearUnread` call site).

- `setActiveRoom` now snapshots the pre-open count before zeroing (`getPreOpenUnreadCount`); the banner reads the snapshot. It's the server-reconciled value (`getUnreadNotificationCount` → `serverUnreadCount` → `bulkSyncRooms`) — the same number on the badge the user tapped, so multi-device reads on other devices are reflected.
- Cold-boot deep links (no snapshot) fall back to the honest `countInboundAfter()` recount — `clearUnread` may have already zeroed the Dexie field there.

## Linear
- Resolves WEE-95 (https://linear.app/wwwee/issue/WEE-95) — follow-up

## Test plan
- [x] Store test: snapshot survives the synchronous badge zeroing, scoped to the opened room
- [x] 7 plan tests incl. cold-boot recount fallback and multi-device "read elsewhere → snapshot 0 wins over stale recount"
- [x] `vue-tsc` — 50 pre-existing baseline errors, none in changed files; targeted suites green on top of current master
- [ ] Manual QA: open a room with unread from the sidebar → banner shows with the badge's count; read the room on another device, then open here → no banner