### PR TITLE
fix(messaging): forward messages sequentially to preserve order (WEE-98)

### DIFF
--- a/src/features/messaging/model/__tests__/forward-order.test.ts
+++ b/src/features/messaging/model/__tests__/forward-order.test.ts
@@ -1,0 +1,281 @@
+/**
+ * WEE-98 regression — bulk forward must preserve the source chronological
+ * order. forwardMessages sorts by source timestamp, but the pre-fix code
+ * then sent everything through Promise.allSettled(collected.map(...)) —
+ * a parallel race where the SyncEngine enqueue order (FIFO = send order)
+ * depended on which send resolved its awaits first, so recipients saw the
+ * messages shuffled. The fix sends strictly sequentially.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { MessageType } from "@/entities/chat";
+
+const mocks = vi.hoisted(() => ({
+  createLocalSpy: vi.fn(),
+  enqueueSpy: vi.fn(),
+  attachmentsAddSpy: vi.fn(),
+  getDecryptedBlobSpy: vi.fn(),
+  fakeStoreMessages: {} as Record<string, unknown[]>,
+  callLog: [] as string[],
+}));
+
+vi.mock("@/shared/lib/local-db", () => ({
+  isChatDbReady: vi.fn(() => true),
+  getChatDb: vi.fn(() => ({
+    messages: {
+      createLocal: mocks.createLocalSpy,
+      markFailed: vi.fn(),
+      getByClientId: vi.fn(),
+      updateUploadProgress: vi.fn(),
+      confirmMediaSent: vi.fn(),
+    },
+    syncEngine: { enqueue: mocks.enqueueSpy },
+    db: {
+      attachments: { add: mocks.attachmentsAddSpy },
+      messages: { where: vi.fn(() => ({ equals: vi.fn(() => ({ modify: vi.fn() })) })) },
+    },
+    eventWriter: {},
+  })),
+}));
+
+vi.mock("@/entities/matrix", () => ({
+  getMatrixClientService: vi.fn(() => ({
+    isReady: () => true,
+    uploadContent: vi.fn(),
+    sendEncryptedText: vi.fn(),
+    setTyping: vi.fn(),
+  })),
+}));
+
+vi.mock("@/entities/matrix/model/matrix-crypto", () => ({
+  ENCRYPTION_REQUIRED_NO_KEYS: "ENCRYPTION_REQUIRED_NO_KEYS",
+}));
+
+vi.mock("@/entities/auth", () => ({
+  useAuthStore: () => ({
+    address: "0xme",
+    pcrypto: { rooms: {} },
+  }),
+}));
+
+vi.mock("@/entities/chat", async () => {
+  const actual = await vi.importActual<typeof import("@/entities/chat")>("@/entities/chat");
+  return {
+    ...actual,
+    useChatStore: () => ({
+      activeRoomId: "!target:server",
+      get messages() {
+        return mocks.fakeStoreMessages;
+      },
+      addMessage: vi.fn(),
+      updateMessageContent: vi.fn(),
+      updateMessageStatus: vi.fn(),
+      updateMessageIdAndStatus: vi.fn(),
+      removeMessage: vi.fn(),
+      getDisplayName: vi.fn((id: string) => `user-${id}`),
+      loadRoomMessages: vi.fn(),
+    }),
+  };
+});
+
+vi.mock("../use-file-download", () => ({
+  getDecryptedBlobForMessage: mocks.getDecryptedBlobSpy,
+  invalidateDownloadCache: vi.fn(),
+}));
+
+vi.mock("@/features/bug-report", () => ({
+  useBugReport: () => ({ open: vi.fn() }),
+}));
+
+vi.mock("@/shared/lib/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock("@/shared/lib/i18n", () => ({ tRaw: (k: string) => k }));
+
+vi.mock("@/shared/lib/connectivity", () => ({
+  useConnectivity: () => ({ isOnline: { value: true } }),
+}));
+
+vi.mock("@/shared/lib/offline-queue", () => ({
+  enqueue: vi.fn(),
+  dequeue: vi.fn(),
+  getQueue: vi.fn(() => []),
+}));
+
+vi.mock("./use-link-preview", () => ({
+  detectUrl: vi.fn(() => null),
+  fetchPreview: vi.fn(),
+}));
+
+import { useMessages } from "../use-messages";
+
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+const textMessage = (id: string, content: string, timestamp: number) => ({
+  id,
+  roomId: "!source:server",
+  senderId: "alice",
+  content,
+  timestamp,
+  type: MessageType.text,
+});
+
+describe("forwardMessages — order preservation (WEE-98)", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mocks.createLocalSpy.mockReset();
+    mocks.enqueueSpy.mockReset();
+    mocks.attachmentsAddSpy.mockReset();
+    mocks.getDecryptedBlobSpy.mockReset();
+    mocks.callLog.length = 0;
+    for (const k of Object.keys(mocks.fakeStoreMessages)) delete mocks.fakeStoreMessages[k];
+
+    mocks.createLocalSpy.mockImplementation(async (args: { content: string }) => {
+      mocks.callLog.push(`createLocal:${args.content}`);
+      return { clientId: `client-${args.content}`, localId: 1 };
+    });
+    mocks.enqueueSpy.mockImplementation(async (...call: unknown[]) => {
+      const payload = call[2] as { content?: string; msgtype?: string };
+      mocks.callLog.push(`enqueue:${payload.content ?? payload.msgtype}`);
+      return 1;
+    });
+    mocks.attachmentsAddSpy.mockResolvedValue(7);
+    mocks.getDecryptedBlobSpy.mockResolvedValue(new Blob(["x"], { type: "image/jpeg" }));
+
+    class StubImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      naturalWidth = 320;
+      naturalHeight = 240;
+      private _src = "";
+      get src(): string { return this._src; }
+      set src(v: string) {
+        this._src = v;
+        queueMicrotask(() => this.onload?.());
+      }
+    }
+    // @ts-expect-error — override global Image
+    globalThis.Image = StubImage;
+  });
+
+  it("sends strictly sequentially: each message fully enqueued before the next starts", async () => {
+    // Pre-fix, Promise.allSettled(map) kicked off every send at once, so the
+    // call log started with three createLocal entries back-to-back. The
+    // sequential loop must interleave createLocal/enqueue pairs instead.
+    mocks.fakeStoreMessages["!source:server"] = [
+      textMessage("m1", "first", 100),
+      textMessage("m2", "second", 200),
+      textMessage("m3", "third", 300),
+    ];
+
+    const { forwardMessages } = useMessages();
+    const result = await forwardMessages(["m1", "m2", "m3"], "!target:server");
+
+    expect(result).toEqual({ succeeded: 3, failed: 0 });
+    expect(mocks.callLog).toEqual([
+      "createLocal:first",
+      "enqueue:first",
+      "createLocal:second",
+      "enqueue:second",
+      "createLocal:third",
+      "enqueue:third",
+    ]);
+  });
+
+  it("preserves source-timestamp order even when the earliest message is the slowest", async () => {
+    // Give the chronologically-first message the slowest createLocal. A
+    // parallel implementation would enqueue the fast ones first and shuffle
+    // the recipient's order; sequential sending keeps t1 < t2 < t3.
+    const slowness: Record<string, number> = { first: 30, second: 15, third: 0 };
+    mocks.createLocalSpy.mockImplementation(async (args: { content: string }) => {
+      await delay(slowness[args.content] ?? 0);
+      mocks.callLog.push(`createLocal:${args.content}`);
+      return { clientId: `client-${args.content}`, localId: 1 };
+    });
+
+    // Selection order is also scrambled — forwardMessages must sort by timestamp.
+    mocks.fakeStoreMessages["!source:server"] = [
+      textMessage("m3", "third", 300),
+      textMessage("m1", "first", 100),
+      textMessage("m2", "second", 200),
+    ];
+
+    const { forwardMessages } = useMessages();
+    const result = await forwardMessages(["m3", "m2", "m1"], "!target:server");
+
+    expect(result).toEqual({ succeeded: 3, failed: 0 });
+    const enqueued = mocks.enqueueSpy.mock.calls.map(
+      (c) => (c[2] as { content: string }).content,
+    );
+    expect(enqueued).toEqual(["first", "second", "third"]);
+  });
+
+  it("mixed media + text keeps timestamp order across both branches", async () => {
+    mocks.fakeStoreMessages["!source:server"] = [
+      textMessage("t1", "hello", 150),
+      {
+        id: "img1",
+        roomId: "!source:server",
+        senderId: "alice",
+        content: "img1",
+        timestamp: 100,
+        type: MessageType.image,
+        fileInfo: { name: "1.jpg", type: "image/jpeg", size: 1, url: "mxc://1" },
+      },
+      {
+        id: "img2",
+        roomId: "!source:server",
+        senderId: "alice",
+        content: "img2",
+        timestamp: 200,
+        type: MessageType.image,
+        fileInfo: { name: "2.jpg", type: "image/jpeg", size: 1, url: "mxc://2" },
+      },
+    ];
+
+    const { forwardMessages } = useMessages();
+    const result = await forwardMessages(["t1", "img1", "img2"], "!target:server");
+
+    expect(result).toEqual({ succeeded: 3, failed: 0 });
+    // timestamps: img1(100) < t1(150) < img2(200)
+    const ops = mocks.enqueueSpy.mock.calls.map((c) => c[0]);
+    expect(ops).toEqual(["send_file", "send_message", "send_file"]);
+  });
+
+  it("continues after a failed message and keeps the rest in order", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Fail "second" at the enqueue level; it then takes the legacy fallback
+    // (mocked to succeed). What this test pins down is that the loop keeps
+    // going and the surrounding messages stay in order.
+    mocks.enqueueSpy.mockImplementation(async (...call: unknown[]) => {
+      const payload = call[2] as { content?: string };
+      if (payload.content === "second") throw new Error("enqueue down");
+      mocks.callLog.push(`enqueue:${payload.content}`);
+      return 1;
+    });
+
+    mocks.fakeStoreMessages["!source:server"] = [
+      textMessage("m1", "first", 100),
+      textMessage("m2", "second", 200),
+      textMessage("m3", "third", 300),
+    ];
+
+    const { forwardMessages } = useMessages();
+    const result = await forwardMessages(["m1", "m2", "m3"], "!target:server");
+
+    // "second" still succeeds via the legacy direct-send fallback (mocked OK,
+    // no encryption gate in this setup) — the loop must not abort on its error.
+    expect(result).toEqual({ succeeded: 3, failed: 0 });
+    expect(mocks.callLog).toEqual([
+      "createLocal:first",
+      "enqueue:first",
+      "createLocal:second",
+      "createLocal:third",
+      "enqueue:third",
+    ]);
+    consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+});

--- a/src/features/messaging/model/use-messages.ts
+++ b/src/features/messaging/model/use-messages.ts
@@ -29,6 +29,11 @@ const ENCRYPT_TIMEOUT_MS = 30_000;
 const UPLOAD_TIMEOUT_MS = 4 * 60 * 1000;
 const SEND_EVENT_TIMEOUT_MS = 20_000;
 
+/** Bulk forward is sequential (WEE-98) — cap each item so one hung media
+ *  download/upload can't block every later message. Covers the worst-case
+ *  media chain: download+decrypt source blob, encrypt, upload, send. */
+const FORWARD_ITEM_TIMEOUT_MS = 5 * 60 * 1000;
+
 /** Max file size for uploads (100 MB — typical Matrix homeserver limit) */
 const MAX_UPLOAD_SIZE = 100 * 1024 * 1024;
 
@@ -1300,98 +1305,112 @@ export function useMessages() {
     // Ship in original chronological order so recipients see the conversation flow.
     collected.sort((a, b) => a.timestamp - b.timestamp);
 
-    const results = await Promise.allSettled(
-      collected.map(async (src) => {
-        const senderName = chatStore.getDisplayName(src.senderId);
-        const fwdMeta = withSenderInfo ? { senderId: src.senderId, senderName } : undefined;
+    // Sends ONE forwarded message; throws on failure. Invoked strictly
+    // sequentially below — SyncEngine is FIFO, so enqueue order is send order,
+    // and a parallel map would race the enqueues and scramble the recipient's
+    // order (WEE-98).
+    const sendOne = async (src: (typeof collected)[number]): Promise<void> => {
+      const senderName = chatStore.getDisplayName(src.senderId);
+      const fwdMeta = withSenderInfo ? { senderId: src.senderId, senderName } : undefined;
 
-        // Media branch — reuse the singular forwardMediaMessage path. It
-        // re-uploads the original blob via sendImage/sendFile/sendAudio so
-        // the recipient receives a real attachment, not a text body.
-        if (src.type !== MessageType.text && src.fileInfo) {
-          // forwardMediaMessage dispatches through sendImage/sendFile, which
-          // read chatStore.activeRoomId. The current UI guarantees
-          // targetRoomId === activeRoomId (ForwardPicker switches the active
-          // room before invoking forwardMessages). Surface that invariant
-          // here so a future caller that forwards into a non-active room
-          // gets a clear error instead of silently posting into the wrong
-          // chat.
-          if (targetRoomId !== chatStore.activeRoomId) {
-            throw new Error(
-              "Bulk media forward requires targetRoomId === activeRoomId " +
-                "(sendImage/sendFile read activeRoomId). Switch the active " +
-                "room before calling forwardMessages, or thread a room " +
-                "override through the per-type send functions.",
-            );
-          }
-          const ok = await forwardMediaMessage(src.content, fwdMeta, {
-            type: src.type,
-            fileInfo: src.fileInfo,
-            sourceMessageId: src.id,
-            roomId: src.roomId,
-            sourceSenderId: src.senderId,
-            sourceTimestamp: src.timestamp,
+      // Media branch — reuse the singular forwardMediaMessage path. It
+      // re-uploads the original blob via sendImage/sendFile/sendAudio so
+      // the recipient receives a real attachment, not a text body.
+      if (src.type !== MessageType.text && src.fileInfo) {
+        // forwardMediaMessage dispatches through sendImage/sendFile, which
+        // read chatStore.activeRoomId. The current UI guarantees
+        // targetRoomId === activeRoomId (ForwardPicker switches the active
+        // room before invoking forwardMessages). Surface that invariant
+        // here so a future caller that forwards into a non-active room
+        // gets a clear error instead of silently posting into the wrong
+        // chat.
+        if (targetRoomId !== chatStore.activeRoomId) {
+          throw new Error(
+            "Bulk media forward requires targetRoomId === activeRoomId " +
+              "(sendImage/sendFile read activeRoomId). Switch the active " +
+              "room before calling forwardMessages, or thread a room " +
+              "override through the per-type send functions.",
+          );
+        }
+        const ok = await forwardMediaMessage(src.content, fwdMeta, {
+          type: src.type,
+          fileInfo: src.fileInfo,
+          sourceMessageId: src.id,
+          roomId: src.roomId,
+          sourceSenderId: src.senderId,
+          sourceTimestamp: src.timestamp,
+        });
+        if (!ok) throw new Error(`forwardMedia failed for ${src.id}`);
+        return;
+      }
+
+      if (isChatDbReady()) {
+        try {
+          const dbKit = getChatDb();
+          const localMsg = await dbKit.messages.createLocal({
+            roomId: targetRoomId,
+            senderId: authStore.address ?? "",
+            content: src.content,
+            type: MessageType.text,
+            forwardedFrom: fwdMeta,
           });
-          if (!ok) throw new Error(`forwardMedia failed for ${src.id}`);
+          await dbKit.syncEngine.enqueue(
+            "send_message",
+            targetRoomId,
+            fwdMeta
+              ? { content: src.content, forwardedFrom: fwdMeta }
+              : { content: src.content },
+            localMsg.clientId,
+          );
           return;
+        } catch (e) {
+          console.warn("[use-messages] Dexie bulk forward failed, falling back:", e);
         }
+      }
 
-        if (isChatDbReady()) {
-          try {
-            const dbKit = getChatDb();
-            const localMsg = await dbKit.messages.createLocal({
-              roomId: targetRoomId,
-              senderId: authStore.address ?? "",
-              content: src.content,
-              type: MessageType.text,
-              forwardedFrom: fwdMeta,
-            });
-            await dbKit.syncEngine.enqueue(
-              "send_message",
-              targetRoomId,
-              fwdMeta
-                ? { content: src.content, forwardedFrom: fwdMeta }
-                : { content: src.content },
-              localMsg.clientId,
-            );
-            return;
-          } catch (e) {
-            console.warn("[use-messages] Dexie bulk forward failed, falling back:", e);
-          }
-        }
-
-        // Legacy fallback — direct encrypted/plaintext send to target room.
-        const roomCrypto = authStore.pcrypto?.rooms[targetRoomId] as PcryptoRoomInstance | undefined;
-        if (roomCrypto?.canBeEncrypt()) {
-          const encrypted = await roomCrypto.encryptEvent(src.content);
-          if (withSenderInfo) {
-            (encrypted as Record<string, unknown>).forwarded_from = {
-              sender_id: src.senderId,
-              sender_name: senderName,
-            };
-          }
-          await matrixService.sendEncryptedText(targetRoomId, encrypted);
-        } else {
-          // Defense in depth: bulk forward multiplies the leak across N
-          // target rooms — Promise.allSettled below keeps the others
-          // going so one locked room does not block the others.
-          if (roomCrypto?.requiresEncryption()) {
-            throw new Error(`${ENCRYPTION_REQUIRED_NO_KEYS} — bulk forward to ${targetRoomId}`);
-          }
-          const payload: Record<string, unknown> = {
-            body: src.content,
-            msgtype: "m.text",
+      // Legacy fallback — direct encrypted/plaintext send to target room.
+      const roomCrypto = authStore.pcrypto?.rooms[targetRoomId] as PcryptoRoomInstance | undefined;
+      if (roomCrypto?.canBeEncrypt()) {
+        const encrypted = await roomCrypto.encryptEvent(src.content);
+        if (withSenderInfo) {
+          (encrypted as Record<string, unknown>).forwarded_from = {
+            sender_id: src.senderId,
+            sender_name: senderName,
           };
-          if (withSenderInfo) {
-            payload.forwarded_from = { sender_id: src.senderId, sender_name: senderName };
-          }
-          await matrixService.sendEncryptedText(targetRoomId, payload);
         }
-      }),
-    );
+        await matrixService.sendEncryptedText(targetRoomId, encrypted);
+      } else {
+        // Defense in depth: bulk forward multiplies the leak across N
+        // target rooms — the per-item try/catch in the sequential loop
+        // keeps going so one locked room does not block the others.
+        if (roomCrypto?.requiresEncryption()) {
+          throw new Error(`${ENCRYPTION_REQUIRED_NO_KEYS} — bulk forward to ${targetRoomId}`);
+        }
+        const payload: Record<string, unknown> = {
+          body: src.content,
+          msgtype: "m.text",
+        };
+        if (withSenderInfo) {
+          payload.forwarded_from = { sender_id: src.senderId, sender_name: senderName };
+        }
+        await matrixService.sendEncryptedText(targetRoomId, payload);
+      }
+    };
 
-    const succeeded = results.filter((r) => r.status === "fulfilled").length;
-    const failed = results.length - succeeded;
+    // Strictly sequential — one failure logs and moves on (same continue-on-error
+    // semantics the previous Promise.allSettled gave), but order is preserved.
+    // Per-item timeout: a hung send would otherwise block every later message.
+    let succeeded = 0;
+    let failed = 0;
+    for (const src of collected) {
+      try {
+        await withTimeout(sendOne(src), FORWARD_ITEM_TIMEOUT_MS, `bulk forward ${src.id}`);
+        succeeded++;
+      } catch (e) {
+        failed++;
+        console.error("[use-messages] bulk forward failed for", src.id, e);
+      }
+    }
     return { succeeded, failed };
   };
 


### PR DESCRIPTION
## Summary
- `forwardMessages` sorted the selection by source timestamp but sent via `Promise.allSettled(collected.map(...))` — parallel sends raced the SyncEngine FIFO enqueues, so recipients received forwarded messages out of order
- Extracted the send body into `sendOne(src)` and replaced the parallel map with a strictly sequential loop (same continue-on-error semantics); enqueue order now matches the sorted order on both the text and media branches
- Added a per-item `withTimeout` (5 min) so one hung media download/upload can't block every later message
- Regression tests in `forward-order.test.ts` (4 tests) — verified to FAIL on the pre-fix parallel implementation and PASS on the fix

## Linear
- Resolves WEE-98 (https://linear.app/wwwee/issue/WEE-98)
- Refs WEE-28

## Test plan
- [x] `vite build` passes; `vue-tsc` shows only the pre-existing baseline errors (none in touched files)
- [x] Unit tests added (`src/features/messaging/model/__tests__/forward-order.test.ts`), all 62 messaging test files pass
- [ ] Manual QA: select 5+ messages (text + media mixed) → forward → order at recipient and sender matches the source chat