### PR TITLE
fix(messaging): suppress noisy room-setup system events (WEE-99)

### DIFF
--- a/src/entities/chat/lib/system-event-filter.test.ts
+++ b/src/entities/chat/lib/system-event-filter.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import {
+  getModeratorChange,
+  isServiceRoomName,
+  isWithinCreationBurst,
+  isCreationBurstMemberEvent,
+  ROOM_CREATION_BURST_WINDOW_MS,
+} from "./system-event-filter";
+
+/**
+ * WEE-99 — regression: noisy system events at chat start.
+ *
+ * At room creation the timeline contained a burst of system messages
+ * ("joined" / "changed room permissions" ×2 / "updated the room" /
+ * "invited"). These helpers reproduce bastyon-chat's filtering:
+ * power_levels render only on a real moderator diff, service hash names
+ * and the creation burst are hidden.
+ */
+
+describe("getModeratorChange (m.room.power_levels diff)", () => {
+  it("без prev_content (initial power_levels при создании) → null", () => {
+    expect(getModeratorChange({ users: { "@a:m": 100 } }, undefined)).toBeNull();
+  });
+
+  it("prev_content есть, но users без изменений → null", () => {
+    const users = { "@a:m": 100, "@b:m": 0 };
+    expect(getModeratorChange({ users }, { users: { ...users } })).toBeNull();
+  });
+
+  it("изменение не-user настроек (events) без diff users → null", () => {
+    expect(
+      getModeratorChange(
+        { users: { "@a:m": 100 }, events: { "m.room.name": 50 } },
+        { users: { "@a:m": 100 }, events: { "m.room.name": 100 } },
+      ),
+    ).toBeNull();
+  });
+
+  it("повышение до 50 → promoted moderator", () => {
+    const change = getModeratorChange(
+      { users: { "@a:m": 100, "@b:m": 50 } },
+      { users: { "@a:m": 100, "@b:m": 0 } },
+    );
+    expect(change).toEqual({ userId: "@b:m", promoted: true });
+  });
+
+  it("снятие с 50 до 0 → unmarked moderator", () => {
+    const change = getModeratorChange(
+      { users: { "@a:m": 100, "@b:m": 0 } },
+      { users: { "@a:m": 100, "@b:m": 50 } },
+    );
+    expect(change).toEqual({ userId: "@b:m", promoted: false });
+  });
+
+  it("удаление модератора из users map → unmarked (level падает к default)", () => {
+    const change = getModeratorChange(
+      { users: { "@a:m": 100 } },
+      { users: { "@a:m": 100, "@b:m": 50 } },
+    );
+    expect(change).toEqual({ userId: "@b:m", promoted: false });
+  });
+
+  it("prevLevel берётся из prev_content.users_default, а не из нового default", () => {
+    // в prev default был 50 (все модераторы), в новом 0; @b:m явно понижен до 0
+    const change = getModeratorChange(
+      { users: { "@a:m": 100, "@b:m": 0 }, users_default: 0 },
+      { users: { "@a:m": 100 }, users_default: 50 },
+    );
+    expect(change).toEqual({ userId: "@b:m", promoted: false });
+  });
+
+  it("self-demote админа (100 → 0) → unmarked для самого себя", () => {
+    const change = getModeratorChange(
+      { users: { "@a:m": 0 } },
+      { users: { "@a:m": 100 } },
+    );
+    expect(change).toEqual({ userId: "@a:m", promoted: false });
+  });
+
+  it("изменение уровня ниже порога модератора (0 → 25) → null", () => {
+    expect(
+      getModeratorChange(
+        { users: { "@a:m": 100, "@b:m": 25 } },
+        { users: { "@a:m": 100, "@b:m": 0 } },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("isServiceRoomName (m.room.name hash/empty)", () => {
+  it("hex-хэш при создании комнаты → служебное имя", () => {
+    expect(isServiceRoomName("a1b2c3d4e5f60718293a4b5c6d7e8f90")).toBe(true);
+    expect(isServiceRoomName("#a1b2c3d4e5f60718293a4b5c6d7e8f90")).toBe(true);
+  });
+
+  it("пустое имя → служебное", () => {
+    expect(isServiceRoomName("")).toBe(true);
+  });
+
+  it("реальное имя комнаты → не служебное (changedName показывается)", () => {
+    expect(isServiceRoomName("Команда Forta")).toBe(false);
+    expect(isServiceRoomName("deadbeef")).toBe(false); // короткий hex — обычное имя
+  });
+});
+
+describe("isWithinCreationBurst", () => {
+  const createTs = 1_700_000_000_000;
+
+  it("событие сразу после m.room.create → в burst-окне", () => {
+    expect(isWithinCreationBurst(createTs + 1_000, createTs)).toBe(true);
+  });
+
+  it("событие чуть раньше m.room.create (часы рассинхронены) → в окне", () => {
+    expect(isWithinCreationBurst(createTs - 1_000, createTs)).toBe(true);
+  });
+
+  it("событие позже окна → не burst", () => {
+    expect(
+      isWithinCreationBurst(createTs + ROOM_CREATION_BURST_WINDOW_MS + 1, createTs),
+    ).toBe(false);
+  });
+
+  it("creation ts неизвестен → не скрывать", () => {
+    expect(isWithinCreationBurst(createTs, null)).toBe(false);
+  });
+});
+
+describe("isCreationBurstMemberEvent", () => {
+  const createTs = 1_700_000_000_000;
+  const inWindow = createTs + 1_000;
+  const later = createTs + ROOM_CREATION_BURST_WINDOW_MS + 60_000;
+
+  it("own-join создателя в окне создания → скрыть", () => {
+    expect(isCreationBurstMemberEvent("join", true, inWindow, createTs)).toBe(true);
+  });
+
+  it("начальный invite в окне создания → скрыть", () => {
+    expect(isCreationBurstMemberEvent("invite", false, inWindow, createTs)).toBe(true);
+  });
+
+  it("invite позже (реальное добавление участника) → показывать", () => {
+    expect(isCreationBurstMemberEvent("invite", false, later, createTs)).toBe(false);
+  });
+
+  it("join другого участника позже → показывать", () => {
+    expect(isCreationBurstMemberEvent("join", true, later, createTs)).toBe(false);
+  });
+
+  it("leave даже в окне создания → показывать", () => {
+    expect(isCreationBurstMemberEvent("leave", true, inWindow, createTs)).toBe(false);
+  });
+});

--- a/src/entities/chat/lib/system-event-filter.ts
+++ b/src/entities/chat/lib/system-event-filter.ts
@@ -1,0 +1,73 @@
+/** WEE-99: filters for noisy room-setup system events.
+ *
+ *  Matches legacy bastyon-chat behavior (events/event/member/index.js):
+ *  - m.room.power_levels renders only when the users map actually changed
+ *    vs unsigned.prev_content (moderator marked/unmarked), otherwise hidden;
+ *  - service room names (creation-time hex hash / empty) are hidden;
+ *  - the room-creation burst (creator's own join, initial invite, initial
+ *    power_levels, avatar set at creation) is hidden.
+ */
+
+/** Power level treated as "moderator" (mirrors bastyon-chat's check). */
+const MODERATOR_LEVEL = 50;
+
+/** Events this close to m.room.create are part of the creation burst. */
+export const ROOM_CREATION_BURST_WINDOW_MS = 60_000;
+
+export interface ModeratorChange {
+  /** Raw matrix user id whose level changed. */
+  userId: string;
+  /** true → marked as moderator, false → unmarked. */
+  promoted: boolean;
+}
+
+/** Diff the `users` maps of an m.room.power_levels event vs its
+ *  unsigned.prev_content. Returns the first moderator change, or null when
+ *  nothing user-visible happened (initial power_levels has no prev_content;
+ *  non-user permission tweaks produce no diff). */
+export const getModeratorChange = (
+  content: Record<string, unknown> | undefined,
+  prevContent: Record<string, unknown> | undefined,
+): ModeratorChange | null => {
+  if (!prevContent) return null;
+  const users = (content?.users ?? {}) as Record<string, number>;
+  const prevUsers = (prevContent.users ?? {}) as Record<string, number>;
+  const defaultLevel = typeof content?.users_default === "number" ? content.users_default : 0;
+  const prevDefaultLevel = typeof prevContent.users_default === "number" ? prevContent.users_default : 0;
+
+  for (const id of new Set([...Object.keys(users), ...Object.keys(prevUsers)])) {
+    const level = users[id] ?? defaultLevel;
+    const prevLevel = prevUsers[id] ?? prevDefaultLevel;
+    if (level === prevLevel) continue;
+    // Mirror bastyon-chat: only the moderator transition is user-visible;
+    // other level changes (e.g. creator 100 at setup) stay hidden.
+    if (level >= MODERATOR_LEVEL && prevLevel < MODERATOR_LEVEL) return { userId: id, promoted: true };
+    if (level < MODERATOR_LEVEL && prevLevel >= MODERATOR_LEVEL) return { userId: id, promoted: false };
+  }
+  return null;
+};
+
+/** Service room names assigned at creation: empty or a long hex hash. */
+export const isServiceRoomName = (name: string): boolean =>
+  !name || /^#?[0-9a-f]{20,}$/i.test(name);
+
+/** True when the event happened within the room-creation burst window. */
+export const isWithinCreationBurst = (
+  eventTs: number,
+  roomCreationTs: number | null,
+): boolean =>
+  roomCreationTs != null
+  && eventTs >= roomCreationTs - ROOM_CREATION_BURST_WINDOW_MS
+  && eventTs - roomCreationTs <= ROOM_CREATION_BURST_WINDOW_MS;
+
+/** Member events that are part of the creation burst and should be hidden:
+ *  the creator's own join and the initial invite. Later joins/invites
+ *  (outside the window) stay visible. */
+export const isCreationBurstMemberEvent = (
+  membership: string,
+  isSelf: boolean,
+  eventTs: number,
+  roomCreationTs: number | null,
+): boolean =>
+  isWithinCreationBurst(eventTs, roomCreationTs)
+  && ((membership === "join" && isSelf) || membership === "invite");

--- a/src/entities/chat/model/__tests__/system-events-filter.test.ts
+++ b/src/entities/chat/model/__tests__/system-events-filter.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * WEE-99 — source-level regression: buildSystemMessage must route noisy
+ * room-setup events through the system-event-filter helpers instead of
+ * unconditionally emitting system messages.
+ *
+ * Behavioral coverage of the filters lives in
+ * `../../lib/system-event-filter.test.ts`; these tests pin the wiring in
+ * chat-store.ts so it can't silently regress to the old unconditional
+ * templates ("changed room permissions" / "updated the room" burst).
+ */
+
+const chatStoreSource = readFileSync(
+  resolve(__dirname, "../chat-store.ts"),
+  "utf-8",
+);
+
+const enLocale = readFileSync(
+  resolve(__dirname, "../../../../shared/lib/i18n/locales/en.ts"),
+  "utf-8",
+);
+const ruLocale = readFileSync(
+  resolve(__dirname, "../../../../shared/lib/i18n/locales/ru.ts"),
+  "utf-8",
+);
+
+const buildSystemMessageBody = (() => {
+  const start = chatStoreSource.indexOf("const buildSystemMessage = (");
+  expect(start).toBeGreaterThan(-1);
+  // The next top-level helper after buildSystemMessage:
+  const end = chatStoreSource.indexOf("const parseSingleEvent = ", start);
+  return chatStoreSource.slice(start, end > -1 ? end : undefined);
+})();
+
+describe("buildSystemMessage wiring (WEE-99)", () => {
+  it("импортирует фильтры из system-event-filter", () => {
+    expect(chatStoreSource).toContain('from "../lib/system-event-filter"');
+    expect(chatStoreSource).toContain("getModeratorChange");
+    expect(chatStoreSource).toContain("isServiceRoomName");
+    expect(chatStoreSource).toContain("isCreationBurstMemberEvent");
+  });
+
+  it("m.room.power_levels не эмитит безусловный system.changedPermissions", () => {
+    expect(buildSystemMessageBody).not.toContain('"system.changedPermissions"');
+    expect(buildSystemMessageBody).toContain("getModeratorChange(");
+    expect(buildSystemMessageBody).toContain('"system.markedModerator"');
+    expect(buildSystemMessageBody).toContain('"system.unmarkedModerator"');
+  });
+
+  it("модераторские шаблоны сохраняют {target} даже при self-demote (target === sender)", () => {
+    expect(buildSystemMessageBody).toContain("keepSelfTarget = true");
+    expect(buildSystemMessageBody).toContain("targetAddr !== sender || keepSelfTarget");
+  });
+
+  it("prev_content читается с фолбэком на deprecated top-level поле", () => {
+    expect(buildSystemMessageBody).toContain("raw.prev_content");
+  });
+
+  it("m.room.name с hash/empty не эмитит system.updatedRoom (скрывается)", () => {
+    expect(buildSystemMessageBody).not.toContain('"system.updatedRoom"');
+    expect(buildSystemMessageBody).toContain("isServiceRoomName(");
+    // реальная смена имени по-прежнему показывается
+    expect(buildSystemMessageBody).toContain('"system.changedName"');
+  });
+
+  it("member join/invite в окне создания скрываются через isCreationBurstMemberEvent", () => {
+    expect(buildSystemMessageBody).toContain("isCreationBurstMemberEvent(");
+    // обычные membership-события сохранены
+    expect(buildSystemMessageBody).toContain('"system.joined"');
+    expect(buildSystemMessageBody).toContain('"system.invited"');
+    expect(buildSystemMessageBody).toContain('"system.left"');
+  });
+
+  it("m.room.avatar в окне создания скрывается, позже — показывается", () => {
+    expect(buildSystemMessageBody).toContain('"system.changedPhoto"');
+    expect(buildSystemMessageBody).toContain("isWithinCreationBurst(");
+  });
+});
+
+describe("i18n ключи модератора (WEE-99)", () => {
+  it.each([
+    ["en", enLocale],
+    ["ru", ruLocale],
+  ])("%s содержит system.markedModerator / system.unmarkedModerator", (_name, src) => {
+    expect(src).toContain('"system.markedModerator"');
+    expect(src).toContain('"system.unmarkedModerator"');
+  });
+});

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -9,6 +9,7 @@ import { classifyOpenedRoomHealth } from "./room-cleanup";
 import { sortMessagesTimelineAsc } from "../lib/message-utils";
 import { resetPowerLevel, isUserBanned } from "../lib/room-guards";
 import { categorizeJoinError, validateRoomId, type JoinRoomResult } from "../lib/join-error";
+import { getModeratorChange, isServiceRoomName, isWithinCreationBurst, isCreationBurstMemberEvent } from "../lib/system-event-filter";
 import { preservePendingRooms } from "../lib/preserve-pending-rooms";
 import {
   readJoinRule,
@@ -4665,23 +4666,52 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     }
   };
 
+  /** origin_server_ts of the room's m.room.create event (null if unknown).
+   *  Used to suppress the room-creation system-event burst (WEE-99). */
+  const getRoomCreationTs = (roomId: string): number | null => {
+    try {
+      const matrixRoom = getMatrixClientService().getRoom(roomId);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const createEvents = (matrixRoom as any)?.currentState?.getStateEvents?.("m.room.create");
+      const createEvent = Array.isArray(createEvents) ? createEvents[0] : createEvents;
+      const ts = createEvent?.getTs?.() ?? createEvent?.event?.origin_server_ts;
+      return typeof ts === "number" ? ts : null;
+    } catch {
+      return null;
+    }
+  };
+
   /** Build a human-readable system message for room state events.
    *  Stores a template + raw addresses in systemMeta so names can be
-   *  re-resolved at render time (avoids stale truncated addresses). */
+   *  re-resolved at render time (avoids stale truncated addresses).
+   *  Returns null for noisy room-setup events (WEE-99): initial
+   *  power_levels, service hash names, creation-burst join/invite/avatar. */
   const buildSystemMessage = (raw: Record<string, unknown>, roomId: string): Message | null => {
     const content = raw.content as Record<string, unknown>;
     const eventType = raw.type as string;
     const sender = matrixIdToAddress(raw.sender as string);
+    const eventTs = (raw.origin_server_ts as number) ?? 0;
+    // prev_content normally lives in unsigned; some servers still emit the
+    // deprecated top-level location
+    const prevContent = ((raw.unsigned as Record<string, unknown> | undefined)?.prev_content
+      ?? raw.prev_content) as Record<string, unknown> | undefined;
 
     let templateKey = "";
     let targetAddr: string | undefined;
     let extraMeta: Record<string, string> | undefined;
+    // member events collapse target===sender to "no target" ("{sender} joined");
+    // moderator templates always need {target}, even on self-demotion
+    let keepSelfTarget = false;
 
     if (eventType === "m.room.member") {
       const membership = content.membership as string;
       const stateKey = raw.state_key as string | undefined;
       targetAddr = stateKey ? matrixIdToAddress(stateKey) : sender;
       const isSelf = targetAddr === sender;
+
+      if (isCreationBurstMemberEvent(membership, isSelf, eventTs, getRoomCreationTs(roomId))) {
+        return null;
+      }
 
       if (membership === "join") {
         templateKey = isSelf ? "system.joined" : "system.added";
@@ -4696,16 +4726,20 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       }
     } else if (eventType === "m.room.name") {
       const newName = (content.name as string) || "";
-      const isHash = /^#?[0-9a-f]{20,}$/i.test(newName);
-      if (isHash || !newName) {
-        templateKey = "system.updatedRoom";
-      } else {
-        templateKey = "system.changedName";
-        extraMeta = { name: newName };
+      if (isServiceRoomName(newName)) {
+        return null;
       }
+      templateKey = "system.changedName";
+      extraMeta = { name: newName };
     } else if (eventType === "m.room.power_levels") {
-      templateKey = "system.changedPermissions";
+      if (isWithinCreationBurst(eventTs, getRoomCreationTs(roomId))) return null;
+      const change = getModeratorChange(content, prevContent);
+      if (!change) return null;
+      templateKey = change.promoted ? "system.markedModerator" : "system.unmarkedModerator";
+      targetAddr = matrixIdToAddress(change.userId);
+      keepSelfTarget = true;
     } else if (eventType === "m.room.avatar") {
+      if (isWithinCreationBurst(eventTs, getRoomCreationTs(roomId))) return null;
       templateKey = "system.changedPhoto";
     } else if (eventType === "m.room.topic") {
       const newTopic = (content.topic as string) || "";
@@ -4719,7 +4753,8 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     // content stores a snapshot for Dexie preview (English fallback);
     // the real display text is resolved at render time via systemMeta.template + i18n
     const senderName = getDisplayName(sender) || sender.slice(0, 8) + "...";
-    const targetName = targetAddr && targetAddr !== sender
+    const hasTarget = !!targetAddr && (targetAddr !== sender || keepSelfTarget);
+    const targetName = hasTarget && targetAddr
       ? (getDisplayName(targetAddr) || targetAddr.slice(0, 8) + "...")
       : senderName;
     const fallbackText = templateKey
@@ -4727,7 +4762,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       .replace(/([A-Z])/g, " $1")
       .toLowerCase();
     const snapshotText = cleanMatrixIds(
-      `${senderName} ${fallbackText}${targetAddr && targetAddr !== sender ? ` ${targetName}` : ""}`,
+      `${senderName} ${fallbackText}${hasTarget ? ` ${targetName}` : ""}`,
     );
 
     return {
@@ -4741,7 +4776,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
       systemMeta: {
         template: templateKey,
         senderAddr: sender,
-        targetAddr: targetAddr !== sender ? targetAddr : undefined,
+        targetAddr: hasTarget ? targetAddr : undefined,
         ...extraMeta && { extra: extraMeta },
       },
     };

--- a/src/shared/lib/i18n/locales/en.ts
+++ b/src/shared/lib/i18n/locales/en.ts
@@ -780,6 +780,8 @@ export const en = {
   "system.updatedRoom": "{sender} updated the room",
   "system.changedName": "{sender} changed the room name to \"{name}\"",
   "system.changedPermissions": "{sender} changed room permissions",
+  "system.markedModerator": "{sender} marked {target} as moderator",
+  "system.unmarkedModerator": "{sender} unmarked {target} as moderator",
   "system.changedPhoto": "{sender} changed the room photo",
   "system.setDescription": "{sender} set the room description",
   "system.clearedDescription": "{sender} cleared the room description",

--- a/src/shared/lib/i18n/locales/ru.ts
+++ b/src/shared/lib/i18n/locales/ru.ts
@@ -782,6 +782,8 @@ export const ru: Record<TranslationKey, string> = {
   "system.updatedRoom": "{sender} обновил комнату",
   "system.changedName": "{sender} изменил название комнаты на \"{name}\"",
   "system.changedPermissions": "{sender} изменил права доступа",
+  "system.markedModerator": "{sender} назначил {target} модератором",
+  "system.unmarkedModerator": "{sender} снял {target} с роли модератора",
   "system.changedPhoto": "{sender} изменил фото комнаты",
   "system.setDescription": "{sender} обновил описание комнаты",
   "system.clearedDescription": "{sender} очистил описание комнаты",


### PR DESCRIPTION
## Summary
- `buildSystemMessage` emitted a system message unconditionally for every `m.room.*` state event — opening a fresh chat showed a creation burst: `joined` / `changed room permissions` ×2 / `updated the room` / `invited`.
- New pure helper `src/entities/chat/lib/system-event-filter.ts` mirrors legacy bastyon-chat filtering: `m.room.power_levels` renders only on a real moderator diff (`content.users` vs `unsigned.prev_content.users`) as `marked/unmarked as moderator` (new en/ru i18n keys); service hash/empty room names are hidden; creator's own join, initial invite, initial power_levels and avatar within ±60s of `m.room.create` are hidden.
- Real later changes (readable name, photo, member add/leave/ban, moderator change incl. self-demote) still show. Fail-open everywhere: missing `prev_content` / unknown creation ts never hides real events.

## Linear
- Resolves WEE-99 (https://linear.app/wwwee/issue/WEE-99)

## Test plan
- [x] `vite build` + `vue-tsc --noEmit` (50 errors = pre-existing baseline, none in touched files)
- [x] Unit tests: `src/entities/chat/lib/system-event-filter.test.ts` (behavioral) + `src/entities/chat/model/__tests__/system-events-filter.test.ts` (wiring regression) — 30 passing; full suite 16 failures = known baseline
- [ ] Manual QA: create a chat/group → no system-message burst in the feed; promote a member to moderator → exactly one "marked as moderator" message; rename room / change photo later → still shown