### PR TITLE
perf(messaging): forward picker opens instantly with skeleton + virtualized list (WEE-100)

### DIFF
--- a/src/features/messaging/ui/ForwardPicker.vue
+++ b/src/features/messaging/ui/ForwardPicker.vue
@@ -209,64 +209,67 @@ const handleClose = () => {
             </div>
 
             <!-- Room list: spinner while the deferred list mounts, then a
-                 virtualized scroller — only visible rows render. -->
-            <div class="min-h-0 flex-1" :class="isMobile ? 'pb-safe' : ''">
-              <div
-                v-if="!listReady"
-                data-testid="forward-list-loading"
-                class="flex h-24 items-center justify-center"
-              >
-                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="animate-spin text-neutral-grad-2">
-                  <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-                </svg>
-              </div>
+                 virtualized scroller — only visible rows render. The scroller
+                 itself is the flex item (mirrors the pre-virtualization
+                 `min-h-0 flex-1 overflow-y-auto` wrapper): a percentage height
+                 inside the auto-height desktop modal resolves to the full
+                 content height and overflows the max-h cap. -->
+            <div
+              v-if="!listReady"
+              data-testid="forward-list-loading"
+              class="flex h-24 shrink-0 items-center justify-center"
+            >
+              <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="animate-spin text-neutral-grad-2">
+                <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+              </svg>
+            </div>
 
-              <RecycleScroller
-                v-else-if="listItems.length > 0"
-                data-testid="forward-room-list"
-                :items="listItems"
-                :item-size="ROW_HEIGHT"
-                key-field="id"
-                class="h-full"
-              >
-                <template #default="{ item }">
-                  <button
-                    class="flex w-full items-center gap-3 px-4 transition-colors hover:bg-neutral-grad-0 active:bg-neutral-grad-0"
-                    :style="{ height: `${ROW_HEIGHT}px` }"
-                    @click="selectRoom(item.room.id)"
-                  >
-                    <div class="relative shrink-0">
-                      <UserAvatar
-                        v-if="item.room.avatar?.startsWith('__pocketnet__:')"
-                        :address="item.room.avatar.replace('__pocketnet__:', '')"
-                        size="md"
-                      />
-                      <Avatar v-else :src="item.room.avatar" :name="item.name || ''" size="md" />
-                      <!-- Group badge -->
-                      <div
-                        v-if="item.room.isGroup"
-                        class="absolute -bottom-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-background-total-theme"
-                      >
-                        <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" class="text-text-on-main-bg-color">
-                          <path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z" />
-                        </svg>
-                      </div>
+            <RecycleScroller
+              v-else-if="listItems.length > 0"
+              data-testid="forward-room-list"
+              :items="listItems"
+              :item-size="ROW_HEIGHT"
+              key-field="id"
+              class="min-h-0 flex-1"
+              :class="isMobile ? 'pb-safe' : ''"
+            >
+              <template #default="{ item }">
+                <button
+                  class="flex w-full items-center gap-3 px-4 transition-colors hover:bg-neutral-grad-0 active:bg-neutral-grad-0"
+                  :style="{ height: `${ROW_HEIGHT}px` }"
+                  @click="selectRoom(item.room.id)"
+                >
+                  <div class="relative shrink-0">
+                    <UserAvatar
+                      v-if="item.room.avatar?.startsWith('__pocketnet__:')"
+                      :address="item.room.avatar.replace('__pocketnet__:', '')"
+                      size="md"
+                    />
+                    <Avatar v-else :src="item.room.avatar" :name="item.name || ''" size="md" />
+                    <!-- Group badge -->
+                    <div
+                      v-if="item.room.isGroup"
+                      class="absolute -bottom-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-background-total-theme"
+                    >
+                      <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" class="text-text-on-main-bg-color">
+                        <path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z" />
+                      </svg>
                     </div>
+                  </div>
 
-                    <div class="min-w-0 flex-1 text-left">
-                      <div v-if="isUnresolvedName(item.name)" class="inline-block h-3.5 w-24 animate-pulse rounded bg-neutral-grad-2" />
-                      <template v-else>
-                        <div class="truncate text-[15px] font-medium text-text-color">{{ item.name }}</div>
-                        <div v-if="getRoomSubtitle(item.room)" class="truncate text-xs text-text-on-main-bg-color">{{ getRoomSubtitle(item.room) }}</div>
-                      </template>
-                    </div>
-                  </button>
-                </template>
-              </RecycleScroller>
+                  <div class="min-w-0 flex-1 text-left">
+                    <div v-if="isUnresolvedName(item.name)" class="inline-block h-3.5 w-24 animate-pulse rounded bg-neutral-grad-2" />
+                    <template v-else>
+                      <div class="truncate text-[15px] font-medium text-text-color">{{ item.name }}</div>
+                      <div v-if="getRoomSubtitle(item.room)" class="truncate text-xs text-text-on-main-bg-color">{{ getRoomSubtitle(item.room) }}</div>
+                    </template>
+                  </div>
+                </button>
+              </template>
+            </RecycleScroller>
 
-              <div v-else class="p-8 text-center text-sm text-text-on-main-bg-color">
-                {{ t("forward.noChats") }}
-              </div>
+            <div v-else class="p-8 text-center text-sm text-text-on-main-bg-color">
+              {{ t("forward.noChats") }}
             </div>
           </div>
         </transition>

--- a/src/features/messaging/ui/ForwardPicker.vue
+++ b/src/features/messaging/ui/ForwardPicker.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick } from "vue";
+import { RecycleScroller } from "vue-virtual-scroller";
+import "vue-virtual-scroller/dist/vue-virtual-scroller.css";
 import { useChatStore, type ChatRoom } from "@/entities/chat";
 import { UserAvatar } from "@/entities/user";
 import { useResolvedRoomName } from "@/entities/chat/lib/use-resolved-room-name";
@@ -7,6 +9,9 @@ import { isUnresolvedName } from "@/entities/chat/lib/chat-helpers";
 import { useMobile } from "@/shared/lib/composables/use-media-query";
 import { useAndroidBackHandler } from "@/shared/lib/composables/use-android-back-handler";
 type FilterValue = "all" | "personal" | "groups";
+
+/** Fixed row height for RecycleScroller: 40px md avatar + 2×10px padding. */
+const ROW_HEIGHT = 60;
 
 interface Props {
   show: boolean;
@@ -33,14 +38,30 @@ useAndroidBackHandler("forward-picker", 95, () => {
   return true;
 });
 
+// WEE-100: the room list is heavy (member counts via Matrix SDK, avatars,
+// name resolution × N rooms) — rendering it synchronously on open left a
+// visible gap between the tap and the modal. Defer it by two frames so the
+// shell (header/search/tabs/spinner) paints first.
+const listReady = ref(false);
+const memberCountCache = new Map<string, number>();
+// Generation counter: a stale rAF chain from a previous open must not
+// short-circuit the defer (or fire after close) on rapid close→reopen.
+let openGeneration = 0;
+
 // Focus search on open
 watch(() => props.show, (v) => {
   if (v) {
     search.value = "";
     activeFilter.value = "all";
+    listReady.value = false;
+    memberCountCache.clear();
+    const gen = ++openGeneration;
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      if (props.show && gen === openGeneration) listReady.value = true;
+    }));
     nextTick(() => searchInputRef.value?.focus());
   }
-});
+}, { immediate: true });
 
 // Escape to close
 const onKeydown = (e: KeyboardEvent) => {
@@ -76,13 +97,28 @@ const filteredRooms = computed(() => {
   return rooms;
 });
 
+/** Pre-resolved rows for the virtual list — one name resolve per room
+ *  instead of 3-4 calls scattered across the row template. */
+interface RoomListItem {
+  id: string;
+  room: ChatRoom;
+  name: string;
+}
+const listItems = computed<RoomListItem[]>(() =>
+  filteredRooms.value.map(room => ({ id: room.id, room, name: resolveRoomName(room) })),
+);
+
 const getRoomSubtitle = (room: ChatRoom): string => {
-  if (room.isGroup) {
-    const count = chatStore.getRoomMemberCount(room.id);
-    if (count > 0) return t("forward.members", { count });
-    return t("tabs.groups");
+  if (!room.isGroup) return "";
+  // getRoomMemberCount goes through the Matrix SDK — cache per open so
+  // scrolling back / re-filtering doesn't repeat the lookup.
+  let count = memberCountCache.get(room.id);
+  if (count === undefined) {
+    count = chatStore.getRoomMemberCount(room.id);
+    memberCountCache.set(room.id, count);
   }
-  return "";
+  if (count > 0) return t("forward.members", { count });
+  return t("tabs.groups");
 };
 
 const selectRoom = async (roomId: string) => {
@@ -117,6 +153,7 @@ const handleClose = () => {
     <transition name="fp-fade">
       <div
         v-if="props.show"
+        data-testid="forward-picker-root"
         class="fixed inset-0 z-[60] flex justify-center"
         :class="isMobile ? 'items-end' : 'items-center bg-black/40'"
         @click.self="handleClose"
@@ -171,42 +208,63 @@ const handleClose = () => {
               </button>
             </div>
 
-            <!-- Room list -->
-            <div class="min-h-0 flex-1 overflow-y-auto" :class="isMobile ? 'pb-safe' : ''">
-              <button
-                v-for="room in filteredRooms"
-                :key="room.id"
-                class="flex w-full items-center gap-3 px-4 py-2.5 transition-colors hover:bg-neutral-grad-0 active:bg-neutral-grad-0"
-                @click="selectRoom(room.id)"
+            <!-- Room list: spinner while the deferred list mounts, then a
+                 virtualized scroller — only visible rows render. -->
+            <div class="min-h-0 flex-1" :class="isMobile ? 'pb-safe' : ''">
+              <div
+                v-if="!listReady"
+                data-testid="forward-list-loading"
+                class="flex h-24 items-center justify-center"
               >
-                <div class="relative shrink-0">
-                  <UserAvatar
-                    v-if="room.avatar?.startsWith('__pocketnet__:')"
-                    :address="room.avatar.replace('__pocketnet__:', '')"
-                    size="md"
-                  />
-                  <Avatar v-else :src="room.avatar" :name="resolveRoomName(room) || ''" size="md" />
-                  <!-- Group badge -->
-                  <div
-                    v-if="room.isGroup"
-                    class="absolute -bottom-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-background-total-theme"
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="animate-spin text-neutral-grad-2">
+                  <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+                </svg>
+              </div>
+
+              <RecycleScroller
+                v-else-if="listItems.length > 0"
+                data-testid="forward-room-list"
+                :items="listItems"
+                :item-size="ROW_HEIGHT"
+                key-field="id"
+                class="h-full"
+              >
+                <template #default="{ item }">
+                  <button
+                    class="flex w-full items-center gap-3 px-4 transition-colors hover:bg-neutral-grad-0 active:bg-neutral-grad-0"
+                    :style="{ height: `${ROW_HEIGHT}px` }"
+                    @click="selectRoom(item.room.id)"
                   >
-                    <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" class="text-text-on-main-bg-color">
-                      <path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z" />
-                    </svg>
-                  </div>
-                </div>
+                    <div class="relative shrink-0">
+                      <UserAvatar
+                        v-if="item.room.avatar?.startsWith('__pocketnet__:')"
+                        :address="item.room.avatar.replace('__pocketnet__:', '')"
+                        size="md"
+                      />
+                      <Avatar v-else :src="item.room.avatar" :name="item.name || ''" size="md" />
+                      <!-- Group badge -->
+                      <div
+                        v-if="item.room.isGroup"
+                        class="absolute -bottom-0.5 -right-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-background-total-theme"
+                      >
+                        <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" class="text-text-on-main-bg-color">
+                          <path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5c-1.66 0-3 1.34-3 3s1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5C6.34 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z" />
+                        </svg>
+                      </div>
+                    </div>
 
-                <div class="min-w-0 flex-1 text-left">
-                  <div v-if="isUnresolvedName(resolveRoomName(room))" class="inline-block h-3.5 w-24 animate-pulse rounded bg-neutral-grad-2" />
-                  <template v-else>
-                    <div class="truncate text-[15px] font-medium text-text-color">{{ resolveRoomName(room) }}</div>
-                    <div v-if="getRoomSubtitle(room)" class="truncate text-xs text-text-on-main-bg-color">{{ getRoomSubtitle(room) }}</div>
-                  </template>
-                </div>
-              </button>
+                    <div class="min-w-0 flex-1 text-left">
+                      <div v-if="isUnresolvedName(item.name)" class="inline-block h-3.5 w-24 animate-pulse rounded bg-neutral-grad-2" />
+                      <template v-else>
+                        <div class="truncate text-[15px] font-medium text-text-color">{{ item.name }}</div>
+                        <div v-if="getRoomSubtitle(item.room)" class="truncate text-xs text-text-on-main-bg-color">{{ getRoomSubtitle(item.room) }}</div>
+                      </template>
+                    </div>
+                  </button>
+                </template>
+              </RecycleScroller>
 
-              <div v-if="filteredRooms.length === 0" class="p-8 text-center text-sm text-text-on-main-bg-color">
+              <div v-else class="p-8 text-center text-sm text-text-on-main-bg-color">
                 {{ t("forward.noChats") }}
               </div>
             </div>

--- a/src/features/messaging/ui/__tests__/forward-picker-perf.test.ts
+++ b/src/features/messaging/ui/__tests__/forward-picker-perf.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, type VueWrapper } from "@vue/test-utils";
+import { nextTick, ref, defineComponent, h } from "vue";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+// WEE-100: forward picker opened slowly with no visual feedback — the whole
+// room list (member counts via Matrix SDK + avatars) rendered synchronously
+// on mount, so users saw nothing between the tap and the modal and tapped
+// 3 times. The picker must now show its shell (header/search/spinner)
+// instantly and defer the room list to the next painted frame.
+
+vi.mock("@/shared/lib/i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k, locale: { value: "en" } }),
+}));
+
+vi.mock("@/shared/lib/composables/use-android-back-handler", () => ({
+  useAndroidBackHandler: vi.fn(),
+}));
+
+const mockIsMobile = ref(false);
+vi.mock("@/shared/lib/composables/use-media-query", () => ({
+  useMobile: () => mockIsMobile,
+}));
+
+const rooms = Array.from({ length: 80 }, (_, i) => ({
+  id: `!room${i}:server`,
+  name: `Room ${i}`,
+  avatar: "",
+  isGroup: i % 2 === 0,
+  membership: "join",
+  members: [],
+}));
+
+const mockChatStore = {
+  sortedRooms: rooms,
+  forwardingMessages: [],
+  getRoomMemberCount: vi.fn(() => 5),
+  saveForwardDraft: vi.fn(),
+  saveBulkForwardDraft: vi.fn(),
+  setActiveRoom: vi.fn(),
+  exitSelectionMode: vi.fn(),
+  cancelForward: vi.fn(),
+};
+
+vi.mock("@/entities/chat", () => ({
+  useChatStore: () => mockChatStore,
+}));
+
+vi.mock("@/entities/chat/lib/use-resolved-room-name", () => ({
+  useResolvedRoomName: () => ({ resolve: (r: { name: string }) => r.name }),
+}));
+
+vi.mock("@/entities/chat/lib/chat-helpers", () => ({
+  isUnresolvedName: () => false,
+}));
+
+vi.mock("@/entities/user", () => ({
+  UserAvatar: defineComponent({ name: "UserAvatar", render: () => h("div") }),
+}));
+
+// RecycleScroller needs real layout measurements — replace with a plain list
+// so we can assert rows mount without a browser.
+vi.mock("vue-virtual-scroller", () => ({
+  RecycleScroller: defineComponent({
+    name: "RecycleScroller",
+    props: { items: { type: Array, default: () => [] } },
+    setup(props, { slots }) {
+      return () =>
+        h(
+          "div",
+          { "data-testid": "forward-room-list" },
+          (props.items as unknown[]).map(item => slots.default?.({ item })),
+        );
+    },
+  }),
+}));
+vi.mock("vue-virtual-scroller/dist/vue-virtual-scroller.css", () => ({}));
+
+import ForwardPicker from "../ForwardPicker.vue";
+
+// Deterministic rAF: collect callbacks, flush manually.
+let rafQueue: FrameRequestCallback[] = [];
+const flushRaf = async () => {
+  // Two passes — the component double-rAFs so the shell paints first.
+  for (let i = 0; i < 2; i++) {
+    const cbs = rafQueue;
+    rafQueue = [];
+    cbs.forEach(cb => cb(0));
+    await nextTick();
+  }
+};
+
+const stubs = { Avatar: defineComponent({ name: "Avatar", render: () => h("div") }) };
+
+let wrapper: VueWrapper | undefined;
+
+describe("ForwardPicker — instant open (WEE-100)", () => {
+  beforeEach(() => {
+    rafQueue = [];
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    });
+    mockChatStore.getRoomMemberCount.mockClear();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+    vi.unstubAllGlobals();
+    document.body.innerHTML = "";
+  });
+
+  it("open показывает каркас сразу (header/spinner) до рендера полного списка", async () => {
+    wrapper = mount(ForwardPicker, {
+      props: { show: false },
+      global: { stubs },
+      attachTo: document.body,
+    });
+
+    await wrapper.setProps({ show: true });
+    await nextTick();
+
+    // Shell is visible immediately…
+    const root = document.body.querySelector('[data-testid="forward-picker-root"]');
+    expect(root).not.toBeNull();
+    expect(document.body.querySelector('[data-testid="forward-list-loading"]')).not.toBeNull();
+    // …but the heavy room list has NOT mounted yet (no rows, no SDK calls).
+    expect(document.body.querySelector('[data-testid="forward-room-list"]')).toBeNull();
+    expect(mockChatStore.getRoomMemberCount).not.toHaveBeenCalled();
+
+    await flushRaf();
+
+    // Next frame: spinner replaced by the actual list.
+    expect(document.body.querySelector('[data-testid="forward-room-list"]')).not.toBeNull();
+    expect(document.body.querySelector('[data-testid="forward-list-loading"]')).toBeNull();
+  });
+
+  it("повторный toggle во время открытия не плодит дублей", async () => {
+    wrapper = mount(ForwardPicker, {
+      props: { show: true },
+      global: { stubs },
+      attachTo: document.body,
+    });
+    await nextTick();
+
+    // Re-open while the deferred list is still pending (user taps again).
+    await wrapper.setProps({ show: false });
+    await wrapper.setProps({ show: true });
+    await flushRaf();
+
+    const roots = document.body.querySelectorAll('[data-testid="forward-picker-root"]');
+    expect(roots.length).toBe(1);
+    expect(document.body.querySelectorAll('[data-testid="forward-room-list"]').length).toBe(1);
+  });
+
+  it("member count кэшируется per-open (не дёргает Matrix SDK на каждый ререндер)", async () => {
+    wrapper = mount(ForwardPicker, {
+      props: { show: false },
+      global: { stubs },
+      attachTo: document.body,
+    });
+    await wrapper.setProps({ show: true });
+    await flushRaf();
+
+    // The list actually mounted and pulled member counts for group rows.
+    expect(document.body.querySelector('[data-testid="forward-room-list"]')).not.toBeNull();
+    const groupCount = rooms.filter(r => r.isGroup).length;
+    expect(mockChatStore.getRoomMemberCount.mock.calls.length).toBeGreaterThan(0);
+    // One SDK call per visible group row, not per render pass.
+    expect(mockChatStore.getRoomMemberCount.mock.calls.length).toBeLessThanOrEqual(groupCount);
+
+    const callsAfterFirstRender = mockChatStore.getRoomMemberCount.mock.calls.length;
+    // Trigger a re-render via search filter round-trip. The picker teleports
+    // to body, so query the document instead of the wrapper.
+    const input = document.body.querySelector("input") as HTMLInputElement;
+    expect(input).not.toBeNull();
+    for (const value of ["Room 1", ""]) {
+      input.value = value;
+      input.dispatchEvent(new Event("input"));
+      await nextTick();
+    }
+
+    // Cached counts are reused — no extra SDK calls for the same rooms.
+    expect(mockChatStore.getRoomMemberCount.mock.calls.length).toBe(callsAfterFirstRender);
+  });
+});
+
+describe("ChatWindow — forward picker open guard (WEE-100)", () => {
+  it("watcher не переоткрывает пикер, если он уже показан", () => {
+    const source = readFileSync(
+      resolve(__dirname, "../../../../widgets/chat-window/ChatWindow.vue"),
+      "utf-8",
+    );
+    const watcherStart = source.indexOf("chatStore.forwardPickerRequested, (v)");
+    expect(watcherStart).toBeGreaterThan(-1);
+    const watcherBody = source.slice(watcherStart, watcherStart + 400);
+    // Guard: repeated forward taps while the picker is open/opening are no-ops.
+    expect(watcherBody).toMatch(/!showForwardPicker\.value/);
+    // The request flag is always reset so the next request still fires.
+    expect(watcherBody).toMatch(/forwardPickerRequested = false/);
+  });
+});

--- a/src/widgets/chat-window/ChatWindow.vue
+++ b/src/widgets/chat-window/ChatWindow.vue
@@ -334,7 +334,9 @@ const handleScrollToMessage = (messageId: string) => {
 // Auto-open ForwardPicker when "forward" is selected from context menu (not on draft restore)
 watch(() => chatStore.forwardPickerRequested, (v) => {
   if (v) {
-    showForwardPicker.value = true;
+    // Defensive no-op guard (WEE-100): re-setting `true` doesn't trigger
+    // reactivity anyway, but makes "repeated taps don't reopen" explicit.
+    if (!showForwardPicker.value) showForwardPicker.value = true;
     chatStore.forwardPickerRequested = false;
   }
 });


### PR DESCRIPTION
## Summary
- ForwardPicker now shows its shell (header / search / tabs / spinner) instantly on tap; the heavy room list is deferred by two frames (double rAF with a generation guard against rapid close→reopen)
- Room list virtualized with `RecycleScroller` (same pattern as `ContactList.vue`) — only visible rows render; room name resolved once per row instead of 3-4 template calls; `getRoomMemberCount` (Matrix SDK) cached per open
- ChatWindow watcher: explicit guard so repeated forward taps while the picker is open are no-ops

## Linear
- Resolves WEE-100 (https://linear.app/wwwee/issue/WEE-100)

## Test plan
- [x] `npx vue-tsc --noEmit` — no errors in touched files (50 pre-existing baseline errors, none new)
- [x] `vite build` passes
- [x] `npm run test` — 4 new tests in `forward-picker-perf.test.ts` pass; 17 failures are pre-existing baseline (verified via `git stash` round-trip)
- [x] Code review agent — HIGH/MEDIUM findings addressed (vacuous cache test fixed, `immediate: true` watcher, rAF generation counter)
- [ ] Manual QA: аккаунт с 50+ чатами → тап forward → модалка-каркас мгновенно, скролл плавный, повторные тапы без дублей, поиск/выбор чата работают