### PR TITLE
fix(channels): per-node RPC timeout + unpin hardcoded backend node (WEE-13)

### DIFF
--- a/src/app/providers/initializers/__tests__/get-subscribes-channels-fallback.test.ts
+++ b/src/app/providers/initializers/__tests__/get-subscribes-channels-fallback.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { resetNodeFailover } from "@/shared/lib/pocketnet";
+
+/**
+ * WEE-13 — bastyon subscriptions must survive a blocked/dying proxy node.
+ *
+ * `getSubscribesChannels` goes through the centralized failover client
+ * (`callPocketnetRpc`), so when the first gateway returns 503 the request must
+ * rotate to the next mirror instead of failing outright — that is the whole
+ * fix for blocked-region users (RU/CIS ISP filtering of `1.pocketnet.app`).
+ * These tests run the REAL failover chain against a stubbed global fetch.
+ */
+
+// Avoid loading the heavy Bastyon chat-scripts / SDK config in the test env,
+// but keep a two-mirror proxy list so the failover chain has somewhere to go.
+vi.mock("../../chat-scripts", () => ({
+  PocketnetInstanceConfigurator: { setTimeDifference: vi.fn() },
+}));
+vi.mock("../../chat-scripts/config/pocketnetinstance", () => ({
+  PocketnetInstance: {
+    options: {
+      listofproxies: [
+        { host: "1.pocketnet.app", port: 8899 },
+        { host: "2.pocketnet.app", port: 8899 },
+      ],
+    },
+  },
+}));
+
+import { createAppInitializer } from "../app-initializer";
+
+function jsonResponse(status: number, body: unknown = {}): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("AppInitializer.getSubscribesChannels — proxy fallback chain (WEE-13)", () => {
+  beforeEach(() => {
+    resetNodeFailover();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("tries the next proxy when the first returns 503", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(503))
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          data: { channels: [{ address: "abc", name: "Test" }], height: 100 },
+        })
+      );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await createAppInitializer().getSubscribesChannels("addr1");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(String(fetchSpy.mock.calls[0][0])).toContain("https://1.pocketnet.app:8899");
+    expect(String(fetchSpy.mock.calls[1][0])).toContain("https://2.pocketnet.app:8899");
+    expect(result?.channels[0].address).toBe("abc");
+    expect(result?.height).toBe(100);
+  });
+
+  it("does not pin a hardcoded backend node (no options.node in the body)", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      jsonResponse(200, { data: { channels: [], height: 1 } })
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await createAppInitializer().getSubscribesChannels("addr1", 0, 0, 20);
+
+    const body = JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.method).toBe("getsubscribeschannels");
+    expect(body.parameters).toEqual(["addr1", 0, 0, 20]);
+    expect(body.options).toBeUndefined();
+  });
+
+  it("returns undefined when every proxy fails — so the store can show error UI", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(jsonResponse(503));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await createAppInitializer().getSubscribesChannels("addr1");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2); // both mirrors tried
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined on an RPC-level error envelope", async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(jsonResponse(200, { error: { code: -1, message: "boom" } }));
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await createAppInitializer().getSubscribesChannels("addr1");
+
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/app/providers/initializers/app-initializer.ts
+++ b/src/app/providers/initializers/app-initializer.ts
@@ -815,8 +815,6 @@ export class AppInitializer {
     }
   }
 
-  private static readonly NODE_ID = "94.156.128.149:38081";
-
   async getSubscribesChannels(
     address: string,
     blockNumber = 0,
@@ -826,10 +824,13 @@ export class AppInitializer {
     try {
       // Centralized RPC client with node failover — node 1 returning 502 must
       // not sink the whole request (it used to be pinned to a single node).
+      // No `options.node` pin: pinning one backend node (94.156.128.149 before
+      // WEE-13) made every gateway proxy hit the same backend, so one dead
+      // backend failed all mirrors identically. Each gateway now picks its own
+      // healthy default backend.
       const envelope = await callPocketnetRpc<{ height?: number; channels?: unknown[] }>({
         method: "getsubscribeschannels",
         parameters: [address, blockNumber, page, pageSize],
-        node: AppInitializer.NODE_ID,
       });
       if (envelope.error) {
         console.error("[appInit] getSubscribesChannels RPC error:", envelope.error);
@@ -867,7 +868,6 @@ export class AppInitializer {
           "",   // keyword
           authorAddress,
         ],
-        node: AppInitializer.NODE_ID,
       });
       if (envelope.error) {
         console.error("[appInit] getProfileFeed RPC error:", envelope.error);

--- a/src/shared/lib/pocketnet/__tests__/node-failover.test.ts
+++ b/src/shared/lib/pocketnet/__tests__/node-failover.test.ts
@@ -198,6 +198,78 @@ describe("rpcFetchWithFailover", () => {
     expect(recover).toHaveBeenCalledTimes(1);
   });
 
+  it("aborts a hung node after timeoutMs and fails over to the next (WEE-13)", async () => {
+    // Node 1 emulates a blackholed host: the fetch never settles on its own,
+    // it only rejects when the failover's deadline aborts it.
+    const hungFetch = (_url: string, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () =>
+          reject(new DOMException("The operation was aborted.", "AbortError"))
+        );
+      });
+    const fetchImpl = vi
+      .fn()
+      .mockImplementationOnce(hungFetch)
+      .mockResolvedValueOnce(fakeResponse(200, { data: { channels: [] } }));
+
+    const json = await rpcFetchWithFailover("/rpc/getsubscribeschannels", {}, {
+      nodes: NODES,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      startIndex: 0,
+      timeoutMs: 30,
+    });
+
+    expect(json).toEqual({ data: { channels: [] } });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl.mock.calls[1][0]).toBe("https://2.pocketnet.app:8899/rpc/getsubscribeschannels");
+  });
+
+  it("enforces the deadline even when fetch ignores the abort signal (old WebViews)", async () => {
+    // Node 1 hangs AND has no AbortController support — the promise never
+    // settles regardless of the signal. The Promise.race deadline must still
+    // advance the loop to node 2.
+    const fetchImpl = vi
+      .fn()
+      .mockImplementationOnce(() => new Promise<Response>(() => { /* never settles */ }))
+      .mockResolvedValueOnce(fakeResponse(200, { ok: 1 }));
+
+    const json = await rpcFetchWithFailover("/rpc/x", {}, {
+      nodes: NODES,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      startIndex: 0,
+      timeoutMs: 30,
+    });
+
+    expect(json).toEqual({ ok: 1 });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("tags timed-out nodes as timeouts in the aggregate error", async () => {
+    const fetchImpl = vi.fn(() => new Promise<Response>(() => { /* never settles */ }));
+    await expect(
+      rpcFetchWithFailover("/rpc/x", {}, {
+        nodes: NODES,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        startIndex: 0,
+        timeoutMs: 20,
+      })
+    ).rejects.toThrow(/timeout after 20ms/);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("passes an abort signal to fetch so the deadline is enforceable", async () => {
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      return fakeResponse(200, { ok: 1 });
+    });
+    await rpcFetchWithFailover("/rpc/x", {}, {
+      nodes: NODES,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      startIndex: 0,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it("remembers the last healthy node (sticky) for the next call", async () => {
     const fetchImpl = vi
       .fn()

--- a/src/shared/lib/pocketnet/node-failover.ts
+++ b/src/shared/lib/pocketnet/node-failover.ts
@@ -56,6 +56,48 @@ export interface RpcFailoverOptions {
   nowMs?: number;
   /** Cooldown for a failed node before it is retried; defaults to {@link NODE_COOLDOWN_MS}. */
   cooldownMs?: number;
+  /** Per-node request ceiling; defaults to {@link NODE_REQUEST_TIMEOUT_MS}. */
+  timeoutMs?: number;
+}
+
+/**
+ * Per-node request ceiling. On blocked networks (RU/CIS ISP filtering — the
+ * WEE-13 root cause) a blackholed host doesn't refuse the connection, it just
+ * never answers; the WebView's own TCP timeout is minutes. Without this bound
+ * the failover loop is stuck on the first dead node and never reaches a
+ * reachable mirror within the user's patience window.
+ */
+export const NODE_REQUEST_TIMEOUT_MS = 10_000;
+
+/** fetch with a hard deadline. The deadline is enforced by Promise.race, so it
+ *  holds even on ancient WebViews without AbortController and with fetch
+ *  implementations that ignore `init.signal`; when AbortController IS available
+ *  the request is also aborted so the underlying socket is actually freed.
+ *  Note: any caller-provided `init.signal` is replaced (no current caller sets
+ *  one; `AbortSignal.any` is unavailable on the old WebViews we support). */
+async function fetchWithDeadline(
+  doFetch: typeof fetch,
+  url: string,
+  init: RequestInit,
+  timeoutMs: number
+): Promise<Response> {
+  const controller = typeof AbortController !== "undefined" ? new AbortController() : null;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      controller?.abort();
+      reject(new Error(`timeout after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+  const request = doFetch(url, controller ? { ...init, signal: controller.signal } : init);
+  // If the deadline wins, the late abort/network rejection of the losing fetch
+  // must not surface as an unhandled rejection.
+  request.catch(() => undefined);
+  try {
+    return await Promise.race([request, deadline]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /** How long a node that returned 502/network-error stays "cut off" before retry. */
@@ -121,19 +163,25 @@ export async function rpcFetchWithFailover(
   const doFetch = opts.fetchImpl ?? fetch;
   const nowMs = opts.nowMs ?? Date.now();
   const cooldownMs = opts.cooldownMs ?? NODE_COOLDOWN_MS;
+  const timeoutMs = opts.timeoutMs ?? NODE_REQUEST_TIMEOUT_MS;
   const start = opts.startIndex ?? stickyIndex;
   const errors: string[] = [];
 
   for (const base of orderedCandidates(nodes, start, nowMs)) {
     let response: Response;
     try {
-      response = await doFetch(`${base}${path}`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-      });
+      response = await fetchWithDeadline(
+        doFetch,
+        `${base}${path}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        },
+        timeoutMs
+      );
     } catch (e) {
-      // Network error / abort → cut the node off and try the next one.
+      // Network error / timeout abort → cut the node off and try the next one.
       errors.push(`${base}: ${e instanceof Error ? e.message : String(e)}`);
       disableNode(base, nowMs, cooldownMs);
       continue;


### PR DESCRIPTION
## Summary
- Add a hard 10s per-node deadline to the Pocketnet RPC failover chain (`rpcFetchWithFailover`). On blocked networks (RU/CIS ISP blackholing of `N.pocketnet.app`) a fetch never settles for minutes, so the failover loop never reached a working mirror and bastyon subscriptions appeared to never load. The deadline is enforced via `Promise.race`, so it holds even on old Android WebViews without `AbortController`; when available, the request is also aborted to free the socket.
- Remove the hardcoded backend node pin (`94.156.128.149:38081`) from `getsubscribeschannels` / `getprofilefeed` — pinning one backend made all 4 gateway mirrors (1/2/3/6.pocketnet.app:8899) hit the same backend, so one dead backend failed every mirror identically.
- Regression tests: hung-node failover, signal-ignoring fetch (old WebView), timeout tagging in the aggregate error, and an integration-style `getSubscribesChannels` fallback-chain suite (503 → next mirror, no `options.node` pin, all-fail → error UI path).

Note: the rest of the WEE-13 plan already landed earlier — multi-mirror failover + circuit breaker (WEE-35), pagination guard and error UI with retry (WEE-24). Tor routing for direct WebView fetches is not feasible without a native reverse proxy and is documented in the Linear ticket as out of scope.

## Linear
- Resolves WEE-13 (https://linear.app/wwwee/issue/WEE-13)

## Closes
Closes greenShirtMystery/forta-bugs#550
Closes greenShirtMystery/forta-bugs#537
Closes greenShirtMystery/forta-bugs#534
Closes greenShirtMystery/forta-bugs#524
Closes greenShirtMystery/forta-bugs#472

Partial: greenShirtMystery/forta-bugs#584 (broader sync regression tracked separately).

## Test plan
- [x] `npx vite build` passes; `vue-tsc` errors identical to master baseline (50 pre-existing, none in touched files)
- [x] Unit/regression tests added (`node-failover.test.ts`, `get-subscribes-channels-fallback.test.ts`) — 26/26 pass
- [x] Full vitest run — only pre-existing baseline failures (verified same set fails on master)
- [ ] Manual QA: block `1.pocketnet.app` (hosts file / firewall) → channels load via mirror within ~10s; block all mirrors → error UI + retry; unblock + retry → channels appear