### PR TITLE
fix(channels): native video player — single-tap start, position memory, no stale-chat resume (WEE-82)

### DIFF
--- a/android/app/src/main/java/com/forta/chat/plugins/push/PushDataPlugin.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/push/PushDataPlugin.kt
@@ -17,6 +17,12 @@ import com.getcapacitor.annotation.CapacitorPlugin
 @CapacitorPlugin(name = "PushData")
 class PushDataPlugin : Plugin() {
 
+    companion object {
+        private const val INTENT_PREFS = "forta_push_intents"
+        private const val KEY_CONSUMED = "consumed_push_keys"
+        private const val MAX_CONSUMED_KEYS = 20
+    }
+
     /** Buffered push intent data for cold-start retrieval by JS */
     private var pendingPushRoom: JSObject? = null
 
@@ -26,6 +32,48 @@ class PushDataPlugin : Plugin() {
 
         // Buffer push intent for cold-start (JS listeners aren't ready yet)
         activity?.intent?.let { bufferPushIntent(it) }
+    }
+
+    // ── Stale-intent guards (WEE-82 / forta-bugs#962) ────────────────────────
+    //
+    // `intent.removeExtra()` below only mutates the in-memory Intent. Android
+    // keeps the ORIGINAL launch intent in the task record: when the process is
+    // killed in background (e.g. memory pressure while the user watched a
+    // video) and the task is re-entered, the activity is recreated with the
+    // push extras present again — and we'd re-open a chat the user tapped into
+    // days ago instead of leaving them where they were. Two guards:
+    //   1. FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY — relaunch via recents is never
+    //      a fresh notification tap.
+    //   2. A persisted LRU of consumed (roomId|eventId) keys — covers
+    //      recreation paths that don't set the history flag. Event IDs are
+    //      unique per message, so a fresh tap is never falsely skipped; null
+    //      eventId intents skip this check (room-only key could swallow a
+    //      legitimate second tap for the same room).
+
+    private fun intentKey(roomId: String, eventId: String?): String? =
+        eventId?.let { "$roomId|$it" }
+
+    private fun consumedKeys(): List<String> =
+        context.getSharedPreferences(INTENT_PREFS, android.content.Context.MODE_PRIVATE)
+            .getString(KEY_CONSUMED, "")
+            ?.split('\n')
+            ?.filter { it.isNotEmpty() }
+            ?: emptyList()
+
+    private fun markConsumed(key: String?) {
+        if (key == null) return
+        val keys = (consumedKeys().filter { it != key } + key).takeLast(MAX_CONSUMED_KEYS)
+        context.getSharedPreferences(INTENT_PREFS, android.content.Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_CONSUMED, keys.joinToString("\n"))
+            .apply()
+    }
+
+    /** True when this intent must not navigate (historical relaunch or already handled). */
+    private fun isStalePushIntent(intent: Intent, roomId: String, eventId: String?): Boolean {
+        if (intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY != 0) return true
+        val key = intentKey(roomId, eventId) ?: return false
+        return consumedKeys().contains(key)
     }
 
     override fun handleOnDestroy() {
@@ -58,6 +106,12 @@ class PushDataPlugin : Plugin() {
         intent.removeExtra(FortaFirebaseMessagingService.EXTRA_PUSH_ROOM_ID)
         intent.removeExtra(FortaFirebaseMessagingService.EXTRA_PUSH_EVENT_ID)
 
+        if (isStalePushIntent(intent, roomId, eventId)) {
+            android.util.Log.d("FortaPush", "bufferPushIntent: stale push intent skipped (roomId=$roomId)")
+            return
+        }
+        markConsumed(intentKey(roomId, eventId))
+
         val data = JSObject()
         data.put("roomId", roomId)
         if (eventId != null) data.put("eventId", eventId)
@@ -72,6 +126,12 @@ class PushDataPlugin : Plugin() {
         // Clear to avoid re-firing
         intent.removeExtra(FortaFirebaseMessagingService.EXTRA_PUSH_ROOM_ID)
         intent.removeExtra(FortaFirebaseMessagingService.EXTRA_PUSH_EVENT_ID)
+
+        if (isStalePushIntent(intent, roomId, eventId)) {
+            android.util.Log.d("FortaPush", "forwardPushIntent: stale push intent skipped (roomId=$roomId)")
+            return
+        }
+        markConsumed(intentKey(roomId, eventId))
 
         val data = JSObject()
         data.put("roomId", roomId)

--- a/src/features/post-player/ui/PostPlayerModal.vue
+++ b/src/features/post-player/ui/PostPlayerModal.vue
@@ -133,7 +133,10 @@ onUnmounted(() => {
 
         <!-- Content -->
         <div class="flex-1 overflow-y-auto">
-          <VideoPlayer v-if="videoInfo" :url="post.url" />
+          <!-- autoplay: the modal itself was opened by a deliberate tap on the
+               post/video, so starting playback here keeps it a single-tap
+               flow (WEE-82 / forta-bugs#963). -->
+          <VideoPlayer v-if="videoInfo" :url="post.url" autoplay />
           <div v-else-if="images.length" class="max-h-80 overflow-hidden">
             <img :src="images[0]" alt="" class="w-full object-cover" loading="lazy" />
           </div>

--- a/src/features/post-player/ui/VideoPlayer.vue
+++ b/src/features/post-player/ui/VideoPlayer.vue
@@ -1,15 +1,18 @@
 <script setup lang="ts">
-import { parseVideoUrl, fetchPeerTubeThumb } from "@/shared/lib/video-embed";
+import { parseVideoUrl, fetchPeerTubeThumb, fetchPeerTubeFileUrl } from "@/shared/lib/video-embed";
 import { useAndroidBackHandler } from "@/shared/lib/composables/use-android-back-handler";
 import { isNative } from "@/shared/lib/platform";
 import { openExternalUrl } from "@/shared/lib/open-external-url";
+import FeedVideoPlayer from "@/shared/ui/feed-video-player/FeedVideoPlayer.vue";
 
 interface Props {
   url: string;
   inline?: boolean;
+  /** Start playback on mount (modal opened from a feed tap — WEE-82/#963). */
+  autoplay?: boolean;
 }
 
-const props = withDefaults(defineProps<Props>(), { inline: false });
+const props = withDefaults(defineProps<Props>(), { inline: false, autoplay: false });
 
 // Inline (channel feed) playback asks the host to open the post instead of
 // embedding the iframe in the feed — see `play()` for why (WEE-74).
@@ -22,6 +25,17 @@ const iframeLoaded = ref(false);
 const spinnerTimedOut = ref(false);
 const peertubeThumb = ref("");
 const isFullscreen = ref(false);
+
+// WEE-82 (#963/#964): direct media file resolved from the PeerTube API. With
+// it we render a native <video> instead of the cross-origin iframe — that's
+// what makes single-tap start and position memory possible at all (the iframe
+// can neither autoplay on Android nor expose currentTime). Stays null for
+// YouTube/Vimeo and when the API exposes no file → iframe fallback below.
+const nativeSrc = ref<string | null>(null);
+
+// Don't switch players mid-flight: if the user already tapped play while the
+// file URL was being resolved, the iframe is up — keep it.
+const nativePlayerActive = computed(() => !!nativeSrc.value && !playing.value);
 
 // Belt-and-suspenders for old Android WebViews where iframe @load may never
 // fire: stop showing our overlay spinner after this long so it can't become
@@ -59,19 +73,53 @@ const onFullscreenChange = () => {
   isFullscreen.value = !!document.fullscreenElement;
 };
 
-onMounted(async () => {
+// The PeerTube file fetch can outlive a quickly-closed modal — its callback
+// must not arm timers on a dead component.
+let unmounted = false;
+
+onMounted(() => {
   document.addEventListener("fullscreenchange", onFullscreenChange);
 
   const info = videoInfo.value;
   if (info?.type === "peertube" && info.apiUrl) {
-    peertubeThumb.value = await fetchPeerTubeThumb(info.apiUrl);
+    void fetchPeerTubeThumb(info.apiUrl).then((thumb) => {
+      peertubeThumb.value = thumb;
+    });
   }
+
+  // WEE-82: native <video> path for PeerTube on native. Inline feed tiles
+  // never play in place (WEE-74 routes them to the post modal), so don't
+  // spend a request there.
+  if (isNative && !props.inline && info?.type === "peertube" && info.apiUrl) {
+    void fetchPeerTubeFileUrl(info.apiUrl).then((fileUrl) => {
+      if (unmounted) return;
+      nativeSrc.value = fileUrl;
+      // No direct file → iframe fallback. Still honour autoplay by loading
+      // the embed immediately so the user only deals with the embed's own
+      // play button instead of our overlay + the embed (#963).
+      if (!fileUrl && props.autoplay) play();
+    });
+    return;
+  }
+
+  if (props.autoplay) play();
 });
 
 onUnmounted(() => {
+  unmounted = true;
   document.removeEventListener("fullscreenchange", onFullscreenChange);
   clearSpinnerTimer();
 });
+
+// A resolved file URL can still fail at playback time (expired link, fMP4 an
+// old WebView can't decode). When the native player exhausts its retries,
+// fall back to the iframe embed — clunkier, but it always works (pre-WEE-82
+// behavior). play() mounts the embed immediately so the user isn't bounced
+// back to the overlay they already tapped through.
+const onNativeFatalError = () => {
+  nativeSrc.value = null;
+  play();
+};
 
 // Android back: exit iframe fullscreen instead of closing the post.
 // Priority 100 matches other full-screen overlays (MediaViewer, CallWindow).
@@ -125,8 +173,19 @@ const openExternal = () => {
 </script>
 
 <template>
+  <!-- WEE-82: native player for PeerTube on native — single-tap + position memory -->
+  <FeedVideoPlayer
+    v-if="videoInfo && nativePlayerActive"
+    data-testid="native-player"
+    :src="nativeSrc"
+    :poster="thumbUrl"
+    :autoplay="autoplay"
+    :start-muted="false"
+    :persist-key="url"
+    @fatal-error="onNativeFatalError"
+  />
   <div
-    v-if="videoInfo"
+    v-else-if="videoInfo"
     class="relative overflow-hidden rounded-lg bg-black"
     :class="'aspect-video w-full'"
   >

--- a/src/features/post-player/ui/__tests__/VideoPlayer.test.ts
+++ b/src/features/post-player/ui/__tests__/VideoPlayer.test.ts
@@ -19,13 +19,32 @@ vi.mock("@/shared/lib/open-external-url", () => ({
   openExternalUrl: (url: string) => openExternalUrl(url),
 }));
 
+// PeerTube API fetchers — control the native <video> path (WEE-82) per test.
+let mockFileUrl: string | null = null;
+const fetchPeerTubeFileUrl = vi.fn(() => Promise.resolve(mockFileUrl));
+vi.mock("@/shared/lib/video-embed", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/lib/video-embed")>();
+  return {
+    ...actual,
+    fetchPeerTubeThumb: vi.fn(() => Promise.resolve("")),
+    fetchPeerTubeFileUrl: () => fetchPeerTubeFileUrl(),
+  };
+});
+
 import VideoPlayer from "../VideoPlayer.vue";
 
 const YT_URL = "https://www.youtube.com/watch?v=dQw4w9WgXcQ";
+const PT_URL = "peertube://videos.example.com/a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+// FeedVideoPlayer is stubbed: its own behavior is covered by
+// use-feed-video-player.test.ts; here we only assert the routing decision.
+const mountOptions = { global: { stubs: { FeedVideoPlayer: true } } };
 
 beforeEach(() => {
   mockIsNative = false;
+  mockFileUrl = null;
   openExternalUrl.mockClear();
+  fetchPeerTubeFileUrl.mockClear();
 });
 
 describe("VideoPlayer iframe security", () => {
@@ -165,5 +184,148 @@ describe("VideoPlayer channel feed touch/scroll lock (WEE-74)", () => {
     // Modal context: the iframe is fine here — it doesn't lock the channel feed.
     expect(wrapper.find("iframe").exists()).toBe(true);
     expect(wrapper.emitted("expand")).toBeUndefined();
+  });
+});
+
+describe("VideoPlayer native <video> path (WEE-82 / forta-bugs#963, #964)", () => {
+  it("peertube в модалке на native рендерит нативный плеер вместо iframe", async () => {
+    mockIsNative = true;
+    mockFileUrl = "https://cdn.example.com/720.mp4";
+    const wrapper = mount(VideoPlayer, { props: { url: PT_URL }, ...mountOptions });
+    await flushPromises();
+
+    const native = wrapper.find("[data-testid='native-player']");
+    expect(native.exists()).toBe(true);
+    expect(wrapper.find("iframe").exists()).toBe(false);
+    // Position memory is keyed by the post video URL
+    expect(native.attributes("persistkey") ?? native.attributes("persist-key")).toBe(PT_URL);
+  });
+
+  it("peertube без прямого файла откатывается на iframe-поток", async () => {
+    mockIsNative = true;
+    mockFileUrl = null;
+    const wrapper = mount(VideoPlayer, { props: { url: PT_URL }, ...mountOptions });
+    await flushPromises();
+
+    expect(wrapper.find("[data-testid='native-player']").exists()).toBe(false);
+    // Old behavior intact: tap the overlay → iframe mounts
+    await wrapper.find("button").trigger("click");
+    await flushPromises();
+    expect(wrapper.find("iframe").exists()).toBe(true);
+  });
+
+  it("YouTube на native не запрашивает PeerTube API и остаётся на iframe", async () => {
+    mockIsNative = true;
+    const wrapper = mount(VideoPlayer, { props: { url: YT_URL }, ...mountOptions });
+    await flushPromises();
+
+    expect(fetchPeerTubeFileUrl).not.toHaveBeenCalled();
+    expect(wrapper.find("[data-testid='native-player']").exists()).toBe(false);
+  });
+
+  it("inline peertube на native не тратит запрос за файлом — тап эмитит expand (WEE-74)", async () => {
+    mockIsNative = true;
+    mockFileUrl = "https://cdn.example.com/720.mp4";
+    const wrapper = mount(VideoPlayer, { props: { url: PT_URL, inline: true }, ...mountOptions });
+    await flushPromises();
+
+    expect(fetchPeerTubeFileUrl).not.toHaveBeenCalled();
+
+    await wrapper.find("button").trigger("click");
+    expect(wrapper.emitted("expand")).toHaveLength(1);
+    expect(wrapper.find("iframe").exists()).toBe(false);
+  });
+
+  it("на web peertube остаётся на iframe (native-путь только для Capacitor)", async () => {
+    mockIsNative = false;
+    mockFileUrl = "https://cdn.example.com/720.mp4";
+    const wrapper = mount(VideoPlayer, { props: { url: PT_URL }, ...mountOptions });
+    await flushPromises();
+
+    expect(fetchPeerTubeFileUrl).not.toHaveBeenCalled();
+    expect(wrapper.find("[data-testid='native-player']").exists()).toBe(false);
+  });
+
+  it("тап по overlay до резолва файла оставляет iframe — плеер не переключается на лету", async () => {
+    mockIsNative = true;
+    let resolveFile!: (url: string | null) => void;
+    fetchPeerTubeFileUrl.mockImplementationOnce(
+      () => new Promise<string | null>((res) => { resolveFile = res; }),
+    );
+    const wrapper = mount(VideoPlayer, { props: { url: PT_URL }, ...mountOptions });
+    await flushPromises();
+
+    // User taps play while the file URL is still being resolved → iframe starts
+    await wrapper.find("button").trigger("click");
+    expect(wrapper.find("iframe").exists()).toBe(true);
+
+    // Late resolve must NOT yank the running iframe out from under the user
+    resolveFile("https://cdn.example.com/720.mp4");
+    await flushPromises();
+
+    expect(wrapper.find("iframe").exists()).toBe(true);
+    expect(wrapper.find("[data-testid='native-player']").exists()).toBe(false);
+  });
+
+  it("fatal-error нативного плеера откатывает на iframe-embed", async () => {
+    mockIsNative = true;
+    mockFileUrl = "https://cdn.example.com/720.mp4";
+    const wrapper = mount(VideoPlayer, { props: { url: PT_URL }, ...mountOptions });
+    await flushPromises();
+
+    expect(wrapper.find("[data-testid='native-player']").exists()).toBe(true);
+
+    // Native playback died after all retries (expired link / undecodable fMP4)
+    wrapper.findComponent({ name: "FeedVideoPlayer" }).vm.$emit("fatal-error");
+    await flushPromises();
+
+    expect(wrapper.find("[data-testid='native-player']").exists()).toBe(false);
+    expect(wrapper.find("iframe").exists()).toBe(true);
+  });
+});
+
+describe("VideoPlayer autoplay prop (WEE-82 / forta-bugs#963 single-tap)", () => {
+  it("autoplay на web сразу монтирует iframe без тапа по overlay", async () => {
+    const wrapper = mount(VideoPlayer, { props: { url: YT_URL, autoplay: true }, ...mountOptions });
+    await flushPromises();
+
+    const iframe = wrapper.find("iframe");
+    expect(iframe.exists()).toBe(true);
+    expect(iframe.attributes("src")).toContain("autoplay=1");
+  });
+
+  it("autoplay + peertube fallback на native сразу грузит iframe (один тап меньше)", async () => {
+    mockIsNative = true;
+    mockFileUrl = null;
+    const wrapper = mount(VideoPlayer, {
+      props: { url: PT_URL, autoplay: true },
+      ...mountOptions,
+    });
+    await flushPromises();
+
+    expect(wrapper.find("iframe").exists()).toBe(true);
+  });
+
+  it("autoplay + peertube native передаёт autoplay нативному плееру", async () => {
+    mockIsNative = true;
+    mockFileUrl = "https://cdn.example.com/720.mp4";
+    const wrapper = mount(VideoPlayer, {
+      props: { url: PT_URL, autoplay: true },
+      ...mountOptions,
+    });
+    await flushPromises();
+
+    const native = wrapper.find("[data-testid='native-player']");
+    expect(native.exists()).toBe(true);
+    // Stub renders props as attributes; boolean true → empty-string attr
+    expect(native.attributes("autoplay")).toBeDefined();
+  });
+
+  it("без autoplay поведение прежнее — overlay ждёт тапа", async () => {
+    const wrapper = mount(VideoPlayer, { props: { url: YT_URL }, ...mountOptions });
+    await flushPromises();
+
+    expect(wrapper.find("iframe").exists()).toBe(false);
+    expect(wrapper.find("button").exists()).toBe(true);
   });
 });

--- a/src/shared/lib/use-feed-video-player.test.ts
+++ b/src/shared/lib/use-feed-video-player.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ref, effectScope, type EffectScope } from "vue";
 import { useFeedVideoPlayer, _resetActivePlayer } from "./use-feed-video-player";
+import {
+  getVideoPosition,
+  saveVideoPosition,
+  _resetVideoPositionCache,
+} from "./video-position-store";
 
 // ---------------------------------------------------------------------------
 // Mock HTMLVideoElement with real event dispatching
@@ -126,7 +131,14 @@ describe("useFeedVideoPlayer", () => {
     vi.useRealTimers();
   });
 
-  function setup(overrides: { src?: string | null; autoplay?: boolean } = {}) {
+  function setup(
+    overrides: {
+      src?: string | null;
+      autoplay?: boolean;
+      persistKey?: string;
+      onFatalError?: () => void;
+    } = {},
+  ) {
     const scope = effectScope();
     scopes.push(scope);
 
@@ -140,6 +152,8 @@ describe("useFeedVideoPlayer", () => {
         containerRef,
         src: srcRef,
         autoplay: overrides.autoplay ?? false,
+        persistKey: overrides.persistKey,
+        onFatalError: overrides.onFatalError,
       }),
     )!;
 
@@ -314,9 +328,154 @@ describe("useFeedVideoPlayer", () => {
       triggerIO(getVisibilityObserver(), true);
       expect(videoEl.play).toHaveBeenCalled();
     });
+
+    it("auto-plays when metadata arrives AFTER visibility fired (WEE-82/#963)", () => {
+      // Modal flow: the player becomes visible while the source is still
+      // loading. The visibility callback can't start playback (not ready yet)
+      // — loadedmetadata must pick it up, otherwise autoplay never happens.
+      setup({ autoplay: true });
+
+      triggerIO(getVisibilityObserver(), true); // visible, but still idle/loading
+      triggerIO(getPreloadObserver(), true); // attach source → loading
+
+      expect(videoEl.play).not.toHaveBeenCalled();
+
+      Object.defineProperty(videoEl, "duration", { value: 30, writable: true });
+      videoEl._emit("loadedmetadata");
+
+      expect(videoEl.play).toHaveBeenCalled();
+    });
+  });
+
+  describe("position persistence (WEE-82 / forta-bugs#964)", () => {
+    const PERSIST_KEY = "peertube://host/uuid";
+
+    beforeEach(() => {
+      localStorage.clear();
+      _resetVideoPositionCache();
+    });
+
+    it("restores the saved position when metadata loads", () => {
+      saveVideoPosition(PERSIST_KEY, 120, 600);
+
+      setup({ persistKey: PERSIST_KEY });
+      triggerIO(getPreloadObserver(), true);
+
+      Object.defineProperty(videoEl, "duration", { value: 600, writable: true });
+      videoEl._emit("loadedmetadata");
+
+      expect(videoEl.currentTime).toBe(120);
+    });
+
+    it("does not touch currentTime when nothing is saved", () => {
+      setup({ persistKey: PERSIST_KEY });
+      triggerIO(getPreloadObserver(), true);
+
+      Object.defineProperty(videoEl, "duration", { value: 600, writable: true });
+      videoEl._emit("loadedmetadata");
+
+      expect(videoEl.currentTime).toBe(0);
+    });
+
+    it("saves the position on pause", async () => {
+      const player = setup({ persistKey: PERSIST_KEY });
+
+      const playPromise = player.play();
+      Object.defineProperty(videoEl, "duration", { value: 600, writable: true });
+      videoEl._emit("loadedmetadata");
+      await playPromise;
+
+      videoEl.currentTime = 240;
+      player.pause();
+
+      expect(getVideoPosition(PERSIST_KEY)).toBe(240);
+    });
+
+    it("flushes the position when the page is hidden (app minimized)", async () => {
+      const player = setup({ persistKey: PERSIST_KEY });
+
+      const playPromise = player.play();
+      Object.defineProperty(videoEl, "duration", { value: 600, writable: true });
+      videoEl._emit("loadedmetadata");
+      await playPromise;
+
+      videoEl.currentTime = 333;
+      Object.defineProperty(document, "visibilityState", {
+        value: "hidden",
+        configurable: true,
+      });
+      document.dispatchEvent(new Event("visibilitychange"));
+
+      expect(getVideoPosition(PERSIST_KEY)).toBe(333);
+
+      Object.defineProperty(document, "visibilityState", {
+        value: "visible",
+        configurable: true,
+      });
+    });
+
+    it("saves the position when the player unmounts", async () => {
+      const player = setup({ persistKey: PERSIST_KEY });
+
+      const playPromise = player.play();
+      Object.defineProperty(videoEl, "duration", { value: 600, writable: true });
+      videoEl._emit("loadedmetadata");
+      await playPromise;
+
+      videoEl.currentTime = 90;
+      simulateUnmount();
+
+      expect(getVideoPosition(PERSIST_KEY)).toBe(90);
+    });
+
+    it("clears the saved position when the video ends", async () => {
+      saveVideoPosition(PERSIST_KEY, 120, 600);
+      const player = setup({ persistKey: PERSIST_KEY });
+
+      const playPromise = player.play();
+      Object.defineProperty(videoEl, "duration", { value: 600, writable: true });
+      videoEl._emit("loadedmetadata");
+      await playPromise;
+
+      videoEl._emit("ended");
+
+      expect(getVideoPosition(PERSIST_KEY)).toBe(0);
+    });
+
+    it("does not persist anything without a persistKey", async () => {
+      const player = setup();
+
+      const playPromise = player.play();
+      Object.defineProperty(videoEl, "duration", { value: 600, writable: true });
+      videoEl._emit("loadedmetadata");
+      await playPromise;
+
+      videoEl.currentTime = 240;
+      player.pause();
+
+      expect(localStorage.getItem("forta-video-positions")).toBeNull();
+    });
   });
 
   describe("error recovery", () => {
+    it("calls onFatalError once retries are exhausted (WEE-82 iframe fallback)", async () => {
+      const onFatalError = vi.fn();
+      const player = setup({ onFatalError });
+
+      await playAndReady(player, videoEl);
+
+      // 3 retries with backoff (1s, 3s, 6s), each failing again
+      for (const delay of [1000, 3000, 6000]) {
+        videoEl._emit("error");
+        expect(onFatalError).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(delay);
+      }
+
+      // 4th error → retry budget gone → fatal
+      videoEl._emit("error");
+      expect(onFatalError).toHaveBeenCalledTimes(1);
+    });
+
     it("retries on error with backoff", async () => {
       const player = setup();
 

--- a/src/shared/lib/use-feed-video-player.ts
+++ b/src/shared/lib/use-feed-video-player.ts
@@ -1,4 +1,9 @@
 import { ref, onMounted, onBeforeUnmount, watch, type Ref } from "vue";
+import {
+  getVideoPosition,
+  saveVideoPosition,
+  clearVideoPosition,
+} from "@/shared/lib/video-position-store";
 
 export type FeedPlayerState = "idle" | "loading" | "ready" | "playing" | "paused" | "error";
 
@@ -15,6 +20,20 @@ export interface FeedPlayerOptions {
   autoplay?: boolean;
   /** rootMargin for preload zone */
   preloadMargin?: string;
+  /** Start muted (default true — feed convention). Pass false for post viewing. */
+  startMuted?: boolean;
+  /**
+   * Stable key (e.g. the post video URL) to persist playback position under
+   * (WEE-82 / forta-bugs#964). When set, the position is restored on load and
+   * saved on pause/background/unmount so minimizing the app doesn't lose it.
+   */
+  persistKey?: string;
+  /**
+   * Called once all error retries are exhausted — the source is not going to
+   * play. Lets the host switch to a different playback strategy (e.g. the
+   * iframe embed fallback in VideoPlayer, WEE-82).
+   */
+  onFatalError?: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -55,13 +74,16 @@ export function useFeedVideoPlayer(options: FeedPlayerOptions) {
     poster,
     autoplay = false,
     preloadMargin = "200px",
+    startMuted = true,
+    persistKey,
+    onFatalError,
   } = options;
 
   const state = ref<FeedPlayerState>("idle");
   const currentTime = ref(0);
   const duration = ref(0);
   const buffered = ref(0);
-  const isMuted = ref(true);
+  const isMuted = ref(startMuted);
   const errorCount = ref(0);
 
   let idleTimer: ReturnType<typeof setTimeout> | null = null;
@@ -91,12 +113,30 @@ export function useFeedVideoPlayer(options: FeedPlayerOptions) {
     const el = videoRef.value;
     if (!el) return;
 
+    flushPosition();
     el.pause();
     el.removeAttribute("src");
     el.load();
     state.value = "idle";
     releaseActivePlayer(playerHandle);
     clearIdleTimer();
+  }
+
+  // --- Position persistence (WEE-82 / forta-bugs#964) ---
+
+  /** Write the current position to the persistent store. */
+  function flushPosition() {
+    if (!persistKey) return;
+    const el = videoRef.value;
+    if (!el || state.value === "idle" || state.value === "error") return;
+    saveVideoPosition(persistKey, el.currentTime, el.duration || 0);
+  }
+
+  // The WebView pauses media on background but never fires our pause() path,
+  // so flush when the page hides — that's exactly the "minimize app" moment
+  // the position must survive.
+  function onVisibilityChange() {
+    if (document.visibilityState === "hidden") flushPosition();
   }
 
   // --- Play / Pause ---
@@ -152,6 +192,7 @@ export function useFeedVideoPlayer(options: FeedPlayerOptions) {
     if (state.value === "playing") {
       state.value = "paused";
     }
+    flushPosition();
     releaseActivePlayer(playerHandle);
     startIdleTimer();
   }
@@ -199,7 +240,10 @@ export function useFeedVideoPlayer(options: FeedPlayerOptions) {
   // --- Error recovery ---
 
   function scheduleRetry() {
-    if (errorCount.value >= MAX_RETRIES) return;
+    if (errorCount.value >= MAX_RETRIES) {
+      onFatalError?.();
+      return;
+    }
 
     const delay = RETRY_DELAYS[errorCount.value] ?? 6000;
     errorCount.value++;
@@ -216,7 +260,25 @@ export function useFeedVideoPlayer(options: FeedPlayerOptions) {
     const el = videoRef.value;
     if (!el) return;
     duration.value = el.duration;
+
+    // Restore the saved position (WEE-82 / forta-bugs#964). The store already
+    // drops near-start/near-end positions, so any non-zero value is resumable.
+    if (persistKey) {
+      const saved = getVideoPosition(persistKey);
+      if (saved > 0 && saved < el.duration) {
+        el.currentTime = saved;
+        currentTime.value = saved;
+      }
+    }
+
     state.value = "ready";
+
+    // Autoplay couldn't fire from the visibility observer: its initial
+    // callback runs while the source is still loading (state !== "ready").
+    // Once metadata lands, start playback if we're visible and asked to.
+    if (autoplay && isInViewport && !playInProgress) {
+      void play();
+    }
   }
 
   function onTimeUpdate() {
@@ -236,6 +298,7 @@ export function useFeedVideoPlayer(options: FeedPlayerOptions) {
     if (el) el.currentTime = 0;
     currentTime.value = 0;
     state.value = "paused";
+    if (persistKey) clearVideoPosition(persistKey);
     releaseActivePlayer(playerHandle);
   }
 
@@ -305,6 +368,9 @@ export function useFeedVideoPlayer(options: FeedPlayerOptions) {
   onMounted(() => {
     bindListeners();
     setupObservers();
+    if (persistKey) {
+      document.addEventListener("visibilitychange", onVisibilityChange);
+    }
   });
 
   watch(src, (newSrc) => {
@@ -314,6 +380,9 @@ export function useFeedVideoPlayer(options: FeedPlayerOptions) {
   });
 
   onBeforeUnmount(() => {
+    if (persistKey) {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    }
     unbindListeners();
     detachSource();
     clearIdleTimer();

--- a/src/shared/lib/video-embed.test.ts
+++ b/src/shared/lib/video-embed.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { parseVideoUrl } from "./video-embed";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { parseVideoUrl, fetchPeerTubeFileUrl } from "./video-embed";
 
 describe("parseVideoUrl", () => {
   // ─── YouTube ────────────────────────────────────────────────────
@@ -61,7 +61,10 @@ describe("parseVideoUrl", () => {
       type: "peertube",
       id: uuid,
       embedUrl: `https://videos.example.com/videos/embed/${uuid}`,
-      thumbUrl: `https://videos.example.com/lazy-static/previews/${uuid}.jpg`,
+      // Thumb is resolved lazily via the API (the preview UUID differs from
+      // the video UUID) — parse returns the API URL instead.
+      thumbUrl: "",
+      apiUrl: `https://videos.example.com/api/v1/videos/${uuid}`,
     });
   });
 
@@ -81,5 +84,73 @@ describe("parseVideoUrl", () => {
 
   it("returns null for YouTube-like URL with wrong ID length", () => {
     expect(parseVideoUrl("https://youtube.com/watch?v=short")).toBeNull();
+  });
+});
+
+describe("fetchPeerTubeFileUrl (WEE-82)", () => {
+  const API_URL = "https://videos.example.com/api/v1/videos/abc";
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubFetch(payload: unknown, ok = true) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve({
+          ok,
+          json: () => Promise.resolve(payload),
+        }),
+      ),
+    );
+  }
+
+  it("picks the web-video file closest to 720p", async () => {
+    stubFetch({
+      files: [
+        { fileUrl: "https://cdn/240.mp4", resolution: { id: 240 } },
+        { fileUrl: "https://cdn/720.mp4", resolution: { id: 720 } },
+        { fileUrl: "https://cdn/1080.mp4", resolution: { id: 1080 } },
+      ],
+    });
+    await expect(fetchPeerTubeFileUrl(API_URL)).resolves.toBe("https://cdn/720.mp4");
+  });
+
+  it("falls back to streamingPlaylists files when web videos are absent", async () => {
+    stubFetch({
+      files: [],
+      streamingPlaylists: [
+        {
+          files: [{ fileUrl: "https://cdn/hls-480.mp4", resolution: { id: 480 } }],
+        },
+      ],
+    });
+    await expect(fetchPeerTubeFileUrl(API_URL)).resolves.toBe("https://cdn/hls-480.mp4");
+  });
+
+  it("returns null when no files exist (caller falls back to iframe)", async () => {
+    stubFetch({ files: [], streamingPlaylists: [] });
+    await expect(fetchPeerTubeFileUrl(API_URL)).resolves.toBeNull();
+  });
+
+  it("returns null on HTTP error", async () => {
+    stubFetch({}, false);
+    await expect(fetchPeerTubeFileUrl(API_URL)).resolves.toBeNull();
+  });
+
+  it("returns null on network failure", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.reject(new Error("offline"))));
+    await expect(fetchPeerTubeFileUrl(API_URL)).resolves.toBeNull();
+  });
+
+  it("ignores entries without fileUrl", async () => {
+    stubFetch({
+      files: [
+        { resolution: { id: 720 } },
+        { fileUrl: "https://cdn/360.mp4", resolution: { id: 360 } },
+      ],
+    });
+    await expect(fetchPeerTubeFileUrl(API_URL)).resolves.toBe("https://cdn/360.mp4");
   });
 });

--- a/src/shared/lib/video-embed.ts
+++ b/src/shared/lib/video-embed.ts
@@ -49,6 +49,54 @@ export function parseVideoUrl(url: string): VideoInfo | null {
   return null;
 }
 
+interface PeerTubeFile {
+  fileUrl?: string;
+  resolution?: { id?: number };
+}
+
+/** Pick the file closest to 720p — good quality without mobile bandwidth waste. */
+const TARGET_RESOLUTION = 720;
+
+function pickBestFile(files: PeerTubeFile[]): string | null {
+  const candidates = files.filter((f) => typeof f.fileUrl === "string" && f.fileUrl);
+  if (candidates.length === 0) return null;
+  const best = candidates.reduce((a, b) => {
+    const da = Math.abs((a.resolution?.id ?? 0) - TARGET_RESOLUTION);
+    const db = Math.abs((b.resolution?.id ?? 0) - TARGET_RESOLUTION);
+    return db < da ? b : a;
+  });
+  return best.fileUrl ?? null;
+}
+
+/**
+ * Resolve a direct media file URL for a PeerTube video (WEE-82).
+ *
+ * Cross-origin iframe embeds can't single-tap-play on Android (autoplay is
+ * blocked inside the sandbox) and never expose currentTime, so the native
+ * `<video>` path needs a direct file. PeerTube lists progressive "web video"
+ * files at the top level and fMP4 files under streamingPlaylists — both play
+ * in Chrome WebView as plain <video> sources. Returns null when the instance
+ * exposes neither (caller falls back to the iframe embed).
+ */
+export async function fetchPeerTubeFileUrl(apiUrl: string): Promise<string | null> {
+  try {
+    const resp = await fetch(apiUrl, { signal: AbortSignal.timeout(5000) });
+    if (!resp.ok) return null;
+    const data = await resp.json();
+
+    const direct = pickBestFile(Array.isArray(data.files) ? data.files : []);
+    if (direct) return direct;
+
+    const playlists = Array.isArray(data.streamingPlaylists) ? data.streamingPlaylists : [];
+    const playlistFiles = playlists.flatMap((p: { files?: PeerTubeFile[] }) =>
+      Array.isArray(p.files) ? p.files : [],
+    );
+    return pickBestFile(playlistFiles);
+  } catch {
+    return null;
+  }
+}
+
 /** Fetch PeerTube thumbnail via API (the preview UUID differs from the video UUID) */
 export async function fetchPeerTubeThumb(apiUrl: string): Promise<string> {
   try {

--- a/src/shared/lib/video-position-store.test.ts
+++ b/src/shared/lib/video-position-store.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getVideoPosition,
+  saveVideoPosition,
+  clearVideoPosition,
+  _resetVideoPositionCache,
+} from "./video-position-store";
+
+const KEY = "peertube://host/abc";
+
+beforeEach(() => {
+  localStorage.clear();
+  _resetVideoPositionCache();
+});
+
+describe("video-position-store (WEE-82 / forta-bugs#964)", () => {
+  it("returns 0 when no position is saved", () => {
+    expect(getVideoPosition(KEY)).toBe(0);
+  });
+
+  it("saves and restores a mid-video position", () => {
+    saveVideoPosition(KEY, 120, 600);
+    expect(getVideoPosition(KEY)).toBe(120);
+  });
+
+  it("persists across cache resets (localStorage survives reload)", () => {
+    saveVideoPosition(KEY, 90, 600);
+    _resetVideoPositionCache();
+    expect(getVideoPosition(KEY)).toBe(90);
+  });
+
+  it("drops near-start positions — restarting is fine", () => {
+    saveVideoPosition(KEY, 3, 600);
+    expect(getVideoPosition(KEY)).toBe(0);
+  });
+
+  it("clears the entry near the end — rewatch starts from 0", () => {
+    saveVideoPosition(KEY, 120, 600);
+    saveVideoPosition(KEY, 598, 600);
+    expect(getVideoPosition(KEY)).toBe(0);
+  });
+
+  it("clearVideoPosition removes a saved entry", () => {
+    saveVideoPosition(KEY, 120, 600);
+    clearVideoPosition(KEY);
+    expect(getVideoPosition(KEY)).toBe(0);
+  });
+
+  it("evicts oldest entries beyond the LRU cap", () => {
+    for (let i = 0; i < 55; i++) {
+      saveVideoPosition(`video-${i}`, 100 + i, 600);
+    }
+    // First entries were evicted, last ones survive
+    expect(getVideoPosition("video-0")).toBe(0);
+    expect(getVideoPosition("video-54")).toBe(154);
+  });
+
+  it("survives a broken localStorage payload", () => {
+    localStorage.setItem("forta-video-positions", "{not json");
+    _resetVideoPositionCache();
+    expect(getVideoPosition(KEY)).toBe(0);
+    saveVideoPosition(KEY, 60, 600);
+    expect(getVideoPosition(KEY)).toBe(60);
+  });
+});

--- a/src/shared/lib/video-position-store.ts
+++ b/src/shared/lib/video-position-store.ts
@@ -1,0 +1,97 @@
+/**
+ * Persistent per-video playback positions (WEE-82 / forta-bugs#964).
+ *
+ * Cross-origin iframes can't expose currentTime, so position memory only
+ * works for natively-played videos. Keyed by video URL; survives modal
+ * close/reopen and app cold restarts via localStorage (bounded LRU).
+ */
+
+const STORAGE_KEY = "forta-video-positions";
+const MAX_ENTRIES = 50;
+
+/** Don't bother saving positions in the first seconds — restarting is fine. */
+const MIN_SAVE_POSITION_S = 5;
+/** Treat positions this close to the end as "watched" — restart next time. */
+const END_GRACE_S = 5;
+
+interface PositionEntry {
+  /** Position in seconds */
+  pos: number;
+  /** Last-update timestamp for LRU eviction */
+  at: number;
+}
+
+type PositionMap = Record<string, PositionEntry>;
+
+// In-memory cache: localStorage is read once and written through on flush.
+let cache: PositionMap | null = null;
+
+function load(): PositionMap {
+  if (cache) return cache;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    cache = raw ? (JSON.parse(raw) as PositionMap) : {};
+  } catch {
+    cache = {};
+  }
+  return cache;
+}
+
+function persist(map: PositionMap): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    /* quota / privacy mode — position memory degrades gracefully */
+  }
+}
+
+function evictOldest(map: PositionMap): void {
+  const keys = Object.keys(map);
+  if (keys.length <= MAX_ENTRIES) return;
+  keys
+    .sort((a, b) => map[a].at - map[b].at)
+    .slice(0, keys.length - MAX_ENTRIES)
+    .forEach((k) => delete map[k]);
+}
+
+/** Saved position for the video, or 0 when none / too close to start or end. */
+export function getVideoPosition(key: string): number {
+  const entry = load()[key];
+  return entry?.pos ?? 0;
+}
+
+/**
+ * Save the playback position. Positions near the start are dropped and
+ * positions near the end clear the entry (rewatch starts from 0).
+ */
+export function saveVideoPosition(key: string, positionS: number, durationS: number): void {
+  if (!key) return;
+  const map = load();
+
+  const nearStart = positionS < MIN_SAVE_POSITION_S;
+  const nearEnd = durationS > 0 && positionS > durationS - END_GRACE_S;
+  if (nearStart || nearEnd) {
+    if (map[key]) {
+      delete map[key];
+      persist(map);
+    }
+    return;
+  }
+
+  map[key] = { pos: positionS, at: Date.now() };
+  evictOldest(map);
+  persist(map);
+}
+
+/** Remove the saved position (e.g. video finished). */
+export function clearVideoPosition(key: string): void {
+  const map = load();
+  if (!map[key]) return;
+  delete map[key];
+  persist(map);
+}
+
+/** Test-only: drop the in-memory cache so localStorage is re-read. */
+export function _resetVideoPositionCache(): void {
+  cache = null;
+}

--- a/src/shared/ui/feed-video-player/FeedVideoPlayer.vue
+++ b/src/shared/ui/feed-video-player/FeedVideoPlayer.vue
@@ -7,12 +7,20 @@ interface Props {
   poster?: string;
   aspectRatio?: string;
   autoplay?: boolean;
+  /** Start muted (default true — feed convention). Pass false for post viewing. */
+  startMuted?: boolean;
+  /** Persist playback position under this key (WEE-82 / forta-bugs#964). */
+  persistKey?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   aspectRatio: "16/9",
   autoplay: false,
+  startMuted: true,
 });
+
+// Fired when all retries are exhausted — host may switch playback strategy.
+const emit = defineEmits<{ "fatal-error": [] }>();
 
 const containerRef = ref<HTMLElement | null>(null);
 const videoRef = ref<HTMLVideoElement | null>(null);
@@ -30,6 +38,9 @@ const {
   src: toRef(props, "src"),
   poster: props.poster,
   autoplay: props.autoplay,
+  startMuted: props.startMuted,
+  persistKey: props.persistKey,
+  onFatalError: () => emit("fatal-error"),
 });
 
 const progress = computed(() =>


### PR DESCRIPTION
## Summary
- **#963 multi-tap to start video**: PeerTube (Bastyon-hosted) channel videos now resolve a direct media file via the PeerTube API and play in the native `FeedVideoPlayer` (`<video>`) with autoplay on post open — one tap total. The cross-origin iframe embed remains as fallback (YouTube/Vimeo, instances without direct files, or fatal native playback errors → automatic fallback to iframe).
- **#964 position lost after minimizing**: new persistent per-video position store (localStorage, LRU 50) wired into `use-feed-video-player` — restored on load, saved on pause / app background / unmount, cleared when the video ends. Only possible with the native player (cross-origin iframes can't expose `currentTime`).
- **#962 returning to the app opens a previous chat**: root cause is a stale push intent — Android re-delivers the original launch intent (with `push_room_id` extras from a long-consumed notification tap) when the activity is recreated after background process death (the bug report shows `Uptime 14s` = cold restart on return). `PushDataPlugin` now skips `FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY` relaunches and dedups consumed `(roomId|eventId)` intents via a SharedPreferences LRU.

Regression guards kept intact: WEE-70 (spinner timeout / iframe `@load`) and WEE-74 (inline feed tiles never embed a playing iframe — they still route to the post modal).

## Linear
- Resolves WEE-82 (https://linear.app/wwwee/issue/WEE-82)

## Closes
Closes greenShirtMystery/forta-bugs#963
Closes greenShirtMystery/forta-bugs#964
Closes greenShirtMystery/forta-bugs#962

## Test plan
- [x] Touched test suites: 104 passed (`video-embed`, `video-position-store`, `use-feed-video-player`, post-player components)
- [x] `vue-tsc --noEmit`: 0 errors in touched files (50 pre-existing baseline errors unchanged)
- [x] Full `npm run test`: 2863 passed, 15 failed — all failures are the known pre-existing baseline set (unrelated files)
- [x] Android Kotlin compiles (`gradlew compileDebugKotlin`)
- [x] Code review (`superpowers:code-reviewer`): approved; the one should-fix (no iframe fallback on fatal native playback error) addressed + tested
- [ ] Manual QA on device: канал → тап по видео (1 тап → играет) → свернуть → вернуть (позиция сохранена, экран тот же) → проверить YouTube-пост (iframe fallback)