### PR TITLE
fix(calls): bidirectional audio on broken-AEC OEMs missed by vendor gate (WEE-103)

### DIFF
--- a/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/AudioRouter.kt
@@ -140,9 +140,10 @@ class AudioRouter private constructor(private val context: Context) {
          * the OEM re-apply window.
          *
          * [applyVendorStartTweaks] clears the global mic-mute flag once at t=0
-         * for vendors that need it (HONOR MagicOS, realme RealmeUI / OPPO
-         * ColorOS / Xiaomi MIUI — WEE-87), but those same aggressive ROMs can
-         * re-assert that flag in the same async window they reset the audio
+         * for the broken-HW-AEC family that needs it (HONOR MagicOS; realme /
+         * OPPO / Xiaomi — WEE-87; Infinix / ZTE / Huawei — WEE-103), but those
+         * same aggressive HALs can re-assert that flag in the same async window
+         * they reset the audio
          * mode (the [modeReapplyScheduleMs] ticks). When that happens the
          * one-time unmute is clobbered and the peer hears one-way silence.
          *
@@ -268,6 +269,13 @@ class AudioRouter private constructor(private val context: Context) {
     // proven WEE-54 generic path is the default and vendor branches are purely
     // additive (acceptance criterion A5).
     private val vendor: CallVendor = VendorAudioPolicy.detect(Build.MANUFACTURER, Build.BRAND)
+    // WEE-103: whether this device's audio HAL strands the mic-mute flag asserted
+    // on call setup (the broken-HW-AEC family). Resolved once from Build like
+    // [vendor]; keyed off manufacturer/brand rather than the coarse CallVendor
+    // enum so OEMs that detect() classifies as GENERIC (Infinix/XOS #1008,
+    // ZTE/nubia #1009) — and HUAWEI (#1009) — are no longer missed by the gate.
+    private val requiresMicUnmute: Boolean =
+        VendorAudioPolicy.requiresExplicitMicUnmuteOnStart(Build.MANUFACTURER, Build.BRAND)
     // WEE-16: @Volatile so the periodic re-apply runnables observe a
     // stop()/forceStop()-side write across threads. start()/stop()/
     // forceStop() are invoked from arbitrary Capacitor plugin threads
@@ -376,7 +384,7 @@ class AudioRouter private constructor(private val context: Context) {
                     // need it (gated + mic-actually-muted guard → no-op otherwise).
                     if (
                         shouldReapplyMicUnmute(
-                            VendorAudioPolicy.requiresExplicitMicUnmuteOnStart(vendor),
+                            requiresMicUnmute,
                             isActive,
                             audioManager.isMicrophoneMute,
                         )
@@ -456,13 +464,14 @@ class AudioRouter private constructor(private val context: Context) {
      * unrecognised devices, so this is a no-op on the working majority.
      */
     private fun applyVendorStartTweaks() {
-        // Aggressive Chinese ROMs (HONOR MagicOS #872/#873; realme RealmeUI /
-        // OPPO ColorOS / Xiaomi MIUI — WEE-87 #993/#994/#995): the comm-device
-        // routing above can leave the global mic-mute flag asserted, producing
-        // caller-only / self-echo one-way audio. An explicit unmute releases the
-        // capture path. Wrapped because the setter is documented to throw on a
-        // few privacy-shield ROMs and must never crash call setup.
-        if (VendorAudioPolicy.requiresExplicitMicUnmuteOnStart(vendor)) {
+        // Broken-HW-AEC family (HONOR MagicOS #872/#873; realme/OPPO/Xiaomi
+        // WEE-87 #993/#994/#995; Infinix/XOS #1008, ZTE/nubia + Huawei #1009 —
+        // WEE-103): the comm-device routing above can leave the global mic-mute
+        // flag asserted, producing one-way or both-ways silence while video plays.
+        // An explicit unmute releases the capture path. Wrapped because the setter
+        // is documented to throw on a few privacy-shield ROMs and must never crash
+        // call setup.
+        if (requiresMicUnmute) {
             try {
                 audioManager.setMicrophoneMute(false)
                 Log.d(LIFECYCLE_TAG, "[vendor=$vendor] explicit setMicrophoneMute(false) on start")

--- a/android/app/src/main/java/com/forta/chat/plugins/calls/VendorAudioPolicy.kt
+++ b/android/app/src/main/java/com/forta/chat/plugins/calls/VendorAudioPolicy.kt
@@ -97,54 +97,41 @@ object VendorAudioPolicy {
     }
 
     /**
-     * Aggressive Chinese ROMs (MagicOS / RealmeUI / ColorOS / MIUI) that are
-     * known to re-assert the process-global microphone-mute flag during call
-     * setup, stranding the local capture path in silence so the peer hears
-     * nothing. These all already ship broken HW AEC (see
-     * [BROKEN_HW_AEC_VENDORS]) — the same audio HAL that mutes capture also
-     * flips the mute flag — so they are the family that needs the explicit
-     * start-time + reapply-window unmute, not just MagicOS.
+     * Whether [AudioRouter.start] must force an explicit `setMicrophoneMute(false)`
+     * after the comm-device routing, and re-release it on each OEM mode-reapply
+     * tick — because the device's audio HAL is known to leave the process-global
+     * microphone-mute flag asserted during call setup, stranding the local
+     * capture path in silence so the peer hears nothing while video (a separate
+     * track) plays normally.
      *
-     * Deliberately excludes SAMSUNG / GENERIC (working HW AEC, proven WEE-54
-     * generic path — acceptance criterion A5) and HUAWEI (its #874 symptom was
-     * HW-AEC capture mute, fixed via [prefersSoftwareAudioProcessing]; no
-     * mic-mute-flag report, so its routing path stays untouched).
+     * WEE-103: keyed off the SAME broken-HW-AEC family as
+     * [prefersSoftwareAudioProcessing] (see [BROKEN_HW_AEC_VENDORS]) rather than a
+     * hand-maintained [CallVendor] subset. The mic-mute-flag bug and the broken
+     * HW-AEC bug share one root — the vendor audio HAL — so every device that
+     * needs software AEC is also a device that can strand the capture path muted.
+     * The previous gate keyed off the coarse [detect] enum ({HONOR, REALME, OPPO,
+     * XIAOMI}), which kept missing OEMs that [detect] classifies as GENERIC:
+     * Infinix/XOS (#1008) and ZTE/nubia (#1009) both ship broken HW AEC yet fell
+     * through to the generic path with the mic left muted → both-ways silence on
+     * 1.10.44. HUAWEI was also excluded by WEE-87 on the assumption it had "no
+     * mic-mute-flag report" — #1009 (Huawei pure 70 ultra ↔ nubia, both-ways
+     * silence + working video) falsifies that, and Huawei is in the broken-AEC
+     * family too, so it is now covered.
+     *
+     * This is the same too-narrow-vendor-gate regression that bit WEE-76→WEE-87;
+     * tying the predicate to the broken-AEC family (instead of re-enumerating
+     * vendors by hand) ends that cycle — the next broken-AEC OEM is covered
+     * automatically.
+     *
+     * Samsung / Pixel / OnePlus / unknown-working OEMs are NOT in
+     * [BROKEN_HW_AEC_VENDORS], so the proven generic WEE-54 start path stays
+     * byte-for-byte unchanged on the working majority (acceptance criterion A5).
+     * Re-asserting the unmute is itself documented-safe — it can only release a
+     * stuck capture path, never break a healthy one (the in-call Mute button
+     * toggles the WebRTC track's `enabled`, not this AudioManager flag).
      */
-    private val AGGRESSIVE_MIC_MUTE_VENDORS = setOf(
-        CallVendor.HONOR,
-        CallVendor.REALME,
-        CallVendor.OPPO,
-        CallVendor.XIAOMI,
-    )
-
-    /**
-     * Aggressive Chinese ROMs (HONOR MagicOS #872/#873, realme RealmeUI / OPPO
-     * ColorOS / Xiaomi MIUI WEE-87 #993/#994/#995) — caller-only / one-way audio
-     * because the global microphone-mute flag is left asserted.
-     *
-     * On these HALs the explicit `setCommunicationDevice` routing applied by
-     * [AudioRouter.start] can leave the global microphone-mute flag asserted, so
-     * the local capture path is silent and the peer hears nothing while the
-     * caller hears themselves. An explicit `setMicrophoneMute(false)` after the
-     * mode flip releases it, and the OEM mode-reapply window re-releases it on
-     * each tick because these same ROMs re-assert the flag asynchronously after
-     * setup (see [AudioRouter.shouldReapplyMicUnmute]).
-     *
-     * WEE-87: WEE-76 gated this to HONOR only, so the mirror-image one-way
-     * reports on realme 12 (#994 — peer hears me, I don't) / realme C25s (#995 —
-     * I hear, peer doesn't) and the both-way silence on 1.10.40 (#993) slipped
-     * through. Extending to the ColorOS/RealmeUI/MIUI family closes that gap.
-     *
-     * Still gated (not applied everywhere on *start*) because the proven generic
-     * WEE-54 path must stay byte-for-byte unchanged on the working majority
-     * (Samsung / Pixel / OnePlus / unknown OEMs — A5); the post-call reset
-     * ([shouldUnmuteMicOnStop]) is what defensively covers every other vendor.
-     * Re-asserting the unmute is itself safe (it can only release a stuck
-     * capture path, never break a healthy one), so this gate is about avoiding
-     * needless mid-call AudioManager churn on devices that never exhibit the bug.
-     */
-    fun requiresExplicitMicUnmuteOnStart(vendor: CallVendor): Boolean =
-        vendor in AGGRESSIVE_MIC_MUTE_VENDORS
+    fun requiresExplicitMicUnmuteOnStart(manufacturer: String?, brand: String?): Boolean =
+        matchesBrokenHwAecFamily(manufacturer, brand)
 
     /**
      * Post-call defensive microphone unmute for **every** vendor
@@ -183,16 +170,26 @@ object VendorAudioPolicy {
      * is observable only on emulator / malformed-ROM builds — and there the
      * brand-aware answer is the safer one.
      */
-    fun prefersSoftwareAudioProcessing(manufacturer: String?, brand: String?): Boolean {
+    fun prefersSoftwareAudioProcessing(manufacturer: String?, brand: String?): Boolean =
+        matchesBrokenHwAecFamily(manufacturer, brand)
+
+    /**
+     * Case-insensitive substring membership test against [BROKEN_HW_AEC_VENDORS]
+     * over both `Build.MANUFACTURER` and `Build.BRAND`. Shared by
+     * [prefersSoftwareAudioProcessing] and [requiresExplicitMicUnmuteOnStart]
+     * (WEE-103) so the two HAL-driven remedies key off one definition of the
+     * broken-audio-HAL family and can never drift apart again.
+     *
+     * WEE-60: substring match, not strict equality. detect() above already uses
+     * contains(); the prior `==` predicate missed OEMs that report a multi-word
+     * Build.MANUFACTURER/BRAND (e.g. "Infinix Mobility Limited", "TECNO MOBILE
+     * LIMITED", brand "Itel it2163") and kept the broken hardware AEC — muting
+     * the capture path into one-way audio (#894 Xiaomi 12X, #921 Pixel-adjacent).
+     */
+    private fun matchesBrokenHwAecFamily(manufacturer: String?, brand: String?): Boolean {
         val m = manufacturer?.trim()?.lowercase().orEmpty()
         val b = brand?.trim()?.lowercase().orEmpty()
         if (m.isEmpty() && b.isEmpty()) return false
-        // WEE-60: substring match, not strict equality. detect() above already
-        // uses contains(); this predicate lagged behind with `==`, so OEMs that
-        // report a multi-word Build.MANUFACTURER/BRAND (e.g. "Infinix Mobility
-        // Limited", "TECNO MOBILE LIMITED", brand "Itel it2163") never matched
-        // and kept the broken hardware AEC — muting the capture path into
-        // one-way audio (#894 Xiaomi 12X, #921 Pixel-adjacent reports).
         return BROKEN_HW_AEC_VENDORS.any { v -> m.contains(v) || b.contains(v) }
     }
 }

--- a/android/app/src/test/java/com/forta/chat/plugins/calls/VendorAudioPolicyTest.kt
+++ b/android/app/src/test/java/com/forta/chat/plugins/calls/VendorAudioPolicyTest.kt
@@ -87,46 +87,84 @@ class VendorAudioPolicyTest {
     }
 
     // -------------------------------------------------------------------------
-    // requiresExplicitMicUnmuteOnStart() — aggressive Chinese ROM family (A1)
+    // requiresExplicitMicUnmuteOnStart() — broken-HW-AEC family (A1)
+    // WEE-103: keyed off manufacturer/brand (the broken-AEC family), not the
+    // coarse CallVendor enum, so OEMs detect() classifies as GENERIC are covered.
     // -------------------------------------------------------------------------
 
     @Test
-    fun honorRequiresExplicitMicUnmuteOnStart() {
-        assertTrue(VendorAudioPolicy.requiresExplicitMicUnmuteOnStart(CallVendor.HONOR))
+    fun colorOsFamilyRequiresExplicitMicUnmuteOnStart() {
+        // WEE-87 family: HONOR MagicOS, realme RealmeUI (#994/#995), OPPO ColorOS
+        // and Xiaomi MIUI re-assert the global mic-mute flag mid-setup and must
+        // force a start-time unmute.
+        for (mfr in listOf("HONOR", "realme", "OPPO", "Xiaomi", "Redmi", "POCO")) {
+            assertTrue(
+                "$mfr (broken-HW-AEC ROM) must force a mic unmute mid-setup",
+                VendorAudioPolicy.requiresExplicitMicUnmuteOnStart(mfr, ""),
+            )
+        }
     }
 
     @Test
-    fun colorOsFamilyRequiresExplicitMicUnmuteOnStart() {
-        // WEE-87 regression: WEE-76 gated the start-time mic unmute to HONOR
-        // only, leaving realme RealmeUI (#994/#995), OPPO ColorOS and Xiaomi
-        // MIUI — the same aggressive HALs that re-assert the global mic-mute
-        // flag mid-setup — without the protection. Mirror-image one-way audio
-        // and 1.10.40 both-way silence followed. These must now opt in.
-        for (v in listOf(CallVendor.REALME, CallVendor.OPPO, CallVendor.XIAOMI)) {
-            assertTrue(
-                "$v (ColorOS/RealmeUI/MIUI) must force a mic unmute mid-setup",
-                VendorAudioPolicy.requiresExplicitMicUnmuteOnStart(v),
+    fun brokenAecOemsMissedByDetectStillRequireMicUnmute() {
+        // WEE-103 regression: the previous gate keyed off detect()'s coarse
+        // CallVendor enum, which returns GENERIC for Infinix/XOS (#1008) and
+        // ZTE/nubia (#1009) — both ship broken HW AEC and strand the mic-mute
+        // flag, but fell through to the generic path → both-ways silence on
+        // 1.10.44 while video played. HUAWEI (#1009) was excluded by WEE-87 on a
+        // "no mic-mute-flag report" assumption that #1009 falsifies. All three
+        // are in the broken-HW-AEC family and must now force the unmute.
+        assertTrue(
+            "Infinix/XOS (#1008) must force a mic unmute mid-setup",
+            VendorAudioPolicy.requiresExplicitMicUnmuteOnStart("Infinix Mobility Limited", "Infinix X665E"),
+        )
+        assertTrue(
+            "ZTE/nubia (#1009) must force a mic unmute mid-setup",
+            VendorAudioPolicy.requiresExplicitMicUnmuteOnStart("ZTE", "nubia NX733J"),
+        )
+        assertTrue(
+            "HUAWEI (#1009) must force a mic unmute mid-setup",
+            VendorAudioPolicy.requiresExplicitMicUnmuteOnStart("HUAWEI", "HUAWEI pure 70 ultra"),
+        )
+        assertTrue(
+            "TECNO (broken-AEC family) must force a mic unmute mid-setup",
+            VendorAudioPolicy.requiresExplicitMicUnmuteOnStart("TECNO MOBILE LIMITED", "TECNO KI5k"),
+        )
+    }
+
+    @Test
+    fun micUnmuteStaysInLockstepWithSoftwareAecFamily() {
+        // The two HAL-driven remedies must key off ONE definition of the
+        // broken-audio-HAL family so they can never drift apart again (the
+        // WEE-76→WEE-87→WEE-103 too-narrow-gate cycle). For every (mfr, brand)
+        // pair, needing software AEC ⇔ needing the start-time mic unmute.
+        val samples = listOf(
+            "HONOR" to "", "huawei" to "", "realme" to "", "Xiaomi" to "Redmi",
+            "OPPO" to "", "Infinix Mobility Limited" to "Infinix X665E",
+            "X665E" to "Infinix", // brand-only match (manufacturer carries no token)
+            "ZTE" to "nubia NX733J", "TECNO MOBILE LIMITED" to "TECNO KI5k",
+            "itel" to "Itel it2163",
+            "samsung" to "samsung", "Google" to "Pixel", "OnePlus" to "",
+            "" to "", null to null,
+        )
+        for ((mfr, brand) in samples) {
+            assertEquals(
+                "mic-unmute gate must match software-AEC gate for ($mfr, $brand)",
+                VendorAudioPolicy.prefersSoftwareAudioProcessing(mfr, brand),
+                VendorAudioPolicy.requiresExplicitMicUnmuteOnStart(mfr, brand),
             )
         }
     }
 
     @Test
     fun workingVendorsDoNotForceMicUnmuteOnStart() {
-        // SAMSUNG / GENERIC ship working HW AEC and must stay byte-for-byte on
-        // the proven generic WEE-54 start path (A5). HUAWEI's #874 symptom was
-        // HW-AEC capture mute (fixed via software AEC), not a mic-mute flag, so
-        // its routing path stays untouched too. Derived as the complement of the
-        // aggressive family over the WHOLE enum so a future CallVendor (e.g.
-        // VIVO / ONEPLUS) is automatically asserted negative until someone opts
-        // it in deliberately — the regression net stays exhaustive.
-        val aggressive = setOf(CallVendor.HONOR, CallVendor.REALME, CallVendor.OPPO, CallVendor.XIAOMI)
-        for (v in CallVendor.entries) {
-            if (v in aggressive) continue
-            assertFalse(
-                "$v must not force a mic unmute mid-setup",
-                VendorAudioPolicy.requiresExplicitMicUnmuteOnStart(v),
-            )
-        }
+        // Samsung / Pixel / OnePlus / unknown-working OEMs ship working HW AEC and
+        // must stay byte-for-byte on the proven generic WEE-54 start path (A5).
+        assertFalse(VendorAudioPolicy.requiresExplicitMicUnmuteOnStart("samsung", "samsung"))
+        assertFalse(VendorAudioPolicy.requiresExplicitMicUnmuteOnStart("Google", "Pixel"))
+        assertFalse(VendorAudioPolicy.requiresExplicitMicUnmuteOnStart("OnePlus", ""))
+        assertFalse(VendorAudioPolicy.requiresExplicitMicUnmuteOnStart(null, null))
+        assertFalse(VendorAudioPolicy.requiresExplicitMicUnmuteOnStart("", ""))
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Root cause:** the native start-time microphone-unmute gate (`requiresExplicitMicUnmuteOnStart`) keyed off the coarse `CallVendor` enum from `VendorAudioPolicy.detect()`, whose recognized set ({HONOR, HUAWEI, REALME, XIAOMI, OPPO, SAMSUNG, GENERIC}) is **narrower** than the `BROKEN_HW_AEC_VENDORS` family used for software-AEC selection (which also includes infinix, itel, tecno, zte). Infinix/XOS (#1008) and ZTE/nubia (#1009) therefore classified as `GENERIC`, and HUAWEI (#1009) was deliberately excluded by WEE-87 — so their aggressive audio HAL left the process-global mic-mute flag asserted, producing **both-ways silence while video (a separate track) played** on 1.10.44. This is the same too-narrow-vendor-gate regression that bit WEE-76→WEE-87.
- **Fix:** re-key `requiresExplicitMicUnmuteOnStart` from `CallVendor` to manufacturer/brand substring matching against the **same** broken-HW-AEC family as `prefersSoftwareAudioProcessing` (extracted shared private helper `matchesBrokenHwAecFamily`). The two HAL-driven remedies now share one source of truth, enforced by a lockstep invariant test — ending the WEE-76→WEE-87→WEE-103 recurrence. Samsung/Pixel/OnePlus/unknown stay off the list, so the proven generic path is byte-for-byte unchanged (acceptance criterion A5).
- `AudioRouter` resolves the predicate once into a `requiresMicUnmute` field (used at both the start tweak and each OEM reapply tick).

## Verified build context
- ✅ H0: confirmed WEE-87 (PR #191) **is** in `v1.10.44` — these are genuine post-fix regression reports, not pre-fix.

## Linear
- Resolves WEE-103 (https://linear.app/wwwee/issue/WEE-103)
- Refs WEE-87

## Closes
Closes greenShirtMystery/forta-bugs#1007
Closes greenShirtMystery/forta-bugs#1008
Closes greenShirtMystery/forta-bugs#1009

## Test plan
- [x] Android compile (`:app:compileDebugKotlin`) + all `plugins.calls.*` unit tests pass (gradle)
- [x] New regression tests: `brokenAecOemsMissedByDetectStillRequireMicUnmute` (Infinix/ZTE/Huawei/Tecno) + `micUnmuteStaysInLockstepWithSoftwareAecFamily` invariant
- [ ] **Manual on-device QA (required, P0 audio path):** forta↔forta two-way audio + simultaneous video on at least one broken-AEC handset (Infinix X665E / nubia NX733J / Huawei pure 70 ultra); confirm WEE-87/76/60 OEMs not regressed
- [ ] Note: #1007 (Xiaomi) was already covered by WEE-87's mic-unmute; if it persists on-device it needs logcat (separate from this gate fix)