### PR TITLE
fix(contacts): restore invite/join deep-link interception on 1.10.44 (WEE-104)

### DIFF
--- a/public/invite/index.html
+++ b/public/invite/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>Forta Chat</title>
+  <script>
+    // Static browser fallback for https://forta.chat/invite?ref=... (WEE-104).
+    //
+    // On a device with Forta installed, Android's App-Link intent-filter
+    // (pathPrefix="/invite") intercepts this URL and opens the app before this
+    // page ever loads. Reaching this HTML means we are in a plain browser —
+    // a recipient without the app, or a device where App-Link verification
+    // never took — so bounce into the SPA hash route, preserving ?ref=...,
+    // instead of 404ing on the static host (the original WEE-27 blocker,
+    // forta-bugs#435/#29). The link is generated in src/shared/lib/invite-link.ts.
+    (function () {
+      var search = window.location.search || "";
+      window.location.replace("/#/invite" + search);
+    })();
+  </script>
+</head>
+<body>
+  <noscript>
+    <p>Open <a href="/#/invite">Forta Chat</a> to accept this invitation.</p>
+  </noscript>
+</body>
+</html>

--- a/public/join/index.html
+++ b/public/join/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex">
+  <title>Forta Chat</title>
+  <script>
+    // Static browser fallback for https://forta.chat/join?room=... (WEE-104).
+    //
+    // On a device with Forta installed, Android's App-Link intent-filter
+    // (pathPrefix="/join") intercepts this URL and opens the app before this
+    // page ever loads. Reaching this HTML means we are in a plain browser, so
+    // bounce into the SPA hash route, preserving ?room=..., instead of 404ing
+    // on the static host. The link is generated in src/shared/lib/invite-link.ts.
+    (function () {
+      var search = window.location.search || "";
+      window.location.replace("/#/join" + search);
+    })();
+  </script>
+</head>
+<body>
+  <noscript>
+    <p>Open <a href="/#/join">Forta Chat</a> to join this chat.</p>
+  </noscript>
+</body>
+</html>

--- a/src/app/providers/initializers/__tests__/deep-link-invite-regression.test.ts
+++ b/src/app/providers/initializers/__tests__/deep-link-invite-regression.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Capacitor App plugin is native-only; mock so the handler module imports
+// cleanly in happy-dom (mirrors deep-link-handler.test.ts).
+vi.mock("@capacitor/app", () => ({
+  App: { addListener: vi.fn().mockResolvedValue({ remove: vi.fn() }) },
+}));
+vi.mock("@/shared/lib/platform", () => ({ isNative: false }));
+
+import {
+  onDeepLinkOpen,
+  registerDeepLinkHandlers,
+  resetDeepLinkHandlerForTesting,
+} from "../deep-link-handler";
+import { buildInviteUrl, buildJoinUrl } from "@/shared/lib/invite-link";
+
+/**
+ * WEE-104 regression — invite/join deep-links on 1.10.44.
+ *
+ * Root cause: WEE-27 switched the generators to the hash form
+ * `https://forta.chat/#/invite?ref=...`, whose URL *path* is "/". Android App
+ * Links match the intent-filter `pathPrefix` against the path (the fragment is
+ * invisible to the OS), so the installed app was never offered the URL and it
+ * opened in the browser instead (forta-bugs#1014).
+ *
+ * These tests lock the *generated* link to two invariants at once:
+ *   1. the target rides in the URL path, so the App-Link intent-filter matches;
+ *   2. the same link still dispatches through the native handler to onInvite/
+ *      onJoin — so generation and delivery can never silently drift apart again.
+ */
+
+const ADDR = "PMyAddress1234567890ABCDEFGHIJKLMN";
+const ROOM_ID = "!abcdef123:matrix.pocketnet.app";
+
+describe("WEE-104 invite/join deep-link regression", () => {
+  beforeEach(() => {
+    resetDeepLinkHandlerForTesting();
+  });
+
+  it("generated invite link carries the target in the path (App-Link matchable)", () => {
+    const url = new URL(buildInviteUrl(ADDR));
+    // The intent-filter declares pathPrefix="/invite"; only a real path matches.
+    expect(url.pathname.startsWith("/invite")).toBe(true);
+    expect(url.hash).toBe("");
+  });
+
+  it("generated join link carries the target in the path (App-Link matchable)", () => {
+    const url = new URL(buildJoinUrl(ROOM_ID));
+    expect(url.pathname.startsWith("/join")).toBe(true);
+    expect(url.hash).toBe("");
+  });
+
+  it("generated invite link dispatches to onInvite when delivered natively", () => {
+    const onInvite = vi.fn();
+    const onJoin = vi.fn();
+    registerDeepLinkHandlers({ onInvite, onJoin });
+
+    onDeepLinkOpen(buildInviteUrl(ADDR));
+
+    expect(onInvite).toHaveBeenCalledWith({ address: ADDR });
+    expect(onJoin).not.toHaveBeenCalled();
+  });
+
+  it("generated join link dispatches to onJoin when delivered natively", () => {
+    const onInvite = vi.fn();
+    const onJoin = vi.fn();
+    registerDeepLinkHandlers({ onInvite, onJoin });
+
+    onDeepLinkOpen(buildJoinUrl(ROOM_ID));
+
+    expect(onJoin).toHaveBeenCalledWith({ roomId: ROOM_ID });
+    expect(onInvite).not.toHaveBeenCalled();
+  });
+
+  it("survives cold-start buffering with the generated link", () => {
+    const onInvite = vi.fn();
+    const onJoin = vi.fn();
+
+    // URL arrives before the router is ready (cold start), then drains.
+    onDeepLinkOpen(buildInviteUrl(ADDR));
+    expect(onInvite).not.toHaveBeenCalled();
+
+    registerDeepLinkHandlers({ onInvite, onJoin });
+    expect(onInvite).toHaveBeenCalledWith({ address: ADDR });
+  });
+});

--- a/src/features/chat-info/ui/ChatInfoPanel.vue
+++ b/src/features/chat-info/ui/ChatInfoPanel.vue
@@ -89,10 +89,11 @@ const roomShareable = computed(() => {
   return chatStore.isRoomShareableByLink(room.value.id);
 });
 
-// Hash-routing URL via the shared builder. A bare-path `/join?room=...` 404s
-// on the static host (no such file under hash routing), which is the WEE-27
-// onboarding blocker — see invite-link.ts. Native deep-linking still works:
-// legacy bare-path links and `forta://` are accepted by parse-invite-url.ts.
+// Bare-path join URL via the shared builder so Android App Links match the
+// /join intent-filter (WEE-104). A browser without the app is caught by the
+// static shim public/join/index.html, which bounces to the SPA hash route —
+// no 404 (the old WEE-27 blocker). Native deep-linking also accepts forta://
+// and legacy hash links via parse-invite-url.ts — see invite-link.ts.
 const inviteLink = computed(() => {
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
   stateMarker.value;

--- a/src/shared/lib/invite-link.test.ts
+++ b/src/shared/lib/invite-link.test.ts
@@ -7,12 +7,14 @@ const ADDR = "PABCdefGHIjklMNOpqrSTUvwx12";
 const ROOM_ID = "!abc123:matrix.bastyon.com";
 
 describe("buildInviteUrl", () => {
-  it("emits the hash-routing path so the static host never 404s", () => {
-    const url = buildInviteUrl(ADDR);
-    expect(url).toContain("#/invite");
-    // The bug we are fixing: a bare `forta.chat/invite` path has no file on
-    // the static host and returns 404. Assert we never regress to it.
-    expect(url).not.toMatch(/forta\.chat\/invite/);
+  it("puts the target in the URL path (not the hash) so Android App Links match", () => {
+    // WEE-104 regression: a hash-form link `forta.chat/#/invite?ref=...` has
+    // path "/" — the `/invite` lives in the fragment, which Android App Links
+    // never see — so the OS hands it to the browser (forta-bugs#1014). The
+    // intent-filter `pathPrefix="/invite"` can only match a real path.
+    const url = new URL(buildInviteUrl(ADDR));
+    expect(url.pathname).toBe("/invite");
+    expect(url.hash).toBe("");
   });
 
   it("carries the referral address", () => {
@@ -25,12 +27,13 @@ describe("buildInviteUrl", () => {
 });
 
 describe("buildJoinUrl", () => {
-  it("emits the hash-routing path so the static host never 404s", () => {
-    const url = buildJoinUrl(ROOM_ID);
-    expect(url).toContain("#/join");
-    // Confirmed root cause of WEE-27 (forta-bugs#435/#29): the bare
-    // `forta.chat/join?room=...` link 404s under hash routing.
-    expect(url).not.toMatch(/forta\.chat\/join/);
+  it("puts the target in the URL path (not the hash) so Android App Links match", () => {
+    // Same App-Link path requirement as invites: the room id travels in the
+    // query with `/join` as the real path the intent-filter claims, never the
+    // fragment (which the OS can't route to the installed app).
+    const url = new URL(buildJoinUrl(ROOM_ID));
+    expect(url.pathname).toBe("/join");
+    expect(url.hash).toBe("");
   });
 
   it("URL-encodes the room id separator", () => {

--- a/src/shared/lib/invite-link.ts
+++ b/src/shared/lib/invite-link.ts
@@ -3,17 +3,24 @@
  * `parse-invite-url.ts` (the read-side). They live together on purpose: the
  * link shapes we emit and the shapes we accept must never drift apart.
  *
- * Forta's SPA uses hash routing (`createWebHashHistory`). A bare-path link
- * such as `https://forta.chat/join?room=...` has no corresponding file on the
- * static host, so tapping it in a browser — a recipient without the app, or a
- * device where Android App Link verification never took — returns a 404. That
- * is the onboarding blocker reported in forta-bugs#435 / #29 (WEE-27).
+ * These links MUST carry the target in the URL *path* (`/invite`, `/join`),
+ * not in the hash fragment. Android App Links match an incoming URI against
+ * the intent-filter `pathPrefix` (`AndroidManifest.xml`), and the fragment is
+ * never part of the path: a hash-form link such as
+ * `https://forta.chat/#/invite?ref=...` has path `/`, so the OS can't match it
+ * to the app and hands it to the browser instead — the regression reported in
+ * forta-bugs#1014 (invite opens browser though the app is installed; WEE-104).
  *
- * Emitting the hash form `https://forta.chat/#/join?room=...` always resolves
- * through `index.html` + the client-side router, so the link works everywhere
- * the recipient lands. Native deep-linking is unaffected: legacy bare-path
- * links and the `forta://` custom scheme are still accepted by
- * `parse-invite-url.ts` when delivered through Capacitor's `appUrlOpen`.
+ * The original bare-path 404 (forta-bugs#435 / #29; WEE-27) is solved on the
+ * static host, not by mangling the link: `public/invite/index.html` and
+ * `public/join/index.html` are tiny redirect shims that bounce a browser
+ * (recipient without the app, or unverified App Links) to the SPA hash route
+ * (`/#/invite?...`), preserving the query string. So one path serves both:
+ *   - installed app  → App Link path match → `appUrlOpen` → parse-invite-url
+ *   - browser, no app → static shim → hash route → welcome / join screen
+ *
+ * Native deep-linking also accepts the `forta://` custom scheme as a fallback
+ * (see `parse-invite-url.ts`) when App Link verification never took.
  */
 
 import { APP_PUBLIC_URL } from "@/shared/config";
@@ -21,10 +28,10 @@ import { APP_PUBLIC_URL } from "@/shared/config";
 /** Personal invite: opens the welcome screen and pre-fills the inviter's
  *  Bastyon address so accepting creates a 1:1 chat. */
 export function buildInviteUrl(address: string): string {
-  return `${APP_PUBLIC_URL}/#/invite?ref=${encodeURIComponent(address)}`;
+  return `${APP_PUBLIC_URL}/invite?ref=${encodeURIComponent(address)}`;
 }
 
 /** Group / room join: opens the welcome screen primed to join `roomId`. */
 export function buildJoinUrl(roomId: string): string {
-  return `${APP_PUBLIC_URL}/#/join?room=${encodeURIComponent(roomId)}`;
+  return `${APP_PUBLIC_URL}/join?room=${encodeURIComponent(roomId)}`;
 }


### PR DESCRIPTION
## Summary
- **Root cause (P0 regression, forta-bugs#1014):** WEE-27 (`ab6cae8`) switched `buildInviteUrl`/`buildJoinUrl` to the hash form `https://forta.chat/#/invite?ref=...`. Android App Links match the intent-filter `pathPrefix` against the URL **path**, and a hash-form link's path is just `/` (the `/invite` lives in the fragment, invisible to the OS) — so the `autoVerify` filter never matched and every invite opened in the browser, neutralizing the existing `assetlinks.json` + manifest App-Links setup.
- **Fix:** restore bare-path link generation (`/invite?ref=`, `/join?room=`) so App Links intercept the URL into the installed app.
- **No re-break of WEE-27:** added the static fallback WEE-27 was missing — `public/invite/index.html` + `public/join/index.html` bounce a no-app browser to the SPA hash route (preserving the query string), so the bare path no longer 404s (the original blocker, forta-bugs#435/#29).
- The read-side parser (`parse-invite-url.ts`), manifest intent-filter, and `forta://` custom-scheme fallback were already correct and are unchanged.

## Linear
- Resolves [WEE-104](https://linear.app/wwwee/issue/WEE-104) — Refs WEE-27.

## Closes
Closes greenShirtMystery/forta-bugs#1011
Closes greenShirtMystery/forta-bugs#1014
Closes greenShirtMystery/forta-bugs#1016

## Test plan
- [x] `npm run test` — new/updated suites pass (`invite-link.test.ts`, `deep-link-invite-regression.test.ts`, `deep-link-handler.test.ts`, `parse-invite-url.test.ts`); no new failures vs. master baseline.
- [x] `npx vue-tsc --noEmit` — zero errors in changed files (49 pre-existing baseline errors in unrelated files unchanged).
- [x] No `lint` script in repo; build TS check clean for changed files.
- [x] Code review (1 LOW finding — stale comment — fixed; approved).
- [ ] **Manual QA (device, 1.10.44+):** tap an invite link from an external app (e.g. messenger) → installed Forta opens (not browser) → welcome/join screen → chat. Requires deployed `assetlinks.json` with the real release fingerprint (CI-injected on deploy).
- [ ] **Manual QA (no app):** open the same link in a desktop browser → static shim redirects to the SPA → welcome screen, no 404.

## Notes
- #1011 ("can't add contact, even profile photo") and #1016 (web add-contact) also reference a broader RPC/network failure; the add-contact flow (`use-contacts.ts`) already has a robust multi-tier search + Matrix fallback and showed no regression, so this PR scopes to the definitive, provable deep-link regression (#1014) per the ticket's out-of-scope guidance. The invite path fix also covers the "can't add by invite" half of #1016.