### PR TITLE
fix(profile): local aliases at cold boot + offline (WEE-102)

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -410,6 +410,12 @@ onMounted(async () => {
     }
   }
 
+  // WEE-102: on reload, hydrate local contact aliases from Dexie BEFORE the
+  // (network) profile fetch + Matrix init below. Offline, fetchUserInfo can
+  // stall and initMatrix's own hydration would never run, so renamed contacts
+  // would show raw nicknames forever. Reading Dexie needs no connectivity.
+  authStore.hydrateLocalAliasesEarly().catch(() => { /* best-effort */ });
+
   try {
     await authStore.fetchUserInfo();
   } catch (e) {

--- a/src/entities/auth/model/stores.ts
+++ b/src/entities/auth/model/stores.ts
@@ -1177,6 +1177,16 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
           privateKey: convertToHexString(keyPair.privateKey)
         };
         setAuthData(authData);
+
+        // WEE-102: hydrate local contact aliases from Dexie BEFORE any network
+        // step (fetchUserInfo / verifyAndRepublishKeys / initMatrix). Offline,
+        // those steps can stall and the alias hydration buried inside initMatrix
+        // would never run, leaving every renamed contact stuck on its raw
+        // nickname. Reading Dexie needs no connectivity, so it is safe and
+        // user-visible from the first frame; initMatrix's loadLocalAliases later
+        // refreshes it via the live kit.
+        useChatStore().hydrateLocalAliasesEarly(addr).catch(() => { /* best-effort */ });
+
         await fetchUserInfo();
 
         // Verify encryption keys are published; re-publish if missing
@@ -1197,6 +1207,15 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
       }
     }
   );
+
+  /** WEE-102: hydrate local contact aliases from Dexie ahead of any network
+   *  step. Used by the cold-boot path (App.vue) where `fetchUserInfo()` runs —
+   *  and can stall offline — before `initMatrix()` would otherwise hydrate them.
+   *  No-op until the session address is known. Best-effort; never throws. */
+  const hydrateLocalAliasesEarly = async (): Promise<void> => {
+    if (!address.value) return;
+    await useChatStore().hydrateLocalAliasesEarly(address.value);
+  };
 
   const logout = async () => {
     const logoutAddress = activeAddress.value;
@@ -1909,6 +1928,7 @@ export const useAuthStore = defineStore(NAMESPACE, () => {
     fetchUserInfo,
     findRegistrationProxy,
     generateRegistrationKeys,
+    hydrateLocalAliasesEarly,
     cachePost,
     getCachedPost,
     getBastyonUserData,

--- a/src/entities/chat/model/__tests__/local-aliases-boot.test.ts
+++ b/src/entities/chat/model/__tests__/local-aliases-boot.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia } from "pinia";
+import { createTestingPinia } from "@pinia/testing";
+
+/**
+ * WEE-102 regression — local contact aliases must apply at cold boot and
+ * fully offline.
+ *
+ * Root cause: `loadLocalAliases()` was only reachable inside `initMatrix()`,
+ * which runs after the network steps of `login()` / the cold-boot
+ * `fetchUserInfo()`. Offline, those steps stall before the alias hydration is
+ * ever reached, so `localAliases` stays empty and every renamed contact shows
+ * its raw nickname forever.
+ *
+ * Fix: `hydrateLocalAliasesEarly(rawAddress)` reads aliases straight from Dexie
+ * (`readUserAliases`) with no SyncEngine / Matrix / network dependency, so the
+ * cache is populated from the first frame regardless of connectivity. This file
+ * pins that Dexie-only, network-independent behaviour.
+ */
+
+// Override ONLY readUserAliases; keep the rest of the local-db module real so
+// chat-store's other imports (ChatDatabase, useLiveQuery, mappers) still work.
+const mockReadUserAliases = vi.fn();
+vi.mock("@/shared/lib/local-db", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/lib/local-db")>();
+  return {
+    ...actual,
+    readUserAliases: (...args: unknown[]) => mockReadUserAliases(...args),
+  };
+});
+
+import { useChatStore } from "../chat-store";
+import { hexEncode } from "@/shared/lib/matrix/functions";
+
+describe("WEE-102 — local aliases hydrate at cold boot / offline", () => {
+  let store: ReturnType<typeof useChatStore>;
+
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockReadUserAliases.mockReset();
+    setActivePinia(createTestingPinia({ stubActions: false }));
+    store = useChatStore();
+  });
+
+  it("hydrateLocalAliasesEarly populates localAliases straight from Dexie (no Matrix)", async () => {
+    mockReadUserAliases.mockResolvedValue({ PMama: { alias: "Мама", updatedAt: 10 } });
+
+    await store.hydrateLocalAliasesEarly("PaddrSelf");
+
+    expect(mockReadUserAliases).toHaveBeenCalledWith("PaddrSelf");
+    expect(store.localAliases["PMama"]).toBe("Мама");
+  });
+
+  it("getDisplayName returns the alias right after early hydration (no /sync)", async () => {
+    mockReadUserAliases.mockResolvedValue({ PMama: { alias: "Мама", updatedAt: 10 } });
+
+    // Before hydration: no alias, no profile → must NOT already be the alias.
+    expect(store.getDisplayName("PMama")).not.toBe("Мама");
+
+    await store.hydrateLocalAliasesEarly("PaddrSelf");
+
+    expect(store.getDisplayName("PMama")).toBe("Мама");
+    // Hex form (room.members shape) resolves to the same alias.
+    expect(store.getDisplayName(hexEncode("PMama"))).toBe("Мама");
+  });
+
+  it("is offline-safe: a Dexie read failure resolves without throwing", async () => {
+    mockReadUserAliases.mockRejectedValue(new Error("Dexie closed"));
+
+    await expect(store.hydrateLocalAliasesEarly("PaddrSelf")).resolves.toBeUndefined();
+    expect(store.localAliases).toEqual({});
+  });
+
+  it("no-ops on an empty address — never touches Dexie", async () => {
+    await store.hydrateLocalAliasesEarly("");
+    expect(mockReadUserAliases).not.toHaveBeenCalled();
+  });
+
+  it("loadLocalAliases reads only from Dexie via the live kit (no network)", async () => {
+    const getAllAliases = vi
+      .fn()
+      .mockResolvedValue({ PPapa: { alias: "Папа", updatedAt: 5 } });
+    store.setChatDbKit({
+      users: { getAllAliases },
+      rooms: {
+        getAllRooms: vi.fn().mockResolvedValue([]),
+        observeRoomChanges: vi.fn().mockReturnValue(() => {}),
+      },
+      eventWriter: { enableBatching: vi.fn() },
+    } as never);
+
+    await store.loadLocalAliases();
+
+    expect(getAllAliases).toHaveBeenCalledTimes(1);
+    expect(store.getDisplayName("PPapa")).toBe("Папа");
+  });
+});

--- a/src/entities/chat/model/chat-store.ts
+++ b/src/entities/chat/model/chat-store.ts
@@ -37,7 +37,7 @@ import { parseCallLinkBody, callLinkPreview } from "@/shared/lib/call-link";
 
 import type { ChatDbKit, ParsedMessage, LocalRoom } from "@/shared/lib/local-db";
 import type { RoomChange } from "@/shared/lib/local-db";
-import { ChatDatabase, useLiveQuery, localToMessages, localStatusToMessageStatus, deriveOutboundStatus } from "@/shared/lib/local-db";
+import { ChatDatabase, useLiveQuery, localToMessages, localStatusToMessageStatus, deriveOutboundStatus, readUserAliases } from "@/shared/lib/local-db";
 import type { ChatRoom, FileInfo, ForwardingMessage, LinkPreview, Message, PeerKeysStatus, PollInfo, ReplyTo, TransferInfo } from "./types";
 import { MessageStatus, MessageType } from "./types";
 import { resolveCachedRoomsAddress } from "./cached-rooms-address";
@@ -730,22 +730,51 @@ export const useChatStore = defineStore(NAMESPACE, () => {
   /** True iff a local alias is set for the address (raw or hex form). */
   const hasLocalAlias = (address: string): boolean => getLocalAlias(address) !== null;
 
-  /** Load the alias cache from Dexie. Called on login + chat-db init. */
+  /** Replace the in-memory alias caches from a raw Dexie alias map.
+   *  Full replace (not a merge) on purpose: `getAllAliases()` only returns rows
+   *  that currently HAVE an alias, so an alias cleared on another device (and
+   *  LWW-synced into Dexie) is absent from `all` and must drop out of the
+   *  in-memory cache too. A merge would leave the stale alias stuck on screen.
+   *  Per-entry LWW tombstoning lives in handleAccountDataEvent, which receives
+   *  explicit cleared entries; this path is a wholesale reload from Dexie. */
+  const applyAliasMap = (all: Record<string, { alias: string; updatedAt: number }>) => {
+    const nameNext: Record<string, string> = {};
+    const tsNext: Record<string, number> = {};
+    for (const [addr, { alias, updatedAt }] of Object.entries(all)) {
+      nameNext[addr] = alias;
+      tsNext[addr] = updatedAt;
+    }
+    localAliases.value = nameNext;
+    aliasUpdatedAtCache.value = tsNext;
+  };
+
+  /** Load the alias cache from Dexie via the live kit. Called on login +
+   *  chat-db init (refreshes whatever hydrateLocalAliasesEarly seeded). */
   const loadLocalAliases = async () => {
     const kit = chatDbKitRef.value;
     if (!kit) return;
     try {
-      const all = await kit.users.getAllAliases();
-      const nameNext: Record<string, string> = {};
-      const tsNext: Record<string, number> = {};
-      for (const [addr, { alias, updatedAt }] of Object.entries(all)) {
-        nameNext[addr] = alias;
-        tsNext[addr] = updatedAt;
-      }
-      localAliases.value = nameNext;
-      aliasUpdatedAtCache.value = tsNext;
+      applyAliasMap(await kit.users.getAllAliases());
     } catch (e) {
       console.warn("[chat-store] loadLocalAliases failed:", e);
+    }
+  };
+
+  /** Hydrate the alias cache directly from Dexie BEFORE Matrix/network init.
+   *  Local-first invariant (WEE-102): a user's contact renames must apply from
+   *  the first frame and fully offline, never gated behind /sync, RPC, or the
+   *  late chat-db kit that `login()` only wires after its network steps. Reads
+   *  Dexie through `readUserAliases`, which needs no SyncEngine/crypto/network. */
+  const hydrateLocalAliasesEarly = async (rawAddress: string) => {
+    if (!rawAddress) return;
+    // Already seeded (a prior hydrate, or an in-session setContactAlias that
+    // beat this boot-time read) — skip so a pre-edit Dexie snapshot can't
+    // clobber it. The live-kit loadLocalAliases() still does the full refresh.
+    if (Object.keys(localAliases.value).length > 0) return;
+    try {
+      applyAliasMap(await readUserAliases(rawAddress));
+    } catch (e) {
+      console.warn("[chat-store] hydrateLocalAliasesEarly failed:", e);
     }
   };
 
@@ -7124,6 +7153,7 @@ export const useChatStore = defineStore(NAMESPACE, () => {
     hasLocalAlias,
     localAliases,
     loadLocalAliases,
+    hydrateLocalAliasesEarly,
     setContactAlias,
     getRoomMemberCount,
     getRoomPowerLevels,

--- a/src/shared/lib/local-db/__tests__/read-user-aliases.test.ts
+++ b/src/shared/lib/local-db/__tests__/read-user-aliases.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import "fake-indexeddb/auto";
+import { ChatDatabase } from "../schema";
+import { UserRepository } from "../user-repository";
+import { initChatDb, closeChatDb, readUserAliases } from "../index";
+
+/**
+ * WEE-102 — direct coverage for `readUserAliases`, the network-independent
+ * Dexie read used to hydrate local contact aliases at cold boot / offline.
+ *
+ * Two branches:
+ *   - cold: no live kit → open a short-lived ChatDatabase, read, close it.
+ *   - warm: a kit is already open for this user → reuse its connection.
+ * Plus the finally-closes-on-error contract.
+ */
+describe("readUserAliases", () => {
+  const USER = "PselfAddr";
+
+  beforeEach(async () => {
+    closeChatDb();
+    await new ChatDatabase(USER).delete();
+  });
+
+  afterEach(() => {
+    closeChatDb();
+  });
+
+  it("cold branch: reads aliases from Dexie with no live kit", async () => {
+    // Seed via a throwaway connection, then close it so no kit is open.
+    const seed = new ChatDatabase(USER);
+    await new UserRepository(seed).setAlias("Pmama", "Мама", 111);
+    await new UserRepository(seed).setAlias("Ppapa", "Папа", 222);
+    seed.close();
+
+    const aliases = await readUserAliases(USER);
+
+    expect(aliases).toEqual({
+      Pmama: { alias: "Мама", updatedAt: 111 },
+      Ppapa: { alias: "Папа", updatedAt: 222 },
+    });
+  });
+
+  it("cold branch: closes the short-lived connection after the read", async () => {
+    const closeSpy = vi.spyOn(ChatDatabase.prototype, "close");
+    try {
+      await readUserAliases(USER);
+      expect(closeSpy).toHaveBeenCalled();
+    } finally {
+      closeSpy.mockRestore();
+    }
+  });
+
+  it("cold branch: still closes the connection when the read throws", async () => {
+    const closeSpy = vi.spyOn(ChatDatabase.prototype, "close");
+    const getAllSpy = vi
+      .spyOn(UserRepository.prototype, "getAllAliases")
+      .mockRejectedValueOnce(new Error("Dexie blew up"));
+    try {
+      await expect(readUserAliases(USER)).rejects.toThrow("Dexie blew up");
+      expect(closeSpy).toHaveBeenCalled();
+    } finally {
+      getAllSpy.mockRestore();
+      closeSpy.mockRestore();
+    }
+  });
+
+  it("warm branch: reuses the live kit and does NOT open/close a new connection", async () => {
+    const kit = initChatDb(USER, async () => undefined);
+    await kit.users.setAlias("Pfriend", "Друг", 333);
+
+    const closeSpy = vi.spyOn(ChatDatabase.prototype, "close");
+    try {
+      const aliases = await readUserAliases(USER);
+      expect(aliases).toEqual({ Pfriend: { alias: "Друг", updatedAt: 333 } });
+      // Reuse path must not tear down a connection — that would close the live kit.
+      expect(closeSpy).not.toHaveBeenCalled();
+    } finally {
+      closeSpy.mockRestore();
+    }
+    // Let initChatDb's immediate background work (processQueue / recovery ticks)
+    // settle against the still-open DB so afterEach's close doesn't race it into
+    // a benign DatabaseClosedError unhandled rejection.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  });
+
+  it("returns an empty map when the user has no aliases", async () => {
+    expect(await readUserAliases(USER)).toEqual({});
+  });
+});

--- a/src/shared/lib/local-db/index.ts
+++ b/src/shared/lib/local-db/index.ts
@@ -261,6 +261,30 @@ export function initChatDb(
 }
 
 /**
+ * Read a user's local contact aliases straight from Dexie, WITHOUT spinning up
+ * the full ChatDbKit (no SyncEngine, no decryption worker, no recovery scans,
+ * no network). Used to hydrate chat-store.localAliases at cold boot / offline
+ * BEFORE Matrix init, so locally renamed contacts render their alias from the
+ * first frame even with zero connectivity (WEE-102).
+ *
+ * Reuses the live kit's connection when one is already open for this user;
+ * otherwise opens a short-lived connection and closes it after the read.
+ */
+export async function readUserAliases(
+  userId: string,
+): Promise<Record<string, { alias: string; updatedAt: number }>> {
+  if (currentKit && currentUserId === userId) {
+    return currentKit.users.getAllAliases();
+  }
+  const db = new ChatDatabase(userId);
+  try {
+    return await new UserRepository(db).getAllAliases();
+  } finally {
+    db.close();
+  }
+}
+
+/**
  * Get the current ChatDbKit. Throws if not initialized.
  * Use this in composables/stores after login.
  */


### PR DESCRIPTION
## Summary
- Local contact aliases (Telegram-style "rename contact") now hydrate straight from Dexie **before any network step**, so renamed contacts show their alias from the first frame and **fully offline** — no more raw-nickname flash, and no more "nicknames forever" when the device is offline.
- Root cause: `loadLocalAliases()` (Dexie-only) was only reachable inside `initMatrix()`, which runs after the network steps of `login()` (`fetchUserInfo`/`verifyAndRepublishKeys`) and App.vue's cold-boot `fetchUserInfo()`. Offline those steps stall before hydration is ever reached.
- New `readUserAliases(userId)` reads aliases without spinning up the full ChatDbKit (no SyncEngine/crypto/network); `chat-store.hydrateLocalAliasesEarly()` is wired ahead of the network in both entry paths (`login()` + App.vue). `applyAliasMap()` keeps wholesale-replace semantics so cross-device alias clears still propagate; the early hydrate skips when already seeded to avoid clobbering in-session edits.

## Linear
- Resolves WEE-102 (https://linear.app/wwwee/issue/WEE-102)

## Closes
Closes greenShirtMystery/forta-bugs#999
Closes greenShirtMystery/forta-bugs#1005
Closes greenShirtMystery/forta-bugs#1015

## Test plan
- [x] `vue-tsc --noEmit` — no new type errors (49 = pre-existing master baseline)
- [x] Vite build passes (exit 0)
- [x] Unit tests added: `local-aliases-boot.test.ts` (early/offline hydration, getDisplayName) + `read-user-aliases.test.ts` (cold open/close, live-kit reuse, finally-on-error)
- [x] Full suite: no regressions vs baseline (same failing files identical with/without the change)
- [ ] Manual QA: rename a contact → kill app → relaunch in airplane mode → name shows the alias immediately, not the nickname