### PR TITLE
fix(matrix): homeserver failover + sync watchdog for stuck /sync (WEE-105)

### DIFF
--- a/src/entities/matrix/model/__tests__/sync-failover.test.ts
+++ b/src/entities/matrix/model/__tests__/sync-failover.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+import {
+  pickLiveMatrixHost,
+  nextMatrixHost,
+  hostFromBaseUrl,
+  SyncWatchdog,
+  type SyncWatchdogDeps,
+} from "../sync-failover";
+import { MATRIX_SERVER, MATRIX_MIRRORS } from "@/shared/config/constants";
+
+const HOSTS = [MATRIX_SERVER, ...MATRIX_MIRRORS] as const;
+
+describe("pickLiveMatrixHost — ping-and-pick живого homeserver", () => {
+  it("выбирает первый отвечающий из [primary, ...mirrors] (primary жив → primary)", async () => {
+    const probe = vi.fn(async (host: string) => host === MATRIX_SERVER);
+    const picked = await pickLiveMatrixHost(probe, HOSTS);
+    expect(picked).toBe(MATRIX_SERVER);
+    // Hot path (A5): healthy primary → no mirror probe at all.
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(probe).toHaveBeenCalledWith(MATRIX_SERVER);
+  });
+
+  it("primary мёртв → берёт первый живой mirror", async () => {
+    const probe = vi.fn(async (host: string) => host !== MATRIX_SERVER);
+    const picked = await pickLiveMatrixHost(probe, HOSTS);
+    expect(picked).toBe(MATRIX_MIRRORS[0]);
+  });
+
+  it("primary бросает исключение → продолжает к mirror", async () => {
+    const probe = vi.fn(async (host: string) => {
+      if (host === MATRIX_SERVER) throw new Error("ECONNREFUSED");
+      return true;
+    });
+    const picked = await pickLiveMatrixHost(probe, HOSTS);
+    expect(picked).toBe(MATRIX_MIRRORS[0]);
+  });
+
+  it("никто не отвечает → fallback на primary (boot-retry разрулит)", async () => {
+    const probe = vi.fn(async () => false);
+    const picked = await pickLiveMatrixHost(probe, HOSTS);
+    expect(picked).toBe(MATRIX_SERVER);
+  });
+
+  it("соблюдает приоритет mirror-порядка: первый живой при мёртвом primary", async () => {
+    // primary "a.host" dead, both mirrors live → first mirror wins.
+    const probe = vi.fn(async (host: string) => host !== "a.host");
+    const picked = await pickLiveMatrixHost(probe, ["a.host", "b.host", "c.host"]);
+    expect(picked).toBe("b.host");
+  });
+});
+
+describe("nextMatrixHost / hostFromBaseUrl — host rotation", () => {
+  it("ротация primary → mirror → primary (wrap)", () => {
+    expect(nextMatrixHost(MATRIX_SERVER)).toBe(MATRIX_MIRRORS[0]);
+    expect(nextMatrixHost(MATRIX_MIRRORS[0])).toBe(MATRIX_SERVER);
+  });
+
+  it("неизвестный host → первый mirror", () => {
+    expect(nextMatrixHost("unknown.host", ["p", "m1", "m2"])).toBe("m1");
+  });
+
+  it("hostFromBaseUrl снимает протокол и хвостовой слэш", () => {
+    expect(hostFromBaseUrl("https://matrix.pocketnet.app")).toBe("matrix.pocketnet.app");
+    expect(hostFromBaseUrl("https://matrix.pocketnet.app/")).toBe("matrix.pocketnet.app");
+  });
+});
+
+/** Build a SyncWatchdog with controllable clock/timers/online for tests. */
+function makeWatchdog(
+  overrides: Partial<SyncWatchdogDeps> = {},
+  config?: { maxConsecutiveErrors?: number; staleTimeoutMs?: number; maxConsecutiveFailovers?: number },
+) {
+  const onFailover = vi.fn();
+  let online = true;
+  let nowMs = 0;
+  const timers = new Map<number, { cb: () => void; due: number }>();
+  let seq = 1;
+
+  const deps: SyncWatchdogDeps = {
+    onFailover,
+    isOnline: () => online,
+    setTimer: (cb, ms) => {
+      const id = seq++;
+      timers.set(id, { cb, due: nowMs + ms });
+      return id as unknown as ReturnType<typeof setTimeout>;
+    },
+    clearTimer: (h) => {
+      timers.delete(h as unknown as number);
+    },
+    ...overrides,
+  };
+
+  const wd = new SyncWatchdog(deps, {
+    maxConsecutiveErrors: config?.maxConsecutiveErrors ?? 4,
+    staleTimeoutMs: config?.staleTimeoutMs ?? 45_000,
+    maxConsecutiveFailovers: config?.maxConsecutiveFailovers ?? 99,
+  });
+
+  return {
+    wd,
+    onFailover,
+    setOnline: (v: boolean) => {
+      online = v;
+    },
+    advance: (ms: number) => {
+      nowMs += ms;
+      for (const [id, t] of [...timers.entries()]) {
+        if (t.due <= nowMs) {
+          timers.delete(id);
+          t.cb();
+        }
+      }
+    },
+  };
+}
+
+describe("SyncWatchdog — consecutive ERROR failover", () => {
+  it("после N подряд ERROR (online) → onFailover", () => {
+    const { wd, onFailover } = makeWatchdog({}, { maxConsecutiveErrors: 4 });
+    wd.notifySync("ERROR");
+    wd.notifySync("ERROR");
+    wd.notifySync("ERROR");
+    expect(onFailover).not.toHaveBeenCalled();
+    wd.notifySync("ERROR"); // 4th
+    expect(onFailover).toHaveBeenCalledTimes(1);
+  });
+
+  it("offline → НЕ переключается даже после N ERROR (A5 regression guard)", () => {
+    const { wd, onFailover, setOnline } = makeWatchdog({}, { maxConsecutiveErrors: 2 });
+    setOnline(false);
+    wd.notifySync("ERROR");
+    wd.notifySync("ERROR");
+    wd.notifySync("ERROR");
+    expect(onFailover).not.toHaveBeenCalled();
+  });
+
+  it("PREPARED сбрасывает счётчик подряд-ошибок", () => {
+    const { wd, onFailover } = makeWatchdog({}, { maxConsecutiveErrors: 3 });
+    wd.notifySync("ERROR");
+    wd.notifySync("ERROR");
+    wd.notifySync("PREPARED"); // reset
+    wd.notifySync("ERROR");
+    wd.notifySync("ERROR");
+    expect(onFailover).not.toHaveBeenCalled();
+  });
+
+  it("одного failover на эпизод (firing-guard) — повторные ERROR не дёргают onFailover", () => {
+    const { wd, onFailover } = makeWatchdog({}, { maxConsecutiveErrors: 1 });
+    wd.notifySync("ERROR");
+    wd.notifySync("ERROR");
+    wd.notifySync("ERROR");
+    expect(onFailover).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("SyncWatchdog — stale-timer failover", () => {
+  it("нет PREPARED/SYNCING > порога при online → triggert failover", () => {
+    const { wd, onFailover, advance } = makeWatchdog({}, { maxConsecutiveErrors: 999, staleTimeoutMs: 45_000 });
+    wd.notifySync("RECONNECTING");
+    expect(onFailover).not.toHaveBeenCalled();
+    advance(45_000);
+    expect(onFailover).toHaveBeenCalledTimes(1);
+  });
+
+  it("stale-дедлайн НЕ продлевается на каждой ошибке (anchor к первой)", () => {
+    const { wd, onFailover, advance } = makeWatchdog({}, { maxConsecutiveErrors: 999, staleTimeoutMs: 30_000 });
+    wd.notifySync("RECONNECTING"); // arms at t=0, due t=30000
+    advance(20_000);
+    wd.notifySync("RECONNECTING"); // must NOT push the deadline out
+    advance(10_000); // total 30000 → fire
+    expect(onFailover).toHaveBeenCalledTimes(1);
+  });
+
+  it("PREPARED до истечения порога → failover не происходит", () => {
+    const { wd, onFailover, advance } = makeWatchdog({}, { maxConsecutiveErrors: 999, staleTimeoutMs: 30_000 });
+    wd.notifySync("RECONNECTING");
+    advance(20_000);
+    wd.notifySync("PREPARED");
+    advance(20_000);
+    expect(onFailover).not.toHaveBeenCalled();
+  });
+
+  it("stop() гасит таймер — failover не срабатывает после teardown", () => {
+    const { wd, onFailover, advance } = makeWatchdog({}, { maxConsecutiveErrors: 999, staleTimeoutMs: 30_000 });
+    wd.notifySync("RECONNECTING");
+    wd.stop();
+    advance(60_000);
+    expect(onFailover).not.toHaveBeenCalled();
+  });
+
+  it("reset() снимает firing-guard — следующий эпизод может снова failover", () => {
+    const { wd, onFailover } = makeWatchdog({}, { maxConsecutiveErrors: 1 });
+    wd.notifySync("ERROR");
+    expect(onFailover).toHaveBeenCalledTimes(1);
+    wd.reset();
+    wd.notifySync("ERROR");
+    expect(onFailover).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("SyncWatchdog — STOPPED нейтрален + failover-cap (review M1/L2)", () => {
+  it("STOPPED не вооружает stale-таймер и не вызывает failover (intentional teardown)", () => {
+    const { wd, onFailover, advance } = makeWatchdog({}, { maxConsecutiveErrors: 999, staleTimeoutMs: 30_000 });
+    wd.notifySync("STOPPED");
+    advance(60_000);
+    expect(onFailover).not.toHaveBeenCalled();
+  });
+
+  it("перестаёт ротацию после исчерпания failover-бюджета (нет teardown+login навечно)", () => {
+    const { wd, onFailover } = makeWatchdog({}, { maxConsecutiveErrors: 1, maxConsecutiveFailovers: 2 });
+    // Each episode: ERROR triggers failover, then recreate calls reset().
+    wd.notifySync("ERROR"); wd.reset(); // failover 1
+    wd.notifySync("ERROR"); wd.reset(); // failover 2
+    wd.notifySync("ERROR"); wd.reset(); // budget spent → no failover 3
+    expect(onFailover).toHaveBeenCalledTimes(2);
+  });
+
+  it("здоровый sync восстанавливает failover-бюджет", () => {
+    const { wd, onFailover } = makeWatchdog({}, { maxConsecutiveErrors: 1, maxConsecutiveFailovers: 1 });
+    wd.notifySync("ERROR"); wd.reset(); // failover 1 (budget spent)
+    wd.notifySync("ERROR"); wd.reset(); // blocked
+    expect(onFailover).toHaveBeenCalledTimes(1);
+    wd.notifySync("PREPARED"); // healthy → resets budget
+    wd.notifySync("ERROR"); wd.reset(); // failover allowed again
+    expect(onFailover).toHaveBeenCalledTimes(2);
+  });
+});
+
+/**
+ * Source-level wiring guards for matrix-client.ts. The service wires the SDK
+ * directly (IndexedDB/crypto/sync filters) so behavioral mocking is too costly;
+ * these assertions make sure the failover wiring cannot silently regress.
+ */
+describe("matrix-client.ts wiring", () => {
+  const source = readFileSync(resolve(__dirname, "../matrix-client.ts"), "utf-8");
+
+  it("импортирует failover-примитивы из sync-failover", () => {
+    expect(source).toMatch(/from\s+["']\.\/sync-failover["']/);
+    expect(source).toContain("pickLiveMatrixHost");
+    expect(source).toContain("nextMatrixHost");
+    expect(source).toContain("SyncWatchdog");
+  });
+
+  it("ping-and-pick живого homeserver в init() до подключения", () => {
+    expect(source).toMatch(/pingServers\s*\(/);
+    expect(source).toContain("pickLiveMatrixHost");
+  });
+
+  it("на ERROR использует backoff вместо тугого retryImmediately", () => {
+    // retryImmediately must no longer be called directly in the sync listener;
+    // it is now scheduled behind a backoff timer.
+    expect(source).toMatch(/scheduleErrorRetry|errorRetry/);
+  });
+
+  it("watchdog получает каждое sync-состояние и пересоздаёт клиента на mirror", () => {
+    expect(source).toMatch(/watchdog[^\n]*notifySync/);
+    expect(source).toMatch(/recreateOnNextMirror|nextMatrixHost/);
+  });
+
+  it("destroy() останавливает watchdog (без утечки при logout)", () => {
+    const destroyIdx = source.indexOf("destroy() {");
+    expect(destroyIdx).toBeGreaterThan(-1);
+    const destroyBody = source.slice(destroyIdx, destroyIdx + 500);
+    expect(destroyBody).toMatch(/watchdog[^\n]*\.stop\(\)/);
+  });
+
+  it("recreate уступает in-flight client-creation (building-guard, review H1)", () => {
+    expect(source).toMatch(/this\.building/);
+    const recreateIdx = source.indexOf("recreateOnNextMirror");
+    const recreateBody = source.slice(recreateIdx, recreateIdx + 400);
+    expect(recreateBody).toMatch(/if\s*\(\s*this\.failoverActive\s*\|\|\s*this\.building\s*\)\s*return/);
+  });
+
+  it("pingServers пропускается под Tor (review M2)", () => {
+    const pingIdx = source.indexOf("async pingServers(");
+    const pingBody = source.slice(pingIdx, pingIdx + 400);
+    expect(pingBody).toMatch(/torProxyUrl/);
+  });
+});

--- a/src/entities/matrix/model/matrix-client.ts
+++ b/src/entities/matrix/model/matrix-client.ts
@@ -18,6 +18,15 @@ import { getmatrixid } from "@/shared/lib/matrix/functions";
 import { withTimeout } from "@/shared/lib/with-timeout";
 
 import { getStoredDeviceId, storeDeviceId } from "./device-id-storage";
+import {
+  pickLiveMatrixHost,
+  nextMatrixHost,
+  hostFromBaseUrl,
+  SyncWatchdog,
+  PING_TIMEOUT_MS,
+  ERROR_RETRY_BASE_MS,
+  ERROR_RETRY_MAX_MS,
+} from "./sync-failover";
 import type { MatrixCredentials, MatrixClient, MatrixSDK } from "./types";
 
 export type SyncCallback = (state: "PREPARED" | "SYNCING" | "ERROR" | "STOPPED" | "RECONNECTING") => void;
@@ -41,6 +50,21 @@ export class MatrixClientService {
   private sdk = sdk;
   store: Record<string, unknown> | null = null;
   private torProxyUrl: string = '';
+
+  // Runtime sync watchdog + mirror failover (WEE-105). Created lazily on first
+  // init, persists across mirror recreates, stopped on destroy/logout.
+  private watchdog: SyncWatchdog | null = null;
+  // True while a watchdog-driven mirror recreate is in flight, so init() does
+  // not ping-and-pick the baseUrl back to the primary mid-failover.
+  private failoverActive = false;
+  // True while any client (re)creation is in flight (boot init OR mirror
+  // recreate). Serializes the two writers of `this.client` so a watchdog
+  // failover can't race a concurrent boot-retry init() for ownership.
+  private building = false;
+  // Exponential backoff state for retrying the SAME host on a sync ERROR,
+  // replacing the old tight retryImmediately() loop (WEE-105 H2).
+  private errorRetryAttempt = 0;
+  private errorRetryTimer: ReturnType<typeof setTimeout> | null = null;
 
   setTorProxyUrl(url: string) {
     this.torProxyUrl = url;
@@ -491,13 +515,121 @@ export class MatrixClientService {
         if (!this.chatsReady) {
           this.chatsReady = true;
         }
+        // Healthy sync — drop any pending backoff retry and reset its attempt
+        // counter so the next error episode starts from the base delay again.
+        this.clearErrorRetry();
       } else if (state === "ERROR") {
-        console.warn("[matrix] Sync error — requesting immediate retry");
-        this.client?.retryImmediately();
+        // Was retryImmediately() on every ERROR — that hammered the SAME dead
+        // host with no backoff and span the ERROR↔RECONNECTING loop forever
+        // (WEE-105 H2). Now we retry the same host behind exponential backoff
+        // while the watchdog (below) escalates to a mirror if it stays stuck.
+        this.scheduleErrorRetry();
       } else if (state === "STOPPED") {
         console.warn("[matrix] Sync stopped unexpectedly");
       }
+      // Feed every state to the watchdog so it can fail over to a mirror when
+      // the sync is wedged while online (WEE-105 H3).
+      this.watchdog?.notifySync(state);
       this.onSync?.(state as "PREPARED" | "SYNCING" | "ERROR" | "STOPPED" | "RECONNECTING");
+    });
+  }
+
+  /** Schedule a single retry of the CURRENT host behind exponential backoff.
+   *  No-op when a retry is already pending (one in flight at a time). */
+  private scheduleErrorRetry(): void {
+    if (this.errorRetryTimer !== null) return;
+    const delay = Math.min(ERROR_RETRY_BASE_MS * 2 ** this.errorRetryAttempt, ERROR_RETRY_MAX_MS);
+    this.errorRetryAttempt += 1;
+    console.warn(`[matrix] Sync error — backoff retry in ${delay}ms (attempt ${this.errorRetryAttempt})`);
+    this.errorRetryTimer = setTimeout(() => {
+      this.errorRetryTimer = null;
+      try {
+        this.client?.retryImmediately();
+      } catch (e) {
+        console.warn("[matrix] retryImmediately failed:", e);
+      }
+    }, delay);
+  }
+
+  /** Cancel any pending backoff retry and reset its attempt counter. */
+  private clearErrorRetry(): void {
+    if (this.errorRetryTimer !== null) {
+      clearTimeout(this.errorRetryTimer);
+      this.errorRetryTimer = null;
+    }
+    this.errorRetryAttempt = 0;
+  }
+
+  /** Probe `[primary, ...mirrors]` and return the first live homeserver host.
+   *  Used before connecting so a dead/throttled primary doesn't strand /sync
+   *  (WEE-105 H1). Honours primary priority so a healthy primary is untouched. */
+  async pingServers(): Promise<string> {
+    // Under Tor the SDK routes through the local reverse proxy; a bare axios
+    // ping would always fail and just burn 2×PING_TIMEOUT_MS of dead boot
+    // latency. Tor is out of scope here (it isn't a working transport for us),
+    // so keep the current host and skip probing entirely.
+    if (this.torProxyUrl) return hostFromBaseUrl(this.baseUrl);
+    return pickLiveMatrixHost((host) =>
+      axios
+        .get(`https://${host}/_matrix/client/versions`, { timeout: PING_TIMEOUT_MS })
+        .then(() => true)
+        .catch(() => false),
+    );
+  }
+
+  /** Stop the current SDK client without tearing down handlers/credentials/
+   *  watchdog — used by the mirror failover recreate so the rebuilt client
+   *  keeps the same callbacks and the watchdog keeps monitoring. */
+  private stopClientOnly(): void {
+    this.clearErrorRetry();
+    if (this.client) {
+      try { this.client.removeAllListeners(); } catch { /* ignore */ }
+      try { this.client.stopClient(); } catch { /* ignore */ }
+    }
+    this.client = null;
+    this.chatsReady = false;
+  }
+
+  /** Watchdog-triggered recovery: rotate baseUrl to the next mirror and rebuild
+   *  the client without a page reload (WEE-105 A2). */
+  private async recreateOnNextMirror(): Promise<void> {
+    // Yield to any in-flight client (re)creation — a concurrent boot-retry
+    // init() or a previous recreate owns `this.client` until it settles.
+    if (this.failoverActive || this.building) return;
+    this.failoverActive = true;
+    this.building = true;
+    const current = hostFromBaseUrl(this.baseUrl);
+    const next = nextMatrixHost(current);
+    console.warn(`[matrix] sync stuck — failing over ${current} → ${next}`);
+    try {
+      this.stopClientOnly();
+      this.baseUrl = `https://${next}`;
+      this.client = await this.getClient();
+      if (this.client) {
+        this.store = this.client.store;
+        this.ready = true;
+      }
+    } catch (e) {
+      console.error("[matrix] mirror failover recreate error:", e);
+    } finally {
+      this.building = false;
+      this.failoverActive = false;
+      // Re-arm so the new mirror is watched too — if it is also dead the
+      // watchdog rotates to the next host on the following episode (up to the
+      // failover budget).
+      this.watchdog?.reset();
+    }
+  }
+
+  /** Create the sync watchdog once. Persists across mirror recreates so the
+   *  rebuilt client is monitored too; torn down only in destroy(). */
+  private ensureWatchdog(): void {
+    if (this.watchdog) return;
+    this.watchdog = new SyncWatchdog({
+      onFailover: () => { void this.recreateOnNextMirror(); },
+      isOnline: () => (typeof navigator === "undefined" ? true : navigator.onLine),
+      setTimer: (cb, ms) => setTimeout(cb, ms),
+      clearTimer: (h) => clearTimeout(h),
     });
   }
 
@@ -509,7 +641,19 @@ export class MatrixClientService {
     // healthy attempt N+1 — see WEE-46 retry path.
     this.error = false;
     this.ready = false;
+    this.building = true;
     try {
+      // Ping-and-pick a live homeserver before connecting (WEE-105 H1/A1).
+      // Skipped during an in-flight mirror failover, which has already set
+      // baseUrl to the mirror it wants and must not be reset back to primary.
+      if (!this.failoverActive) {
+        try {
+          this.baseUrl = `https://${await this.pingServers()}`;
+        } catch (e) {
+          console.warn("[matrix] pingServers failed, using current baseUrl:", e);
+        }
+      }
+      this.ensureWatchdog();
       this.client = await this.getClient();
       if (this.client) {
         this.store = this.client.store;
@@ -518,6 +662,8 @@ export class MatrixClientService {
     } catch (e) {
       console.error("Matrix init error:", e);
       this.error = String(e);
+    } finally {
+      this.building = false;
     }
 
     // Init file storage
@@ -984,6 +1130,11 @@ export class MatrixClientService {
 
   /** Destroy the client */
   destroy() {
+    this.watchdog?.stop();
+    this.watchdog = null;
+    this.failoverActive = false;
+    this.building = false;
+    this.clearErrorRetry();
     if (this.client) {
       this.client.removeAllListeners();
       this.client.stopClient();

--- a/src/entities/matrix/model/sync-failover.ts
+++ b/src/entities/matrix/model/sync-failover.ts
@@ -1,0 +1,189 @@
+/**
+ * Homeserver failover primitives for the /sync transport (WEE-105).
+ *
+ * The Matrix SDK connects to a SINGLE homeserver chosen once at init and never
+ * rotates it. When that host is throttled/blocked/overloaded, /sync loops
+ * ERROR↔RECONNECTING forever and only a manual reload (a fresh lottery on the
+ * same host) recovers — sometimes on the 2nd-3rd try. Media downloads already
+ * alternate primary↔mirror (WEE-90); this brings the same resilience to /sync.
+ *
+ * This module holds the PURE, side-effect-free decision logic so it can be unit
+ * tested in isolation. `matrix-client.ts` wires it to axios/SDK/timers.
+ */
+import { MATRIX_SERVER, MATRIX_MIRRORS } from "@/shared/config/constants";
+
+/** Short per-host probe budget for the boot ping-and-pick (A1/A5). */
+export const PING_TIMEOUT_MS = 4_000;
+
+/** Exponential backoff bounds for retrying the SAME host on a sync ERROR.
+ *  Replaces the old tight `retryImmediately()` loop (WEE-105 H2). */
+export const ERROR_RETRY_BASE_MS = 2_000;
+export const ERROR_RETRY_MAX_MS = 30_000;
+
+/** Ordered homeserver hosts for /sync: primary first, then mirrors. */
+export const MATRIX_SYNC_HOSTS: readonly string[] = [MATRIX_SERVER, ...MATRIX_MIRRORS];
+
+/** Strip protocol/trailing slash from a base URL → bare host. */
+export function hostFromBaseUrl(baseUrl: string): string {
+  return baseUrl.replace(/^https?:\/\//, "").replace(/\/+$/, "");
+}
+
+/** Next host in rotation after `currentHost`, wrapping around. An unknown host
+ *  rotates to the first mirror (or stays on primary when no mirrors exist). */
+export function nextMatrixHost(currentHost: string, hosts: readonly string[] = MATRIX_SYNC_HOSTS): string {
+  const idx = hosts.indexOf(currentHost);
+  if (idx === -1) return hosts[hosts.length > 1 ? 1 : 0];
+  return hosts[(idx + 1) % hosts.length];
+}
+
+/** Resolves `true` when the host answered, `false`/throw when it did not. */
+export type HostProbe = (host: string) => Promise<boolean>;
+
+/**
+ * Pick the first live homeserver from `[primary, ...mirrors]` with primary
+ * priority. The primary is probed first: when it is healthy we return it after
+ * a single probe and never wait on mirrors, so a healthy primary keeps the hot
+ * path untouched (A5). Only when the primary fails do we walk the mirrors in
+ * order. When nothing answers we keep the primary so the normal boot retry path
+ * still gets a chance.
+ */
+export async function pickLiveMatrixHost(
+  probe: HostProbe,
+  hosts: readonly string[] = MATRIX_SYNC_HOSTS,
+): Promise<string> {
+  const [primary, ...mirrors] = hosts;
+  try {
+    if (await probe(primary)) return primary;
+  } catch {
+    /* primary unreachable — fall through to mirrors */
+  }
+  for (const mirror of mirrors) {
+    try {
+      if (await probe(mirror)) return mirror;
+    } catch {
+      /* try next mirror */
+    }
+  }
+  return primary;
+}
+
+export interface SyncWatchdogDeps {
+  /** Invoked once when the watchdog decides the sync is stuck. */
+  onFailover: () => void;
+  /** Network reachability gate — never fail over while genuinely offline. */
+  isOnline: () => boolean;
+  setTimer: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clearTimer: (handle: ReturnType<typeof setTimeout>) => void;
+}
+
+export interface SyncWatchdogConfig {
+  /** Consecutive ERROR states (while online) that trigger a failover. */
+  maxConsecutiveErrors: number;
+  /** No PREPARED/SYNCING for this long while online → trigger a failover.
+   *  Kept above the SDK's own reconnect cadence so a transient blip self-heals
+   *  before we pay a client recreate. */
+  staleTimeoutMs: number;
+  /** Cap on consecutive failovers WITHOUT a healthy sync in between. Once hit,
+   *  the watchdog stops rotating (a teardown+login every staleTimeout forever
+   *  on a permanently-dead network helps nobody) and lets the error banner
+   *  take over until a healthy PREPARED/SYNCING resets the counter. */
+  maxConsecutiveFailovers: number;
+}
+
+export const DEFAULT_WATCHDOG_CONFIG: SyncWatchdogConfig = {
+  maxConsecutiveErrors: 4,
+  staleTimeoutMs: 45_000,
+  maxConsecutiveFailovers: 4,
+};
+
+/**
+ * Runtime watchdog over the /sync state stream. Fires `onFailover` when the
+ * client is online but the sync is wedged — either N consecutive ERROR states
+ * or no healthy PREPARED/SYNCING for `staleTimeoutMs`. The stale deadline is
+ * anchored to the FIRST unhealthy state and is NOT pushed out on every error
+ * (the bug behind the never-clearing banner); only a healthy state clears it.
+ */
+export class SyncWatchdog {
+  private consecutiveErrors = 0;
+  private consecutiveFailovers = 0;
+  private staleTimer: ReturnType<typeof setTimeout> | null = null;
+  private firing = false;
+  private stopped = false;
+
+  constructor(
+    private readonly deps: SyncWatchdogDeps,
+    private readonly config: SyncWatchdogConfig = DEFAULT_WATCHDOG_CONFIG,
+  ) {}
+
+  notifySync(state: string): void {
+    if (this.stopped || this.firing) return;
+
+    if (state === "PREPARED" || state === "SYNCING") {
+      // A healthy sync is the only thing that proves a host is good — reset
+      // both the error and the failover budgets here.
+      this.consecutiveErrors = 0;
+      this.consecutiveFailovers = 0;
+      this.clearStaleTimer();
+      return;
+    }
+
+    // STOPPED is an intentional teardown (logout/stopClient), not a "wedged
+    // while online" condition — it must not arm a failover. Only the genuine
+    // stuck-transport states (ERROR / RECONNECTING) drive the watchdog.
+    if (state === "ERROR" || state === "RECONNECTING") {
+      if (state === "ERROR") this.consecutiveErrors += 1;
+      // Stop rotating once the failover budget is spent — let the banner show.
+      if (this.consecutiveFailovers >= this.config.maxConsecutiveFailovers) return;
+      if (this.deps.isOnline() && this.consecutiveErrors >= this.config.maxConsecutiveErrors) {
+        this.trigger();
+        return;
+      }
+      this.armStaleTimer();
+    }
+  }
+
+  private armStaleTimer(): void {
+    if (!this.deps.isOnline()) {
+      this.clearStaleTimer();
+      return;
+    }
+    // Anchor to the first unhealthy state: do not re-arm while already running.
+    if (this.staleTimer !== null) return;
+    this.staleTimer = this.deps.setTimer(() => {
+      this.staleTimer = null;
+      if (this.stopped || this.firing) return;
+      if (this.deps.isOnline()) this.trigger();
+    }, this.config.staleTimeoutMs);
+  }
+
+  private clearStaleTimer(): void {
+    if (this.staleTimer !== null) {
+      this.deps.clearTimer(this.staleTimer);
+      this.staleTimer = null;
+    }
+  }
+
+  private trigger(): void {
+    if (this.firing || this.stopped) return;
+    this.firing = true;
+    this.consecutiveFailovers += 1;
+    this.clearStaleTimer();
+    this.consecutiveErrors = 0;
+    this.deps.onFailover();
+  }
+
+  /** Re-arm after a failover recreate completes so the next mirror is watched
+   *  too. The failover budget is NOT reset here — only a healthy sync clears
+   *  it — so a permanently-dead network can't loop teardown+login forever. */
+  reset(): void {
+    this.firing = false;
+    this.consecutiveErrors = 0;
+    this.clearStaleTimer();
+  }
+
+  /** Permanently stop (logout / client teardown). */
+  stop(): void {
+    this.stopped = true;
+    this.clearStaleTimer();
+  }
+}

--- a/src/features/sync-status/model/use-sync-status.test.ts
+++ b/src/features/sync-status/model/use-sync-status.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { ref } from "vue";
+
+// Keep the composable isolated from real connectivity / i18n side effects.
+vi.mock("@/shared/lib/connectivity", () => ({
+  useConnectivity: () => ({ isOnline: ref(true) }),
+}));
+vi.mock("@/shared/lib/i18n", () => ({
+  useI18n: () => ({ t: (k: string) => k }),
+}));
+
+import { handleSdkSync, resetSyncStatus, useSyncStatus } from "./use-sync-status";
+
+const ERROR_STALE_TIMEOUT = 60_000;
+const STALE_TIMEOUT = 30_000;
+
+describe("use-sync-status — bounded reconnect banner (WEE-105 H4)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetSyncStatus();
+  });
+
+  afterEach(() => {
+    resetSyncStatus();
+    vi.useRealTimers();
+  });
+
+  it("stale-таймер ERROR анкорится к ПЕРВОЙ ошибке и не продлевается на повторных", () => {
+    const { rawStatus } = useSyncStatus();
+
+    handleSdkSync("ERROR"); // arms ERROR_STALE_TIMEOUT at t=0
+    expect(rawStatus.value).toBe("error");
+
+    vi.advanceTimersByTime(ERROR_STALE_TIMEOUT - 10_000); // t=50s
+    handleSdkSync("ERROR"); // must NOT push the deadline out
+    expect(rawStatus.value).toBe("error");
+
+    vi.advanceTimersByTime(10_000); // t=60s from the first error → cap fires
+    expect(rawStatus.value).toBe("up_to_date");
+  });
+
+  it("RECONNECTING-шторм не держит баннер вечно (anchor к первой)", () => {
+    const { rawStatus } = useSyncStatus();
+
+    handleSdkSync("RECONNECTING"); // arms STALE_TIMEOUT at t=0
+    expect(rawStatus.value).toBe("connecting");
+
+    // Reconnects arriving faster than the timeout used to re-arm it forever —
+    // now they are ignored (deadline stays anchored to the first one).
+    vi.advanceTimersByTime(10_000);
+    handleSdkSync("RECONNECTING"); // t=10s, no re-arm
+    vi.advanceTimersByTime(10_000);
+    handleSdkSync("RECONNECTING"); // t=20s, no re-arm
+
+    vi.advanceTimersByTime(STALE_TIMEOUT - 20_000); // t=30s → anchored cap fires
+    expect(rawStatus.value).toBe("up_to_date");
+  });
+
+  it("PREPARED гасит баннер и снимает stale-таймер (восстановление после failover)", () => {
+    const { rawStatus } = useSyncStatus();
+
+    handleSdkSync("ERROR");
+    expect(rawStatus.value).toBe("error");
+
+    handleSdkSync("PREPARED");
+    expect(rawStatus.value).toBe("up_to_date");
+
+    // Timer was cleared — no later flip surprises.
+    vi.advanceTimersByTime(ERROR_STALE_TIMEOUT * 2);
+    expect(rawStatus.value).toBe("up_to_date");
+  });
+});

--- a/src/features/sync-status/model/use-sync-status.ts
+++ b/src/features/sync-status/model/use-sync-status.ts
@@ -49,7 +49,13 @@ function clearStaleTimer() {
 }
 
 function startStaleTimer() {
-  clearStaleTimer();
+  // Anchor the cap to the FIRST active-phase entry of an episode. The old code
+  // cleared and re-armed the timer on every ERROR/RECONNECTING, so as long as
+  // errors arrived more often than the timeout the deadline was pushed out
+  // forever and the banner never cleared (WEE-105 H4). Arm once per episode; a
+  // healthy PREPARED/SYNCING clears it via clearStaleTimer, and the matrix
+  // watchdog escalates a genuinely stuck sync to a mirror failover.
+  if (staleTimer) return;
   const timeout = rawStatus.value === "error" ? ERROR_STALE_TIMEOUT : STALE_TIMEOUT;
   staleTimer = setTimeout(() => {
     staleTimer = null;


### PR DESCRIPTION
## Summary
- **Ping-and-pick** a live homeserver from `[primary, ...mirrors]` before connecting (primary-priority — a healthy primary keeps the hot path untouched, A5).
- **Runtime sync-watchdog + mirror-failover**: when online but `/sync` is wedged (N consecutive `ERROR`, or no `PREPARED/SYNCING` for >45s) the client is destroyed, `baseUrl` rotates to the next mirror, and the client is rebuilt — no page reload (A2). Bounded by a consecutive-failover budget so a permanently-dead network can't loop teardown+login forever.
- **Exponential backoff** replaces the tight `retryImmediately()` loop on `ERROR` (no more ERROR↔RECONNECTING hammering of a dead host).
- **Banner** stale-timer anchored to the first error of an episode instead of re-arming on every error, so it clears after recovery (A3).
- Pure failover logic (`pingServers`/rotation/`SyncWatchdog`) split into `sync-failover.ts` with injected timers/online → full unit coverage; `matrix-client.ts` is only wiring.

## Root cause
`/sync` used a single homeserver (`matrix.pocketnet.app`) set once at init with no failover (media already had mirror failover, sync didn't). When that host was throttled/blocked/region-cut, the SDK looped `ERROR↔RECONNECTING`, never reached `PREPARED`, the chat list froze, and the banner re-armed its stale timer on every error so it never cleared. Recovery was manual reload — same host, so it helped only after 2-3 tries.

## Linear
- Resolves [WEE-105](https://linear.app/wwwee/issue/WEE-105) (P1/Urgent)

## Closes
Closes greenShirtMystery/forta-bugs#492
Closes greenShirtMystery/forta-bugs#1003
Closes greenShirtMystery/forta-bugs#383
Closes greenShirtMystery/forta-bugs#941

## Test plan
- [x] `vite build` passed; `vue-tsc --noEmit` clean on changed files (repo baseline 49 errors unchanged, none in changed files)
- [x] Unit tests added — `sync-failover.test.ts` (27) + `use-sync-status.test.ts` (3): ping-and-pick priority, host rotation, watchdog consecutive-error/stale-timer/offline-guard/failover-cap/STOPPED-neutral, bounded banner; all matrix/auth/sync-status suites (331) green
- [x] Code review (superpowers:code-reviewer) — H1 (init↔watchdog client race), M1 (STOPPED spurious failover), M2 (Tor ping skip), L1 (unused dep), L2 (failover cap) all addressed
- [ ] Manual QA: block primary host (hosts/firewall) → app auto-switches to mirror, banner clears, chat list loads without reload; restore primary → no spurious switches (A5)

## Out of scope (per ticket)
Tor/proxy (not a working transport for us — `pingServers` deliberately skips it), media-failover (WEE-90), outbound `SyncEngine` queue, WEE-80 skeleton-flicker.