### PR TITLE
fix: bump local-ai pin to fix broken npm ci (@capacitor/core)

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -351,7 +351,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 11201;
+				CURRENT_PROJECT_VERSION = 11301;
 				DEVELOPMENT_TEAM = Y5JW9JU787;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -359,7 +359,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.12.1;
+				MARKETING_VERSION = 1.13.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.forta.chat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -375,7 +375,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 11201;
+				CURRENT_PROJECT_VERSION = 11301;
 				DEVELOPMENT_TEAM = Y5JW9JU787;
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -383,7 +383,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.12.1;
+				MARKETING_VERSION = 1.13.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.forta.chat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forta-chat",
-  "version": "1.12.1",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "forta-chat",
-      "version": "1.12.1",
+      "version": "1.13.1",
       "hasInstallScript": true,
       "dependencies": {
         "@capacitor-community/file-opener": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "file-saver": "^2.0.5",
         "heic2any": "^0.0.4",
         "llama-cpp-pro": "github:maxgithubprofile/llama-cpp-pro#v0.2.4-local-ai.1",
-        "local-ai": "github:maxgithubprofile/local-ai#53f94003faa53887309f71a76ab6d158d3212dc1",
+        "local-ai": "github:maxgithubprofile/local-ai#76697733968f19298143115fe9e247ca348ed269",
         "matrix-js-sdk-bastyon": "^23.2.5",
         "miscreant": "^0.3.2",
         "node-fetch": "^2.7.0",
@@ -7182,8 +7182,8 @@
     },
     "node_modules/local-ai": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/maxgithubprofile/local-ai.git#53f94003faa53887309f71a76ab6d158d3212dc1",
-      "integrity": "sha512-ZOZ7yc6E0UzIVD7fiRm/ckgppwnf94QkPCopoYVlWCYwwvEItaZmyOYjoQ1XUSsN/F3x1f2PIk8LrDK9iDT1yA==",
+      "resolved": "git+ssh://git@github.com/maxgithubprofile/local-ai.git#76697733968f19298143115fe9e247ca348ed269",
+      "integrity": "sha512-EsR9QYhOJYtRe283+7DgK1HpB7rPM9c4TqIzS91O9ZO9G5ceYcRuY4UC7qSyLRjNYWU0ZEB1yXjN5z+hEvWAwg==",
       "license": "UNLICENSED",
       "dependencies": {
         "@noble/hashes": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "file-saver": "^2.0.5",
     "heic2any": "^0.0.4",
     "llama-cpp-pro": "github:maxgithubprofile/llama-cpp-pro#v0.2.4-local-ai.1",
-    "local-ai": "github:maxgithubprofile/local-ai#53f94003faa53887309f71a76ab6d158d3212dc1",
+    "local-ai": "github:maxgithubprofile/local-ai#76697733968f19298143115fe9e247ca348ed269",
     "matrix-js-sdk-bastyon": "^23.2.5",
     "miscreant": "^0.3.2",
     "node-fetch": "^2.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "forta-chat",
   "private": true,
-  "version": "1.12.1",
+  "version": "1.13.1",
   "description": "Forta Chat — Decentralized Messenger",
   "author": {
     "name": "Forta",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3021,10 +3021,10 @@ llama-cpp-pro@>=0.2.4, "llama-cpp-pro@github:maxgithubprofile/llama-cpp-pro#v0.2
   version "0.2.4"
   resolved "git+ssh://git@github.com/maxgithubprofile/llama-cpp-pro.git#fa59c356cdf7fd9a2601387a3c072ec474daeeb4"
 
-"local-ai@github:maxgithubprofile/local-ai#53f94003faa53887309f71a76ab6d158d3212dc1":
+"local-ai@github:maxgithubprofile/local-ai#76697733968f19298143115fe9e247ca348ed269":
   version "0.0.0"
-  resolved "git+ssh://git@github.com/maxgithubprofile/local-ai.git#53f94003faa53887309f71a76ab6d158d3212dc1"
-  integrity sha512-ZOZ7yc6E0UzIVD7fiRm/ckgppwnf94QkPCopoYVlWCYwwvEItaZmyOYjoQ1XUSsN/F3x1f2PIk8LrDK9iDT1yA==
+  resolved "git+ssh://git@github.com/maxgithubprofile/local-ai.git#76697733968f19298143115fe9e247ca348ed269"
+  integrity sha512-EsR9QYhOJYtRe283+7DgK1HpB7rPM9c4TqIzS91O9ZO9G5ceYcRuY4UC7qSyLRjNYWU0ZEB1yXjN5z+hEvWAwg==
   dependencies:
     "@noble/hashes" "^2.3.0"
 


### PR DESCRIPTION
master's local-ai pin (53f9400) predates a real fix upstream: `@capacitor/core` was a peerDependency-only in local-ai, so npm's isolated git-dependency install flow (clone to temp dir, install only that dir's own dependencies+devDependencies, then run `prepare`) failed the `prepare` script's tsup dts build with `Cannot find module '@capacitor/core'` — this is what broke GitHub Actions.

`local-ai@7669773` fixes it (adds `@capacitor/core` to devDependencies). This bumps the pin to that commit.

Verified locally: fresh `rm -rf node_modules/local-ai && npm install` resolves and builds `dist/` cleanly, and `npm run build` (vue-tsc + vite) completes in ~1m.

🤖 Generated with [Claude Code](https://claude.com/claude-code)