### PR TITLE
ci(android): accept SDK licenses before Gradle build

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -67,6 +67,13 @@ jobs:
           sed -i 's/versionCode .*/versionCode ${{ steps.version.outputs.VERSION_CODE }}/' android/app/build.gradle
           sed -i 's/versionName ".*"/versionName "${{ steps.version.outputs.VERSION }}"/' android/app/build.gradle
 
+      - name: Accept Android SDK licenses
+        # llama-cpp-pro pins a specific NDK side-by-side version
+        # (android/build.gradle's ndkVersion) that Gradle auto-downloads on
+        # first build — the runner's preinstalled SDK has it cached but not
+        # pre-licensed, so the download's license gate fails without this.
+        run: yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses || true
+
       - name: Make gradlew executable
         run: chmod +x android/gradlew
 

--- a/.github/workflows/android-test-apk.yml
+++ b/.github/workflows/android-test-apk.yml
@@ -53,6 +53,13 @@ jobs:
       - name: Inject test version into build.gradle
         run: node scripts/inject-android-test-version.mjs --version "${{ steps.version.outputs.version }}"
 
+      - name: Accept Android SDK licenses
+        # llama-cpp-pro pins a specific NDK side-by-side version
+        # (android/build.gradle's ndkVersion) that Gradle auto-downloads on
+        # first build — the runner's preinstalled SDK has it cached but not
+        # pre-licensed, so the download's license gate fails without this.
+        run: yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses || true
+
       - name: Make gradlew executable
         run: chmod +x android/gradlew
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -215,6 +215,13 @@ jobs:
           sed -i 's/versionCode .*/versionCode ${{ steps.version.outputs.VERSION_CODE }}/' android/app/build.gradle
           sed -i 's/versionName ".*"/versionName "${{ steps.version.outputs.VERSION }}"/' android/app/build.gradle
 
+      - name: Accept Android SDK licenses
+        # llama-cpp-pro pins a specific NDK side-by-side version
+        # (android/build.gradle's ndkVersion) that Gradle auto-downloads on
+        # first build — the runner's preinstalled SDK has it cached but not
+        # pre-licensed, so the download's license gate fails without this.
+        run: yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses || true
+
       - name: Make gradlew executable
         run: chmod +x android/gradlew
 


### PR DESCRIPTION
llama-cpp-pro/android/build.gradle pins a specific NDK side-by-side version (currently 29.0.13113456). Gradle auto-downloads it on first build if missing, but the runner's SDK license for that package isn't pre-accepted, so the download's license gate fails: "LicenceNotAcceptedException: ... ndk;29.0.13113456 ... not accepted".

Not something the local-ai/llama-cpp-pro fork switch changed — same ndkVersion pin as the original npm-published package — this is a pre-existing gap in these three workflows' Android build steps that apparently hadn't been exercised on CI since native compilation was added. Same fix applied to all three (android-test-apk.yml, android-release.yml, release.yml): accept SDK licenses right before the Gradle build step, so Gradle's own NDK auto-install can proceed.