### PR TITLE
ci(android): add --stacktrace to the release Gradle build

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Build sideload APK and Play AAB
         working-directory: android
-        run: ./gradlew assembleSideloadRelease bundlePlayRelease
+        run: ./gradlew assembleSideloadRelease bundlePlayRelease --stacktrace
         env:
           RELEASE_STORE_FILE: release-keystore.jks
           RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}

--- a/.github/workflows/android-test-apk.yml
+++ b/.github/workflows/android-test-apk.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Build sideload APK and Play AAB
         working-directory: android
-        run: ./gradlew assembleSideloadRelease bundlePlayRelease
+        run: ./gradlew assembleSideloadRelease bundlePlayRelease --stacktrace
         env:
           RELEASE_STORE_FILE: release-keystore.jks
           RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,7 +227,7 @@ jobs:
 
       - name: Build sideload APK and Play AAB
         working-directory: android
-        run: ./gradlew assembleSideloadRelease bundlePlayRelease
+        run: ./gradlew assembleSideloadRelease bundlePlayRelease --stacktrace
         env:
           RELEASE_STORE_FILE: release-keystore.jks
           RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}


### PR DESCRIPTION
The packageSideloadRelease failure reported on CI ("A failure occurred while executing ...IncrementalSplitterRunnable") is Gradle's generic wrapper message with no underlying cause shown, because the workflow never passed --stacktrace — Gradle's own output says as much ("Run with --stacktrace option to get the stack trace"). Local repro with the exact same task and a valid signing keystore succeeded cleanly, so the next failure needs its real "Caused by" chain to diagnose further (most likely something specific to the real ANDROID_KEYSTORE/ ANDROID_KEYSTORE_PASSWORD/ANDROID_KEY_ALIAS/ANDROID_KEY_PASSWORD secrets, since that's the one code path not exercised by the local repro).