### PR TITLE
fix(android): raise Gradle heap to fix OOM in release APK packaging

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx4096m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit


### PR DESCRIPTION
Root cause of the packageSideloadRelease failure ("A failure occurred while executing ...IncrementalSplitterRunnable"), found from the real CI run's --stacktrace output (fetched via the GitHub API, since the workflow wasn't passing --stacktrace before the previous commit):

  Caused by: java.lang.OutOfMemoryError: Java heap space
    at ...NioFileInterceptors.intercept_readAllBytes
    at com.android.zipflinger.BytesSource.<init>
    at com.android.builder.internal.packaging.ApkFlinger$writeFile$1.call

android/gradle.properties capped the Gradle daemon at -Xmx1536m. This app bundles several large native libraries per ABI (WebRTC, llama-cpp, Tor/snowflake/obfs4proxy, sqlcipher, zmq) that the APK packager reads fully into heap while zipping — 1.5GB wasn't enough, especially with `assembleSideloadRelease bundlePlayRelease` packaging both flavors in the same Gradle daemon. Not something the local-ai/llama-cpp-pro fork switch changed — this heap cap predates it and would eventually have hit the same wall as native libraries grew.

Verified: reran the exact CI command (assembleSideloadRelease bundlePlayRelease, with a throwaway signing keystore matching the real signing code path) — BUILD SUCCESSFUL in 3m 40s with -Xmx4096m, including packageSideloadRelease and bundlePlayRelease/ signPlayReleaseBundle.